### PR TITLE
Make app header reflect changes in user status

### DIFF
--- a/src/mmw/apps/home/templates/home/home.html
+++ b/src/mmw/apps/home/templates/home/home.html
@@ -2,17 +2,6 @@
 
 {% block header %}
 <header> <!-- Search Header -->
-
-    <nav id="app-header" class="navbar-watershed">
-        <div class="brand"><a href="#">Model My Watershed</a></div>
-        <div class="navigation">
-            <ul class="main">
-                <li><a href="#">Community</a></li>
-                <li><a href="#">ctaylor</a></li>
-            </ul>
-        </div>
-    </nav>
-
 </header> <!-- End Search Header -->
 {% endblock header %}
 

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -19,6 +19,10 @@ var App = new Marionette.Application({
         this.rootView = new views.RootView();
         this.user = new userModels.UserModel({});
         this.showLoginModal();
+        var header = new views.HeaderView({
+            el: 'header',
+            model: this.user
+        }).render();
     },
 
     load: function(data) {

--- a/src/mmw/js/src/core/templates/header.ejs
+++ b/src/mmw/js/src/core/templates/header.ejs
@@ -1,0 +1,23 @@
+<nav id="app-header" class="navbar-watershed">
+    <div class="brand"><a href="#">Model My Watershed</a></div>
+    <div class="navigation">
+        <ul class="main">
+            <li class="header-link"><a href="#">Community</a></li>
+            <% if (guest) { %>
+                <li class="header-link"><a class="show-login" href="javascript:void(0);">Login</a></li>
+            <% } else { %>
+                <li class="dropdown header-link">
+                    <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+                        <%= username %>
+                        <span class="caret"></span>
+                    </a>
+                    <ul class="dropdown-menu">
+                        <li><a href="#">Profile</a></li>
+                        <li><a href="accounts/logout">Logout</a></li>
+                    </ul>
+                </li>
+            <% } %>
+        </ul>
+    </div>
+</nav>
+

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -4,7 +4,8 @@ var $ = require('jquery'),
     L = require('leaflet'),
     _ = require('lodash'),
     Marionette = require('../../shim/backbone.marionette'),
-    TransitionRegion = require('../../shim/marionette.transition-region');
+    TransitionRegion = require('../../shim/marionette.transition-region'),
+    headerTmpl = require('./templates/header.ejs');
 
 /**
  * A basic view for showing a static message.
@@ -36,6 +37,29 @@ var RootView = Marionette.LayoutView.extend({
             selector: '#footer'
         }
     }
+});
+
+var HeaderView = Marionette.ItemView.extend({
+    template: headerTmpl,
+
+    ui: {
+        login: '.show-login'
+    },
+
+    events: {
+        'click @ui.login': 'showLogin'
+    },
+
+    modelEvents: {
+        'change': 'render'
+    },
+
+    showLogin: function() {
+        // Defer requiring app until needed as it is not defined when
+        // core.views are initialized (they are required in app.js)
+        require('../app').showLoginModal();
+    }
+
 });
 
 // This view houses a Leaflet instance. The map container element must exist
@@ -150,6 +174,7 @@ var MapView = Marionette.ItemView.extend({
 
 
 module.exports = {
+    HeaderView: HeaderView,
     MapView: MapView,
     RootView: RootView,
     StaticView: StaticView

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -3,6 +3,10 @@
 var Backbone = require('../../shim/backbone');
 
 var UserModel = Backbone.Model.extend({
+    defaults: {
+        guest: true
+    },
+
     url: 'user/ajaxlogin'
 });
 

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -76,14 +76,12 @@ var LoginModalView = Marionette.ItemView.extend({
 
     handleSignInSuccess: function() {
         this.$el.modal('hide');
-
-        // TODO: Temporary. For demo purposes only.
-        // This should be handled in a view for the header
-        $('.main li a:last').text(App.user.get('username'));
+        App.user.set('guest', false);
     },
 
     handleSignInFail: function() {
         this.model.set('signInError', true);
+        App.user.set('guest', true);
     },
 
     // TODO: Move this to a general helpers file if it's needed elsewhere

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -38,13 +38,17 @@ header{
       list-style-type: none;
       display: inline-block;
 
-      li {
-        line-height: $height-lg;
+      li.header-link {
+        line-height: $height-lg !important;
         font-size: 0.7rem;
         font-weight: 300;
         margin-left: 1rem;
         display: inline-block;
         float: left;
+
+        .dropdown-menu a {
+          color: $ui-secondary;
+        }
 
         a{
           color: $paper-54;


### PR DESCRIPTION
Adds a view for the header which currently displays user/account menu
items which update when the guest status changes.

Connects #149 
Connects #150 
##### To Test:
1. Be logged out
2. Close the initial login modal on page load
3. The upper right region should have a link to lauch the login modal
4. Log in via the model
5. The upper right region should be your user name and drop down a menu for user options (currently Profile (TODO) and Logout.

Some known issues
- #161 - page won't remember login status after reload
- accounts/\* pages have their header styling compromised, but they are all in line to be removed, so not fixing.
- User dropdown clips off the screen, will let that hang for now until we're sure what the design of that section will be.
