### PR TITLE
Make backbone analyze model use POST for reads.

### DIFF
--- a/src/mmw/apps/analyze/views.py
+++ b/src/mmw/apps/analyze/views.py
@@ -7,7 +7,7 @@ from rest_framework import decorators
 from rest_framework.permissions import AllowAny
 
 
-@decorators.api_view(['GET'])
+@decorators.api_view(['POST'])
 @decorators.permission_classes((AllowAny, ))
 def analyze(request, format=None):
     results = [

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -31,7 +31,7 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
     },
 
     onShow: function() {
-        this.collection.fetch({ reset: true });
+        this.collection.fetch({ reset: true, method: 'POST' });
     },
 
     showRegions: function() {


### PR DESCRIPTION
Large GET strings were causing application errors so we switch to using POST for
the api endpoint.

Fixes #87
