### PR TITLE
ITSI Login Error

### DIFF
--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -12,4 +12,5 @@ urlpatterns = patterns(
     url(r'^analyze$', home_page, name='home_page'),
     url(r'^model$', home_page, name='home_page'),
     url(r'^compare$', compare, name='compare'),
+    url(r'^error', home_page, name='home_page'),
 )

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -63,14 +63,14 @@ def itsi_auth(request):
 
     # Basic validation
     if code is None:
-        return redirect('/error-itsi')  # TODO Make this Backbone route
+        return redirect('/error/itsi')
 
     try:
         session = itsi.get_session_from_code(code)
         itsi_user = session.get_user()
     except:
         # In case we are unable to reach ITSI and get an unexpected response
-        return redirect('/error-itsi')   # TODO Make this Backbone route
+        return redirect('/error/itsi')
 
     user = authenticate(itsi_id=itsi_user['id'])
     if user is not None and user.is_active:

--- a/src/mmw/js/src/core/error/controllers.js
+++ b/src/mmw/js/src/core/error/controllers.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var ErrorHandlers = require('./handlers').ErrorHandlers;
+
+var ErrorController = {
+    error: function(type) {
+        switch(type) {
+            case 'itsi':
+                ErrorHandlers.itsi();
+                break;
+            default:
+                ErrorHandlers.generic(type);
+        }
+    }
+};
+
+module.exports = {
+    ErrorController: ErrorController
+};

--- a/src/mmw/js/src/core/error/handlers.js
+++ b/src/mmw/js/src/core/error/handlers.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var router = require('../../router').router,
+    App = require('../../app');
+
+var ErrorHandlers = {
+    itsi: function() {
+        router.navigate('');
+        alert("We're sorry, but there was an error logging you in with your" +
+            " ITSI credentials. Please log in using another method or" +
+            " continue as a guest."
+        );
+        App.showLoginModal();
+    },
+
+    generic: function(type) {
+        router.navigate('');
+        alert("We're sorry, but an error occurred in the application.");
+        console.log("[MMW] An unknown error occurred: " + type);
+    }
+};
+
+module.exports = {
+    ErrorHandlers: ErrorHandlers
+};

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -3,6 +3,7 @@
 var router = require('./router').router,
     controllers = require('./controllers'),
     AppController = controllers.AppController,
+    ErrorController = require('./core/error/controllers').ErrorController,
     DrawController = require('./draw/controllers').DrawController,
     ModelingController = require('./modeling/controllers').ModelingController,
     AnalyzeController = require('./analyze/controllers').AnalyzeController;
@@ -11,3 +12,4 @@ router.addRoute(/^/, DrawController, 'draw');
 router.addRoute(/^analyze/, AnalyzeController, 'analyze');
 router.addRoute(/^model/, ModelingController, 'model');
 router.addRoute(/^compare/, AppController, 'compare');
+router.addRoute('error(/)(:type)', ErrorController, 'error');


### PR DESCRIPTION
This PR presents a tentative approach for route based error handling, with the immediate application of handling route based errors due to ITSI OAuth failures. It can be outlined as follows:

 * All `/error[.*]` routes will be handled by Django to render the main Backbone app
 * The Backbone app will pass these routes to an `ErrorController`
 * The `ErrorController` has a list of error `types` from which it looks up a specific `ErrorHandler` and fires it.

The following questions are raised by this work:

 * Currently the `ErrorHandler` for ITSI just pops up an `alert` message, which is rather inelegant. We should probably have design guidelines for showing error messages. Created #224 for this.
 * What should happen if the `ErrorController` is not passed in any error `type`, e.g. `/error` or `/error/`? Currently this is handled by `ErrorHandler.generic` and pops up a bland `alert` box.
 * What should happen if the `ErrorController` cannot find a matching error `type`, e.g. `/error/xyz`? Currently this is handled by `ErrorHandler.unknown` and silently logs the error to the console.

If we find `ErrorController` growing into having models and views, we might consider moving it out of the generic `controllers.js` into its own folder.

This PR addresses part of #180, namely the error view. I will wait for work on #152 to finish before adding a registration view.

Connects #180 