### PR TITLE
Allow saving and retrieving of projects and scenarios

### DIFF
--- a/src/mmw/apps/modeling/admin.py
+++ b/src/mmw/apps/modeling/admin.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.contrib import admin
+from .models import Project, Scenario
+
+admin.site.register(Project)
+admin.site.register(Scenario)

--- a/src/mmw/apps/modeling/admin.py
+++ b/src/mmw/apps/modeling/admin.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.contrib import admin
-from .models import Project, Scenario
+from apps.modeling.models import Project, Scenario
 
 admin.site.register(Project)
 admin.site.register(Scenario)

--- a/src/mmw/apps/modeling/migrations/0002_add_projects_scenarios.py
+++ b/src/mmw/apps/modeling/migrations/0002_add_projects_scenarios.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import django.contrib.gis.db.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('modeling', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Project',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=255)),
+                ('area_of_interest', django.contrib.gis.db.models.fields.MultiPolygonField(help_text='Base geometry for all scenarios of project', srid=4326)),
+                ('is_private', models.BooleanField(default=True)),
+                ('model_package', models.CharField(help_text='Which model pack was chosen for this project', max_length=255, choices=[('tr-55', 'Simple Model')])),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('modified_at', models.DateTimeField(auto_now=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Scenario',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=255)),
+                ('current_condition', models.BooleanField(default=False, help_text='A special type of scenario without modification abilities')),
+                ('modifications', models.TextField(help_text='Serialized JSON representation of this scenarios applied modification, with respect to the model package', null=True)),
+                ('modification_hash', models.CharField(help_text='A hash of the values for modifications & inputs to compare to the existing model results, to determine if the persisted result apply to the current values', max_length=255, null=True)),
+                ('results', models.TextField(help_text='Serialized JSON representation of the model results', null=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('modified_at', models.DateTimeField(auto_now=True)),
+                ('project', models.ForeignKey(related_name='scenarios', to='modeling.Project')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='scenario',
+            unique_together=set([('name', 'project')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='project',
+            unique_together=set([('name', 'user')]),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -6,6 +6,8 @@ from __future__ import division
 from django.contrib.gis.db import models
 from django.forms.models import model_to_dict
 
+from django.contrib.auth.models import User
+
 
 class District(models.Model):
     state_fips = models.CharField(
@@ -40,3 +42,64 @@ class District(models.Model):
         dictionary = model_to_dict(self)
         dictionary.pop('polygon', None)
         return str(dictionary)
+
+
+class Project(models.Model):
+    class Meta:
+        unique_together = ('name', 'user')
+
+    TR55 = 'tr-55'
+    MODEL_PACKAGES = ((TR55, 'Simple Model'),)
+
+    user = models.ForeignKey(User)
+    name = models.CharField(
+        max_length=255)
+    area_of_interest = models.MultiPolygonField(
+        help_text='Base geometry for all scenarios of project')
+    is_private = models.BooleanField(
+        default=True)
+    model_package = models.CharField(
+        choices=MODEL_PACKAGES,
+        max_length=255,
+        help_text='Which model pack was chosen for this project')
+    created_at = models.DateTimeField(
+        auto_now=False,
+        auto_now_add=True)
+    modified_at = models.DateTimeField(
+        auto_now=True)
+
+    def __unicode__(self):
+        return self.name
+
+
+class Scenario(models.Model):
+    class Meta:
+        unique_together = ('name', 'project')
+
+    name = models.CharField(
+        max_length=255)
+    project = models.ForeignKey(Project, related_name='scenarios')
+    current_condition = models.BooleanField(
+        default=False,
+        help_text='A special type of scenario without modification abilities')
+    modifications = models.TextField(
+        null=True,
+        help_text='Serialized JSON representation of this scenarios ' +
+                  'applied modification, with respect to the model package')
+    modification_hash = models.CharField(
+        max_length=255,
+        null=True,
+        help_text='A hash of the values for modifications & inputs to ' +
+                  'compare to the existing model results, to determine if ' +
+                  'the persisted result apply to the current values')
+    results = models.TextField(
+        null=True,
+        help_text='Serialized JSON representation of the model results')
+    created_at = models.DateTimeField(
+        auto_now=False,
+        auto_now_add=True)
+    modified_at = models.DateTimeField(
+        auto_now=True)
+
+    def __unicode__(self):
+        return self.name

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.contrib.auth.models import User
+from rest_framework import serializers
+
+from apps.modeling.models import Project, Scenario
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'email')
+
+
+class ScenarioSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Scenario
+
+
+class ProjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Project
+        depth = 1
+
+    user = UserSerializer(default=serializers.CurrentUserDefault())
+    scenarios = ScenarioSerializer(many=True, read_only=True)

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -17,6 +17,10 @@ uuid_regex = '(?P<job_uuid>[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-' \
 
 urlpatterns = patterns(
     '',
+    url(r'projects/$', views.projects, name='projects'),
+    url(r'projects/(?P<proj_id>[0-9]+)$', views.project, name='project'),
+    url(r'scenarios/$', views.scenarios, name='scenarios'),
+    url(r'scenarios/(?P<scen_id>[0-9]+)$', views.scenario, name='scenario'),
     url(r'start/analyze/$', views.start_analyze, name='start_analyze'),
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),


### PR DESCRIPTION
** Supercedes #198 **

Testing instructions:

* Migrations
* Log into the app

Create a few new projects at `POST` http://localhost:8000/api/modeling/projects/
```json
{
"area_of_interest": "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))",
"name": "My Project",
"model_package": "tr-55"
}
```

* List your projects at `GET` http://localhost:8000/api/modeling/projects/
* Project details: `GET` http://localhost:8000/api/modeling/projects/<id-from-create>
* Add a scenario to a project:  `POST` http://localhost:8000/api/modeling/scenarios/

```json
{ "project": 5, "name": "Current Conditions", "current_conditions": true, "modifications": { "a": "b" }}
```

* View project and see scenario added to it `GET` http://localhost:8000/api/modeling/projects/<id>
* Delete project `GET` http://localhost:8000/api/modeling/projects/<id>, confirm the scenarios are also deleted.
* Non authenticated users shouldn't have access to any of those endpoints.
* Users should only be able to modify projects they own.

Connects #136 