### PR TITLE
Add support for Nginx, Celery, Django, and Windshaft log shipping

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -21,3 +21,4 @@ azavea.collectd,0.2.0
 azavea.java,0.1.1
 azavea.build-essential,0.1.0
 azavea.mapnik,0.1.0
+azavea.beaver,0.1.3

--- a/deployment/ansible/roles/model-my-watershed.app/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/meta/main.yml
@@ -4,4 +4,5 @@ dependencies:
   - { role: "azavea.pip" }
   - { role: "azavea.postgresql-support" }
   - { role: "azavea.phantomjs" }
+  - { role: "model-my-watershed.monitoring", collectd_prefix: "collectd.app.", when: "['test'] | is_not_in(group_names)" }
   - { role: "model-my-watershed.celery" }

--- a/deployment/ansible/roles/model-my-watershed.beaver/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.beaver/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.beaver" }

--- a/deployment/ansible/roles/model-my-watershed.beaver/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.beaver/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Configure Beaver to ship logs
+  template: src="{{ item }}.conf.j2"
+            dest="{{ beaver_conf_dir }}/conf.d/{{ item }}"
+  with_items:
+    - nginx
+    - django
+    - gunicorn
+    - windshaft
+    - celery
+  notify:
+    - Restart Beaver
+
+- name: Add Beaver user to service group
+  user: name=beaver
+        append=yes
+        groups=adm
+        state=present

--- a/deployment/ansible/roles/model-my-watershed.beaver/templates/celery.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.beaver/templates/celery.conf.j2
@@ -1,0 +1,5 @@
+[/var/log/celery/*.log]
+multiline_regex_after = (^\s+File.*, line \d+, in)
+multiline_regex_before = (^Traceback \(most recent call last\):)|(^\s+File.*, line \d+, in)|(^\w+Error: )
+type: celery
+tags: celery,beaver

--- a/deployment/ansible/roles/model-my-watershed.beaver/templates/django.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.beaver/templates/django.conf.j2
@@ -1,0 +1,5 @@
+[/var/log/{upstart/mmw-app.log,mmw-app.log}]
+multiline_regex_after = (^\s+File.*, line \d+, in)
+multiline_regex_before = (^Traceback \(most recent call last\):)|(^\s+File.*, line \d+, in)|(^\w+Error: )
+type: django
+tags: django,beaver

--- a/deployment/ansible/roles/model-my-watershed.beaver/templates/gunicorn.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.beaver/templates/gunicorn.conf.j2
@@ -1,0 +1,3 @@
+[/var/log/mmw-gunicorn.log]
+type: gunicorn
+tags: gunicorn,beaver

--- a/deployment/ansible/roles/model-my-watershed.beaver/templates/nginx.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.beaver/templates/nginx.conf.j2
@@ -1,0 +1,13 @@
+[/var/log/nginx/error.log]
+type: nginx
+tags: nginx,beaver
+
+[/var/log/nginx/access.log]
+format: rawjson
+type: nginx
+tags: nginx,beaver
+
+[/var/log/nginx/*.access.log]
+format: rawjson
+type: nginx
+tags: nginx,beaver

--- a/deployment/ansible/roles/model-my-watershed.beaver/templates/windshaft.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.beaver/templates/windshaft.conf.j2
@@ -1,0 +1,4 @@
+[/var/log/{upstart/mmw-tiler.log,mmw-tiler.log}]
+format: rawjson
+type: windshaft
+tags: windshaft,beaver

--- a/deployment/ansible/roles/model-my-watershed.beaver/vars/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.beaver/vars/main.yml
@@ -1,0 +1,3 @@
+---
+beaver_version: "33.3.0"
+beaver_redis_url: "redis://{{ redis_host }}:{{ redis_port }}/0"

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/meta/main.yml
@@ -3,4 +3,5 @@ dependencies:
   - { role: "azavea.python", python_development: True }
   - { role: "azavea.pip" }
   - { role: "azavea.postgresql-support" }
+  - { role: "model-my-watershed.monitoring", collectd_prefix: "collectd.worker.", when: "['test'] | is_not_in(group_names)" }
   - { role: "model-my-watershed.celery" }

--- a/deployment/ansible/roles/model-my-watershed.logstash/templates/logstash.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.logstash/templates/logstash.conf.j2
@@ -11,6 +11,18 @@ input {
   }
 }
 
+filter {
+  if [type] == "windshaft" {
+    if ![@fields] {
+        drop { }
+    }
+
+    date {
+      match => [ "timestamp", "E, dd MMM yyyy HH:mm:ss z" ]
+    }
+  }
+}
+
 output {
   elasticsearch {
     embedded => false

--- a/deployment/ansible/roles/model-my-watershed.monitoring/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.monitoring/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - { role: "azavea.relp" }
+  - { role: "model-my-watershed.collectd" }
+  - { role: "model-my-watershed.beaver" }

--- a/deployment/ansible/roles/model-my-watershed.tiler/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/meta/main.yml
@@ -2,3 +2,4 @@
 dependencies:
   - { role: "azavea.mapnik" }
   - { role: "azavea.build-essential" }
+  - { role: "model-my-watershed.monitoring", collectd_prefix: "collectd.tiler.", when: "['test'] | is_not_in(group_names)" }

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -34,6 +34,7 @@ var config = {
         host: redisHost,
         port: redisPort
     },
+    log_format: '{ "timestamp": ":date[iso]", "@fields": { "remote_addr": ":remote-addr", "body_bytes_sent": ":res[content-length]", "request_time": ":response-time", "status": ":status", "request": ":method :url HTTP/:http-version", "request_method": ":method", "http_referrer": ":referrer", "http_user_agent": ":user-agent" } }',
     beforeTileRender: function(req, res, callback) {
         callback(null);
     },


### PR DESCRIPTION
This changeset adds log shipping support (via Beaver and syslog) to Logstash. In some cases, Logstash does a little processing, but ultimately, flushes the logs to ElasticSearch. From there, they are queryable through Kibana.

In addition, each machine runs Collectd to emit system resource metrics to Graphite.

---

To test, attempt to generate different types of log messages (normal, and exceptions) in the application and Celery tasks. Then, query for the messages using the Kibana UI. In addition, take a look at the Graphite UI after provisioning to see if there are entries for each machine type under the `collectd` metric namespace.
