### PR TITLE
Add Ansible callback plugin to profile tasks

### DIFF
--- a/deployment/ansible/callback_plugins/profile_tasks.py
+++ b/deployment/ansible/callback_plugins/profile_tasks.py
@@ -1,0 +1,58 @@
+"""
+Author: Jharrod LaFon
+See also: https://github.com/jlafon/ansible-profile
+"""
+
+import time
+
+
+class CallbackModule(object):
+    """
+    A plugin for timing tasks
+    """
+    def __init__(self):
+        self.stats = {}
+        self.current = None
+
+    def playbook_on_task_start(self, name, is_conditional):
+        """
+        Logs the start of each task
+        """
+        if self.current is not None:
+            # Record the running time of the last executed task
+            self.stats[self.current] = time.time() - self.stats[self.current]
+
+        # Record the start time of the current task
+        self.current = name
+        self.stats[self.current] = time.time()
+
+    def playbook_on_stats(self, stats):
+        """
+        Prints the timings
+        """
+        # Record the timing of the very last task
+        if self.current is not None:
+            self.stats[self.current] = time.time() - self.stats[self.current]
+
+        # Sort the tasks by their running time
+        results = sorted(
+            self.stats.items(),
+            key=lambda value: value[1],
+            reverse=True,
+        )
+
+        # Just keep the top 10
+        results = results[:10]
+
+        print
+
+        # Print the timings
+        for name, elapsed in results:
+            print(
+                "{0:-<70}{1:->9}".format(
+                    '{0} '.format(name),
+                    ' {0:.02f}s'.format(elapsed),
+                )
+            )
+
+        print


### PR DESCRIPTION
In order to try and speed up provisioning, this changeset adds a plugin that gives you the per task duration breakdown of a playbook. From here, we can identify the outliers and spend a little time making them faster.

Example tiler output:

```
PLAY RECAP ********************************************************************

azavea.mapnik | Install Mapnik ----------------------------------------- 35.60s
azavea.nginx | Configure the Nginx PPA --------------------------------- 22.61s
Update APT cache ------------------------------------------------------- 11.47s
azavea.beaver | Install Beaver ------------------------------------------ 9.48s
azavea.nodejs | Upgrade NPM --------------------------------------------- 8.94s
azavea.collectd | Install Collectd -------------------------------------- 8.70s
azavea.nodejs | Download Node.js ---------------------------------------- 5.91s
model-my-watershed.tiler | Install tiler javascript dependencies -------- 4.55s
azavea.nginx | Install Nginx -------------------------------------------- 3.97s
model-my-watershed.tiler | Install canvas rendering dependencies -------- 3.95s

tiler                      : ok=62   changed=56   unreachable=0    failed=0
```