### PR TITLE
Add bundle --minify flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ Test bundles are not created unless the `--tests` flag is used.
 In general, you should be able to combine `--vendor`, `--tests`, `--debug`,
 and `--watch` and have it behave as you would expect.
 
+You can also minify bundles by using the `--minify` flag. This operation is
+not fast, and also disables source maps.
+
 The `--list` flag displays module dependencies and does not actually generate
 any bundles. It doesn't make sense to combine this with `--watch`.
 This flag is for troubleshooting purposes only.
@@ -158,6 +161,7 @@ This flag is for troubleshooting purposes only.
      Options:
       --watch      Listen for file changes
       --debug      Generate source maps
+      --minify     Minify bundles (**SLOW**); Disables source maps
       --tests      Generate test bundles
       --list       List browserify dependencies
       --vendor     Generate vendor bundle and copy assets

--- a/deployment/ansible/roles/model-my-watershed.app/tasks/static-files.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/static-files.yml
@@ -16,15 +16,23 @@
     chdir: "{{ app_home }}"
   sudo: False
 
-- name: Create static files and run collectstatic (staging/production)
-  command: "./bundle.sh --vendor --tests"
+- name: Create minified JS vendor bundle (staging/production)
+  command: "./bundle.sh --vendor --minify"
   args:
     chdir: "{{ app_home }}"
   environment: app_config
   sudo: False
   when: "['development'] | is_not_in(group_names)"
 
-- name: Create static files and run collectstatic (development)
+- name: Create primary JS bundles (staging/production)
+  command: "./bundle.sh --tests"
+  args:
+    chdir: "{{ app_home }}"
+  environment: app_config
+  sudo: False
+  when: "['development'] | is_not_in(group_names)"
+
+- name: Create JS bundles (development)
   command: "./bundle.sh --vendor --tests --debug"
   args:
     chdir: "{{ app_home }}"

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -20,6 +20,7 @@ ENTRY_JS_FILES="./js/src/main.js"
 ENTRY_JS_FILES_WATER_BALANCE="./js/src/main_water_balance.js"
 
 NUNJUCKS_TRANSFORM="-t [ nunjucksify --extension='.html' ]"
+MINIFY_PLUGIN="-p [ minifyify --no-map ]"
 
 NODE_SASS="$BIN/node-sass"
 ENTRY_SASS_DIR="./sass/"
@@ -36,6 +37,7 @@ Bundle JS and CSS static assets.
  Options:
   --watch      Listen for file changes
   --debug      Generate source maps
+  --minify     Minify bundles (**SLOW**); Disables source maps
   --tests      Generate test bundles
   --list       List browserify dependencies
   --vendor     Generate vendor bundle and copy assets
@@ -48,6 +50,7 @@ while [[ -n $1 ]]; do
     case $1 in
         --watch) ENABLE_WATCH=1 ;;
         --debug) ENABLE_DEBUG=1 ;;
+        --minify) ENABLE_MINIFY=1 ;;
         --tests) ENABLE_TESTS=1 ;;
         --list) LIST_DEPS=1 ;;
         --vendor) BUILD_VENDOR_BUNDLE=1 ;;
@@ -70,6 +73,10 @@ if [ -n "$ENABLE_DEBUG" ]; then
     BROWSERIFY="$BROWSERIFY --debug"
     NODE_SASS="$NODE_SASS --source-map ${STATIC_CSS_DIR}main.css.map \
         --source-map-contents"
+fi
+
+if [ -n "$ENABLE_MINIFY" ]; then
+    EXTRA_ARGS="$MINIFY_PLUGIN $EXTRA_ARGS"
 fi
 
 if [ -n "$LIST_DEPS" ]; then

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -1397,6 +1397,352 @@
       "from": "lodash@3.6.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
     },
+    "minifyify": {
+      "version": "7.0.0",
+      "from": "minifyify@*",
+      "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.4.8",
+          "from": "concat-stream@>=1.4.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "1.1.1",
+          "from": "convert-source-map@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+        },
+        "lodash.bind": {
+          "version": "3.1.0",
+          "from": "lodash.bind@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
+          "dependencies": {
+            "lodash._createwrapper": {
+              "version": "3.0.6",
+              "from": "lodash._createwrapper@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.6.tgz",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                },
+                "lodash._basecreate": {
+                  "version": "3.0.2",
+                  "from": "lodash._basecreate@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.2.tgz"
+                }
+              }
+            },
+            "lodash._replaceholders": {
+              "version": "3.0.0",
+              "from": "lodash._replaceholders@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz"
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            }
+          }
+        },
+        "lodash.defaults": {
+          "version": "3.1.1",
+          "from": "lodash.defaults@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.1.tgz",
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "from": "lodash.assign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash._createassigner": {
+                  "version": "3.1.1",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.9",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.1",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.0",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.3",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.3",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            }
+          }
+        },
+        "lodash.foreach": {
+          "version": "3.0.3",
+          "from": "lodash.foreach@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
+          "dependencies": {
+            "lodash._arrayeach": {
+              "version": "3.0.0",
+              "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+            },
+            "lodash._baseeach": {
+              "version": "3.0.4",
+              "from": "lodash._baseeach@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+              "dependencies": {
+                "lodash.keys": {
+                  "version": "3.1.1",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.0",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.3",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+            },
+            "lodash.isarray": {
+              "version": "3.0.3",
+              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.4.2",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.7",
+          "from": "through@>=2.3.6 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+        },
+        "tmp": {
+          "version": "0.0.25",
+          "from": "tmp@>=0.0.25 <0.0.26",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz"
+        },
+        "transform-filter": {
+          "version": "0.1.1",
+          "from": "transform-filter@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/transform-filter/-/transform-filter-0.1.1.tgz",
+          "dependencies": {
+            "multimatch": {
+              "version": "2.0.0",
+              "from": "multimatch@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+              "dependencies": {
+                "array-differ": {
+                  "version": "1.0.0",
+                  "from": "array-differ@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                },
+                "array-union": {
+                  "version": "1.0.1",
+                  "from": "array-union@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "1.0.2",
+                      "from": "array-uniq@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.4.23",
+          "from": "uglify-js@>=2.4.16 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "source-map@0.1.34",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.5.4",
+              "from": "yargs@>=3.5.4 <3.6.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.1.0",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                },
+                "decamelize": {
+                  "version": "1.0.0",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "window-size@0.1.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "mocha": {
       "version": "2.0.1",
       "from": "mocha@2.0.1",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -29,6 +29,7 @@
     "leaflet": "0.7.3",
     "leaflet-draw": "0.2.3",
     "lodash": "3.6.0",
+    "minifyify": "7.0.0",
     "mocha": "2.0.1",
     "node-sass": "3.1.1",
     "nunjucks": "1.3.4",


### PR DESCRIPTION
Use the `--minify` flag to generate minified bundles. Note that this is
a slow operation and also disables source maps.

Could be used to minify *just* the vendor bundle for development and
testing over slow network connections.

    ./scripts/bundle.sh --vendor --minify

Fixes #68