### PR TITLE
Fix issues with empty lines in roles.txt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,8 @@ def install_dependent_roles
   ansible_roles_txt = File.join(ansible_directory, "roles.txt")
 
   File.foreach(ansible_roles_txt) do |line|
+    next if line.strip.empty?
+
     role_name, role_version = line.split(",")
     role_path = File.join(ansible_directory, "roles", role_name)
     galaxy_metadata = galaxy_install_info(role_name)


### PR DESCRIPTION
The `Vagrantfile` launches `ansible-galaxy` to ensure that all of the dependent roles in `roles.txt` are installed locally. This changeset prevents that process from failing if one of the lines in `roles.txt` is empty.
