### PR TITLE
Create a working stub tiler and tiler VM.

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -19,3 +19,5 @@ azavea.logstash,0.1.0
 azavea.kibana,0.3.1
 azavea.collectd,0.2.0
 azavea.java,0.1.1
+azavea.build-essential,0.1.0
+azavea.mapnik,0.1.0

--- a/deployment/ansible/roles/model-my-watershed.tiler/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+tiler_home: /opt/tiler
+tiler_config_home: /etc/mmw.d/env
+tiler_deploy_branch: "master"
+
+tiler_config:
+  - { file: "MMW_DB_USER", content: "{{ postgresql_username }}" }
+  - { file: "MMW_DB_NAME", content: "{{ postgresql_database }}" }
+  - { file: "MMW_DB_PASSWORD", content: "{{ postgresql_password }}" }
+  - { file: "MMW_DB_HOST", content: "{{ postgresql_host }}" }
+  - { file: "MMW_DB_PORT", content: "{{ postgresql_port }}" }
+  - { file: "MMW_STATSD_HOST", content: "{{ statsite_host }}" }
+  - { file: "MMW_REDIS_HOST", content: "{{ redis_host }}" }
+  - { file: "MMW_REDIS_PORT", content: "{{ redis_port }}" }
+
+tiler_log: /var/log/mmw-tiler.log
+tiler_log_rotate_count: 5
+tiler_log_rotate_interval: daily

--- a/deployment/ansible/roles/model-my-watershed.tiler/handlers/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart mmw-tiler
+  service: name=mmw-tiler state=restarted

--- a/deployment/ansible/roles/model-my-watershed.tiler/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: "azavea.mapnik" }
+  - { role: "azavea.build-essential" }

--- a/deployment/ansible/roles/model-my-watershed.tiler/tasks/app.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/tasks/app.yml
@@ -1,0 +1,18 @@
+---
+- name: Clone application source
+  git: repo=https://github.com/azavea/model-my-watershed.git
+       dest=/opt/model-my-watershed
+       version="{{ tiler_deploy_branch }}"
+
+- name: Ensure that tiler_home exists
+  file: path="{{ tiler_home }}"
+        state=directory
+
+- name: Synchronize tiler code into into tiler_home
+  synchronize: archive=no
+               checksum=yes
+               compress=no
+               recursive=yes
+               set_remote_user=no
+               src=/opt/model-my-watershed/src/tiler
+               dest="{{ tiler_home }}/"

--- a/deployment/ansible/roles/model-my-watershed.tiler/tasks/configuration.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/tasks/configuration.yml
@@ -1,0 +1,43 @@
+---
+- name: Create service account for application
+  user: name=mmw
+        system=yes
+        home=/var/lib/mmw
+        shell=/bin/false
+        state=present
+
+- name: Add Vagrant user to the mmw group
+  user: name=vagrant
+        append=yes
+        group=mmw
+        state=present
+  when: "['development', 'test'] | some_are_in(group_names)"
+
+- name: Add Ubuntu user to the mmw group
+  user: name=ubuntu
+        append=yes
+        group=mmw
+        state=present
+  when: "['packer'] | is_in(group_names)"
+
+- name: Create configuration file directory
+  file: path={{ tiler_config_home }}
+        owner=root
+        group=mmw
+        mode=0750
+        state=directory
+
+- name: Configure application
+  copy: content={{ item.content }}
+        dest={{ tiler_config_home }}/{{ item.file }}
+        owner=root
+        group=mmw
+        mode=0750
+  with_items: tiler_config
+  notify:
+    - Restart mmw-tiler
+
+- name: Configure service definition
+  template: src=upstart-mmw-tiler.conf.j2 dest=/etc/init/mmw-tiler.conf
+  notify:
+    - Restart mmw-tiler

--- a/deployment/ansible/roles/model-my-watershed.tiler/tasks/dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/tasks/dependencies.yml
@@ -1,0 +1,15 @@
+---
+- name: Install canvas rendering dependencies
+  apt: pkg={{ item }} state=present
+  with_items:
+    - "libcairo2-dev=1.13.*"
+    - "libpango1.0-dev=1.36.*"
+    - "libjpeg8-dev=8c*"
+    - "libgif-dev=4.1.*"
+
+- name: Install tiler javascript dependencies
+  command: npm install --unsafe-perm
+  args:
+    chdir: "{{ tiler_home }}"
+  environment:
+    PKG_CONFIG_PATH: "/usr/lib/pkgconfig/pycairo.pc"

--- a/deployment/ansible/roles/model-my-watershed.tiler/tasks/log-rotation.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/tasks/log-rotation.yml
@@ -1,0 +1,10 @@
+---
+- name: Touch log file if it does not exist
+  command: touch {{ tiler_log }}
+           creates={{ tiler_log }}
+
+- name: Set log file permissions
+  file: path={{ tiler_log }} owner=mmw group=mmw mode=0644
+
+- name: Configure Tiler log rotation
+  template: src=logrotate-mmw-tiler.j2 dest=/etc/logrotate.d/mmw-tiler

--- a/deployment/ansible/roles/model-my-watershed.tiler/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- { include: configuration.yml }
+- { include: app.yml, when: "['packer'] | is_in(group_names)" }
+- { include: dependencies.yml }
+- { include: reverse-proxy.yml }
+- { include: log-rotation.yml }

