### PR TITLE
Allow saving and retrieving of projects and scenarios

### DIFF
--- a/src/mmw/apps/modeling/admin.py
+++ b/src/mmw/apps/modeling/admin.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.contrib import admin
+from .models import Project, Scenario
+
+admin.site.register(Project)
+admin.site.register(Scenario)

--- a/src/mmw/apps/modeling/admin.py
+++ b/src/mmw/apps/modeling/admin.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.contrib import admin
-from .models import Project, Scenario
+from apps.modeling.models import Project, Scenario
 
 admin.site.register(Project)
 admin.site.register(Scenario)

--- a/src/mmw/apps/modeling/migrations/0002_auto_20150521_1125.py
+++ b/src/mmw/apps/modeling/migrations/0002_auto_20150521_1125.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import django.contrib.gis.db.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('modeling', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Project',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=255)),
+                ('area_of_interest', django.contrib.gis.db.models.fields.MultiPolygonField(help_text='Base geometry for all scenarios of project', srid=4326)),
+                ('private', models.BooleanField(default=True)),
+                ('model_package', models.CharField(help_text='Which model pack was chosen for this project', max_length=255)),
+                ('created', models.DateField(auto_now_add=True)),
+                ('modified', models.DateField(auto_now=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Scenario',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=255)),
+                ('current_condition', models.BooleanField(default=False, help_text='A special type of scenario without modification abilities')),
+                ('modifications', models.TextField(help_text='Serialized JSON representation of this scenarios applied modification, with respect to the model package', null=True)),
+                ('modification_hash', models.CharField(help_text='A hash of the values for modifications & inputs to compare to the existing model results, to determine if the persisted result apply to the current values', max_length=255, null=True)),
+                ('results', models.TextField(help_text='Serialized JSON representation of the model results', null=True)),
+                ('project', models.ForeignKey(related_name='scenarios', to='modeling.Project')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='scenario',
+            unique_together=set([('name', 'project')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='project',
+            unique_together=set([('name', 'user')]),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -6,6 +6,8 @@ from __future__ import division
 from django.contrib.gis.db import models
 from django.forms.models import model_to_dict
 
+from django.contrib.auth.models import User
+
 
 class District(models.Model):
     state_fips = models.CharField(
@@ -40,3 +42,55 @@ class District(models.Model):
         dictionary = model_to_dict(self)
         dictionary.pop('polygon', None)
         return str(dictionary)
+
+
+class Project(models.Model):
+    class Meta:
+        unique_together = ('name', 'user')
+
+    user = models.ForeignKey(User)
+    name = models.CharField(
+        max_length=255)
+    area_of_interest = models.MultiPolygonField(
+        help_text='Base geometry for all scenarios of project')
+    private = models.BooleanField(
+        default=True)
+    model_package = models.CharField(
+        max_length=255,
+        help_text='Which model pack was chosen for this project')
+    created = models.DateField(
+        auto_now=False,
+        auto_now_add=True)
+    modified = models.DateField(
+        auto_now=True)
+
+    def __unicode__(self):
+        return self.name
+
+
+class Scenario(models.Model):
+    class Meta:
+        unique_together = ('name', 'project')
+
+    name = models.CharField(
+        max_length=255)
+    project = models.ForeignKey(Project, related_name='scenarios')
+    current_condition = models.BooleanField(
+        default=False,
+        help_text='A special type of scenario without modification abilities')
+    modifications = models.TextField(
+        null=True,
+        help_text='Serialized JSON representation of this scenarios ' +
+                  'applied modification, with respect to the model package')
+    modification_hash = models.CharField(
+        max_length=255,
+        null=True,
+        help_text='A hash of the values for modifications & inputs to ' +
+                  'compare to the existing model results, to determine if ' +
+                  'the persisted result apply to the current values')
+    results = models.TextField(
+        null=True,
+        help_text='Serialized JSON representation of the model results')
+
+    def __unicode__(self):
+        return self.name

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.contrib.auth.models import User
+from rest_framework import serializers
+
+from apps.modeling.models import Project, Scenario
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'email')
+
+
+class ScenarioSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Scenario
+
+
+class ProjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Project
+        depth = 1
+
+    user = UserSerializer(default=serializers.CurrentUserDefault())
+    scenarios = ScenarioSerializer(many=True, read_only=True)

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -17,6 +17,12 @@ uuid_regex = '(?P<job_uuid>[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-' \
 
 urlpatterns = patterns(
     '',
+    url(r'projects/$', views.project_list, name='project_list'),
+    url(r'projects/(?P<proj_id>[0-9]+)$', views.project_detail,
+        name='project_detail'),
+    url(r'scenarios/$', views.scenario_list, name='scenario_list'),
+    url(r'scenarios/(?P<scen_id>[0-9]+)$', views.scenario_detail,
+        name='scenario_detail'),
     url(r'start/analyze/$', views.start_analyze, name='start_analyze'),
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from rest_framework.response import Response
-from rest_framework import decorators
-from rest_framework.permissions import AllowAny
+from rest_framework import decorators, status
+from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
@@ -14,7 +14,103 @@ from celery import chain
 from apps.core.models import Job
 from apps.core.task_helpers import save_job_error, save_job_result
 from apps.modeling import tasks
-from apps.modeling.models import District
+from apps.modeling.models import District, Project, Scenario
+from apps.modeling.serializers import ProjectSerializer, ScenarioSerializer
+
+
+@decorators.api_view(['GET', 'POST'])
+@decorators.permission_classes((IsAuthenticated, ))
+def project_list(request):
+    """Get a list of all projects with embedded scenarios available for
+       the logged in user.  POST to create a new project associated with the
+       logged in user."""
+    if request.method == 'GET':
+        projects = Project.objects.filter(user=request.user)
+        serializer = ProjectSerializer(projects, many=True)
+
+        return Response(serializer.data)
+
+    elif request.method == 'POST':
+        serializer = ProjectSerializer(data=request.data,
+                                       context={"request": request})
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@decorators.api_view(['DELETE', 'GET', 'PUT'])
+@decorators.permission_classes((IsAuthenticated, ))
+def project_detail(request, proj_id):
+    """Retrieve, update or delete a project"""
+    try:
+        project = Project.objects.get(user=request.user, id=proj_id)
+    except Project.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == 'GET':
+        serializer = ProjectSerializer(project)
+        return Response(serializer.data)
+
+    elif request.method == 'PUT':
+        serializer = ProjectSerializer(project, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    elif request.method == 'DELETE':
+        project.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@decorators.api_view(['POST'])
+@decorators.permission_classes((IsAuthenticated, ))
+def scenario_list(request):
+    """Create a scenario for projects which authenticated user has access to"""
+    if request.method == 'POST':
+        serializer = ScenarioSerializer(data=request.data,
+                                        context={"request": request})
+
+        project_id = serializer.initial_data.get('project')
+
+        try:
+            Project.objects.get(id=project_id, user=request.user)
+        except Project.DoesNotExist:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors,
+                        status=status.HTTP_400_BAD_REQUEST)
+
+
+@decorators.api_view(['DELETE', 'GET', 'PUT'])
+@decorators.permission_classes((IsAuthenticated, ))
+def scenario_detail(request, scen_id):
+    """Retrieve, update or delete a scenario"""
+    try:
+        scenario = Scenario.objects.filter(user=request.user, id=scen_id)
+    except Scenario.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == 'GET':
+        serializer = ScenarioSerializer(scenario)
+        return Response(serializer.data)
+
+    elif request.method == 'PUT':
+        serializer = ScenarioSerializer(scenario, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    elif request.method == 'DELETE':
+        scenario.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @decorators.api_view(['POST'])


### PR DESCRIPTION
Testing instructions:

* Migrations
* Log into the app

Create a few new projects at `POST` http://localhost:8000/api/modeling/projects/
```json
{
"area_of_interest": "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))",
"name": "My Project",
"model_package": "tr-55"
}
```

* List your projects at `GET` http://localhost:8000/api/modeling/projects/
* Project details: `GET` http://localhost:8000/api/modeling/projects/<id-from-create>
* Add a scenario to a project:  `POST` http://localhost:8000/api/modeling/scenarios/

```json
{ "project": 5, "name": "Current Conditions", "current_conditions": true, "modifications": { "a": "b" }}
```

* View project and see scenario added to it `GET` http://localhost:8000/api/modeling/projects/<id>
* Delete project `GET` http://localhost:8000/api/modeling/projects/<id>, confirm the scenarios are also deleted.
* Non authenticated users shouldn't have access to any of those endpoints.
* Users should only be able to modify projects they own.

Connects #136 