### PR TITLE
Add bootstrap jquery plugins to test instances

### DIFF
--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require('../core/testInit.js');
+
 var _ = require('lodash'),
     $ = require('jquery'),
     assert = require('chai').assert,

--- a/src/mmw/js/src/core/testInit.js
+++ b/src/mmw/js/src/core/testInit.js
@@ -1,0 +1,10 @@
+/*
+Ensure that the tests have access to jQuery and boostrap, which can be
+called from js modules without explicitly requiring it.  These contents
+will end up mirroring main.js to some degree, but should be imported in
+test modules.
+*/
+
+var $ = require('jquery');
+window.jQuery = window.$ = $;
+require('bootstrap');

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require('../core/testInit.js');
+
 var $ = require('jquery'),
     assert = require('chai').assert,
     _ = require('lodash'),

--- a/src/mmw/js/src/draw/tests.js
+++ b/src/mmw/js/src/draw/tests.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require('../core/testInit.js');
+
 var _ = require('lodash'),
     $ = require('jquery'),
     assert = require('chai').assert,

--- a/src/mmw/js/src/geocode/tests.js
+++ b/src/mmw/js/src/geocode/tests.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require('../core/testInit.js');
+
 var _ = require('lodash'),
     L = require('leaflet'),
     $ = require('jquery'),


### PR DESCRIPTION
Adds a new js module that behaves similarly to main.js entry point for
app code.  In this particular case it ensures that code which requires
bootstrap jquery plugin have access to them.

Connects #170 
