### PR TITLE
Setup Javascript test harness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,15 @@ envdir: fatal: unable to switch to directory /etc/mmw.d/env: access denied
 
 The Vagrant configuration maps the following host ports to services running in the virtual machines.
 
-Service                | Port  | URL
----------------------- | ----- | ------------------------------------------------
-Django Web Application | 8000  | [http://localhost:8000](http://localhost:8000)
-Graphite Dashboard     | 8080  | [http://localhost:8080](http://localhost:8080)
+Service                | Port | URL
+---------------------- | -----| ------------------------------------------------
+Django Web Application | 8000 | [http://localhost:8000](http://localhost:8000)
+Graphite Dashboard     | 8080 | [http://localhost:8080](http://localhost:8080)
 Kibana Dashboard       | 5601 | [http://localhost:5601](http://localhost:5601)
 PostgreSQL             | 5432 | `psql -h localhost`
 pgweb                  | 5433 | [http://localhost:5433](http://localhost:5433)
 Redis                  | 6379 | `redis-cli -h localhost 6379`
+Testem                 | 7357 |
 
 ### Caching
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,5 +18,7 @@ vagrant ssh app -c "cd /opt/app && envdir /etc/mmw.d/env ./manage.py test --noin
 # vagrant ssh app -c "cd /opt/app && npm run lint"
 
 # Run JS unit tests.
-# vagrant ssh app -c "cd /var/www/nyc-trees/static &&
+# vagrant ssh app -c "cd /var/www/mmw/static &&
 #    xvfb-run /opt/app/node_modules/.bin/testem -f /opt/app/testem.json ci"
+vagrant ssh app -c "cd /var/www/mmw/static &&
+    xvfb-run /opt/app/node_modules/.bin/testem -f /opt/app/testem.json ci Firefox $*"

--- a/scripts/testem.sh
+++ b/scripts/testem.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -x
+
+vagrant ssh app -c "cd /var/www/mmw/static &&
+    /opt/app/node_modules/.bin/testem -f /opt/app/testem.json $*"

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -23,6 +23,7 @@ ENTRY_SASS_DIR=./sass/
 ENTRY_SASS_FILE="${ENTRY_SASS_DIR}main.scss"
 VENDOR_CSS_FILE="${STATIC_CSS_DIR}vendor.css"
 
+TEST_DIR=./js/test/
 
 usage() {
     echo -n "$(basename $0) [OPTION]...
@@ -88,7 +89,9 @@ VAGRANT_COMMAND="cd /opt/app && \
     $CONCAT_VENDOR_CSS_COMMAND &
     $NODE_SASS $ENTRY_SASS_FILE -o ${STATIC_CSS_DIR} & \
     $BROWSERIFY $ENTRY_JS_FILES $JSTIFY_TRANSFORM \
-        -o ${STATIC_JS_DIR}main.js $EXTRA_ARGS; }"
+        -o ${STATIC_JS_DIR}main.js $EXTRA_ARGS; \
+    $BROWSERIFY ${TEST_DIR}*.js $JSTIFY_TRANSFORM \
+        -o ${STATIC_JS_DIR}test.bundle.js $EXTRA_ARGS; }"
 
 echo "$VAGRANT_COMMAND"
 eval "$VAGRANT_COMMAND"

--- a/src/mmw/js/test/testHarness.js
+++ b/src/mmw/js/test/testHarness.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var assert = require('chai').assert;
+
+suite('Harness test', function() {
+    test('Ensure the test harness is working', function() {
+	assert.equal(1, 1);
+    });
+});

--- a/src/mmw/js/test/tests.js
+++ b/src/mmw/js/test/tests.js
@@ -1,0 +1,2 @@
+// Require all test suites here.
+require('./testHarness');

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -28,6 +28,9 @@
     "lodash": "3.6.0",
     "node-sass": "git://github.com/sass/node-sass#v3.0.0-pre",
     "underscore": "1.8.3",
-    "watchify": "3.1.0"
+    "watchify": "3.1.0",
+    "chai": "1.10.0",
+    "mocha": "2.0.1",
+    "testem": "0.5.15"
   }
 }

--- a/src/mmw/testem.json
+++ b/src/mmw/testem.json
@@ -1,0 +1,3 @@
+{
+ "test_page": "test.html"
+}


### PR DESCRIPTION
Most of this was brought over nyc-trees with little or no change.

To test, type `./scripts/bundle.sh` from the project root directory.
That script has been modified to place the browserified test bundle
into the static javascript directory of the the `app` VM.  After that,
typing `./scripts/test.sh` or `./scripts/testem.sh` should show one
successful test.

Fixes #44
