### PR TITLE
Predefined shape outlines.

### DIFF
--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -21,6 +21,5 @@ urlpatterns = patterns(
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),
     url(r'boundary_layers/$', views.boundary_layers, name='boundary_layers'),
-    url(r'congressional_districts$', views.district, name='district'),
     url(r'congressional_districts/id/(?P<id>[0-9]+)$', views.district, name='district'),  # noqa
 )

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -20,6 +20,7 @@ urlpatterns = patterns(
     url(r'start/analyze/$', views.start_analyze, name='start_analyze'),
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),
+    url(r'boundary_layers/$', views.boundary_layers, name='boundary_layers'),
     url(r'congressional_districts$', views.district, name='district'),
     url(r'congressional_districts/id/(?P<id>[0-9]+)$', views.district, name='district'),  # noqa
 )

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -8,8 +8,11 @@ from rest_framework.permissions import AllowAny
 
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
+from django.conf import settings
 
 from celery import chain
+
+from urlparse import urljoin
 
 from apps.core.models import Job
 from apps.core.task_helpers import save_job_error, save_job_result
@@ -117,3 +120,22 @@ def district(request, id=None, state=None):
         shapes = [{'id': shape.id, 'name': shape.name()} for shape in shapes]
         dictionary = {'shapes': shapes}
         return Response(dictionary)
+
+
+@decorators.api_view(['GET'])
+@decorators.permission_classes((AllowAny, ))
+def boundary_layers(request, id=None, state=None):
+    tiler_prefix = '//'
+    tiler_host = getattr(settings, 'MMW_TILER_HOST')
+    tiler_port = getattr(settings, 'MMW_TILER_PORT')
+    tiler_postfix = '/{z}/{x}/{y}'
+    tiler_base = tiler_prefix + tiler_host + ':' + tiler_port
+
+    def augment(d):
+        retval = d.copy()
+        retval['endpoint'] = urljoin(tiler_base, d['name'] + tiler_postfix)
+        return retval
+
+    layers = [augment(d) for d in getattr(settings, 'BOUNDARY_LAYERS')]
+
+    return Response(layers)

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -105,21 +105,15 @@ def _initiate_tr55_job_chain(model_input, job_id):
 @decorators.api_view(['GET'])
 @decorators.permission_classes((AllowAny, ))
 def district(request, id=None, state=None):
-    if id:  # query by unique id
-        district = get_object_or_404(District, id=id)
-        coordinates = []
-        for polygon in district.polygon.coords:
-            coordinates.append(polygon[0])
-        dictionary = {'type': 'Feature',
-                      'properties': {},
-                      'geometry': {'type': 'Polygon',
-                                   'coordinates': coordinates}}
-        return Response(dictionary)
-    else:  # provide list of all ids
-        shapes = District.objects.order_by('state_fips', 'district_fips')
-        shapes = [{'id': shape.id, 'name': shape.name()} for shape in shapes]
-        dictionary = {'shapes': shapes}
-        return Response(dictionary)
+    district = get_object_or_404(District, id=id)
+    coordinates = []
+    for polygon in district.polygon.coords:
+        coordinates.append(polygon[0])
+    dictionary = {'type': 'Feature',
+                  'properties': {},
+                  'geometry': {'type': 'Polygon',
+                               'coordinates': coordinates}}
+    return Response(dictionary)
 
 
 @decorators.api_view(['GET'])