--- a/deployment/ansible/roles/model-my-watershed.tiler/tasks/reverse-proxy.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/tasks/reverse-proxy.yml
@@ -1,0 +1,13 @@
+---
+- name: Configure Nginx site
+  template: src=nginx-mmw-tiler.conf.j2
+            dest=/etc/nginx/sites-available/mmw-tiler.conf
+  notify:
+    - Restart Nginx
+
+- name: Enable Nginx site
+  file: src=/etc/nginx/sites-available/mmw-tiler.conf
+        dest=/etc/nginx/sites-enabled/mmw-tiler
+        state=link
+  notify:
+    - Restart Nginx

--- a/deployment/ansible/roles/model-my-watershed.tiler/templates/logrotate-mmw-tiler.j2
+++ b/deployment/ansible/roles/model-my-watershed.tiler/templates/logrotate-mmw-tiler.j2
@@ -1,0 +1,7 @@
+{{ tiler_log }} {
+  rotate {{ tiler_log_rotate_count }}
+  {{ tiler_log_rotate_interval }}
+  compress
+  missingok
+  notifempty
+}

--- a/deployment/ansible/roles/model-my-watershed.tiler/templates/nginx-mmw-tiler.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.tiler/templates/nginx-mmw-tiler.conf.j2
@@ -1,0 +1,17 @@
+server {
+  listen *:80;
+  server_name _;
+
+  access_log /var/log/nginx/mmw-tiler.access.log logstash_json;
+
+  location / {
+    {% if ['packer'] | is_in(group_names) -%}
+    expires max;
+    {% endif %}
+
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://127.0.0.1:4000;
+  }
+}

--- a/deployment/ansible/roles/model-my-watershed.tiler/templates/upstart-mmw-tiler.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.tiler/templates/upstart-mmw-tiler.conf.j2
@@ -1,0 +1,15 @@
+description	"mmw-tiler"
+
+{% if ['development', 'test'] | some_are_in(group_names) -%}
+start on (vagrant-mounted)
+{% else %}
+start on (local-filesystems and net-device-up IFACE!=lo)
+{% endif %}
+stop on shutdown
+
+respawn
+setuid mmw
+chdir {{ tiler_home }}
+env HOME="/var/lib/mmw"
+
+exec envdir /etc/mmw.d/env node server.js >> {{ tiler_log }} 2>&1

--- a/deployment/ansible/tile-servers.yml
+++ b/deployment/ansible/tile-servers.yml
@@ -1,0 +1,11 @@
+---
+- hosts: tile-servers
+  sudo: True
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes cache_valid_time=3600
+
+  roles:
+    - { role: "model-my-watershed.common" }
+    - { role: "model-my-watershed.tiler" }

