### PR TITLE
Fix tab switching issues

### DIFF
--- a/src/mmw/js/shim/backbone.marionette.js
+++ b/src/mmw/js/shim/backbone.marionette.js
@@ -6,13 +6,13 @@ var Backbone = require('./backbone'),
     Marionette = require('backbone.marionette');
 
 // Enable support for bundled templates (jstify).
-Backbone.Marionette.Renderer.render = function(template, data) {
-    return template(data);
+Backbone.Marionette.Renderer.render = function(template, data, view) {
+    return template.call(view, data);
 };
 
 // Expose Backbone and Marionette for the Marionette Inspector
 if (window.__agent) {
-  window.__agent.start(Backbone, Marionette);
+    window.__agent.start(Backbone, Marionette);
 }
 
 module.exports = Marionette;

--- a/src/mmw/js/src/draw/templates/placeMarker.ejs
+++ b/src/mmw/js/src/draw/templates/placeMarker.ejs
@@ -4,7 +4,7 @@
     Delineate Watershed
     <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu menu-left" role="menu" aria-labelledby="select-area">
+  <ul class="dropdown-menu menu-left" role="menu">
     <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-shape-type="slope">Hill Slope</a></li>
     <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-shape-type="stream">Stream Network</a></li>
     <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-shape-type="flow">Trace Flow Down</a></li>

--- a/src/mmw/js/src/draw/templates/selectType.ejs
+++ b/src/mmw/js/src/draw/templates/selectType.ejs
@@ -4,7 +4,7 @@
     Select by Boundary
     <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu menu-left" role="menu" aria-labelledby="select-area" id="wrapper">
+  <ul class="dropdown-menu menu-left" role="menu" id="wrapper">
   <% _.each(predefinedShapeTypes, function(item) { %>
       <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-endpoint="<%- item.endpoint %>" data-tableid="<%- item.tableId %>"><%- item.display %></a></li>
   <% }) %>

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -27,8 +27,17 @@ var ProjectModel = Backbone.Model.extend({
         // itself in the future, with more modification
         // and input control data.
         this.set('model_package', 'tr-55');
-        this.set('active_scenario_slug', 'current-conditions');
         this.set('taskModel', new Tr55TaskModel());
+
+        this.makeFirstScenarioActive();
+    },
+
+    makeFirstScenarioActive: function() {
+        var scenariosColl = this.get('scenarios'),
+            scenario = scenariosColl.first();
+        if (scenario) {
+            scenariosColl.setActiveScenario(scenario.cid);
+        }
     },
 
     saveAll: function() {
@@ -82,27 +91,30 @@ var ProjectModel = Backbone.Model.extend({
 var ScenarioModel = Backbone.Model.extend({
     urlRoot: '/api/modeling/scenarios/',
 
-    initialize: function() {
-        this.slugifyName();
-    },
-
     defaults: {
-        currentConditions: false
+        name: '',
+        is_current_conditions: false,
+        active: false
     },
 
-    slugifyName: function() {
+    getSlug: function() {
         var slug = this.get('name')
                        .toLowerCase()
                        .replace(/ /g, '-') // Spaces to hyphens
                        .replace(/[^\w-]/g, ''); // Remove non-alphanumeric characters
-
-        this.set('slug', slug);
+        return slug;
     }
 });
 
 var ScenariosCollection = Backbone.Collection.extend({
     model: ScenarioModel,
-    comparator: 'created_at'
+    comparator: 'created_at',
+
+    setActiveScenario: function(cid) {
+        this.each(function(model) {
+            model.set('active', model.cid === cid);
+        });
+    }
 });
 
 module.exports = {

--- a/src/mmw/js/src/modeling/templates/projectMenu.ejs
+++ b/src/mmw/js/src/modeling/templates/projectMenu.ejs
@@ -7,7 +7,7 @@
         <button class="btn btn-sm btn-icon light dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
         <i class="fa fa-caret-down"></i>
         </button>
-        <ul class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area">
+        <ul class="dropdown-menu menu-right" role="menu">
             <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" data-target="#rename-project">Rename</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" data-target="#share-project">Share</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" onclick="window.print();return false;">Print</a></li>

--- a/src/mmw/js/src/modeling/templates/scenarioMenu.ejs
+++ b/src/mmw/js/src/modeling/templates/scenarioMenu.ejs
@@ -1,4 +1,4 @@
 <button class="btn btn btn-tab dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
   <i class="fa fa-bars"></i>
 </button>
-<ul class="dropdown-menu menu-left" role="menu" aria-labelledby="select-area"></ul>
+<ul class="dropdown-menu menu-left" role="menu"></ul>

--- a/src/mmw/js/src/modeling/templates/scenarioMenuItem.ejs
+++ b/src/mmw/js/src/modeling/templates/scenarioMenuItem.ejs
@@ -1,1 +1,1 @@
-<a href="#<%= slug %>" data-toggle="tab"><%= name %></a>
+<a href="#<%- this.model.cid %>" data-scenario-cid="<%- this.model.cid %>"><%- name %></a>

--- a/src/mmw/js/src/modeling/templates/scenarioMenuItem.ejs
+++ b/src/mmw/js/src/modeling/templates/scenarioMenuItem.ejs
@@ -1,1 +1,7 @@
-<a href="#<%- this.model.cid %>" data-scenario-cid="<%- this.model.cid %>"><%- name %></a>
+<a href="#<%- this.model.cid %>" data-scenario-cid="<%- this.model.cid %>">
+<% if (active) { %>
+    <strong><%- name %></strong>
+<% } else { %>
+    <%- name %>
+<% } %>
+</a>

--- a/src/mmw/js/src/modeling/templates/scenarioTabPanel.ejs
+++ b/src/mmw/js/src/modeling/templates/scenarioTabPanel.ejs
@@ -4,7 +4,7 @@
         <button class="btn btn-sm btn-icon dark dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
         <i class="fa fa-caret-down"></i>
         </button>
-        <ul class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area">
+        <ul class="dropdown-menu menu-right" role="menu">
             <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Share</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Print</a></li>
             <% if (!currentConditions) { %>

--- a/src/mmw/js/src/modeling/templates/scenarioTabPanel.ejs
+++ b/src/mmw/js/src/modeling/templates/scenarioTabPanel.ejs
@@ -1,4 +1,4 @@
-<a href="#<%= slug %>" data-scenario-slug="<%= slug %>" aria-controls="home" role="tab" data-toggle="tab"><%= name %></a>
+<a href="#<%- this.model.cid %>" data-scenario-cid="<%- this.model.cid %>" aria-controls="home" role="tab" data-toggle="tab"><%- name %></a>
 <div class="scenario-btn-dropdown">
     <div class="dropdown">
         <button class="btn btn-sm btn-icon dark dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
@@ -7,7 +7,7 @@
         <ul class="dropdown-menu menu-right" role="menu">
             <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Share</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Print</a></li>
-            <% if (!currentConditions) { %>
+            <% if (!is_current_conditions) { %>
             <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Rename</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Delete</a></li>
             <% } %>

--- a/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.ejs
+++ b/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.ejs
@@ -2,7 +2,7 @@
     <button class="btn btn-sm btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
     <i class="fa fa-plus-circle"></i> Land Cover
     </button>
-    <div id="land-tools" class="dropdown-menu menu-left" role="menu" aria-labelledby="select-area"> <!-- Dropdown -->
+    <div id="land-tools" class="dropdown-menu menu-left" role="menu"> <!-- Dropdown -->
         <div class="pad-1"> <!-- Dropdown Content -->
             <ul class="row">
                 <li>
@@ -60,7 +60,7 @@
     <button class="btn btn-sm btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
     <i class="fa fa-plus-circle"></i> Conservation Practice
     </button>
-    <div id="conserve-tools" class="dropdown-menu draw-tools menu-left" role="menu" aria-labelledby="select-area"> <!-- Dropdown -->
+    <div id="conserve-tools" class="dropdown-menu draw-tools menu-left" role="menu"> <!-- Dropdown -->
         <div class="pad-1"> <!-- Dropdown Content -->
             <ul class="row">
                 <li>
@@ -110,7 +110,7 @@
     <button class="btn btn-sm btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
     <i class="fa fa-cog"></i>
     </button>
-    <ul class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area">
+    <ul class="dropdown-menu menu-right" role="menu">
         <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Advanced Inputs</a></li>
     </ul>
 </div>
@@ -120,7 +120,7 @@
         <button class="btn btn-sm btn-default inverted" type="button" data-toggle="dropdown" aria-expanded="true">
         <span id="modification-number"><strong>3</strong></span> Modifications
         </button>
-        <div id="modifications" class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area"> <!-- DropdownContent -->
+        <div id="modifications" class="dropdown-menu menu-right" role="menu"> <!-- DropdownContent -->
             <div class="pad-1 brd-bottom"> <!-- Land Cover Modifications -->
                 <table id="mod-landCover" class="table modifications custom-hover">
                     <label class="medium">Land Cover</label>


### PR DESCRIPTION
Replaces usage of `slug` with `cid` throughout. This fixes an edge case
where tabs could fall out of sync with their tab panels when the `slug`
changed.

Ex.
![image](https://cloud.githubusercontent.com/assets/43062/7898948/ca8b3db4-06de-11e5-9740-c06700f2a95f.png)

This also defines a standard way of setting the active tab by using
a method on the `ScenariosCollection` called `setActiveScenario`.

Fixes #164