### PR TITLE
Make bar chart responsive

### DIFF
--- a/src/mmw/js/src/analyze/chart.js
+++ b/src/mmw/js/src/analyze/chart.js
@@ -5,58 +5,116 @@ var d3 = require('d3');
 // Somewhat based on the reusable chart pattern
 // by Mike Bostock http://bost.ocks.org/mike/chart/
 // and http://bl.ocks.org/mbostock/3885304
-function makeBarChart(selector, data, xValue, yValue) {
-    var margin = {top: 20, right: 20, bottom: 30, left: 80},
-        width = 750 - margin.left - margin.right,
-        height = 375 - margin.top - margin.bottom;
+//
+// options is an optional argument that has optional properties: margin, height, width and numYTicks.
+// If height and/or width aren't specified, then they are responsive (ie. set automatically according to the
+// size of the element selected by selector). margin should be an object with properties
+// top, right, bottom and left.
+function makeBarChart(selector, data, xValue, yValue, options) {
+    var options = options || {},
+        margin = options.margin || {top: 20, right: 20, bottom: 30, left: 80},
+        numYTicks = options.numYTicks || 10,
+        // containerWidth will be 0 if the chart is in a
+        // tab that is currently hidden.
+        containerWidth = options.width || $(selector).get(0).offsetWidth,
+        width = containerWidth - margin.left - margin.right,
+        containerHeight = options.height || $(selector).get(0).offsetHeight,
+        height = containerHeight - margin.top - margin.bottom;
+
+    // Set to legal dummy value if it's non-positive because
+    // the container is hidden and containerWidth == 0.
+    var hiddenSize = 100;
+    width = width > 0 ? width : hiddenSize;
+    height = height > 0 ? height : hiddenSize;
 
     var x = d3.scale.ordinal()
-        .rangeRoundBands([0, width], 0.1);
+            .rangeRoundBands([0, width], 0.1);
 
     var y = d3.scale.linear()
-        .range([height, 0]);
+            .range([height, 0]);
 
     var xAxis = d3.svg.axis()
-        .scale(x)
-        .orient("bottom");
+            .scale(x)
+            .orient("bottom");
 
     var yAxis = d3.svg.axis()
-        .scale(y)
-        .orient("left")
-        .ticks(10, "%");
+            .scale(y)
+            .orient("left")
+            .ticks(numYTicks, "%");
 
     var svg = d3.select(selector).append("svg")
-        .attr("width", width + margin.left + margin.right)
-        .attr("height", height + margin.top + margin.bottom)
-      .append("g")
-        .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+            .attr("width", containerWidth)
+            .attr("height", containerHeight);
+
+    var chartGroup = svg.append("g")
+            .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
     x.domain(data.map(function(d) { return d[xValue]; }));
     y.domain([0, d3.max(data, function(d) { return d[yValue]; })]);
 
-    svg.append("g")
-      .attr("class", "x axis")
-      .attr("transform", "translate(0," + height + ")")
-      .call(xAxis);
+    var xAxisGroup = chartGroup.append("g")
+            .attr("class", "x axis")
+            .attr("transform", "translate(0," + height + ")")
+            .call(xAxis);
 
-    svg.append("g")
-      .attr("class", "y axis")
-      .call(yAxis)
-    .append("text")
-      .attr("transform", "rotate(-90)")
-      .attr("y", 6)
-      .attr("dy", ".71em")
-      .style("text-anchor", "end")
-      .text(yValue.toUpperCase());
+    var yAxisGroup = chartGroup.append("g")
+            .attr("class", "y axis")
+            .call(yAxis);
 
-    svg.selectAll(".bar")
-      .data(data)
-    .enter().append("rect")
-      .attr("class", "bar")
-      .attr("x", function(d) { return x(d[xValue]); })
-      .attr("width", x.rangeBand())
-      .attr("y", function(d) { return y(d[yValue]); })
-      .attr("height", function(d) { return height - y(d[yValue]); });
+    var yLabelGroup = yAxisGroup.append("g")
+            .append("text")
+            .attr("transform", "rotate(-90)")
+            .attr("y", 6)
+            .attr("dy", ".71em")
+            .style("text-anchor", "end")
+            .text(yValue.toUpperCase());
+
+    var bars = chartGroup.selectAll(".bar")
+            .data(data)
+            .enter().append("rect")
+            .attr("class", "bar")
+            .attr("x", function(d) { return x(d[xValue]); })
+            .attr("width", x.rangeBand())
+            .attr("y", function(d) { return y(d[yValue]); })
+            .attr("height", function(d) { return height - y(d[yValue]); });
+
+    // Ideas for making d3 charts responsive from
+    // http://eyeseast.github.io/visible-data/2013/08/28/responsive-charts-with-d3/
+    var resize = function() {
+
+        containerWidth = options.width || $(selector).get(0).offsetWidth;
+        width = containerWidth - margin.left - margin.right;
+        containerHeight = options.height || $(selector).get(0).offsetHeight;
+        height = containerHeight - margin.top - margin.bottom;
+
+        width = width > 0 ? width : hiddenSize;
+        height = height > 0 ? height : hiddenSize;
+
+        x.rangeRoundBands([0, width], 0.1);
+        xAxis.scale(x)
+            .orient("bottom");
+        xAxisGroup.attr("transform", "translate(0," + height + ")")
+            .call(xAxis);
+
+        y.range([height, 0]);
+        yAxis.scale(y);
+        yAxisGroup.call(yAxis);
+
+        bars.attr("x", function(d) {
+            return x(d[xValue]);
+        }).attr("width", x.rangeBand())
+            .attr("y", function(d) { return y(d[yValue]); })
+            .attr("height", function(d) { return height - y(d[yValue]); });
+
+        svg.attr("width", containerWidth)
+            .attr("height", containerHeight);
+    };
+
+    $(window).on("resize", resize);
+    // bar-chart-refresh events occur when a tab in the Analyze view is selected.
+    // We need to listen for them since the chart might have been hidden when the last
+    // resize occured, in which case the size would have been set to the default.
+    $(selector).on("bar-chart:refresh", resize);
 }
 
 module.exports = {

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -103,6 +103,15 @@ var TabPanelsView = Marionette.CollectionView.extend({
         role: 'tablist'
     },
     childView: TabPanelView,
+
+    events: {
+        'shown.bs.tab li a ': 'triggerBarChartRefresh'
+    },
+
+    triggerBarChartRefresh: function() {
+        $('#analyze-output-wrapper .bar-chart').trigger('bar-chart:refresh');
+    },
+
     onRender: function() {
         this.$el.find('li:first').addClass('active');
     }
@@ -155,7 +164,7 @@ var TableRowView = Marionette.ItemView.extend({
 var TableView = Marionette.CompositeView.extend({
     childView: TableRowView,
     childViewContainer: 'tbody',
-    template: tableTmpl,
+    template: tableTmpl
 });
 
 var ChartView = Marionette.ItemView.extend({
@@ -163,6 +172,7 @@ var ChartView = Marionette.ItemView.extend({
     id: function() {
         return 'chart-' + this.model.get('name');
     },
+    className: 'chart-container',
 
     onAttach: function() {
         this.addChart();

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -1,3 +1,12 @@
+// The height and width must be set to 100%
+// so that the actual height and width of the
+// enclosing element will get propagated down to the
+// bar-chart elements.
+.chart-container{
+  width: 100%;
+  height: 100%;
+}
+
 .bar-chart{
   width: 100%;
   display: block;


### PR DESCRIPTION
The bar chart should now change its dimensions automatically upon resizing of the browser. Two shortcomings of this implementation are addressed in the following new issues:
- Crowding of the x-axis labels: https://github.com/azavea/model-my-watershed/issues/102
- The height of the bars is initially 200px: https://github.com/azavea/model-my-watershed/issues/103

The optional options argument to makeBarChart will be tested as part of #78.

I will change the double quotes to single quotes in chart.js after getting feedback.
