### PR TITLE
Add udev rule to start Celery after VirtualBox share mounted

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
@@ -10,3 +10,11 @@
   template: src=celeryd-defaults.j2 dest=/etc/default/celeryd
   notify:
     - Restart Celery
+
+- name: Configure udev rules to wait for Vagrant mount
+  template: src=50-vagrant-mount.rules.j2
+            dest=/etc/udev/rules.d/50-vagrant-mount.rules
+  when: "['development', 'test'] | some_are_in(group_names)"
+
+- name: Enable Celery service
+  service: name=celeryd enabled=yes state=started

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/dependencies.yml
@@ -14,9 +14,14 @@
 - name: Install PostgreSQL client
   apt: pkg=postgresql-client-{{ postgresql_version }}={{ postgresql_package_version }}
 
-- name: Install application Python dependencies for dev
-  pip: chdir="{{ celery_dir }}/requirements" requirements=development.txt
-  when: "['development'] | is_in(group_names)"
+- name: Install application Python dependencies for development and test
+  pip: chdir="{{ celery_dir }}/requirements" requirements={{ item }}.txt
+  with_items:
+    - development
+    - test
+  when: "['development', 'test'] | some_are_in(group_names)"
+  notify:
+    - Restart Celery
 
 - name: Install application Python dependencies for production
   pip: chdir="{{ celery_dir }}/requirements" requirements=production.txt

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/templates/50-vagrant-mount.rules.j2
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/templates/50-vagrant-mount.rules.j2
@@ -1,0 +1,2 @@
+SUBSYSTEM=="bdi",ACTION=="add",RUN+="/usr/bin/screen -m -d bash -c 'sleep 5; /usr/sbin/service celeryd start'"
+SUBSYSTEM=="bdi",ACTION=="remove",RUN+="/usr/bin/screen -m -d bash -c 'sleep 5; /usr/sbin/service celeryd stop'"

--- a/deployment/ansible/roles/model-my-watershed.celery/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery/tasks/main.yml
@@ -5,7 +5,6 @@
 - name: Install Django Celery
   pip: name="django-celery" version={{ djcelery_version }} state=present
 
-
 - name: Patch celery
   copy: src=django.py
         dest=/usr/local/lib/python2.7/dist-packages/celery/fixups/django.py


### PR DESCRIPTION
This changeset adds a `udev` rule that waits for Vagrant to mount the VirtualBox share containing Celery task definitions before attempting to start the Celery service. This should aid in development and testing environments that involve halting or reloading the `worker` virtual machine.

Resolves #111.
