### PR TITLE
Create templates for `/model` page.

### DIFF
--- a/src/mmw/apps/home/templates/home/home.html
+++ b/src/mmw/apps/home/templates/home/home.html
@@ -18,7 +18,7 @@
 
 {% block content %}
 <div class="container-fluid top-nav"> <!-- Container -->
-
+    <div id="extra-header"></div> <!-- Extra Header -->
     <div id="search-map"> <!-- Search Tools -->
         <div id="geocode-search-region"></div> <!-- Search Input -->
         <div id="draw-tools-region"></div>

--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.conf.urls import patterns, url
-from apps.home.views import home_page, model, compare
+from apps.home.views import home_page, compare
 from apps.predefined_shapes.views import district
 
 
@@ -14,6 +14,6 @@ urlpatterns = patterns(
     url(r'^analyze$', home_page, name='home_page'),
     url(r'^api/congressional_districts$', district, name='district'),
     url(r'^api/congressional_districts/id/(?P<id>[0-9]+)$', district, name='district'),  # noqa
-    url(r'^model$', model, name='model'),
+    url(r'^model$', home_page, name='home_page'),
     url(r'^compare$', compare, name='compare'),
 )

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -25,9 +25,5 @@ def home_page(request):
     return render_to_response('home/home.html')
 
 
-def model(request):
-    return render_to_response('home/model.html')
-
-
 def compare(request):
     return render_to_response('home/compare.html')

--- a/src/mmw/js/src/analyze/templates/header.ejs
+++ b/src/mmw/js/src/analyze/templates/header.ejs
@@ -6,6 +6,6 @@
     <label class="light"><%= area %> acres</label>
 </div>
 <div class="cta-wrapper">
-    <a href="model" class="btn btn-lg btn-cta"><i class="fa fa-arrow-right"></i></a>
+    <a data-url="/model" class="btn btn-lg btn-cta"><i class="fa fa-arrow-right"></i></a>
     <label class="paper center-block text-center">Model</label>
 </div>

