### PR TITLE
Faster bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ After pulling in new commits, you may need to run the following two commands:
 ```bash
 $ ./scripts/manage.sh migrate
 $ ./scripts/manage.sh reload_dev_data
+$ ./scripts/bundle.sh
 ```
 
 See debug messages from the web app server:
@@ -130,5 +131,34 @@ First, start the testem process.
 ```bash
 $ ./scripts/testem.sh
 ```
-
 Then view the test runner page at [http://localhost:7357](http://localhost:7357).
+
+#### Bundling static assets
+
+The `bundle.sh` script runs browserify, node-sass, and othe pre-processing
+tasks to generate static assets.
+
+The vendor bundle is not created until you run this command with the
+`--vendor` flag. This bundle will be very large if combined with `--debug`.
+
+Test bundles are not created unless the `--tests` flag is used.
+
+In general, you should be able to combine `--vendor`, `--tests`, `--debug`,
+and `--watch` and have it behave as you would expect.
+
+The `--list` flag displays module dependencies and does not actually generate
+any bundles. It doesn't make sense to combine this with `--watch`.
+This flag is for troubleshooting purposes only.
+
+    > bundle.sh -h
+    bundle.sh [OPTION]...
+
+    Bundle JS and CSS static assets.
+
+     Options:
+      --watch      Listen for file changes
+      --debug      Generate source maps
+      --tests      Generate test bundles
+      --list       List browserify dependencies
+      --vendor     Generate vendor bundle and copy assets
+      -h, --help   Display this help text

--- a/deployment/ansible/roles/model-my-watershed.app/tasks/static-files.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/static-files.yml
@@ -17,7 +17,7 @@
   sudo: False
 
 - name: Create static files and run collectstatic (staging/production)
-  command: "./bundle.sh"
+  command: "./bundle.sh --vendor"
   args:
     chdir: "{{ app_home }}"
   environment: app_config
@@ -25,7 +25,7 @@
   when: "['development'] | is_not_in(group_names)"
 
 - name: Create static files and run collectstatic (development)
-  command: "./bundle.sh --debug"
+  command: "./bundle.sh --vendor --tests --debug"
   args:
     chdir: "{{ app_home }}"
   environment: app_config

--- a/deployment/ansible/roles/model-my-watershed.app/templates/testem-harness.html.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/testem-harness.html.j2
@@ -13,6 +13,7 @@
 <body>
 <div id="mocha"></div>
 <div id="map" style="display: none;"></div>
+<script src="js/test.vendor.js"></script>
 <script src="js/test.bundle.js"></script>
 <script>
 mocha.run()

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -92,10 +92,9 @@ CONCAT_VENDOR_CSS_COMMAND="cat \
     > $VENDOR_CSS_FILE"
 
 JS_DEPS=(jquery backbone backbone.marionette \
-        bootstrap bootstrap-select \
-        leaflet leaflet-draw lodash underscore \
-        chai d3)
-
+         bootstrap bootstrap-select \
+         leaflet leaflet-draw lodash underscore \
+         d3)
 BROWSERIFY_EXT=""
 BROWSERIFY_REQ=""
 for DEP in "${JS_DEPS[@]}"
@@ -104,8 +103,17 @@ do
     BROWSERIFY_REQ+="-r $DEP "
 done
 
-JS_DEPS_WATER_BALANCE=(jquery bootstrap bootstrap-select retina.js)
+JS_TEST_DEPS=(chai sinon)
+BROWSERIFY_TEST_EXT=""
+BROWSERIFY_TEST_REQ=""
+for DEP in "${JS_TEST_DEPS[@]}"
+do
+    BROWSERIFY_TEST_EXT+="-x $DEP "
+    BROWSERIFY_TEST_REQ+="-r $DEP "
+done
 
+# TODO: Combine with original vendor bundle.
+JS_DEPS_WATER_BALANCE=(jquery bootstrap bootstrap-select retina.js)
 BROWSERIFY_EXT_WATER_BALANCE=""
 BROWSERIFY_REQ_WATER_BALANCE=""
 for DEP in "${JS_DEPS_WATER_BALANCE[@]}"
@@ -122,6 +130,8 @@ if [ -n "$BUILD_VENDOR_BUNDLE" ]; then
         $CONCAT_VENDOR_CSS_COMMAND &
         $BROWSERIFY $BROWSERIFY_REQ \
             -o ${STATIC_JS_DIR}vendor.js $EXTRA_ARGS &
+        $BROWSERIFY $BROWSERIFY_REQ $BROWSERIFY_TEST_REQ \
+            -o ${STATIC_JS_DIR}test.vendor.js $EXTRA_ARGS &
         $BROWSERIFY $BROWSERIFY_REQ_WATER_BALANCE \
             -o ${STATIC_JS_DIR}vendor_water_balance.js $EXTRA_ARGS &"
 fi
@@ -129,7 +139,7 @@ fi
 TEST_COMMAND=""
 if [ -n "$ENABLE_TESTS" ]; then
     TEST_COMMAND="
-        $BROWSERIFY $TEST_FILES $JSTIFY_TRANSFORM \
+        $BROWSERIFY $TEST_FILES $BROWSERIFY_EXT $BROWSERIFY_TEST_EXT $JSTIFY_TRANSFORM \
             -o ${STATIC_JS_DIR}test.bundle.js $EXTRA_ARGS &"
 fi
 

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -149,3 +149,10 @@ mkdir -p \
 
 echo "$VAGRANT_COMMAND"
 eval "$VAGRANT_COMMAND"
+
+# Wait for background jobs to finish if watch is not enabled.
+if [ -z "$ENABLE_WATCH" ]; then
+    echo "Waiting..."
+    wait
+    echo "Done"
+fi

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -90,7 +90,7 @@ CONCAT_VENDOR_CSS_COMMAND="cat \
 JS_DEPS=(jquery backbone backbone.marionette \
         bootstrap bootstrap-select \
         leaflet leaflet-draw lodash underscore \
-        chai)
+        chai d3)
 
 BROWSERIFY_EXT=""
 BROWSERIFY_REQ=""

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -8,7 +8,7 @@ if [ -z "$DJANGO_STATIC_ROOT" ]; then
 fi
 
 # Default settings
-BIN=./node_modules/.bin
+BIN="./node_modules/.bin"
 
 STATIC_JS_DIR="${DJANGO_STATIC_ROOT}js/"
 STATIC_CSS_DIR="${DJANGO_STATIC_ROOT}css/"
@@ -22,11 +22,11 @@ ENTRY_JS_FILES_WATER_BALANCE="./js/src/main_water_balance.js"
 JSTIFY_TRANSFORM="-t [ jstify --noMinify ]"
 
 NODE_SASS="$BIN/node-sass"
-ENTRY_SASS_DIR=./sass/
+ENTRY_SASS_DIR="./sass/"
 ENTRY_SASS_FILE="${ENTRY_SASS_DIR}main.scss"
 VENDOR_CSS_FILE="${STATIC_CSS_DIR}vendor.css"
 
-TEST_FILES=./js/src/**/tests.js
+TEST_FILES="./js/src/**/tests.js"
 
 usage() {
     echo -n "$(basename $0) [OPTION]...


### PR DESCRIPTION
I've added a few flags to the bundle script which should make rebuilding a lot faster.

1. The vendor bundle rarely changes so it is no longer generated by default. Use the `--vendor` flag instead.
2. Test bundles are no longer generated by default. Use the `--tests` flag instead.
3. Created a vendor bundle for tests.
4. Moved d3 to the vendor bundle.

**Note:** You'll need to reprovision the app VM to use testem since a vendor bundle has been added to the test harness.
