### PR TITLE
Make backbone analyze model use POST for reads.

### DIFF
--- a/src/mmw/apps/analyze/views.py
+++ b/src/mmw/apps/analyze/views.py
@@ -7,7 +7,7 @@ from rest_framework import decorators
 from rest_framework.permissions import AllowAny
 
 
-@decorators.api_view(['GET'])
+@decorators.api_view(['POST'])
 @decorators.permission_classes((AllowAny, ))
 def analyze(request, format=None):
     results = [

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -18,7 +18,17 @@ var LayerModel = Backbone.Model.extend({
 // Land, soil, etc.
 var LayerCollection = Backbone.Collection.extend({
     url: '/api/analyze/',
-    model: LayerModel
+    model: LayerModel,
+    sync: function(method, model, options) {
+        if (method === 'read') {
+            // Convert GET into POST. All else remains the same.
+            // We do this because the analisis requires large polygons as input
+            // data and they make for unwieldy and potentially problematically
+            // long GET strings.
+            method = 'create';
+        }
+        return Backbone.sync(method, model, options);
+    }
 });
 
 // Each category that makes up the areas of each layer


### PR DESCRIPTION
Large GET strings were causing application errors so we switch to using POST for
the api endpoint and as a result must override backbone's default handling for
fetching/reading models.
