### PR TITLE
Remove initial zoom when page loads

### DIFF
--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -11,23 +11,6 @@ require('leaflet-draw');
 // See: https://github.com/Leaflet/Leaflet/issues/766
 L.Icon.Default.imagePath = '/static/images/';
 
-// Fetch data from server based on current URL.
-function loadData() {
-    var defer = $.Deferred();
-    // Simulate an ajax request on page load.
-    // Should be replaced at a later point.
-    setTimeout(function() {
-        defer.resolve({
-            map: {
-                lat: 39.955929,
-                lng: -75.157457,
-                zoom: 12
-            }
-        });
-    }, 1500);
-    return defer.promise();
-}
-
 var Backbone = require('../shim/backbone'),
     App = require('./app'),
     router = require('./router').router,
@@ -52,10 +35,6 @@ App.on('start', function() {
 });
 
 App.start();
-
-loadData().then(function(data) {
-    App.load(data);
-});
 
 window.MMW = App;
 window.MMW.router = router;


### PR DESCRIPTION
This code was a proof of concept to show how we could restore saved state
when the page loads. It was supposed to be temporary but never got removed...
until now.