--- a/src/tiler/npm-shrinkwrap.json
+++ b/src/tiler/npm-shrinkwrap.json
@@ -1,0 +1,2386 @@
+{
+  "name": "mmw_tiler",
+  "version": "1.0.0",
+  "dependencies": {
+    "windshaft": {
+      "version": "0.36.0",
+      "from": "windshaft@0.36.0",
+      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-0.36.0.tgz",
+      "dependencies": {
+        "chronograph": {
+          "version": "0.1.0",
+          "from": "../../tmp/npm-27066-476c1c90/1430229677714-0.46457168622873724/0b8c35eee510cfa14a16be24d70533b38ecc1d2d",
+          "resolved": "git://github.com/CartoDB/chronographjs.git#0b8c35eee510cfa14a16be24d70533b38ecc1d2d"
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "from": "underscore@>=1.6.0 <1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+        },
+        "step": {
+          "version": "0.0.5",
+          "from": "step@>=0.0.5 <0.1.0",
+          "resolved": "https://registry.npmjs.org/step/-/step-0.0.5.tgz"
+        },
+        "queue-async": {
+          "version": "1.0.7",
+          "from": "queue-async@>=1.0.7 <1.1.0",
+          "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.0.7.tgz"
+        },
+        "grainstore": {
+          "version": "0.23.0",
+          "from": "grainstore@>=0.23.0 <0.24.0",
+          "resolved": "https://registry.npmjs.org/grainstore/-/grainstore-0.23.0.tgz",
+          "dependencies": {
+            "carto": {
+              "version": "0.9.5-cdb2",
+              "from": "https://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
+              "resolved": "https://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@>=1.4.3 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                },
+                "mapnik-reference": {
+                  "version": "5.0.9",
+                  "from": "mapnik-reference@>=5.0.7 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-5.0.9.tgz"
+                },
+                "xml2js": {
+                  "version": "0.2.8",
+                  "from": "xml2js@>=0.2.4 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+                  "dependencies": {
+                    "sax": {
+                      "version": "0.5.8",
+                      "from": "sax@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "millstone": {
+              "version": "0.6.14",
+              "from": "millstone@0.6.14",
+              "resolved": "https://registry.npmjs.org/millstone/-/millstone-0.6.14.tgz",
+              "dependencies": {
+                "generic-pool": {
+                  "version": "2.0.4",
+                  "from": "generic-pool@>=2.0.3 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz"
+                },
+                "request": {
+                  "version": "2.34.0",
+                  "from": "request@>=2.34.0 <2.35.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "0.6.6",
+                      "from": "qs@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.3",
+                      "from": "node-uuid@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "1.0.0",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.0.0.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.3.2",
+                          "from": "punycode@>=0.2.0",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                        }
+                      }
+                    },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "from": "form-data@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.7",
+                          "from": "combined-stream@>=0.0.4 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "async": {
+                          "version": "0.9.0",
+                          "from": "async@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.3.0",
+                      "from": "tunnel-agent@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.1",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "from": "ctype@0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "from": "oauth-sign@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.0.0",
+                      "from": "hawk@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@>=0.4.0 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    }
+                  }
+                },
+                "srs": {
+                  "version": "0.4.7",
+                  "from": "srs@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/srs/-/srs-0.4.7.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.7.0",
+                      "from": "nan@>=1.7.0 <1.8.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.4",
+                      "from": "node-pre-gyp@~0.6.4",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.4.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "3.0.1",
+                          "from": "nopt@>=3.0.1 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.5",
+                              "from": "abbrev@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                            }
+                          }
+                        },
+                        "npmlog": {
+                          "version": "1.1.0",
+                          "from": "npmlog@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.1.0.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.3.0",
+                              "from": "ansi@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                            },
+                            "are-we-there-yet": {
+                              "version": "1.0.2",
+                              "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.2.tgz",
+                              "dependencies": {
+                                "delegates": {
+                                  "version": "0.1.0",
+                                  "from": "delegates@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                                }
+                              }
+                            },
+                            "gauge": {
+                              "version": "1.1.0",
+                              "from": "gauge@>=1.1.0 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.1.0.tgz",
+                              "dependencies": {
+                                "has-unicode": {
+                                  "version": "1.0.0",
+                                  "from": "has-unicode@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                                },
+                                "lodash.pad": {
+                                  "version": "3.0.0",
+                                  "from": "lodash.pad@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.0.0.tgz",
+                                  "dependencies": {
+                                    "lodash._basetostring": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                                    },
+                                    "lodash._createpad": {
+                                      "version": "3.0.1",
+                                      "from": "lodash._createpad@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._createpad/-/lodash._createpad-3.0.1.tgz",
+                                      "dependencies": {
+                                        "lodash.repeat": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash.padleft": {
+                                  "version": "3.0.0",
+                                  "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.0.0.tgz",
+                                  "dependencies": {
+                                    "lodash._basetostring": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                                    },
+                                    "lodash._createpad": {
+                                      "version": "3.0.1",
+                                      "from": "lodash._createpad@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._createpad/-/lodash._createpad-3.0.1.tgz",
+                                      "dependencies": {
+                                        "lodash.repeat": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash.padright": {
+                                  "version": "3.0.0",
+                                  "from": "lodash.padright@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.0.0.tgz",
+                                  "dependencies": {
+                                    "lodash._basetostring": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                                    },
+                                    "lodash._createpad": {
+                                      "version": "3.0.1",
+                                      "from": "lodash._createpad@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._createpad/-/lodash._createpad-3.0.1.tgz",
+                                      "dependencies": {
+                                        "lodash.repeat": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "request": {
+                          "version": "2.53.0",
+                          "from": "request@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+                          "dependencies": {
+                            "bl": {
+                              "version": "0.9.4",
+                              "from": "bl@>=0.9.0 <0.10.0",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.33",
+                                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "caseless": {
+                              "version": "0.9.0",
+                              "from": "caseless@>=0.9.0 <0.10.0",
+                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                            },
+                            "forever-agent": {
+                              "version": "0.5.2",
+                              "from": "forever-agent@>=0.5.0 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                            },
+                            "form-data": {
+                              "version": "0.2.0",
+                              "from": "form-data@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                              "dependencies": {
+                                "async": {
+                                  "version": "0.9.0",
+                                  "from": "async@>=0.9.0 <0.10.0",
+                                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                                }
+                              }
+                            },
+                            "json-stringify-safe": {
+                              "version": "5.0.0",
+                              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                            },
+                            "mime-types": {
+                              "version": "2.0.9",
+                              "from": "mime-types@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                              "dependencies": {
+                                "mime-db": {
+                                  "version": "1.7.0",
+                                  "from": "mime-db@>=1.7.0 <1.8.0",
+                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                                }
+                              }
+                            },
+                            "node-uuid": {
+                              "version": "1.4.2",
+                              "from": "node-uuid@>=1.4.0 <1.5.0",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                            },
+                            "qs": {
+                              "version": "2.3.3",
+                              "from": "qs@>=2.3.1 <2.4.0",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                            },
+                            "tunnel-agent": {
+                              "version": "0.4.0",
+                              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "0.12.1",
+                              "from": "tough-cookie@>=0.12.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.3.2",
+                                  "from": "punycode@>=0.2.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                                }
+                              }
+                            },
+                            "http-signature": {
+                              "version": "0.10.1",
+                              "from": "http-signature@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.1.5",
+                                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                                },
+                                "asn1": {
+                                  "version": "0.1.11",
+                                  "from": "asn1@0.1.11",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                },
+                                "ctype": {
+                                  "version": "0.5.3",
+                                  "from": "ctype@0.5.3",
+                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                                }
+                              }
+                            },
+                            "oauth-sign": {
+                              "version": "0.6.0",
+                              "from": "oauth-sign@>=0.6.0 <0.7.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                            },
+                            "hawk": {
+                              "version": "2.3.1",
+                              "from": "hawk@>=2.3.0 <2.4.0",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                              "dependencies": {
+                                "hoek": {
+                                  "version": "2.11.0",
+                                  "from": "hoek@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
+                                },
+                                "boom": {
+                                  "version": "2.6.1",
+                                  "from": "boom@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+                                },
+                                "cryptiles": {
+                                  "version": "2.0.4",
+                                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                                },
+                                "sntp": {
+                                  "version": "1.0.9",
+                                  "from": "sntp@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                                }
+                              }
+                            },
+                            "aws-sign2": {
+                              "version": "0.5.0",
+                              "from": "aws-sign2@>=0.5.0 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                            },
+                            "stringstream": {
+                              "version": "0.0.4",
+                              "from": "stringstream@>=0.0.4 <0.1.0",
+                              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                            },
+                            "combined-stream": {
+                              "version": "0.0.7",
+                              "from": "combined-stream@>=0.0.5 <0.1.0",
+                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                              "dependencies": {
+                                "delayed-stream": {
+                                  "version": "0.0.5",
+                                  "from": "delayed-stream@0.0.5",
+                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                }
+                              }
+                            },
+                            "isstream": {
+                              "version": "0.1.1",
+                              "from": "isstream@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "4.3.0",
+                          "from": "semver@>=4.3.0 <4.4.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz"
+                        },
+                        "tar": {
+                          "version": "1.0.3",
+                          "from": "tar@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+                          "dependencies": {
+                            "block-stream": {
+                              "version": "0.0.7",
+                              "from": "block-stream@*",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                            },
+                            "fstream": {
+                              "version": "1.0.4",
+                              "from": "fstream@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.5",
+                                  "from": "graceful-fs@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-pack": {
+                          "version": "2.0.0",
+                          "from": "tar-pack@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                          "dependencies": {
+                            "uid-number": {
+                              "version": "0.0.3",
+                              "from": "uid-number@0.0.3",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                            },
+                            "once": {
+                              "version": "1.1.1",
+                              "from": "once@>=1.1.1 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                            },
+                            "debug": {
+                              "version": "0.7.4",
+                              "from": "debug@>=0.7.2 <0.8.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                            },
+                            "fstream": {
+                              "version": "0.1.31",
+                              "from": "fstream@>=0.1.22 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.5",
+                                  "from": "graceful-fs@>=3.0.2 <3.1.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "tar": {
+                              "version": "0.1.20",
+                              "from": "tar@>=0.1.17 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                              "dependencies": {
+                                "block-stream": {
+                                  "version": "0.0.7",
+                                  "from": "block-stream@*",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "fstream-ignore": {
+                              "version": "0.0.7",
+                              "from": "fstream-ignore@0.0.7",
+                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                              "dependencies": {
+                                "minimatch": {
+                                  "version": "0.2.14",
+                                  "from": "minimatch@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.5.0",
+                                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.0",
+                                      "from": "sigmund@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@>=1.0.2 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@>=1.2.0 <1.3.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "rc": {
+                          "version": "0.6.0",
+                          "from": "rc@>=0.6.0 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.6.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@>=0.0.7 <0.1.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.11",
+                              "from": "deep-extend@>=0.2.5 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.3.3",
+                              "from": "ini@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@>=2.2.8 <2.3.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "zipfile": {
+                  "version": "0.5.7",
+                  "from": "zipfile@>=0.5.2 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/zipfile/-/zipfile-0.5.7.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.5.3",
+                      "from": "nan@>=1.5.1 <1.6.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.2",
+                      "from": "node-pre-gyp@>=0.6.2 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.2.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "3.0.1",
+                          "from": "nopt@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.5",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                            }
+                          }
+                        },
+                        "npmlog": {
+                          "version": "0.1.1",
+                          "from": "npmlog@~0.1.1",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.3.0",
+                              "from": "ansi@~0.3.0",
+                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                            }
+                          }
+                        },
+                        "request": {
+                          "version": "2.51.0",
+                          "from": "request@2.x",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                          "dependencies": {
+                            "bl": {
+                              "version": "0.9.3",
+                              "from": "bl@~0.9.0",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.33",
+                                  "from": "readable-stream@~1.0.26",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "caseless": {
+                              "version": "0.8.0",
+                              "from": "caseless@~0.8.0",
+                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                            },
+                            "forever-agent": {
+                              "version": "0.5.2",
+                              "from": "forever-agent@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                            },
+                            "form-data": {
+                              "version": "0.2.0",
+                              "from": "form-data@~0.2.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                              "dependencies": {
+                                "async": {
+                                  "version": "0.9.0",
+                                  "from": "async@~0.9.0",
+                                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                                },
+                                "mime-types": {
+                                  "version": "2.0.7",
+                                  "from": "mime-types@~2.0.3",
+                                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+                                  "dependencies": {
+                                    "mime-db": {
+                                      "version": "1.5.0",
+                                      "from": "mime-db@~1.5.0",
+                                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "json-stringify-safe": {
+                              "version": "5.0.0",
+                              "from": "json-stringify-safe@~5.0.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                            },
+                            "mime-types": {
+                              "version": "1.0.2",
+                              "from": "mime-types@~1.0.1",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                            },
+                            "node-uuid": {
+                              "version": "1.4.2",
+                              "from": "node-uuid@~1.4.0",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                            },
+                            "qs": {
+                              "version": "2.3.3",
+                              "from": "qs@~2.3.1",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                            },
+                            "tunnel-agent": {
+                              "version": "0.4.0",
+                              "from": "tunnel-agent@~0.4.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "0.12.1",
+                              "from": "tough-cookie@>=0.12.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.3.2",
+                                  "from": "punycode@>=0.2.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                                }
+                              }
+                            },
+                            "http-signature": {
+                              "version": "0.10.1",
+                              "from": "http-signature@~0.10.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.1.5",
+                                  "from": "assert-plus@^0.1.5",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                                },
+                                "asn1": {
+                                  "version": "0.1.11",
+                                  "from": "asn1@0.1.11",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                },
+                                "ctype": {
+                                  "version": "0.5.3",
+                                  "from": "ctype@0.5.3",
+                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                                }
+                              }
+                            },
+                            "oauth-sign": {
+                              "version": "0.5.0",
+                              "from": "oauth-sign@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                            },
+                            "hawk": {
+                              "version": "1.1.1",
+                              "from": "hawk@1.1.1",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                              "dependencies": {
+                                "hoek": {
+                                  "version": "0.9.1",
+                                  "from": "hoek@0.9.x",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                                },
+                                "boom": {
+                                  "version": "0.4.2",
+                                  "from": "boom@0.4.x",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                                },
+                                "cryptiles": {
+                                  "version": "0.2.2",
+                                  "from": "cryptiles@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                                },
+                                "sntp": {
+                                  "version": "0.2.4",
+                                  "from": "sntp@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                                }
+                              }
+                            },
+                            "aws-sign2": {
+                              "version": "0.5.0",
+                              "from": "aws-sign2@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                            },
+                            "stringstream": {
+                              "version": "0.0.4",
+                              "from": "stringstream@~0.0.4",
+                              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                            },
+                            "combined-stream": {
+                              "version": "0.0.7",
+                              "from": "combined-stream@~0.0.5",
+                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                              "dependencies": {
+                                "delayed-stream": {
+                                  "version": "0.0.5",
+                                  "from": "delayed-stream@0.0.5",
+                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "4.2.0",
+                          "from": "semver@~4.2.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.0.tgz"
+                        },
+                        "tar": {
+                          "version": "1.0.3",
+                          "from": "tar@~1.0.2",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+                          "dependencies": {
+                            "block-stream": {
+                              "version": "0.0.7",
+                              "from": "block-stream@*",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                            },
+                            "fstream": {
+                              "version": "1.0.3",
+                              "from": "fstream@^1.0.2",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.3.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.5",
+                                  "from": "graceful-fs@3",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-pack": {
+                          "version": "2.0.0",
+                          "from": "tar-pack@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                          "dependencies": {
+                            "uid-number": {
+                              "version": "0.0.3",
+                              "from": "uid-number@0.0.3",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                            },
+                            "once": {
+                              "version": "1.1.1",
+                              "from": "once@~1.1.1",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                            },
+                            "debug": {
+                              "version": "0.7.4",
+                              "from": "debug@~0.7.2",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                            },
+                            "fstream": {
+                              "version": "0.1.31",
+                              "from": "fstream@~0.1.22",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.5",
+                                  "from": "graceful-fs@3",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "tar": {
+                              "version": "0.1.20",
+                              "from": "tar@~0.1.17",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                              "dependencies": {
+                                "block-stream": {
+                                  "version": "0.0.7",
+                                  "from": "block-stream@*",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "fstream-ignore": {
+                              "version": "0.0.7",
+                              "from": "fstream-ignore@0.0.7",
+                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                              "dependencies": {
+                                "minimatch": {
+                                  "version": "0.2.14",
+                                  "from": "minimatch@~0.2.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.5.0",
+                                      "from": "lru-cache@2",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.0",
+                                      "from": "sigmund@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@~1.0.2",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@~1.0.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@~0.10.x",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@1.2",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@~0.5.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "rc": {
+                          "version": "0.5.5",
+                          "from": "rc@~0.5.1",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@~0.0.7",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.11",
+                              "from": "deep-extend@~0.2.5",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@0.1.x",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.3.2",
+                              "from": "ini@~1.3.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.2.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@~2.2.8",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "sqlite3": {
+                  "version": "2.2.7",
+                  "from": "sqlite3@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-2.2.7.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.1.2",
+                      "from": "nan@1.1.2",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.5.22",
+                      "from": "node-pre-gyp@0.5.22",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.5.22.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "3.0.1",
+                          "from": "nopt@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.5",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                            }
+                          }
+                        },
+                        "npmlog": {
+                          "version": "0.1.1",
+                          "from": "npmlog@~0.1.1",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.3.0",
+                              "from": "ansi@~0.3.0",
+                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                            }
+                          }
+                        },
+                        "request": {
+                          "version": "2.39.0",
+                          "from": "request@2.x",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.39.0.tgz",
+                          "dependencies": {
+                            "qs": {
+                              "version": "0.6.6",
+                              "from": "qs@~0.6.0",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                            },
+                            "json-stringify-safe": {
+                              "version": "5.0.0",
+                              "from": "json-stringify-safe@~5.0.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                            },
+                            "mime-types": {
+                              "version": "1.0.2",
+                              "from": "mime-types@~1.0.1",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                            },
+                            "forever-agent": {
+                              "version": "0.5.2",
+                              "from": "forever-agent@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                            },
+                            "node-uuid": {
+                              "version": "1.4.1",
+                              "from": "node-uuid@~1.4.0",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "0.12.1",
+                              "from": "tough-cookie@>=0.12.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.3.0",
+                                  "from": "punycode@>=0.2.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.0.tgz"
+                                }
+                              }
+                            },
+                            "form-data": {
+                              "version": "0.1.4",
+                              "from": "form-data@~0.1.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                              "dependencies": {
+                                "combined-stream": {
+                                  "version": "0.0.5",
+                                  "from": "combined-stream@~0.0.4",
+                                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                                  "dependencies": {
+                                    "delayed-stream": {
+                                      "version": "0.0.5",
+                                      "from": "delayed-stream@0.0.5",
+                                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                    }
+                                  }
+                                },
+                                "mime": {
+                                  "version": "1.2.11",
+                                  "from": "mime@~1.2.11",
+                                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                                },
+                                "async": {
+                                  "version": "0.9.0",
+                                  "from": "async@~0.9.0",
+                                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                                }
+                              }
+                            },
+                            "tunnel-agent": {
+                              "version": "0.4.0",
+                              "from": "tunnel-agent@~0.4.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                            },
+                            "http-signature": {
+                              "version": "0.10.0",
+                              "from": "http-signature@~0.10.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.1.2",
+                                  "from": "assert-plus@0.1.2",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                                },
+                                "asn1": {
+                                  "version": "0.1.11",
+                                  "from": "asn1@0.1.11",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                },
+                                "ctype": {
+                                  "version": "0.5.2",
+                                  "from": "ctype@0.5.2",
+                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                                }
+                              }
+                            },
+                            "oauth-sign": {
+                              "version": "0.3.0",
+                              "from": "oauth-sign@~0.3.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                            },
+                            "hawk": {
+                              "version": "1.1.1",
+                              "from": "hawk@1.1.1",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                              "dependencies": {
+                                "hoek": {
+                                  "version": "0.9.1",
+                                  "from": "hoek@0.9.x",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                                },
+                                "boom": {
+                                  "version": "0.4.2",
+                                  "from": "boom@0.4.x",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                                },
+                                "cryptiles": {
+                                  "version": "0.2.2",
+                                  "from": "cryptiles@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                                },
+                                "sntp": {
+                                  "version": "0.2.4",
+                                  "from": "sntp@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                                }
+                              }
+                            },
+                            "aws-sign2": {
+                              "version": "0.5.0",
+                              "from": "aws-sign2@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                            },
+                            "stringstream": {
+                              "version": "0.0.4",
+                              "from": "stringstream@~0.0.4",
+                              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "3.0.1",
+                          "from": "semver@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
+                        },
+                        "tar": {
+                          "version": "1.0.0",
+                          "from": "tar@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.0.tgz",
+                          "dependencies": {
+                            "block-stream": {
+                              "version": "0.0.7",
+                              "from": "block-stream@*",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                            },
+                            "fstream": {
+                              "version": "1.0.1",
+                              "from": "fstream@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.1.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.2",
+                                  "from": "graceful-fs@3",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-pack": {
+                          "version": "2.0.0",
+                          "from": "tar-pack@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                          "dependencies": {
+                            "uid-number": {
+                              "version": "0.0.3",
+                              "from": "uid-number@0.0.3",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                            },
+                            "once": {
+                              "version": "1.1.1",
+                              "from": "once@>=1.1.1 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                            },
+                            "debug": {
+                              "version": "0.7.4",
+                              "from": "debug@>=0.7.2 <0.8.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                            },
+                            "fstream": {
+                              "version": "0.1.31",
+                              "from": "fstream@>=0.1.22 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.6",
+                                  "from": "graceful-fs@>=3.0.2 <3.1.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "tar": {
+                              "version": "0.1.20",
+                              "from": "tar@>=0.1.17 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                              "dependencies": {
+                                "block-stream": {
+                                  "version": "0.0.7",
+                                  "from": "block-stream@*",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "fstream-ignore": {
+                              "version": "0.0.7",
+                              "from": "fstream-ignore@0.0.7",
+                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                              "dependencies": {
+                                "minimatch": {
+                                  "version": "0.2.14",
+                                  "from": "minimatch@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.6.2",
+                                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.0",
+                                      "from": "sigmund@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@>=1.0.2 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@>=1.2.0 <1.3.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@~0.5.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "rc": {
+                          "version": "0.5.0",
+                          "from": "rc@~0.5.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@~0.0.7",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.11",
+                              "from": "deep-extend@~0.2.5",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@0.1.x",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.1.0",
+                              "from": "ini@~1.1.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@~2.2.8",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        }
+                      }
+                    },
+                    "set-immediate": {
+                      "version": "0.1.1",
+                      "from": "set-immediate@0.1.1",
+                      "resolved": "https://registry.npmjs.org/set-immediate/-/set-immediate-0.1.1.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@>=1.2.9 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.3 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "express": {
+          "version": "2.5.11",
+          "from": "express@>=2.5.11 <2.6.0",
+          "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+          "dependencies": {
+            "connect": {
+              "version": "1.9.2",
+              "from": "connect@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+              "dependencies": {
+                "formidable": {
+                  "version": "1.0.17",
+                  "from": "formidable@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+                }
+              }
+            },
+            "mime": {
+              "version": "1.2.4",
+              "from": "mime@1.2.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
+            },
+            "qs": {
+              "version": "0.4.2",
+              "from": "qs@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            }
+          }
+        },
+        "tilelive": {
+          "version": "4.5.3",
+          "from": "tilelive@>=4.5.3 <4.6.0",
+          "resolved": "https://registry.npmjs.org/tilelive/-/tilelive-4.5.3.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "tilelive-mapnik": {
+          "version": "0.6.15",
+          "from": "https://github.com/CartoDB/tilelive-mapnik/tarball/cdb",
+          "resolved": "https://github.com/CartoDB/tilelive-mapnik/tarball/cdb",
+          "dependencies": {
+            "generic-pool": {
+              "version": "2.1.1",
+              "from": "generic-pool@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@>=1.2.11 <1.3.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            }
+          }
+        },
+        "mapnik": {
+          "version": "1.4.15-cdb1",
+          "from": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb1",
+          "resolved": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb1",
+          "dependencies": {
+            "nan": {
+              "version": "1.2.0",
+              "from": "nan@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.2.0.tgz"
+            },
+            "mapnik-vector-tile": {
+              "version": "0.5.5",
+              "from": "mapnik-vector-tile@0.5.5",
+              "resolved": "https://registry.npmjs.org/mapnik-vector-tile/-/mapnik-vector-tile-0.5.5.tgz"
+            },
+            "node-pre-gyp": {
+              "version": "0.5.25",
+              "from": "node-pre-gyp@0.5.25",
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.5.25.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "3.0.1",
+                  "from": "nopt@~3.0.1",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@1",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "0.1.1",
+                  "from": "npmlog@~0.1.1",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
+                  "dependencies": {
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.40.0",
+                  "from": "request@2.x",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "1.0.2",
+                      "from": "qs@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@~5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "1.0.2",
+                      "from": "mime-types@~1.0.1",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "from": "node-uuid@~1.4.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "0.12.1",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.3.1",
+                          "from": "punycode@>=0.2.0",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "from": "form-data@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.5",
+                          "from": "combined-stream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "mime": {
+                          "version": "1.2.11",
+                          "from": "mime@~1.2.11",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                        },
+                        "async": {
+                          "version": "0.9.0",
+                          "from": "async@~0.9.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.0",
+                      "from": "tunnel-agent@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "from": "http-signature@~0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "from": "assert-plus@0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "from": "ctype@0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "from": "oauth-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.1.1",
+                      "from": "hawk@1.1.1",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@0.4.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@0.2.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@0.2.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.4",
+                      "from": "stringstream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "3.0.1",
+                  "from": "semver@~3.0.1",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
+                },
+                "tar": {
+                  "version": "1.0.1",
+                  "from": "tar@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.1.tgz",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.7",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.2",
+                      "from": "fstream@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.2.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "3.0.2",
+                          "from": "graceful-fs@3",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "tar-pack": {
+                  "version": "2.0.0",
+                  "from": "tar-pack@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                  "dependencies": {
+                    "uid-number": {
+                      "version": "0.0.3",
+                      "from": "uid-number@0.0.3",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                    },
+                    "once": {
+                      "version": "1.1.1",
+                      "from": "once@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@~0.7.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "fstream": {
+                      "version": "0.1.31",
+                      "from": "fstream@~0.1.22",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "3.0.2",
+                          "from": "graceful-fs@~3.0.2",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "tar": {
+                      "version": "0.1.20",
+                      "from": "tar@~0.1.17",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                      "dependencies": {
+                        "block-stream": {
+                          "version": "0.0.7",
+                          "from": "block-stream@*",
+                          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "0.0.7",
+                      "from": "fstream-ignore@0.0.7",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@~0.2.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@2",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.31",
+                      "from": "readable-stream@~1.0.2",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@1.2",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "from": "mkdirp@~0.5.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "0.5.1",
+                  "from": "rc@~0.5.0",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@~0.0.7",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.2.11",
+                      "from": "deep-extend@~0.2.5",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "strip-json-comments@0.1.x",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                    },
+                    "ini": {
+                      "version": "1.1.0",
+                      "from": "ini@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@~2.2.8",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "canvas": {
+          "version": "1.1.6",
+          "from": "canvas@1.1.6",
+          "resolved": "https://registry.npmjs.org/canvas/-/canvas-1.1.6.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "1.2.0",
+              "from": "nan@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.2.0.tgz"
+            }
+          }
+        },
+        "semver": {
+          "version": "1.1.4",
+          "from": "semver@>=1.1.4 <1.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
+        },
+        "redis-mpool": {
+          "version": "0.1.0",
+          "from": "../../tmp/npm-27066-476c1c90/1430229677692-0.30779228755272925/47510b8d4525ee24aa2e5328976372274a1d144e",
+          "resolved": "git://github.com/CartoDB/node-redis-mpool.git#47510b8d4525ee24aa2e5328976372274a1d144e",
+          "dependencies": {
+            "generic-pool": {
+              "version": "2.1.1",
+              "from": "generic-pool@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
+            },
+            "redis": {
+              "version": "0.12.1",
+              "from": "redis@>=0.12.1 <0.13.0",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz"
+            },
+            "hiredis": {
+              "version": "0.1.17",
+              "from": "hiredis@>=0.1.17 <0.2.0",
+              "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
+              "dependencies": {
+                "bindings": {
+                  "version": "1.2.1",
+                  "from": "bindings@*",
+                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                },
+                "nan": {
+                  "version": "1.1.2",
+                  "from": "nan@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "carto": {
+          "version": "0.14.0",
+          "from": "https://github.com/CartoDB/carto/tarball/update_to_master",
+          "resolved": "https://github.com/CartoDB/carto/tarball/update_to_master",
+          "dependencies": {
+            "mapnik-reference": {
+              "version": "6.0.5",
+              "from": "mapnik-reference@>=6.0.2 <6.1.0",
+              "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "step-profiler": {
+          "version": "0.1.0",
+          "from": "../../tmp/npm-27066-476c1c90/1430229677746-0.8612696477212012/9b97881e450445bd8a307a9cc372b5129cb4529a",
+          "resolved": "git://github.com/CartoDB/node-step-profiler.git#9b97881e450445bd8a307a9cc372b5129cb4529a"
+        },
+        "cartodb-psql": {
+          "version": "0.4.0",
+          "from": "https://github.com/CartoDB/node-cartodb-psql/tarball/0.4.0",
+          "resolved": "https://github.com/CartoDB/node-cartodb-psql/tarball/0.4.0",
+          "dependencies": {
+            "pg": {
+              "version": "2.6.2-cdb1",
+              "from": "../../tmp/npm-27066-476c1c90/1430229690446-0.6160484990105033/836a2dc3131e873fc4ba20cd16e7fb69a7dca98a",
+              "resolved": "git://github.com/CartoDB/node-postgres.git#836a2dc3131e873fc4ba20cd16e7fb69a7dca98a",
+              "dependencies": {
+                "generic-pool": {
+                  "version": "2.0.3",
+                  "from": "generic-pool@2.0.3",
+                  "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz"
+                },
+                "buffer-writer": {
+                  "version": "1.0.0",
+                  "from": "buffer-writer@1.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "torque.js": {
+          "version": "2.7.1",
+          "from": "https://github.com/CartoDB/torque/tarball/2.8",
+          "resolved": "https://github.com/CartoDB/torque/tarball/2.8",
+          "dependencies": {
+            "carto": {
+              "version": "0.15.1-cdb1",
+              "from": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+              "resolved": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+              "dependencies": {
+                "mapnik-reference": {
+                  "version": "6.0.5",
+                  "from": "mapnik-reference@>=6.0.2 <6.1.0",
+                  "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "request": {
+          "version": "2.48.0",
+          "from": "request@2.48.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.48.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.7.0",
+              "from": "caseless@>=0.7.0 <0.8.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.7.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "form-data@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "dependencies": {
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@>=1.2.11 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "mime-types@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "qs@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "1.0.0",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.0.0.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.5.0",
+              "from": "oauth-sign@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+            },
+            "hawk": {
+              "version": "1.1.1",
+              "from": "hawk@1.1.1",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "abaculus": {
+          "version": "1.1.0",
+          "from": "https://github.com/CartoDB/abaculus/tarball/cdb",
+          "resolved": "https://github.com/CartoDB/abaculus/tarball/cdb"
+        },
+        "sphericalmercator": {
+          "version": "1.0.2",
+          "from": "sphericalmercator@1.0.2",
+          "resolved": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.2.tgz"
+        },
+        "node-statsd": {
+          "version": "0.0.7",
+          "from": "node-statsd@>=0.0.7 <0.1.0",
+          "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.0.7.tgz"
+        }
+      }
+    }
+  }
+}

--- a/src/tiler/package.json
+++ b/src/tiler/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mmw_tiler",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "dependencies": {
+    "windshaft": "0.36.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -1,0 +1,61 @@
+var Windshaft = require('windshaft'),
+    fs = require('fs'),
+    styles = fs.readFileSync('styles.mss', { encoding: 'utf8' });
+
+var dbUser = process.env.MMW_DB_USER,
+    dbPass = process.env.MMW_DB_PASSWORD,
+    dbHost = process.env.MMW_DB_HOST,
+    dbName = process.env.MMW_DB_NAME,
+    dbPort = process.env.MMW_DB_PORT,
+    redisHost = process.env.MMW_REDIS_HOST,
+    redisPort = process.env.MMW_REDIS_PORT;
+
+var config = {
+    base_url: '/tiles',
+    base_url_notable: '/tiles',
+    grainstore: {
+        datasource: {
+            user: dbUser,
+            host: dbHost,
+            port: dbPort,
+            password: dbPass,
+            geometry_field: 'polygon', // TODO Change name.
+            srid: 4326
+        }
+    },
+    renderCache: {
+        ttl: 60000, // seconds
+    },
+    mapnik: {
+        metatile: 4,
+        bufferSize:64,
+    },
+    redis: {
+        host: redisHost,
+        port: redisPort
+    },
+    beforeTileRender: function(req, res, callback) {
+        callback(null);
+    },
+    afterTileRender: function(req, res, tile, headers, callback) {
+        callback(null, tile, headers);
+    },
+    req2params: function(req, callback) {
+        try {
+            // TODO make this dynamic.
+            req.params.table = 'predefined_shapes_district';
+            req.params.dbname = dbName;
+            req.params.style = styles;
+            // TODO make this dynamic.
+            req.params.interactivity = 'state_short,id'; // TODO make this configurable for data set.
+            callback(null, req);
+        } catch(err) {
+            callback(err, null);
+        }
+    }
+};
+
+// Initialize tile server on port 4000
+var ws = new Windshaft.Server(config);
+ws.listen(4000);
+console.log('Starting MMW Windshaft tiler on http://localhost:4000' + config.base_url + '/:z/:x/:y.*');

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -1,0 +1,6 @@
+#predefined_shapes_district {
+  polygon-fill: #FF0000;
+  polygon-opacity: 0.25;
+  line-color: #000;
+  line-opacity: 0.5;
+}


### PR DESCRIPTION
We want to serve tiles for our national scale data such as congressional
district from Windshaft which is a nodejs tiler that wraps calls to mapnik. The
tiler will live on its own VM for development and will be one of potentially
many machines on production. Windshaft serves on port 4000 but this is proxied
through Nginx on port 80. The tiler grabs info from the database on the services
machines and uses Redis on the services machines. In this stub, we only serve
congressional districts.

Fixes #91 
