### PR TITLE
Add area of interest mask layer

### DIFF
--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -2,6 +2,8 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
+
 from rest_framework.response import Response
 from rest_framework import decorators
 from rest_framework.permissions import AllowAny
@@ -104,14 +106,8 @@ def _initiate_tr55_job_chain(model_input, job_id):
 def district(request, id=None, state=None):
     if id:  # query by unique id
         district = get_object_or_404(District, id=id)
-        coordinates = []
-        for polygon in district.polygon.coords:
-            coordinates.append(polygon[0])
-        dictionary = {'type': 'Feature',
-                      'properties': {},
-                      'geometry': {'type': 'Polygon',
-                                   'coordinates': coordinates}}
-        return Response(dictionary)
+        geojson = json.loads(district.polygon.geojson)
+        return Response(geojson)
     else:  # provide list of all ids
         shapes = District.objects.order_by('state_fips', 'district_fips')
         shapes = [{'id': shape.id, 'name': shape.name()} for shape in shapes]

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -62,12 +62,12 @@ var App = new Marionette.Application({
 
 function RestAPI() {
     return {
-        getPredefinedShapes: function() {
+        getPredefinedShapes: _.memoize(function() {
             return $.ajax({
                 'url': '/api/modeling/congressional_districts',
                 'type': 'GET'
             });
-        },
+        }),
 
         getPolygon: function(args) {
             return $.ajax({

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -37,34 +37,6 @@ var ToolbarView = Marionette.LayoutView.extend({
     }
 });
 
-// map.fitBounds((new L.GeoJSON(shape)).getBounds()) or similar does
-// not work because getBounds only returns the bounding box around the
-// first component of the (possibly multi-component) shape.
-function conformMapToShape(shape) {
-    function second(pair) {
-        return pair[1];
-    }
-
-    var map = App.getLeafletMap(),
-        flatShape = _.flatten(shape.geometry.coordinates),
-        lngs = _.map(flatShape, _.first),
-        lats = _.map(flatShape, second),
-        minlat = _.min(lats),
-        minlng = _.min(lngs),
-        maxlat = _.max(lats),
-        maxlng = _.max(lngs);
-
-    if (minlat && minlng && maxlat && maxlng) {
-        map.fitBounds([[minlat, minlng],
-                       [maxlat, maxlng]]);
-    } else {
-        // if the bounding box of the shape could not be computed, use
-        // the bounding box for the US.
-        map.fitBounds([[-124.848974, 24.396308],
-                       [-66.885444, 49.384358]]);
-    }
-}
-
 var SelectAreaView = Marionette.ItemView.extend({
     ui: {
         'items': '[data-shape-id]',
@@ -186,7 +158,6 @@ function clearLayer(layer) {
 
 function addLayer(shape) {
     App.map.set('areaOfInterest', shape);
-    conformMapToShape(shape);
 }
 
 function drawPolygon() {


### PR DESCRIPTION
This adds a shadow to the map with a cutout of the selected area of
interest.

The conformMapToShape logic is no longer needed since we now return
properly serialized MultiPolygon geojson.

Connects #222 