### PR TITLE
Fix hidden login modal

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -26,6 +26,9 @@
         </div>
     </div>
 
+    {% block modals %}
+    {% endblock modals %}
+
     {% block javascript %}
     <script type="text/javascript" src="{% static 'js/vendor.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/main.js' %}"></script>

--- a/src/mmw/apps/home/templates/home/home.html
+++ b/src/mmw/apps/home/templates/home/home.html
@@ -12,10 +12,13 @@
     </div>
 
     <div id="map"></div>
+
 {% endblock content %}
 
 {% block footer %}
 {% endblock footer %}
 
-<div class="modal modal-large fade" id="login" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="false">
-</div>
+{% block modals %}
+    <div class="modal modal-large fade" id="login" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="false">
+    </div>
+{% endblock modals %}


### PR DESCRIPTION
The login modal was dropped from the content of the body, but cannot be
nested within the new container-fluid div, which would nest it behind
its own layover div.

Connects #183 

To test, check that the login modal pops up on page load or when clicking the login link in the header.
