### PR TITLE
Restore map state from saved data

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -1,13 +1,18 @@
 "use strict";
 
 var Marionette = require('../shim/backbone.marionette'),
-    regions = require('./regions');
+    views = require('./views');
 
-var App = new Marionette.Application();
+var App = new Marionette.Application({
+    load: function(data) {
+        App.rootView.load(data);
+    },
 
-App.addRegions({
-    mainRegion: '#container',
-    mapRegion: regions.MapRegion
+    // Return Leaflet map instance.
+    getMap: function() {
+        return App.rootView.mapRegion.map;
+    }
 });
+App.rootView = new views.RootView();
 
 module.exports = window.MMW = App;

--- a/src/mmw/js/src/controllers.js
+++ b/src/mmw/js/src/controllers.js
@@ -13,7 +13,7 @@ var AppController = {
 
     analyze: function() {
         // TODO: Move to view
-        var map = App.mapRegion.map,
+        var map = App.getMap(),
             marker = L.marker([40.1, -75.7]),
             popup = L.popup()
               .setLatLng([40.1, -75.7])

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -1,7 +1,8 @@
 "use strict";
 
 // Global jQuery needed for Bootstrap plugins.
-window.jQuery = window.$ = require('jquery');
+var $ = require('jquery');
+window.jQuery = window.$ = $;
 require('bootstrap');
 require('bootstrap-select');
 
@@ -11,6 +12,23 @@ L.Icon.Default.imagePath = '/static/images/';
 
 require('./router');
 
+// Fetch data from server based on current URL.
+function loadData() {
+    var defer = $.Deferred();
+    // Simulate an ajax request on page load.
+    // Should be replaced at a later point.
+    setTimeout(function() {
+        defer.resolve({
+            map: {
+                lat: 39.955929,
+                lng: -75.157457,
+                zoom: 12
+            }
+        });
+    }, 1500);
+    return defer.promise();
+}
+
 var Backbone = require('../shim/backbone'),
     App = require('./app');
 
@@ -19,3 +37,4 @@ App.on('start', function() {
 });
 
 App.start();
+loadData().then(App.load);

--- a/src/mmw/js/src/regions.js
+++ b/src/mmw/js/src/regions.js
@@ -14,6 +14,13 @@ var MapRegion = Marionette.Region.extend({
             maxZoom: 18
         }).addTo(map);
         this.map = map;
+    },
+
+    load: function(data) {
+        var state = data.map;
+        if (state) {
+            this.map.setView([state.lat, state.lng], state.zoom);
+        }
     }
 });
 

--- a/src/mmw/js/src/views.js
+++ b/src/mmw/js/src/views.js
@@ -1,9 +1,24 @@
 "use strict";
 
-var Marionette = require('../shim/backbone.marionette');
+var Marionette = require('../shim/backbone.marionette'),
+    regions = require('./regions');
 
 var StaticView = Marionette.ItemView.extend({});
 
+var RootView = Marionette.LayoutView.extend({
+    el: 'body',
+
+    regions: {
+        mainRegion: '#container',
+        mapRegion: regions.MapRegion
+    },
+
+    load: function(data) {
+        this.mapRegion.load(data);
+    }
+});
+
 module.exports = {
+    RootView: RootView,
     StaticView: StaticView
 };


### PR DESCRIPTION
These changes allow the map state to be restored from previously saved
data.

You can view the demo in action by hitting any endpoint. After a 1.5 second delay, the map should pan and zoom to Philadelphia.

Fixes #27
