### PR TITLE
Add basic registration functionality.

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -32,4 +32,3 @@
         {% endblock scripts %}
     </script>
 </body>
-</html>

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -250,6 +250,7 @@ DJANGO_APPS = (
 THIRD_PARTY_APPS = (
     'rest_framework',
     'watchman',
+    'registration',
 )
 
 # THIRD-PARTY CONFIGURATION
@@ -269,6 +270,10 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
     ]
 }
+
+# registration
+ACCOUNT_ACTIVATION_DAYS = 7 # One-week activation window.
+REGISTRATION_AUTO_LOGIN = True # Automatically log the user in.
 
 # END THIRD-PARTY CONFIGURATION
 

--- a/src/mmw/mmw/urls.py
+++ b/src/mmw/mmw/urls.py
@@ -7,10 +7,11 @@ from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from rest_framework import routers
 
+import registration.backends.default.urls
 import watchman.urls
 import apps.home.urls
 import apps.home.views
-
+import rest_framework.urls
 
 admin.autodiscover()
 
@@ -21,8 +22,9 @@ urlpatterns = patterns(
     '',
     url(r'^', include(apps.home.urls)),
     url(r'^api/', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls',
+    url(r'^api-auth/', include(rest_framework.urls,
                                namespace='rest_framework')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^watchman/', include(watchman.urls)),
+    url(r'^accounts/', include(registration.backends.default.urls)),
 )

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -6,3 +6,4 @@ django-redis==3.8.3
 hiredis==0.1.6
 djangorestframework==3.1.1
 django-filter==0.9.2
+django-registration-redux==1.1

--- a/src/mmw/templates/registration/activate.html
+++ b/src/mmw/templates/registration/activate.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<p>{% trans "Account activation failed." %}</p>
+{% endblock %}
+
+
+{% comment %}
+**registration/activate.html**
+
+Used if account activation fails. With the default setup, has the following context:
+
+``activation_key``
+    The activation key used during the activation attempt.
+{% endcomment %}

--- a/src/mmw/templates/registration/activation_complete.html
+++ b/src/mmw/templates/registration/activation_complete.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Account Activated" %}{% endblock %}
+
+{% block content %}
+<p>
+    {% trans "Your account is now activated." %}
+    {% if not user.is_authenticated %}
+    {% trans "You can log in." %}
+    {% endif %}
+</p>
+{% endblock %}
+
+
+{% comment %}
+**registration/activation_complete.html**
+
+Used after successful account activation. This template has no context
+variables of its own, and should simply inform the user that their
+account is now active.
+{% endcomment %}

--- a/src/mmw/templates/registration/activation_email.html
+++ b/src/mmw/templates/registration/activation_email.html
@@ -1,0 +1,77 @@
+{% load i18n %}
+{% load url from future %}
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>{{ site.name }} {% trans "registration" %}</title>
+</head>
+
+<body>
+<p>
+    {% blocktrans with site_name=site.name %}
+    You (or someone pretending to be you) have asked to register an account at
+    {{ site_name }}.  If this wasn't you, please ignore this email
+    and your address will be removed from our records.
+    {% endblocktrans %}
+</p>
+<p>
+    {% blocktrans %}
+    To activate this account, please click the following link within the next
+    {{ expiration_days }} days:
+    {% endblocktrans %}
+</p>
+
+<p>
+    <a href="http://{{site.domain}}{% url 'registration_activate' activation_key %}">
+        {{site.domain}}{% url 'registration_activate' activation_key %}
+    </a>
+</p>
+<p>
+    {% blocktrans with site_name=site.name %}
+    Sincerely,
+    {{ site_name }} Management
+    {% endblocktrans %}
+</p>
+</body>
+
+</html>
+
+
+{% comment %}
+**registration/activation_email.html**
+
+Used to generate the html body of the activation email. Should display a
+link the user can click to activate the account. This template has the
+following context:
+
+``activation_key``
+    The activation key for the new account.
+
+``expiration_days``
+    The number of days remaining during which the account may be
+    activated.
+
+``site``
+    An object representing the site on which the user registered;
+    depending on whether ``django.contrib.sites`` is installed, this
+    may be an instance of either ``django.contrib.sites.models.Site``
+    (if the sites application is installed) or
+    ``django.contrib.sites.models.RequestSite`` (if not). Consult `the
+    documentation for the Django sites framework
+    <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
+    details regarding these objects' interfaces.
+
+``user``
+    The new user account
+
+``request``
+    ``HttpRequest`` instance for better flexibility.
+    For example it can be used to compute absolute register URL:
+
+        http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}{% url 'registration_activate' activation_key %}
+
+    or when using Django >= 1.7:
+
+        {{ request.scheme }}://{{ request.get_host }}{% url 'registration_activate' activation_key %}
+{% endcomment %}

--- a/src/mmw/templates/registration/activation_email.txt
+++ b/src/mmw/templates/registration/activation_email.txt
@@ -1,0 +1,57 @@
+{% load i18n %}
+{% load url from future %}
+{% blocktrans with site_name=site.name %}
+You (or someone pretending to be you) have asked to register an account at
+{{ site_name }}.  If this wasn't you, please ignore this email
+and your address will be removed from our records.
+{% endblocktrans %}
+{% blocktrans %}
+To activate this account, please click the following link within the next
+{{ expiration_days }} days:
+{% endblocktrans %}
+
+http://{{site.domain}}{% url 'registration_activate' activation_key %}
+
+{% blocktrans with site_name=site.name %}
+Sincerely,
+{{ site_name }} Management
+{% endblocktrans %}
+
+
+{% comment %}
+**registration/activation_email.txt**
+
+Used to generate the text body of the activation email. Should display a
+link the user can click to activate the account. This template has the
+following context:
+
+``activation_key``
+    The activation key for the new account.
+
+``expiration_days``
+    The number of days remaining during which the account may be
+    activated.
+
+``site``
+    An object representing the site on which the user registered;
+    depending on whether ``django.contrib.sites`` is installed, this
+    may be an instance of either ``django.contrib.sites.models.Site``
+    (if the sites application is installed) or
+    ``django.contrib.sites.models.RequestSite`` (if not). Consult `the
+    documentation for the Django sites framework
+    <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
+    details regarding these objects' interfaces.
+
+``user``
+    The new user account
+
+``request``
+    ``HttpRequest`` instance for better flexibility.
+    For example it can be used to compute absolute register URL:
+
+        http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}{% url 'registration_activate' activation_key %}
+
+    or when using Django >= 1.7:
+
+        {{ request.scheme }}://{{ request.get_host }}{% url 'registration_activate' activation_key %}
+{% endcomment %}

--- a/src/mmw/templates/registration/activation_email_subject.txt
+++ b/src/mmw/templates/registration/activation_email_subject.txt
@@ -1,0 +1,28 @@
+{% load i18n %}{% trans "Account activation on" %} {{ site.name }}
+
+
+{% comment %}
+**registration/activation_email_subject.txt**
+
+Used to generate the subject line of the activation email. Because the
+subject line of an email must be a single line of text, any output
+from this template will be forcibly condensed to a single line before
+being used. This template has the following context:
+
+``activation_key``
+    The activation key for the new account.
+
+``expiration_days``
+    The number of days remaining during which the account may be
+    activated.
+
+``site``
+    An object representing the site on which the user registered;
+    depending on whether ``django.contrib.sites`` is installed, this
+    may be an instance of either ``django.contrib.sites.models.Site``
+    (if the sites application is installed) or
+    ``django.contrib.sites.models.RequestSite`` (if not). Consult `the
+    documentation for the Django sites framework
+    <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
+    details regarding these objects' interfaces.
+{% endcomment %}

--- a/src/mmw/templates/registration/login.html
+++ b/src/mmw/templates/registration/login.html
@@ -1,0 +1,45 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Log in" %}{% endblock %}
+
+{% block content %}
+<form method="post" action="">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="{% trans 'Log in' %}" />
+    <input type="hidden" name="next" value="{{ next }}" />
+</form>
+
+<p>{% trans "Forgot your password?" %} <a href="{% url 'auth_password_reset' %}">{% trans "Reset it" %}</a>.</p>
+<p>{% trans "Not a member?" %} <a href="{% url 'registration_register' %}">{% trans "Register" %}</a>.</p>
+{% endblock %}
+
+
+{% comment %}
+**registration/login.html**
+
+It's your responsibility to provide the login form in a template called
+registration/login.html by default. This template gets passed four
+template context variables:
+
+``form``
+    A Form object representing the login form. See the forms
+    documentation for more on Form objects.
+
+``next``
+    The URL to redirect to after successful login. This may contain a
+    query string, too.
+
+``site``
+    The current Site, according to the SITE_ID setting. If you don't
+    have the site framework installed, this will be set to an instance
+    of RequestSite, which derives the site name and domain from the
+    current HttpRequest.
+
+``site_name``
+    An alias for site.name. If you don't have the site framework
+    installed, this will be set to the value of
+    request.META['SERVER_NAME']. For more on sites, see The
+    "sites" framework.
+{% endcomment %}

--- a/src/mmw/templates/registration/logout.html
+++ b/src/mmw/templates/registration/logout.html
@@ -1,0 +1,8 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Logged out" %}{% endblock %}
+
+{% block content %}
+<p>{% trans "Successfully logged out" %}.</p>
+{% endblock %}

--- a/src/mmw/templates/registration/password_change_done.html
+++ b/src/mmw/templates/registration/password_change_done.html
@@ -1,0 +1,11 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Password changed" %}{% endblock %}
+
+{% block content %}
+<p>{% trans "Password successfully changed!" %}</p>
+{% endblock %}
+
+
+{# This is used by django.contrib.auth #}

--- a/src/mmw/templates/registration/password_change_form.html
+++ b/src/mmw/templates/registration/password_change_form.html
@@ -1,0 +1,15 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Change password" %}{% endblock %}
+
+{% block content %}
+<form method="post" action="">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="{% trans 'Change password' %}" />
+</form>
+{% endblock %}
+
+
+{# This is used by django.contrib.auth #}

--- a/src/mmw/templates/registration/password_reset_complete.html
+++ b/src/mmw/templates/registration/password_reset_complete.html
@@ -1,0 +1,14 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Password reset complete" %}{% endblock %}
+
+{% block content %}
+<p>
+    {% trans "Your password has been reset!" %}
+    {% trans "You may now" %}<a href="{{ login_url }}">{% trans "log in" %}</a>.
+</p>
+{% endblock %}
+
+
+{# This is used by django.contrib.auth #}

--- a/src/mmw/templates/registration/password_reset_confirm.html
+++ b/src/mmw/templates/registration/password_reset_confirm.html
@@ -1,0 +1,16 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Confirm password reset" %}{% endblock %}
+
+{% block content %}
+<p>{% trans "Enter your new password below to reset your password:" %}</p>
+<form method="post" action="">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="{% trans 'Set password' %}" />
+</form>
+{% endblock %}
+
+
+{# This is used by django.contrib.auth #}

--- a/src/mmw/templates/registration/password_reset_done.html
+++ b/src/mmw/templates/registration/password_reset_done.html
@@ -1,0 +1,16 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Password reset" %}{% endblock %}
+
+{% block content %}
+<p>
+    {% blocktrans %}
+    We have sent you an email with a link to reset your password.  Please check
+    your email and click the link to continue.
+    {% endblocktrans %}
+</p>
+{% endblock %}
+
+
+{# This is used by django.contrib.auth #}

--- a/src/mmw/templates/registration/password_reset_email.html
+++ b/src/mmw/templates/registration/password_reset_email.html
@@ -1,0 +1,21 @@
+{% load url from future %}
+
+Greetings {% if user.get_full_name %}{{ user.get_full_name }}{% else %}{{ user }}{% endif %},
+
+You are receiving this email because you (or someone pretending to be you)
+requested that your password be reset on the {{ domain }} site.  If you do not 
+wish to reset your password, please ignore this message.
+
+To reset your password, please click the following link, or copy and paste it
+into your web browser:
+
+{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uid token %}
+
+Your username, in case you've forgotten: {{ user.username }}
+
+
+Best regards,
+{{ site_name }} Management
+
+
+{# This is used by django.contrib.auth #}

--- a/src/mmw/templates/registration/password_reset_form.html
+++ b/src/mmw/templates/registration/password_reset_form.html
@@ -1,0 +1,20 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Reset password" %}{% endblock %}
+
+{% block content %}
+<p>
+    {% blocktrans %}
+    Forgot your password?  Enter your email in the form below and we'll send you instructions for creating a new one.
+    {% endblocktrans %}
+</p>
+<form method="post" action="">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="{% trans 'Reset password' %}" />
+</form>
+{% endblock %}
+
+
+{# This is used by django.contrib.auth #}

--- a/src/mmw/templates/registration/registration_base.html
+++ b/src/mmw/templates/registration/registration_base.html
@@ -1,0 +1,1 @@
+{% extends "base.html" %}

--- a/src/mmw/templates/registration/registration_closed.html
+++ b/src/mmw/templates/registration/registration_closed.html
@@ -1,0 +1,8 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Registration is closed" %}{% endblock %}
+
+{% block content %}
+<p>{% trans "Sorry, but registration is closed at this moment. Come back later." %}</p>
+{% endblock %}

--- a/src/mmw/templates/registration/registration_complete.html
+++ b/src/mmw/templates/registration/registration_complete.html
@@ -1,0 +1,18 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Activation email sent" %}{% endblock %}
+
+{% block content %}
+<p>{% trans "Please check your email to complete the registration process." %}</p>
+{% endblock %}
+
+
+{% comment %}
+**registration/registration_complete.html**
+
+Used after successful completion of the registration form. This
+template has no context variables of its own, and should simply inform
+the user that an email containing account-activation information has
+been sent.
+{% endcomment %}

--- a/src/mmw/templates/registration/registration_form.html
+++ b/src/mmw/templates/registration/registration_form.html
@@ -1,0 +1,25 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Register for an account" %}{% endblock %}
+
+{% block content %}
+<form method="post" action="">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="{% trans 'Submit' %}" />
+</form>
+{% endblock %}
+
+
+{% comment %}
+**registration/registration_form.html**
+Used to show the form users will fill out to register. By default, has
+the following context:
+
+``form``
+    The registration form. This will be an instance of some subclass
+    of ``django.forms.Form``; consult `Django's forms documentation
+    <http://docs.djangoproject.com/en/dev/topics/forms/>`_ for
+    information on how to display this in a template.
+{% endcomment %}


### PR DESCRIPTION
- Use Django Registration Redux to create basic functionality for normal user
  functions.
- Use templates provided by registration redux as defaults which can later be
  overridden.
- Provide a basic base.html file.

Fixes #22 