--- a/src/mmw/js/src/controllers.js
+++ b/src/mmw/js/src/controllers.js
@@ -6,25 +6,6 @@ var $ = require('jquery'),
     App = require('./app');
 
 var AppController = {
-    runModel: function() {
-        // TODO: Move to view
-        $('#output-tab a').click(function (e) {
-            e.preventDefault();
-            $(this).tab('show');
-        });
-
-        $('#scenario-tab a').click(function (e) {
-            e.preventDefault();
-            $(this).tab('show');
-        });
-
-        $('.selectpicker').selectpicker({
-            tickIcon: '',
-        });
-
-        $('[data-toggle="tooltip"]').tooltip();
-    },
-
     compare: function() {
         // TODO: Move to view
         $('#compare-tab a').click(function (e) {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -30,6 +30,7 @@ var RootView = Marionette.LayoutView.extend({
         mainRegion: '#container',
         geocodeSearchRegion: '#geocode-search-region',
         drawToolsRegion: '#draw-tools-region',
+        extraHeaderRegion: '#extra-header',
         footerRegion: {
             regionClass: TransitionRegion,
             selector: '#footer'

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -1,0 +1,40 @@
+"use strict";
+
+var $ = require('jquery'),
+    _ = require('underscore'),
+    L = require('leaflet'),
+    App = require('../app'),
+    router = require('../router').router,
+    views = require('./views'),
+    models = require('./models');
+
+var ModelingController = {
+    modelPrepare: function() {
+        if (!App.map.get('areaOfInterest')) {
+            router.navigate('', { trigger: true });
+            return false;
+        }
+    },
+
+    model: function() {
+        var taskModel = new models.Tr55TaskModel(),
+            rootView = App.rootView,
+            tr55Window = new views.ModelingWindow({
+                id: 'analyze-output-wrapper',
+                model: taskModel
+            }),
+            extraHeader = new views.ExtraHeaderView();
+
+        App.rootView.extraHeaderRegion.show(extraHeader);
+        App.rootView.footerRegion.show(tr55Window);
+    },
+
+    modelCleanUp: function() {
+        App.rootView.extraHeaderRegion.empty();
+        App.rootView.footerRegion.empty();
+    }
+};
+
+module.exports = {
+    ModelingController: ModelingController
+};

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var Backbone = require('../../shim/backbone'),
+    _ = require('lodash'),
+    App = require('../app'),
+    coreModels = require('../core/models');
+
+var Tr55TaskModel = coreModels.TaskModel.extend({});
+
+var ResultModel = Backbone.Model.extend({});
+
+var ResultCollection = Backbone.Collection.extend({
+    model: ResultModel
+});
+
+module.exports = {
+    ResultModel: ResultModel,
+    ResultCollection: ResultCollection,
+    Tr55TaskModel: Tr55TaskModel
+};

--- a/src/mmw/js/src/modeling/templates/details.ejs
+++ b/src/mmw/js/src/modeling/templates/details.ejs
@@ -1,0 +1,12 @@
+<div class="title-row"> <!-- Title Row -->
+  <div class="title">
+    <h3 class="light">Model Output</h3>
+  </div>
+</div> <!-- End Title Row -->
+
+<div id="output-tabs-wrapper"> <!-- Output Tab Wrapper -->
+  <div role="tabpanel" class="tab-panels-region"> <!-- Output Tabs -->
+  </div> <!-- End Output Tabs -->
+  <div class="tab-contents-region"> <!-- Tab Content -->
+  </div> <!-- End Tab Content -->
+</div> <!-- End Output Tab Wrapper -->

--- a/src/mmw/js/src/modeling/templates/extraHeader.ejs
+++ b/src/mmw/js/src/modeling/templates/extraHeader.ejs
@@ -1,0 +1,252 @@
+<header id="model-header"> <!-- Model Header -->
+
+    <div class="top"> <!-- Top Bar -->
+
+        <div class="project"> <!-- Project -->
+            <div class="back"> <!-- Back -->
+                <a data-url="/analyze" class="btn btn-md btn-icon light"><i class="fa fa-arrow-left"></i></a>
+            </div> <!-- End Back -->
+            <div class="project-title"> <!-- Project Name -->
+                <h3 class="light">Project Name</h3>
+                <div id="project-settings" class="dropdown pull-right"> <!-- Project Settings Dropdown -->
+                    <button class="btn btn-sm btn-icon light dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
+                    <i class="fa fa-caret-down"></i>
+                    </button>
+                    <ul class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area">
+                        <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" data-target="#rename-project">Rename</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" data-target="#share-project">Share</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" onclick="window.print();return false;">Print</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" data-target="#delete-project">Delete</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" data-target="#add-tag">Add Tags</a></li>
+                        <li role="presentation" class="divider"></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">My Projects</a></li>
+                        <li role="presentation" class="divider"></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#"><i class="fa fa-plus-circle"></i> New Project</a></li>
+                    </ul>
+                </div> <!-- End Project Settings Dropdown -->
+            </div> <!-- End Project Name -->
+        </div> <!-- End Project -->
+
+        <div class="top-bar"> <!-- Top Bar -->
+            <div class="tab-controls"> <!-- Tab Control Buttons -->
+                <div class="dropdown"> <!-- Tab List -->
+                    <button class="btn btn btn-tab dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
+                    <i class="fa fa-bars"></i>
+                    </button>
+                    <ul class="dropdown-menu menu-left" role="menu" aria-labelledby="select-area">
+                        <li role="presentation"><a href="#current" data-toggle="tab">Current</a></li>
+                        <li role="presentation"><a href="#scenario1" data-toggle="tab">Scenario 1</a></li>
+                    </ul>
+                </div> <!-- End Tab List -->
+                <button class="btn btn-tab"><i class="fa fa-plus"></i></button> <!-- Create New Tab -->
+            </div> <!-- End Tab Control Buttons -->
+            <div id="scenario-wrapper" class="scenario-tabs-wrapper"> <!-- Scenario Tab Wrapper -->
+                <div role="tabpanel"> <!-- Scenario Tabs -->
+                    <ul id="scenario-tab" class="nav nav-tabs" role="tablist">
+                        <li role="presentation"><a href="#current" aria-controls="home" role="tab" data-toggle="tab">Current</a>
+                            <div class="scenario-btn-dropdown"> <!-- Scenario Settings -->
+                                <div class="dropdown">
+                                    <button class="btn btn-sm btn-icon dark dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
+                                    <i class="fa fa-caret-down"></i>
+                                    </button>
+                                    <ul class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area">
+                                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Share</a></li>
+                                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Print</a></li>
+                                    </ul>
+                                </div>
+                            </div> <!-- End Scenario Settings -->
+                        </li>
+                        <li role="presentation" class="active"><a href="#scenario1" aria-controls="profile" role="tab" data-toggle="tab">Scenario 1 </a>
+                            <div class="scenario-btn-dropdown"> <!-- Scenario Settings -->
+                                <div class="dropdown">
+                                    <button class="btn btn-sm btn-icon dark dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
+                                    <i class="fa fa-caret-down"></i>
+                                    </button>
+                                    <ul class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area">
+                                        <li role="presentation"><a role="menuitem" tabindex="-1">Rename</a></li>
+                                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Share</a></li>
+                                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Print</a></li>
+                                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Delete</a></li>
+                                    </ul>
+                                </div>
+                            </div> <!-- End Scenario Settings -->
+                        </li>
+                    </ul>
+                </div> <!-- End Scenario Tabs -->
+            </div> <!-- End Scenario Tab Wrapper -->
+            <div class="fade-tabs"></div> <!-- Fade Tabs -->
+            <div class="compare-top-btn"> <!-- Compare Button -->
+                <a href="compare" class="btn btn-compare"><i class="fa fa-th"></i> Compare</a href="compare">
+            </div> <!-- End Compare Button -->
+        </div> <!-- End Top Bar -->
+    </div> <!-- End Top -->
+
+    <div class="toolbar"> <!-- Modification Bar -->
+        <div class="tab-content"> <!-- Scenario Tools -->
+            <div role="tabpanel" class="tab-pane" id="current"> <!-- Current tab -->
+                Current Conditions
+            </div> <!-- End Current tab -->
+            <div role="tabpanel" class="tab-pane active" id="scenario1"> <!-- Scenario 1 Tools -->
+
+                <div id="land-cover-tools" class="dropdown"> <!-- Landcover Tools -->
+                    <button class="btn btn-sm btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
+                    <i class="fa fa-plus-circle"></i> Land Cover
+                    </button>
+                    <div id="land-tools" class="dropdown-menu menu-left" role="menu" aria-labelledby="select-area"> <!-- Dropdown -->
+                        <div class="pad-1"> <!-- Dropdown Content -->
+                            <ul class="row">
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">LIR</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">HIR</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Commercial</label>
+                                </li>
+                            </ul>
+                            <ul class="row">
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Forest</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Turf Grass</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Pasture</label>
+                                </li>
+                            </ul>
+                            <ul class="row">
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Grassland</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Row Crop</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Wetland</label>
+                                </li>
+                            </ul>
+                        </div> <!-- End Dropdown Content -->
+
+                        <div class="dropdown-footer pad-1"> <!-- Dropdown Footer -->
+                            <h2 class="dark">Grassland</h2>
+                            <br>
+                            <span>Grassland is lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat</span>
+                        </div> <!-- End Dropdown Footer -->
+                    </div> <!-- End Dropdown -->
+                </div> <!-- End Land Cover Tools -->
+
+                <div id="conservation-practice-tools" class="dropdown"> <!-- Conservation Practice Tools -->
+                    <button class="btn btn-sm btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
+                    <i class="fa fa-plus-circle"></i> Conservation Practice
+                    </button>
+                    <div id="conserve-tools" class="dropdown-menu draw-tools menu-left" role="menu" aria-labelledby="select-area"> <!-- Dropdown -->
+                        <div class="pad-1"> <!-- Dropdown Content -->
+                            <ul class="row">
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Rain garden</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Veg Infil Basin</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Porous Paving</label>
+                                </li>
+                            </ul>
+                            <ul class="row">
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Green Roof</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">No-Till Agriculture</label>
+                                </li>
+                                <li>
+                                    <div class="thumb"></div>
+                                    <label class="dark">Cluster Housing</label>
+                                </li>
+                            </ul>
+                        </div> <!-- End Dropdown Content -->
+
+                        <div class="dropdown-footer pad-1"> <!-- Dropdown Footer -->
+                            <h2 class="dark">Cluster Housing</h2>
+                            <br>
+                            <span>Cluster Housing is lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat</span>
+                        </div> <!-- End Dropdown Footer -->
+                    </div> <!-- End Dropdown -->
+                </div> <!-- End Conservation Practice Tools -->
+
+                <select class="selectpicker" data-style="btn btn-sm btn-primary" data-size="3"> <!-- Weather Tools -->
+                    <option data-target="24hour">24 Hour</option>
+                    <option>Historical</option>
+                    <option>Custom</option>
+                </select> <!-- End Weather Tools -->
+
+                <div class="dropdown" data-toggle="tooltip" data-placement="bottom" title="Advanced"> <!-- Advanced Settings -->
+                    <button class="btn btn-sm btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
+                    <i class="fa fa-cog"></i>
+                    </button>
+                    <ul class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area">
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Advanced Inputs</a></li>
+                    </ul>
+                </div>
+
+                <div id="modification-btn-wrapper"> <!-- Modifications Dropdown -->
+                    <div class="dropdown"> <!-- Dropdown Button -->
+                        <button class="btn btn-sm btn-default inverted" type="button" data-toggle="dropdown" aria-expanded="true">
+                        <span id="modification-number"><strong>3</strong></span> Modifications
+                        </button>
+                        <div id="modifications" class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area"> <!-- DropdownContent -->
+                            <div class="pad-1 brd-bottom"> <!-- Land Cover Modifications -->
+                                <table id="mod-landCover" class="table modifications custom-hover">
+                                    <label class="medium">Land Cover</label>
+                                    <tr>
+                                        <td>Grassland</td>
+                                        <td class="strong text-right">+3.2 Acres</td>
+                                        <td class="text-right"><button class="btn btn-sm btn-icon dark" type="button">
+                                        <i class="fa fa-trash"></i>
+                                        </button></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Pasture</td>
+                                        <td class="strong text-right">+2.3 Acres</td>
+                                        <td class="text-right"><button class="btn btn-sm btn-icon dark" type="button">
+                                        <i class="fa fa-trash"></i>
+                                        </button></td>
+                                    </tr>
+                                </table>
+                            </div> <!-- End Land Cover Modifications -->
+                            <div class="pad-1"> <!-- Conservation Practice Modifications -->
+                                <table id="mod-conservationPractice" class="table modifications custom-hover">
+                                    <label class="medium">Conservation Practice</label>
+                                    <tr>
+                                        <td>Cluster Housing</td>
+                                        <td class="strong text-right">+0.5 Acres</td>
+                                        <td class="text-right"><button class="btn btn-sm btn-icon dark" type="button">
+                                        <i class="fa fa-trash"></i>
+                                        </button></td>
+                                    </tr>
+                                </table>
+                            </div> <!-- End Conservation Practice Modifications -->
+                        </div> <!-- End Dropdown Content -->
+                    </div> <!-- End Dropdown Button -->
+                </div> <!-- Modifications Dropdown -->
+            </div> <!-- End Scenario 1 Tools -->
+        </div> <!-- End Scenario Tools -->
+    </div> <!-- End Modification Bar -->
+
+</header>

--- a/src/mmw/js/src/modeling/templates/tabContent.ejs
+++ b/src/mmw/js/src/modeling/templates/tabContent.ejs
@@ -1,0 +1,1 @@
+<h1><%- displayName %></h1>

--- a/src/mmw/js/src/modeling/templates/tabPanel.ejs
+++ b/src/mmw/js/src/modeling/templates/tabPanel.ejs
@@ -1,0 +1,1 @@
+<a href="#<%- name %>" aria-controls="home" role="tab" data-toggle="tab"><%- displayName %></a>

--- a/src/mmw/js/src/modeling/templates/window.ejs
+++ b/src/mmw/js/src/modeling/templates/window.ejs
@@ -1,0 +1,1 @@
+<div id="modeling-details-region"></div>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1,0 +1,133 @@
+"use strict";
+
+var _ = require('lodash'),
+    $ = require('jquery'),
+    L = require('leaflet'),
+    Marionette = require('../../shim/backbone.marionette'),
+    App = require('../app'),
+    models = require('./models'),
+    windowTmpl = require('./templates/window.ejs'),
+    detailsTmpl = require('./templates/details.ejs'),
+    tabPanelTmpl = require('./templates/tabPanel.ejs'),
+    tabContentTmpl = require('./templates/tabContent.ejs'),
+    extraHeaderTmpl = require('./templates/extraHeader.ejs');
+
+var ModelingWindow = Marionette.LayoutView.extend({
+    tagName: 'div',
+    id: 'modeling-output-wrapper',
+    template: windowTmpl,
+
+    regions: {
+        detailsRegion: '#modeling-details-region'
+    },
+
+    onShow: function() {
+        var self = this;
+
+        setTimeout(function() {
+            self.showDetailsRegion();
+        }, 1000);
+    },
+
+    showDetailsRegion: function() {
+        this.detailsRegion.show(new DetailsView({
+            collection: new models.ResultCollection([
+                {name: 'runoff',  displayName: 'Runoff'},
+                {name: 'quality', displayName: 'Water Quality'}
+            ])}));
+    },
+
+    transitionInCss: {
+        height: '0%'
+    },
+
+    animateIn: function() {
+        var self = this;
+
+        this.$el.animate({ height: '55%' }, 400, function() {
+            self.trigger('animateIn');
+            App.map.set('halfSize', true);
+        });
+    },
+
+    animateOut: function() {
+        var self = this;
+
+        this.$el.animate({ height: '0%' }, 100, function() {
+            self.trigger('animateOut');
+            App.map.set('halfSize', false);
+        });
+    }
+});
+
+var DetailsView = Marionette.LayoutView.extend({
+    template: detailsTmpl,
+
+    regions: {
+        panelsRegion: '.tab-panels-region',
+        contentRegion: '.tab-contents-region'
+    },
+
+    onShow: function() {
+        this.panelsRegion.show(new TabPanelsView({
+            collection: this.collection
+        }));
+
+        this.contentRegion.show(new TabContentsView({
+            collection: this.collection
+        }));
+    }
+});
+
+var TabPanelView = Marionette.ItemView.extend({
+    tagName: 'li',
+    template: tabPanelTmpl,
+    attributes: {
+        role: 'presentation'
+    }
+});
+
+var TabPanelsView = Marionette.CollectionView.extend({
+    tagName: 'ul',
+    className: 'nav nav-tabs',
+    attributes: {
+        role: 'tablist'
+    },
+
+    childView: TabPanelView,
+
+    onRender: function() {
+        this.$el.find('li:first').addClass('active');
+    }
+});
+
+var TabContentView = Marionette.LayoutView.extend({
+    tagName: 'div',
+    className: 'tab-pane',
+    id: function() {
+        return this.model.get('name');
+    },
+    template: tabContentTmpl,
+    attributes: {
+        role: 'tabpanel'
+    }
+});
+
+var TabContentsView = Marionette.CollectionView.extend({
+    tagName: 'div',
+    className: 'tab-content',
+    childView: TabContentView,
+    onRender: function() {
+        this.$el.find('.tab-pane:first').addClass('active');
+    }
+
+});
+
+var ExtraHeaderView = Marionette.ItemView.extend({
+    template: extraHeaderTmpl
+});
+
+module.exports = {
+    ModelingWindow: ModelingWindow,
+    ExtraHeaderView: ExtraHeaderView
+};

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -4,9 +4,10 @@ var router = require('./router').router,
     controllers = require('./controllers'),
     AppController = controllers.AppController,
     DrawController = require('./draw/controllers').DrawController,
+    ModelingController = require('./modeling/controllers').ModelingController,
     AnalyzeController = require('./analyze/controllers').AnalyzeController;
 
 router.addRoute(/^/, DrawController, 'draw');
 router.addRoute(/^analyze/, AnalyzeController, 'analyze');
-router.addRoute(/^model/, AppController, 'runModel');
+router.addRoute(/^model/, ModelingController, 'model');
 router.addRoute(/^compare/, AppController, 'compare');


### PR DESCRIPTION
This patch plucks portions from the static version of the `/models` page
and turns them into templates.  The controller, the views, and the
models are all based on those for `/analyze`.

In addition, the map is now visible on the `/models` page.

Connects to azavea/model-my-watershed#130
Connects to azavea/model-my-watershed#131
