### PR TITLE
Use actual tr55 model in celery task.

### DIFF
--- a/src/mmw/apps/watershed_model/tasks.py
+++ b/src/mmw/apps/watershed_model/tasks.py
@@ -8,8 +8,7 @@ from celery import shared_task
 import logging
 import urllib2
 
-# TODO import TR55
-# from tr55.model import simulate_year
+from tr55.model import simulate_year
 
 # TODO REMOVE THIS.
 import time
@@ -54,13 +53,7 @@ def run_tr55(model_input, landscape):
     }
     time.sleep(5)
 
-    # TODO Get the real simpulation data.
-    # (q, et, inf) = simulate_year(landscape)
-
-    # TODO Dummy data. Remove me.
-    q = 2
-    et = 3
-    inf = 4
+    (q, et, inf) = simulate_year(landscape)
     return {
         'q': q,
         'et': et,

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -8,3 +8,4 @@ djangorestframework==3.1.1
 django-filter==0.9.2
 django-registration-redux==1.1
 python-omgeo==1.7.2
+tr55==0.1.0.dev2


### PR DESCRIPTION
We had been returning the data structure that TR55 returns without actually
using TR55. Now we require TR55 via PIP and run data against it, though for now
it is hard coded dummy data.

Connects #132 
