### PR TITLE
Add AnsibleGalaxyHelper to remove noise from Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,47 +2,11 @@
 # vi: set ft=ruby :
 
 Vagrant.require_version ">= 1.6"
-require "yaml"
 
-# Deserialize Ansible Galaxy installation metadata for a role
-def galaxy_install_info(role_name)
-  role_path = File.join("deployment", "ansible", "roles", role_name)
-  galaxy_install_info = File.join(role_path, "meta", ".galaxy_install_info")
+if ["up", "provision", "status"].include?(ARGV.first)
+  require_relative "vagrant/ansible_galaxy_helper"
 
-  if (File.directory?(role_path) || File.symlink?(role_path)) && File.exists?(galaxy_install_info)
-    YAML.load_file(galaxy_install_info)
-  else
-    { install_date: "", version: "0.0.0" }
-  end
-end
-
-# Uses the contents of roles.txt to ensure that ansible-galaxy is run
-# if any dependencies are missing
-def install_dependent_roles
-  ansible_directory = File.join("deployment", "ansible")
-  ansible_roles_txt = File.join(ansible_directory, "roles.txt")
-
-  File.foreach(ansible_roles_txt) do |line|
-    next if line.strip.empty?
-
-    role_name, role_version = line.split(",")
-    role_path = File.join(ansible_directory, "roles", role_name)
-    galaxy_metadata = galaxy_install_info(role_name)
-
-    if galaxy_metadata["version"] != role_version.strip
-      unless system("ansible-galaxy install -f -r #{ansible_roles_txt} -p #{File.dirname(role_path)}")
-        $stderr.puts "\nERROR: An attempt to install Ansible role dependencies failed."
-        exit(1)
-      end
-
-      break
-    end
-  end
-end
-
-# Install missing role dependencies based on the contents of roles.txt
-if [ "up", "provision", "status" ].include?(ARGV.first)
-  install_dependent_roles
+  AnsibleGalaxyHelper.install_dependent_roles("deployment/ansible")
 end
 
 ANSIBLE_GROUPS = {

--- a/vagrant/ansible_galaxy_helper.rb
+++ b/vagrant/ansible_galaxy_helper.rb
@@ -1,0 +1,35 @@
+require "yaml"
+
+module AnsibleGalaxyHelper
+  # Deserialize Ansible Galaxy installation metadata for a role
+  def self.galaxy_install_info(role_path)
+    galaxy_install_info = File.join(role_path, "meta", ".galaxy_install_info")
+
+    if (File.directory?(role_path) || File.symlink?(role_path)) && File.exists?(galaxy_install_info)
+      YAML.load_file(galaxy_install_info)
+    else
+      { install_date: "", version: "0.0.0" }
+    end
+  end
+
+  # Uses the contents of roles.txt to ensure that ansible-galaxy is run
+  # if any dependencies are missing
+  def self.install_dependent_roles(ansible_directory)
+    ansible_roles_txt = File.join(ansible_directory, "roles.txt")
+
+    File.foreach(ansible_roles_txt) do |line|
+      role_name, role_version = line.split(",")
+      role_path = File.join(ansible_directory, "roles", role_name)
+      galaxy_metadata = galaxy_install_info(role_path)
+
+      if galaxy_metadata["version"] != role_version.strip
+        unless system("ansible-galaxy install -f -r #{ansible_roles_txt} -p #{File.dirname(role_path)}")
+          $stderr.puts "\nERROR: An attempt to install Ansible role dependencies failed."
+          exit(1)
+        end
+
+        break
+      end
+    end
+  end
+end


### PR DESCRIPTION
I broke out the Ansible Galaxy related cruft into a Ruby module that gets required in the main `Vagrantfile`. The goal here is just to clean things up before the fold so that people can get to the things they're probably more interested in quicker.

Need to look into getting this into a Vagrant plugin or something at some point.