### PR TITLE
Demonstrate client side URL routing

### DIFF
--- a/src/mmw/apps/home/templates/home/home.html
+++ b/src/mmw/apps/home/templates/home/home.html
@@ -27,7 +27,7 @@
             <span class="caret"></span>
           </button>
           <ul class="dropdown-menu menu-left" role="menu" aria-labelledby="select-area">
-            <li role="presentation"><a role="menuitem" tabindex="-1" href="analyze">Huc 8</a></li>
+            <li role="presentation"><a role="menuitem" tabindex="-1" href="analyze" data-url="analyze">Huc 8</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Huc 10</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Huc 12</a></li>
           </ul>

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -9,7 +9,7 @@ var App = new Marionette.Application({
         this.map = new models.MapModel();
 
         // This view is intentionally not attached to any region.
-        new views.MapView({
+        this.mapView =  new views.MapView({
             model: this.map
         });
 
@@ -25,6 +25,10 @@ var App = new Marionette.Application({
                 zoom: mapState.zoom
             });
         }
+    },
+
+    getLeafletMap: function() {
+        return this.mapView._leafletMap;
     }
 });
 

--- a/src/mmw/js/src/controllers.js
+++ b/src/mmw/js/src/controllers.js
@@ -17,7 +17,7 @@ var AppController = {
 
     analyze: function() {
         // TODO: Move to view
-        var map = App.getMap(),
+        var map = App.getLeafletMap(),
             marker = L.marker([40.1, -75.7]),
             popup = L.popup()
               .setLatLng([40.1, -75.7])

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -10,8 +10,6 @@ var L = require('leaflet');
 // See: https://github.com/Leaflet/Leaflet/issues/766
 L.Icon.Default.imagePath = '/static/images/';
 
-require('./router');
-
 // Fetch data from server based on current URL.
 function loadData() {
     var defer = $.Deferred();
@@ -30,9 +28,14 @@ function loadData() {
 }
 
 var Backbone = require('../shim/backbone'),
-    App = require('./app');
+    App = require('./app'),
+    router = require('./router');
 
 App.on('start', function() {
+    $('body').on('click', '[data-url]', function(e) {
+        e.preventDefault();
+        router.navigate($(this).data('url'), { trigger: true });
+    });
     Backbone.history.start({ pushState: true });
 });
 
@@ -43,3 +46,4 @@ loadData().then(function(data) {
 });
 
 window.MMW = App;
+window.MMW.router = router;

--- a/src/mmw/js/src/router.js
+++ b/src/mmw/js/src/router.js
@@ -1,21 +1,23 @@
 "use strict";
 
 var Backbone = require('../shim/backbone'),
-    controllers = require('./controllers');
+    controllers = require('./controllers'),
+    AppController = controllers.AppController;
 
 var AppRouter = Backbone.Marionette.AppRouter.extend({
+    addRoute: function(route, controller, methodName) {
+        this._addAppRoute(controller, route, methodName);
+    },
+
     onRoute: function(name, path, args) {
         console.log('onRoute', name, path, args);
     }
 });
 
 var router = new AppRouter();
-
-router.processAppRoutes(controllers.AppController, {
-    '': 'index',
-    'analyze': 'analyze',
-    'model': 'runModel',
-    'compare': 'compare'
-});
+router.addRoute(/^/, AppController, 'index');
+router.addRoute(/^analyze/, AppController, 'analyze');
+router.addRoute(/^model/, AppController, 'runModel');
+router.addRoute(/^compare/, AppController, 'compare');
 
 module.exports = router;


### PR DESCRIPTION
This adds a helper to allow the use of Regexp for routes and
demonstrates how to handle client side routing.

Clicking "Select Area" > Huc 8 should trigger the analyze endpoint.
