### PR TITLE
Remove geo data from call to analyze endpoint.

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -31,16 +31,7 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
     },
 
     onShow: function() {
-        this.collection.fetch({
-                // TODO: This is just being passed along for
-                // demonstration purposes. In the future,
-                // the analysis should be customized for the
-                // area of interest.
-                data: {
-                    areaOfInterest: App.map.get('areaOfInterest')
-                },
-                reset: true
-        });
+        this.collection.fetch({ reset: true });
     },
 
     showRegions: function() {


### PR DESCRIPTION
- It was just for demostration purposes, and broke
  the analyze view when tested with #73.

Refs #80, #87
