### PR TITLE
AJAX User Logout Part 2

### DIFF
--- a/src/mmw/apps/user/templates/user/logout.html
+++ b/src/mmw/apps/user/templates/user/logout.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <h1>You have been logged out.</h1>
+
+{% endblock content %}

--- a/src/mmw/apps/user/urls.py
+++ b/src/mmw/apps/user/urls.py
@@ -4,13 +4,14 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.conf.urls import patterns, url
-from apps.user.views import (ajax_login,
+from apps.user.views import (ajax_login, user_logout,
                              itsi_login, itsi_auth, itsi_register)
 
 
 urlpatterns = patterns(
     '',
     url(r'^ajaxlogin$', ajax_login, name='ajax_login'),
+    url(r'^logout$', user_logout, name='logout'),
     url(r'^itsi/login$', itsi_login, name='itsi_login'),
     url(r'^itsi/authenticate$', itsi_auth, name='itsi_auth'),
     url(r'^itsi/register$', itsi_register, name='itsi_register'),

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -1,8 +1,8 @@
 from rest_framework.response import Response
-from django.contrib.auth import authenticate, login
+from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render_to_response
 
 from rest_framework import decorators
 from rest_framework.permissions import AllowAny
@@ -45,6 +45,18 @@ def ajax_login(request):
         status = 400
 
     return Response(data=response_data, status=status)
+
+
+@decorators.api_view(['GET'])
+@decorators.permission_classes((AllowAny, ))
+def user_logout(request):
+    logout(request)
+
+    if request.is_ajax():
+        response_data = {'guest': True, 'result': 'success'}
+        return Response(data=response_data)
+    else:
+        return render_to_response('user/logout.html')
 
 
 itsi = ItsiService()

--- a/src/mmw/js/src/core/templates/header.ejs
+++ b/src/mmw/js/src/core/templates/header.ejs
@@ -13,7 +13,7 @@
                     </a>
                     <ul class="dropdown-menu">
                         <li><a href="#">Profile</a></li>
-                        <li><a href="/user/logout">Logout</a></li>
+                        <li><a href="/user/logout" class="user-logout">Logout</a></li>
                     </ul>
                 </li>
             <% } %>

--- a/src/mmw/js/src/core/templates/header.ejs
+++ b/src/mmw/js/src/core/templates/header.ejs
@@ -13,7 +13,7 @@
                     </a>
                     <ul class="dropdown-menu">
                         <li><a href="#">Profile</a></li>
-                        <li><a href="accounts/logout">Logout</a></li>
+                        <li><a href="/user/logout">Logout</a></li>
                     </ul>
                 </li>
             <% } %>

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -43,11 +43,13 @@ var HeaderView = Marionette.ItemView.extend({
     template: headerTmpl,
 
     ui: {
-        login: '.show-login'
+        login: '.show-login',
+        logout: '.user-logout'
     },
 
     events: {
-        'click @ui.login': 'showLogin'
+        'click @ui.login': 'showLogin',
+        'click @ui.logout': 'userLogout'
     },
 
     modelEvents: {
@@ -59,6 +61,11 @@ var HeaderView = Marionette.ItemView.extend({
         // Defer requiring app until needed as it is not defined when
         // core.views are initialized (they are required in app.js)
         require('../app').showLoginModal();
+    },
+
+    userLogout: function(event) {
+        event.preventDefault();
+        this.model.logout();
     }
 
 });

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -3,6 +3,7 @@
 var $ = require('jquery'),
     L = require('leaflet'),
     _ = require('lodash'),
+    router = require('../router.js').router,
     Marionette = require('../../shim/backbone.marionette'),
     TransitionRegion = require('../../shim/marionette.transition-region'),
     headerTmpl = require('./templates/header.ejs');
@@ -65,7 +66,9 @@ var HeaderView = Marionette.ItemView.extend({
 
     userLogout: function(event) {
         event.preventDefault();
-        this.model.logout();
+        this.model.logout().done(function() {
+            router.navigate('', {trigger: true});
+        });
     }
 
 });

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -7,7 +7,39 @@ var UserModel = Backbone.Model.extend({
         guest: true
     },
 
-    url: 'user/ajaxlogin'
+    url: 'user/ajaxlogin',
+
+    // Both login and logout methods return jqXHR objects so that callbacks can
+    // be specified upon usage. They both update the user model, so any event
+    // listeners that subscribe to the `sync` event will be triggered.
+    login: function(attrs) {
+        return this.fetch({
+            type: 'POST',
+            url: 'user/ajaxlogin',
+            data: attrs
+        });
+    },
+
+    logout: function() {
+        var jqXHR = this.fetch({
+            url: 'user/logout'
+        });
+
+        var user = this;
+        jqXHR.done(function() {
+            // We have to unset the username manually here because when the
+            // server does not return a username (because the user has been
+            // logged out), our model's username is not updated and the old
+            // username persists.
+            // Additionally, we change this silently because the login and
+            // logout functions only advertise firing a single `sync` event,
+            // and this would fire an additional `change` event. We must
+            // suppress this to maintain consistency in our API.
+            user.unset('username', {silent: true});
+        });
+
+        return jqXHR;
+    }
 });
 
 var LoginFormModel = Backbone.Model.extend({

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -56,10 +56,9 @@ var LoginModalView = Marionette.ItemView.extend({
     },
 
     signIn: function() {
-        var formData = this.$el.find('form').serialize();
-        App.user.fetch({
-            method: 'POST',
-            data: formData
+        App.user.login({
+            username: this.model.get('username'),
+            password: this.model.get('password')
         })
         .done(_.bind(this.handleSignInSuccess, this))
         .fail(_.bind(this.handleSignInFail, this));


### PR DESCRIPTION
Connects #173 

Revises #201 

I'm creating a new PR because my old private repo was blown away as a part of the transition. For reference, the old PR is #201.

**Testing Notes**
Login as a user. Click name in the header and logout. Verify that the username now has changed to a Login button. Click the login button to make the login modal show up. Refresh the page without logging in, and it should identify you as not logged in and pop up the login modal.
Login as a user. Right click the logout link and open in new tab. Refresh the first tab, and it should identify you as not logged in and pop up the login modal.

**Further Work**
 * This PR has an unstyled log out page. This probably needs some design attention, and input from @mmcfarland and @ctaylo37 for how best to handle. Created #214 for this.
 * The original issue asks for the user to be redirected the home page in case they are at a page which is for logged-in users only. I don't have a clear idea of which pages this would apply to, and once we have that we will have to figure out how to mark those pages as requiring authentication within Backbone / Marionette. Created #215 for this.