### PR TITLE
Make vendor JS bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ If changes were made to the one of the VM's configuration or requirements since 
 $ vagrant provision app # or services
 ```
 
+If you add a JS dependency and want it to be included in the `vendor.js` bundle, you will need to update the `JS_DEPS` array in `bundle.sh` accordingly.
+
 After provisioning is complete, you can login to the application server and execute Django management commands:
 
 ```bash
@@ -91,4 +93,3 @@ $ ./scripts/testem.sh
 ```
 
 Then view the test runner page at [http://localhost:7357](http://localhost:7357).
-

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,5 +1,5 @@
 azavea.ntp,0.1.1
-azavea.pip,0.1.0
+azavea.pip,0.1.1
 azavea.nodejs,0.3.0
 azavea.git,0.1.0
 azavea.nginx,0.2.0

--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -22,5 +22,6 @@
     {% block footer %}
     {% endblock footer %}
 
+    <script type="text/javascript" src="{% static 'js/vendor.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/main.js' %}"></script>
 </body>

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -86,14 +86,32 @@ CONCAT_VENDOR_CSS_COMMAND="cat \
     ./node_modules/font-awesome/css/font-awesome.min.css \
     > $VENDOR_CSS_FILE"
 
+JS_DEPS=(jquery backbone backbone.marionette \
+        bootstrap bootstrap-select \
+        leaflet leaflet-draw lodash underscore \
+        chai)
+
+BROWSERIFY_EXT=""
+BROWSERIFY_REQ=""
+for DEP in "${JS_DEPS[@]}"
+do
+    BROWSERIFY_EXT+="-x $DEP "
+    BROWSERIFY_REQ+="-r $DEP "
+done
+
 VAGRANT_COMMAND="cd /opt/app && \
     $ENSURE_DIRS_EXIST && { \
     $COPY_IMAGES_COMMAND &
     $COPY_FONTS_COMMAND &
     $CONCAT_VENDOR_CSS_COMMAND &
     $NODE_SASS $ENTRY_SASS_FILE -o ${STATIC_CSS_DIR} & \
-    $BROWSERIFY $ENTRY_JS_FILES $JSTIFY_TRANSFORM \
+
+    $BROWSERIFY $ENTRY_JS_FILES $BROWSERIFY_EXT $JSTIFY_TRANSFORM \
         -o ${STATIC_JS_DIR}main.js $EXTRA_ARGS & \
+
+    $BROWSERIFY $BROWSERIFY_REQ \
+        -o ${STATIC_JS_DIR}vendor.js $EXTRA_ARGS & \
+
     $BROWSERIFY $TEST_FILES $JSTIFY_TRANSFORM \
         -o ${STATIC_JS_DIR}test.bundle.js $EXTRA_ARGS; }"
 


### PR DESCRIPTION
Run `./scripts/bundle.sh --watch` and `./scripts/manage.sh runserver`. Make a small change to a JS file in the project. The bundle script should only regenerate the main.js bundle and not vendor.js. 

Fixes #60