--- a/src/mmw/js/shim/leaflet.utfgrid.js
+++ b/src/mmw/js/shim/leaflet.utfgrid.js
@@ -1,0 +1,359 @@
+L.Util.ajax = function (url, cb) {
+        // the following is from JavaScript: The Definitive Guide
+        // and https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest/Using_XMLHttpRequest_in_IE6
+        if (window.XMLHttpRequest === undefined) {
+                window.XMLHttpRequest = function () {
+                        /*global ActiveXObject:true */
+                        try {
+                                return new ActiveXObject("Microsoft.XMLHTTP");
+                        }
+                        catch  (e) {
+                                throw new Error("XMLHttpRequest is not supported");
+                        }
+                };
+        }
+        var response, request = new XMLHttpRequest();
+        request.open("GET", url);
+        request.onreadystatechange = function () {
+                /*jshint evil: true */
+                if (request.readyState === 4 && request.status === 200) {
+                        if (window.JSON) {
+                                response = JSON.parse(request.responseText);
+                        } else {
+                                response = eval("(" + request.responseText + ")");
+                        }
+                        cb(response);
+                }
+        };
+        request.send();
+        return request;
+};
+L.UtfGrid = (L.Layer || L.Class).extend({
+        includes: L.Mixin.Events,
+        options: {
+                subdomains: 'abc',
+
+                minZoom: 0,
+                maxZoom: 18,
+                tileSize: 256,
+
+                resolution: 4,
+
+                useJsonP: true,
+                pointerCursor: true,
+
+                maxRequests: 4,
+                requestTimeout: 60000
+        },
+
+        //The thing the mouse is currently on
+        _mouseOn: null,
+
+        // The requests
+        _requests: {},
+        _request_queue: [],
+        _requests_in_process: [],
+
+        initialize: function (url, options) {
+                L.Util.setOptions(this, options);
+
+                this._url = url;
+                this._cache = {};
+
+                //Find a unique id in window we can use for our callbacks
+                //Required for jsonP
+                var i = 0;
+                while (window['lu' + i]) {
+                        i++;
+                }
+                this._windowKey = 'lu' + i;
+                window[this._windowKey] = {};
+
+                var subdomains = this.options.subdomains;
+                if (typeof this.options.subdomains === 'string') {
+                        this.options.subdomains = subdomains.split('');
+                }
+        },
+
+        onAdd: function (map) {
+                this._map = map;
+                this._container = this._map._container;
+
+                this._update();
+
+                var zoom = this._map.getZoom();
+
+                if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
+                        return;
+                }
+
+                map.on('click', this._click, this);
+                map.on('mousemove', this._move, this);
+                map.on('moveend', this._update, this);
+        },
+
+        onRemove: function () {
+                var map = this._map;
+                map.off('click', this._click, this);
+                map.off('mousemove', this._move, this);
+                map.off('moveend', this._update, this);
+                if (this.options.pointerCursor) {
+                        this._container.style.cursor = '';
+                }
+        },
+
+        redraw: function () {
+                // Clear cache to force all tiles to reload
+                this._request_queue = [];
+                for (var req_key in this._requests){
+                        if (this._requests.hasOwnProperty(req_key)){
+                                this._abort_request(req_key);
+                        }
+                }
+                this._cache = {};
+                this._update();
+        },
+
+        _click: function (e) {
+                this.fire('click', this._objectForEvent(e));
+        },
+        _move: function (e) {
+                var on = this._objectForEvent(e);
+
+                if (on.data !== this._mouseOn) {
+                        if (this._mouseOn) {
+                                this.fire('mouseout', { latlng: e.latlng, data: this._mouseOn });
+                                if (this.options.pointerCursor) {
+                                        this._container.style.cursor = '';
+                                }
+                        }
+                        if (on.data) {
+                                this.fire('mouseover', on);
+                                if (this.options.pointerCursor) {
+                                        this._container.style.cursor = 'pointer';
+                                }
+                        }
+
+                        this._mouseOn = on.data;
+                } else if (on.data) {
+                        this.fire('mousemove', on);
+                }
+        },
+
+        _objectForEvent: function (e) {
+                var map = this._map,
+                    point = map.project(e.latlng),
+                    tileSize = this.options.tileSize,
+                    resolution = this.options.resolution,
+                    x = Math.floor(point.x / tileSize),
+                    y = Math.floor(point.y / tileSize),
+                    gridX = Math.floor((point.x - (x * tileSize)) / resolution),
+                    gridY = Math.floor((point.y - (y * tileSize)) / resolution),
+                        max = map.options.crs.scale(map.getZoom()) / tileSize;
+
+                x = (x + max) % max;
+                y = (y + max) % max;
+
+                var data = this._cache[map.getZoom() + '_' + x + '_' + y];
+                if (!data || !data.grid) {
+                        return { latlng: e.latlng, data: null };
+                }
+
+                var idx = this._utfDecode(data.grid[gridY].charCodeAt(gridX)),
+                    key = data.keys[idx],
+                    result = data.data[key];
+
+                if (!data.data.hasOwnProperty(key)) {
+                        result = null;
+                }
+
+                return { latlng: e.latlng, data: result};
+        },
+
+        //Load up all required json grid files
+        //TODO: Load from center etc
+        _update: function () {
+
+                var bounds = this._map.getPixelBounds(),
+                    zoom = this._map.getZoom(),
+                    tileSize = this.options.tileSize;
+
+                if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
+                        return;
+                }
+
+                var nwTilePoint = new L.Point(
+                                Math.floor(bounds.min.x / tileSize),
+                                Math.floor(bounds.min.y / tileSize)),
+                        seTilePoint = new L.Point(
+                                Math.floor(bounds.max.x / tileSize),
+                                Math.floor(bounds.max.y / tileSize)),
+                                max = this._map.options.crs.scale(zoom) / tileSize;
+
+                //Load all required ones
+                var visible_tiles = [];
+                for (var x = nwTilePoint.x; x <= seTilePoint.x; x++) {
+                        for (var y = nwTilePoint.y; y <= seTilePoint.y; y++) {
+
+                                var xw = (x + max) % max, yw = (y + max) % max;
+                                var key = zoom + '_' + xw + '_' + yw;
+                                visible_tiles.push(key);
+
+                                if (!this._cache.hasOwnProperty(key)) {
+                                        this._cache[key] = null;
+
+                                        if (this.options.useJsonP) {
+                                                this._loadTileP(zoom, xw, yw);
+                                        } else {
+                                                this._loadTile(zoom, xw, yw);
+                                        }
+                                }
+                        }
+                }
+                // If we still have requests for tiles that have now gone out of sight, attempt to abort them.
+                for (var req_key in this._requests){
+                        if (visible_tiles.indexOf(req_key) < 0){
+                                this._abort_request(req_key);
+                        }
+                }
+        },
+
+        _loadTileP: function (zoom, x, y) {
+                var head = document.getElementsByTagName('head')[0],
+                    key = zoom + '_' + x + '_' + y,
+                    functionName = 'lu_' + key,
+                    wk = this._windowKey,
+                    self = this;
+
+                var url = L.Util.template(this._url, L.Util.extend({
+                        s: L.TileLayer.prototype._getSubdomain.call(this, { x: x, y: y }),
+                        z: zoom,
+                        x: x,
+                        y: y,
+                        cb: wk + '.' + functionName
+                }, this.options));
+
+                var script = document.createElement('script');
+                script.setAttribute("type", "text/javascript");
+                script.setAttribute("src", url);
+
+                window[wk][functionName] = function (data) {
+                        self._cache[key] = data;
+                        delete window[wk][functionName];
+                        try {
+                            head.removeChild(script);
+                        } catch(e) {
+                            ;
+                        }
+                        self._finish_request(key);
+                };
+
+                this._queue_request(key, function(){
+                        head.appendChild(script);
+                        return {
+                                abort: function(){
+                                        head.removeChild(script);
+                                }
+                        };
+                });
+        },
+
+        _loadTile: function (zoom, x, y) {
+                var url = L.Util.template(this._url, L.Util.extend({
+                        s: L.TileLayer.prototype._getSubdomain.call(this, { x: x, y: y }),
+                        z: zoom,
+                        x: x,
+                        y: y
+                }, this.options));
+
+                var key = zoom + '_' + x + '_' + y;
+                var self = this;
+                this._queue_request(key, function(){
+                        return L.Util.ajax(url, function (data) {
+                                self._cache[key] = data;
+                                self._finish_request(key);
+                        });
+                });
+        },
+
+        _queue_request: function(key, callback){
+                this._requests[key] = {
+                        callback: callback,
+                        timeout: null,
+                        handler: null
+                };
+                this._request_queue.push(key);
+                this._process_queued_requests();
+        },
+
+        _finish_request: function(key){
+                // Remove from requests in process
+                var pos = this._requests_in_process.indexOf(key);
+                if (pos >= 0) {
+                        this._requests_in_process.splice(pos, 1);
+                }
+                // Remove from request queue
+                pos = this._request_queue.indexOf(key);
+                if (pos >= 0){
+                        this._request_queue.splice(pos, 1);
+                }
+                // Remove the request entry
+                if (this._requests[key]) {
+                        if (this._requests[key].timeout) {
+                                window.clearTimeout(this._requests[key].timeout);
+                        }
+                        delete this._requests[key];
+                }
+                // Recurse
+                this._process_queued_requests();
+        },
+
+        _abort_request: function(key){
+                // Abort the request if possible
+                if (this._requests[key] && this._requests[key].handler){
+                        if (typeof this._requests[key].handler.abort === 'function'){
+                                this._requests[key].handler.abort();
+                        }
+                }
+                // Ensure we don't keep a false copy of the data in the cache
+                if (this._cache[key] === null){
+                        delete this._cache[key];
+                }
+                // And remove the request
+                this._finish_request(key);
+        },
+
+        _process_queued_requests: function() {
+                while (this._request_queue.length > 0 && (this.options.maxRequests === 0 ||
+                       this._requests_in_process.length < this.options.maxRequests)){
+                        this._process_request(this._request_queue.pop());
+                }
+        },
+
+        _process_request: function(key){
+                var self = this;
+                this._requests[key].timeout = window.setTimeout(function(){
+                        self._abort_request(key);
+                }, this.options.requestTimeout);
+                this._requests_in_process.push(key);
+                // The callback might call _finish_request, so don't assume _requests[key] still exists.
+                var handler = this._requests[key].callback();
+                if (this._requests[key]){
+                        this._requests[key].handler = handler;
+                }
+        },
+
+        _utfDecode: function (c) {
+                if (c >= 93) {
+                        c--;
+                }
+                if (c >= 35) {
+                        c--;
+                }
+                return c - 32;
+        }
+});
+
+L.utfGrid = function (url, options) {
+        return new L.UtfGrid(url, options);
+};

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -69,16 +69,17 @@ var App = new Marionette.Application({
 
 function RestAPI() {
     return {
-        getPredefinedShapes: function() {
+        getPredefinedShapeTypes: function() {
             return $.ajax({
-                'url': '/api/modeling/congressional_districts',
+                'url': '/api/modeling/boundary_layers/',
                 'type': 'GET'
             });
         },
 
         getPolygon: function(args) {
+            var url = '/api/modeling/congressional_districts/id/' + args.id;
             return $.ajax({
-                'url': '/api/modeling/congressional_districts/id/' + args.id,
+                'url': url,
                 'type': 'GET'
             });
         }

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -19,8 +19,8 @@ var DrawController = {
                 model: toolbarModel
             });
 
-        App.restApi.getPredefinedShapes().then(function(data) {
-            toolbarModel.set('predefinedShapes', data.shapes);
+        App.restApi.getPredefinedShapeTypes().then(function(data) {
+            toolbarModel.set('predefinedShapeTypes', data);
         });
 
         App.rootView.geocodeSearchRegion.show(geocodeSearch);

--- a/src/mmw/js/src/draw/models.js
+++ b/src/mmw/js/src/draw/models.js
@@ -6,8 +6,8 @@ var Backbone = require('../../shim/backbone'),
 var ToolbarModel = Backbone.Model.extend({
     defaults: {
         toolsEnabled: true,
-        // Array of { id, name } objects.
-        predefinedShapes: null
+        // Array of { id, name, url } objects.
+        predefinedShapeTypes: null
     },
 
     enableTools: function() {

--- a/src/mmw/js/src/draw/templates/selectType.ejs
+++ b/src/mmw/js/src/draw/templates/selectType.ejs
@@ -1,12 +1,12 @@
 <div id="predefined-shape" class="dropdown">
   <button class="btn btn-md btn-search-tool dropdown-toggle<% if (!toolsEnabled) { %> disabled<% } %>"
       type="button" data-toggle="dropdown" aria-expanded="true">
-    Select Area
+    Select by Boundary
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu menu-left" role="menu" aria-labelledby="select-area" id="wrapper">
-  <% _.each(predefinedShapes, function(item) { %>
-      <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-shape-id="<%- item.id %>"><%- item.name %></a></li>
+  <% _.each(predefinedShapeTypes, function(item) { %>
+      <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-endpoint="<%- item.endpoint %>"><%- item.display %></a></li>
   <% }) %>
   </ul>
 </div>

--- a/src/mmw/js/src/draw/tests.js
+++ b/src/mmw/js/src/draw/tests.js
@@ -96,7 +96,7 @@ function populateSelectAreaDropdown($el, toolbarModel) {
     // Load some shapes...
     toolbarModel.set('predefinedShapeTypes', [
     {
-        "endpoint": "http://localhost:4000/tiles/{z}/{x}/{y}",
+        "endpoint": "http://localhost:4000/congress/{z}/{x}/{y}",
         "display": "Congressional Districts",
         "name": "tiles"
     }]);

--- a/src/mmw/js/src/draw/tests.js
+++ b/src/mmw/js/src/draw/tests.js
@@ -1,6 +1,7 @@
 "use strict";
 
 require('../core/testInit.js');
+require('../../shim/leaflet.utfgrid');
 
 var _ = require('lodash'),
     $ = require('jquery'),
@@ -56,10 +57,10 @@ describe('Draw', function() {
             assert.equal($el.find('.disabled').size(), 0);
         });
 
-        // Simulate clicking a predefined shape in the "Select Area"
-        // control. That should fetch a polygon GeoJSON from the API
-        // and update the `areaOfInterest` property on the map model.
-        it('adds a layer to the map when an area of interest is chosen from the select area dropdown', function() {
+        // Simulate clicking on an item under the "Select by Boundary"
+        // control. That should make it possible to select an area of
+        // interest by clicking on the map.
+        it('adds a layer to the map when an area of interest is chosen by clicking on the map', function() {
             var sandbox = new SandboxRegion(),
                 $el = sandbox.$el,
                 model = new models.ToolbarModel(),
@@ -78,7 +79,7 @@ describe('Draw', function() {
 
             var $li = $($el.find('#select-area-region li a').get(0));
             $li.trigger('click');
-
+            App._mapView._leafletMap.fireEvent('click', {'latlng': [32.81813421450708, -79.99763488769531]});
             assert.equal(App.map.get('areaOfInterest'), TEST_SHAPE);
         });
     });
@@ -93,11 +94,14 @@ function populateSelectAreaDropdown($el, toolbarModel) {
     assertTextEqual($el, '#select-area-region button', 'Loading...');
 
     // Load some shapes...
-    toolbarModel.set('predefinedShapes', [
-        { id: 0, name: 'Test Shape' }
-    ]);
+    toolbarModel.set('predefinedShapeTypes', [
+    {
+        "endpoint": "http://localhost:4000/tiles/{z}/{x}/{y}",
+        "display": "Congressional Districts",
+        "name": "tiles"
+    }]);
 
     // This dropdown should now be populated.
-    assertTextEqual($el, '#select-area-region button', 'Select Area');
-    assertTextEqual($el, '#select-area-region li', 'Test Shape');
+    assertTextEqual($el, '#select-area-region button', 'Select by Boundary');
+    assertTextEqual($el, '#select-area-region li', 'Congressional Districts');
 }

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -8,6 +8,8 @@ require('bootstrap-select');
 
 var L = require('leaflet');
 require('leaflet-draw');
+require('../shim/leaflet.utfgrid');
+
 // See: https://github.com/Leaflet/Leaflet/issues/766
 L.Icon.Default.imagePath = '/static/images/';
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -255,7 +255,7 @@ ROOT_URLCONF = '%s.urls' % SITE_NAME
 # TILER
 MMW_TILER_HOST = environ.get('MMW_TILER_HOST', environ.get('MMW_TILER_IP', 'localhost'))  # noqa
 MMW_TILER_PORT = environ.get('MMW_TILER_PORT', '4000')
-BOUNDARY_LAYERS = [{'display': 'Congressional Districts', 'name': 'tiles'}]
+BOUNDARY_LAYERS = [{'display': 'Congressional Districts', 'name': 'congress'}]
 
 # APP CONFIGURATION
 DJANGO_APPS = (

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -252,6 +252,11 @@ ROOT_URLCONF = '%s.urls' % SITE_NAME
 # END URL CONFIGURATION
 
 
+# TILER
+MMW_TILER_HOST = environ.get('MMW_TILER_HOST', environ.get('MMW_TILER_IP', 'localhost'))  # noqa
+MMW_TILER_PORT = environ.get('MMW_TILER_PORT', '4000')
+BOUNDARY_LAYERS = [{'display': 'Congressional Districts', 'name': 'tiles'}]
+
 # APP CONFIGURATION
 DJANGO_APPS = (
     # Default Django apps:

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -71,5 +71,5 @@
 
 #wrapper {
   overflow:auto;
-  height:333px;
+  height:93px;
 }

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -11,8 +11,8 @@ var dbUser = process.env.MMW_DB_USER,
     redisPort = process.env.MMW_REDIS_PORT;
 
 var config = {
-    base_url: '/tiles',
-    base_url_notable: '/tiles',
+    base_url: '/congress',
+    base_url_notable: '/congress',
     grainstore: {
         datasource: {
             user: dbUser,
@@ -24,7 +24,7 @@ var config = {
         }
     },
     renderCache: {
-        ttl: 60000, // seconds
+        ttl: 1, // seconds
     },
     mapnik: {
         metatile: 4,
@@ -44,7 +44,7 @@ var config = {
     req2params: function(req, callback) {
         try {
             // TODO make this dynamic.
-            req.params.table = 'predefined_shapes_district';
+            req.params.table = 'modeling_district';
             req.params.dbname = dbName;
             req.params.style = styles;
             // TODO make this dynamic.

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -1,4 +1,4 @@
-#predefined_shapes_district {
+#modeling_district {
   polygon-fill: #FF0000;
   polygon-opacity: 0.0;
   line-color: #000;

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -1,6 +1,6 @@
 #predefined_shapes_district {
   polygon-fill: #FF0000;
-  polygon-opacity: 0.25;
+  polygon-opacity: 0.0;
   line-color: #000;
-  line-opacity: 0.5;
+  line-opacity: 0.618;
 }


### PR DESCRIPTION
Instead of giving a selection of predefined shapes in the dropdown,
instead give a selection of types of these shapes.  When a type is
chosen, the outlines of those shapes will appear on the map, allowing
the user choose that way.

This patch assumes the existence of two environment variables on the
`app` VM: `MMW_TILER_HOST` and `MMW_TILER_PORT`.  If they do not exist,
the corresponding variables within Django are given the defaults
`localhost` and `4000`, respectively.

Connects to #176