### PR TITLE
ITSI Registration front-end

### DIFF
--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -15,4 +15,5 @@ urlpatterns = patterns(
     url(r'^analyze$', home_page, name='analyze'),
     url(r'^compare$', compare, name='compare'),
     url(r'^error', home_page, name='error'),
+    url(r'^sign-up', home_page, name='sign_up'),
 )

--- a/src/mmw/apps/user/urls.py
+++ b/src/mmw/apps/user/urls.py
@@ -11,14 +11,14 @@ from apps.user.views import (login,
                              logout,
                              itsi_login,
                              itsi_auth,
-                             itsi_register)
+                             itsi_sign_up)
 
 urlpatterns = patterns(
     '',
     url(r'^logout$', logout, name='logout'),
     url(r'^itsi/login$', itsi_login, name='itsi_login'),
     url(r'^itsi/authenticate$', itsi_auth, name='itsi_auth'),
-    url(r'^itsi/register$', itsi_register, name='itsi_register'),
+    url(r'^itsi/sign_up', itsi_sign_up, name='itsi_sign_up'),
     url(r'^login$', login, name='login'),
     url(r'^sign_up$', sign_up, name='sign_up'),
     url(r'^forgot$', forgot, name='forgot')

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -20,7 +20,6 @@ var App = new Marionette.Application({
 
         this.rootView = new views.RootView();
         this.user = new userModels.UserModel({});
-        this.getUserOrShowLogin();
 
         var header = new views.HeaderView({
             el: 'header',

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -39,6 +39,13 @@ App.on('start', function() {
         router.navigate($(this).data('url'), { trigger: true });
     });
     Backbone.history.start({ pushState: true });
+
+    // Show login modal only if landing on home page
+    if (Backbone.history.getFragment() === "") {
+        this.getUserOrShowLogin();
+    } else {
+        this.user.fetch();
+    }
 });
 
 App.start();

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -17,3 +17,4 @@ router.addRoute('model/:projectId/', ModelingController, 'model');
 router.addRoute(/^compare/, AppController, 'compare');
 router.addRoute('error(/)(:type)', ErrorController, 'error');
 router.addRoute('sign-up(/)', SignUpController, 'signUp');
+router.addRoute('sign-up/itsi(/)(:username)(/:first_name)(/:last_name)', SignUpController, 'itsiSignUp');

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -4,6 +4,7 @@ var router = require('./router').router,
     controllers = require('./controllers'),
     AppController = controllers.AppController,
     ErrorController = require('./core/error/controllers').ErrorController,
+    SignUpController = require('./user/controllers').SignUpController,
     DrawController = require('./draw/controllers').DrawController,
     ModelingController = require('./modeling/controllers').ModelingController,
     AnalyzeController = require('./analyze/controllers').AnalyzeController;
@@ -15,3 +16,4 @@ router.addRoute('model/:projectId', ModelingController, 'model');
 router.addRoute('model/:projectId/', ModelingController, 'model');
 router.addRoute(/^compare/, AppController, 'compare');
 router.addRoute('error(/)(:type)', ErrorController, 'error');
+router.addRoute('sign-up(/)', SignUpController, 'signUp');

--- a/src/mmw/js/src/user/controllers.js
+++ b/src/mmw/js/src/user/controllers.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var App = require('../app'),
+    models = require('./models'),
+    views = require('./views');
+
+var SignUpController = {
+    signUp: function() {
+        new views.SignUpModalView({
+            model: new models.SignUpFormModel({})
+        }).render();
+    }
+};
+
+module.exports = {
+    SignUpController: SignUpController
+};

--- a/src/mmw/js/src/user/controllers.js
+++ b/src/mmw/js/src/user/controllers.js
@@ -9,6 +9,17 @@ var SignUpController = {
         new views.SignUpModalView({
             model: new models.SignUpFormModel({})
         }).render();
+    },
+
+    itsiSignUp: function(username, first_name, last_name) {
+        new views.ItsiSignUpModalView({
+            app: App,
+            model: new models.ItsiSignUpFormModel({
+                username: username,
+                first_name: first_name,
+                last_name: last_name
+            })
+        }).render();
     }
 };
 

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -175,9 +175,54 @@ var ForgotFormModel = ModalBaseModel.extend({
     }
 });
 
+var ItsiSignUpFormModel = ModalBaseModel.extend({
+    defaults: {
+        username: null,
+        first_name: null,
+        last_name: null,
+        agreed: false
+    },
+
+    url: '/user/itsi/sign_up',
+
+    validate: function(attrs) {
+        var errors = [];
+
+        if (!attrs.username) {
+            errors.push('Please enter a username');
+        }
+
+        if (!attrs.first_name) {
+            errors.push('Please enter a first name');
+        }
+
+        if (!attrs.last_name) {
+            errors.push('Please enter a last name');
+        }
+
+        if (!attrs.agreed) {
+            errors.push('Please check the agreement');
+        }
+
+        if (errors.length) {
+            this.set({
+                'client_errors': errors,
+                'server_errors': null
+            });
+            return errors;
+        } else {
+            this.set({
+                'client_errors': null,
+                'server_errors': null
+            })
+        }
+    }
+});
+
 module.exports = {
     UserModel: UserModel,
     LoginFormModel: LoginFormModel,
     SignUpFormModel: SignUpFormModel,
-    ForgotFormModel: ForgotFormModel
+    ForgotFormModel: ForgotFormModel,
+    ItsiSignUpFormModel: ItsiSignUpFormModel
 };

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -16,7 +16,10 @@ var UserModel = Backbone.Model.extend({
         return this.fetch({
             type: 'POST',
             url: '/user/login',
-            data: attrs
+            data: {
+                'username': attrs.username,
+                'password': attrs.password
+            }
         });
     },
 
@@ -42,19 +45,24 @@ var UserModel = Backbone.Model.extend({
     }
 });
 
-var LoginFormModel = Backbone.Model.extend({
+var ModalBaseModel = Backbone.Model.extend({
     defaults: {
-        validationErrors: null,
+        success: false,
+        client_errors: null,
+        server_errors: null
+    }
+});
+
+var LoginFormModel = ModalBaseModel.extend({
+    defaults: {
         username: null,
-        password: null,
-        loginError: null
+        password: null
     },
 
-    validate: function(attrs, options) {
-        var errors = [];
+    url: '/user/login',
 
-        this.set('validationErrors', null);
-        this.set('loginError', null);
+    validate: function(attrs) {
+        var errors = [];
 
         if (!attrs.username) {
             errors.push('Please enter a username');
@@ -64,41 +72,41 @@ var LoginFormModel = Backbone.Model.extend({
             errors.push('Please enter a password');
         }
 
-        if (errors.length >= 1) {
-            this.set('validationErrors', errors);
+        if (errors.length) {
+            this.set({
+                'client_errors': errors,
+                'server_errors': null
+            });
             return errors;
+        } else {
+            this.set({
+                'client_errors': null,
+                'server_errors': null
+            })
         }
     }
 });
 
-var SignUpFormModel = Backbone.Model.extend({
+var SignUpFormModel = ModalBaseModel.extend({
     defaults: {
         username: null,
         password1: null,
         password2: null,
         email: null,
-        agreed: false,
-        clientErrors: null,
-        serverErrors: null,
-        success: false
+        agreed: false
     },
 
     url: '/user/sign_up',
 
-    validate: function(attrs, options) {
+    validate: function(attrs) {
         var errors = [];
-
-        this.set({
-            'clientErrors': null,
-            'serverErrors': null
-        });
 
         if (!attrs.username) {
             errors.push('Please enter a username');
         }
 
         if (!attrs.email) {
-            errors.push('Please enter an email addresss');
+            errors.push('Please enter an email address');
         }
 
         if (!attrs.password1) {
@@ -109,61 +117,40 @@ var SignUpFormModel = Backbone.Model.extend({
             errors.push('Please repeat the password');
         }
 
+        if (!(attrs.password1 === attrs.password2)) {
+            errors.push('Passwords do not match');
+        }
+
         if (!attrs.agreed) {
             errors.push('Please check the agreement');
         }
 
-        if (errors.length >= 1) {
-            this.set('clientErrors', errors);
+        if (errors.length) {
+            this.set({
+                'client_errors': errors,
+                'server_errors': null
+            });
             return errors;
-        }
-    },
-
-    getServerErrors: function(serverResponse) {
-        var errors = [];
-
-        this.set({
-            'clientErrors': null,
-            'serverErrors': null
-        });
-
-        if (serverResponse) {
-            if (!serverResponse['email_valid']) {
-                errors.push('Email is invalid or already in use');
-            }
-            if (!serverResponse['password_valid']) {
-                errors.push('Passwords are invalid or do not match');
-            }
-            if (!serverResponse['username_valid']) {
-                errors.push('User name is invalid or already in use');
-            }
-        }
-
-        if (errors.length >= 1) {
-            this.set('serverErrors', errors);
+        } else {
+            this.set({
+                'client_errors': null,
+                'server_errors': null
+            })
         }
     }
 });
 
-var ForgotFormModel = Backbone.Model.extend({
+var ForgotFormModel = ModalBaseModel.extend({
     defaults: {
-        success: null,
-        clientErrors: null,
-        serverErrors: null,
-        email: null,
         username: false,
-        password: false
+        password: false,
+        email: null
     },
 
     url: '/user/forgot',
 
-    validate: function(attrs, options) {
+    validate: function(attrs) {
         var errors = [];
-
-        this.set({
-            'clientErrors': null,
-            'serverErrors': null
-        });
 
         if (!attrs.email) {
             errors.push('Please enter an email address');
@@ -173,26 +160,17 @@ var ForgotFormModel = Backbone.Model.extend({
             errors.push('Please check user name and/or password');
         }
 
-        if (errors.length >= 1) {
-            this.set('clientErrors', errors);
+        if (errors.length) {
+            this.set({
+                'client_errors': errors,
+                'server_errors': null
+            });
             return errors;
-        }
-    },
-
-    getServerErrors: function(response) {
-        var errors = [];
-
-        this.set({
-            'clientErrors': null,
-            'serverErrors': null
-        });
-
-        if (!response['email_valid']) {
-            errors.push('Email is invalid');
-        }
-
-        if (errors.length >= 1) {
-            this.set('serverErrors', errors);
+        } else {
+            this.set({
+                'client_errors': null,
+                'server_errors': null
+            })
         }
     }
 });

--- a/src/mmw/js/src/user/templates/baseModal.html
+++ b/src/mmw/js/src/user/templates/baseModal.html
@@ -1,0 +1,59 @@
+{% macro field(value, name, label='', type='text') %}
+    <div class="custom-input-group">
+        <input name="{{ name }}" type="{{ type }}" id="{{ name }}" required value="{{ value }}">
+        <span class="highlight"></span>
+        <span class="bar"></span>
+        <label>{{ label }}</label>
+    </div>
+{% endmacro %}
+
+{% macro checkbox(value, name, label='') %}
+    <div class="checkbox">
+        <label>
+            <input name="{{ name }}" type="checkbox" id="{{ name }}" {{ "checked" if value else "" }}>
+            {{ label }}
+        </label>
+    </div>
+{% endmacro %}
+
+<div class="modal-dialog modal-dialog-sm">
+    <div class="modal-content">
+        <div class="modal-header">
+            {% block header %}
+                <h2 class="light">Model My Watershed</h2>
+            {% endblock %}
+        </div>
+
+        <div class="modal-body">
+            {% block preamble %}
+            {% endblock %}
+
+            {% block errors %}
+                {% if client_errors %}
+                    <ul>
+                        {% for error in client_errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                {% if server_errors %}
+                    <ul>
+                        {% for error in server_errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            {% endblock %}
+
+            <form>
+                {% block form %}
+                {% endblock %}
+            </form>
+        </div>
+
+        <div class="modal-footer">
+            {% block footer %}
+            {% endblock %}
+        </div>
+    </div>
+</div>

--- a/src/mmw/js/src/user/templates/forgotModal.html
+++ b/src/mmw/js/src/user/templates/forgotModal.html
@@ -1,65 +1,19 @@
-<div class="modal-dialog modal-dialog-sm" id="forgot-modal">
-    <div class="modal-content">
-        <div class="modal-header">
-            <h2 class="light">Model My Watershed</h2>
-        </div>
+{% extends './baseModal.html' %}
 
-        <div class="modal-body">
-           {% if clientErrors %}
-                <ul>
-                    {% for error in clientErrors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-            {% if serverErrors %}
-                <ul>
-                    {% for error in serverErrors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
+{% block form %}
+    {% if success %}
+        Please check your email to reset your account.
+    {% else %}
+        {{ field(email, 'email', 'Email', 'email') }}
+        {{ checkbox(username, 'username', 'Forgot Username') }}
+        {{ checkbox(password, 'password', 'Forgot Password') }}
+    {% endif %}
+{% endblock %}
 
-            {% if success %}
-                Please check your email to reset your account.
-            {% else %}
-                <form>
-                    <div class="custom-input-group">
-                        <input name="email" type="text" id="email" required value="{{ email }}">
-                        <span class="highlight"></span>
-                        <span class="bar"></span>
-                        <label>Email</label>
-                    </div>
-                    <div class="checkbox">
-                        <label>
-                            {% if username %}
-                                <input name="username" type="checkbox" id="username" checked>
-                            {% else %}
-                                <input name="username" type="checkbox" id="username">
-                            {% endif %}
-                            Forgot Username
-                        </label>
-                    </div>
-                    <div class="checkbox">
-                        <label>
-                            {% if password %}
-                                <input name="password" type="checkbox" id="password" checked>
-                            {% else %}
-                                <input name="password" type="checkbox" id="password">
-                            {% endif %}
-                            Forgot Password
-                        </label>
-                    </div>
-                </form>
-            {% endif %}
-        </div>
-
-        <div class="modal-footer">
-            {% if success %}
-                <button type="button" class="btn btn-lg btn-block btn-active" data-dismiss="modal">Continue As Guest</button>
-            {% else %}
-                <button type="button" class="btn btn-lg btn-block btn-active" id="retrieve-button">Retrieve</button>
-            {% endif %}
-        </div>
-    </div>
-</div>
+{% block footer %}
+    {% if success %}
+        <button type="button" class="btn btn-lg btn-block btn-active" data-dismiss="modal">Continue As Guest</button>
+    {% else %}
+        <button type="button" class="btn btn-lg btn-block btn-active" id="primary-button">Retrieve</button>
+    {% endif %}
+{% endblock %}

--- a/src/mmw/js/src/user/templates/itsiSignUpModal.html
+++ b/src/mmw/js/src/user/templates/itsiSignUpModal.html
@@ -1,0 +1,13 @@
+{% extends './baseModal.html' %}
+
+{% block form %}
+    {{ field(username, 'username', 'Username') }}
+    {{ field(first_name, 'first_name', 'First Name') }}
+    {{ field(last_name, 'last_name', 'Last Name') }}
+    {{ checkbox(agreed, 'agreed', 'I agree to something') }}
+{% endblock %}
+
+{% block footer %}
+    <button type="button" class="btn btn-lg btn-block btn-active margin-bottom-sm" id="primary-button">Sign Up with ITSI</button>
+    <button type="button" class="btn btn-lg btn-block btn-primary" data-dismiss="modal" id="dismiss-button">Continue As Guest</button>
+{% endblock %}

--- a/src/mmw/js/src/user/templates/loginModal.html
+++ b/src/mmw/js/src/user/templates/loginModal.html
@@ -1,46 +1,20 @@
-<div class="modal-dialog modal-dialog-sm" id="login-modal">
-    <div class="modal-content">
-        <div class="modal-header">
-            <h2 class="light">Model My Watershed</h2>
-        </div>
-        <div class="modal-body">
-            <div class="forgot">
-                <button type="button" class="btn btn-sm btn-default">Forgot?</button>
-            </div>
-            <div class="sign-up">
-                <button type="button" class="btn btn-sm btn-default" data-dismiss="modal">Sign Up</button>
-            </div>
-            {% if validationErrors %}
-                <ul>
-                    {% for error in validationErrors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-            <form>
-                <div class="custom-input-group">
-                    <input name="username" type="text" id="id_username" required value="{{ username }}">
-                    <span class="highlight"></span>
-                    <span class="bar"></span>
-                    <label>Username</label>
-                    {% if loginError %}
-                        <span class="error">Incorrect username or password</span>
-                    {% endif %}
-                </div>
-                <div class="custom-input-group">
-                    <input name="password" type="password" id="id_password" required value="{{ password }}">
-                    <span class="highlight"></span>
-                    <span class="bar"></span>
-                    <label>Password</label>
-                    {% if loginError %}
-                        <span class="error">Incorrect username or password</span>
-                    {% endif %}
-                </div>
-            </form>
-        </div>
-        <div class="modal-footer">
-            <button type="button" class="btn btn-lg btn-block btn-primary margin-bottom-sm" data-dismiss="modal" id="continue-as-guest">Continue As Guest</button>
-            <button type="button" class="btn btn-lg btn-block btn-active" id="login-button">Sign In</button>
-        </div>
+{% extends './baseModal.html' %}
+
+{% block preamble %}
+    <div class="forgot">
+        <button type="button" class="btn btn-sm btn-default">Forgot?</button>
     </div>
-</div>
+    <div class="sign-up">
+        <button type="button" class="btn btn-sm btn-default" data-dismiss="modal">Sign Up</button>
+    </div>
+{% endblock %}
+
+{% block form %}
+    {{ field(username, 'username', 'Username') }}
+    {{ field(password, 'password', 'Password', 'password') }}
+{% endblock %}
+
+{% block footer %}
+    <button type="button" class="btn btn-lg btn-block btn-primary margin-bottom-sm" data-dismiss="modal" id="dismiss-button">Continue as Guest</button>
+    <button type="button" class="btn btn-lg btn-block btn-active" id="primary-button">Sign In</button>
+{% endblock %}

--- a/src/mmw/js/src/user/templates/loginModal.html
+++ b/src/mmw/js/src/user/templates/loginModal.html
@@ -15,6 +15,14 @@
 {% endblock %}
 
 {% block footer %}
-    <button type="button" class="btn btn-lg btn-block btn-primary margin-bottom-sm" data-dismiss="modal" id="dismiss-button">Continue as Guest</button>
-    <button type="button" class="btn btn-lg btn-block btn-active" id="primary-button">Sign In</button>
+    <div class="row">
+        <button type="button" class="btn btn-lg btn-block btn-active" id="primary-button">Sign In</button>
+    </div>
+    <div class="text-muted" id="continue-as-divider">
+        Or continue as
+    </div>
+    <div class="row" id="guest-buttons">
+        <button type="button" class="btn btn-lg btn-primary" data-dismiss="modal" id="dismiss-button">Guest</button>
+        <a href="/user/itsi/login" class="btn btn-lg btn-primary">ITSI</a>
+    </div>
 {% endblock %}

--- a/src/mmw/js/src/user/templates/signUpModal.html
+++ b/src/mmw/js/src/user/templates/signUpModal.html
@@ -1,73 +1,21 @@
-<div class="modal-dialog modal-dialog-sm" id="sign-up-modal">
-    <div class="modal-content">
-        <div class="modal-header">
-            <h2 class="light">Model My Watershed</h2>
-        </div>
+{% extends './baseModal.html' %}
 
-        <div class="modal-body">
-            {% if clientErrors %}
-                <ul>
-                    {% for error in clientErrors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-            {% if serverErrors %}
-                <ul>
-                    {% for error in serverErrors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
+{% block form %}
+    {% if success %}
+        Sign up was successful! Please check your email to active your account.
+    {% else %}
+        {{ field(username, 'username', 'Username') }}
+        {{ field(email, 'email', 'Email') }}
+        {{ field(password1, 'password1', 'Password', 'password') }}
+        {{ field(password2, 'password2', 'Repeat Password', 'password') }}
+        {{ checkbox(agreed, 'agreed', 'I agree to something') }}
+    {% endif %}
+{% endblock %}
 
-            {% if success %}
-                Sign up was successful! Please check your email to active your account.
-            {% else %}
-                <form>
-                    <div class="custom-input-group">
-                        <input name="username" type="text" id="username" required value="{{ username }}">
-                        <span class="highlight"></span>
-                        <span class="bar"></span>
-                        <label>Username</label>
-                    </div>
-                    <div class="custom-input-group">
-                        <input name="email" type="text" id="email" required value="{{ email }}">
-                        <span class="highlight"></span>
-                        <span class="bar"></span>
-                        <label>Email</label>
-                    </div>
-                    <div class="custom-input-group">
-                        <input name="password1" type="password" id="password1" required value="{{ password1 }}">
-                        <span class="highlight"></span>
-                        <span class="bar"></span>
-                        <label>Password</label>
-                    </div>
-                    <div class="custom-input-group">
-                        <input name="password2" type="password" id="password2" required value="{{ password2 }}">
-                        <span class="highlight"></span>
-                        <span class="bar"></span>
-                        <label>Repeat Password</label>
-                    </div>
-                    <div class="checkbox">
-                        <label>
-                            {% if agreed %}
-                                <input type="checkbox" id="agreed" checked>
-                            {% else %}
-                                <input type="checkbox" id="agreed">
-                            {% endif %}
-                            I agree to something
-                        </label>
-                    </div>
-                </form>
-            {% endif %}
-        </div>
-
-        <div class="modal-footer">
-            {% if success %}
-                <button type="button" class="btn btn-lg btn-block btn-active" data-dismiss="modal">Continue As Guest</button>
-            {% else %}
-                <button type="button" class="btn btn-lg btn-block btn-active" id="sign-up-button">Sign Up</button>
-            {% endif %}
-        </div>
-    </div>
-</div>
+{% block footer %}
+    {% if success %}
+        <button type="button" class="btn btn-lg btn-block btn-active" data-dismiss="modal">Continue As Guest</button>
+    {% else %}
+        <button type="button" class="btn btn-lg btn-block btn-active" id="primary-button">Sign Up</button>
+    {% endif %}
+{% endblock %}

--- a/src/mmw/js/src/user/tests.js
+++ b/src/mmw/js/src/user/tests.js
@@ -42,9 +42,9 @@ describe('User', function() {
                 app: App
             }).render();
 
-            loginView.$el.find('#id_username').val('');
-            loginView.$el.find('#id_password').val('password');
-            loginView.$el.find('#login-button').click();
+            loginView.$el.find('#username').val('');
+            loginView.$el.find('#password').val('password');
+            loginView.$el.find('#primary-button').click();
             var validationError = loginView.$el.find('ul li').first().text();
             assert.equal(validationError, 'Please enter a username', 'Could not find missing username message.');
         });
@@ -56,27 +56,27 @@ describe('User', function() {
                 app: App
             }).render();
 
-            loginView.$el.find('#id_username').val('bob');
-            loginView.$el.find('#id_password').val('');
-            loginView.$el.find('#login-button').click();
+            loginView.$el.find('#username').val('bob');
+            loginView.$el.find('#password').val('');
+            loginView.$el.find('#primary-button').click();
             var validationError = loginView.$el.find('ul li').first().text();
             assert.equal(validationError, 'Please enter a password', 'Could not find missing password message.');
         });
 
         it('creates an error when trying to fetch a user with bad credentials', function() {
-            this.server.respondWith([400, { 'Content-Type': 'application/json' }, '{"result": "error"}']);
+            this.server.respondWith([400, { 'Content-Type': 'application/json' }, '{"errors": ["Invalid username or password"], "guest": true}']);
             var loginView = new views.LoginModalView({
                 el: '#sandbox',
                 model: new models.LoginFormModel({}),
                 app: App
             }).render();
 
-            loginView.$el.find('#id_username').val('bad');
-            loginView.$el.find('#id_password').val('apple');
-            loginView.$el.find('#login-button').click();
-            var validationError = loginView.$el.find('span.error').first().text();
+            loginView.$el.find('#username').val('bad');
+            loginView.$el.find('#password').val('apple');
+            loginView.$el.find('#primary-button').click();
+            var validationError = loginView.$el.find('ul li').first().text();
 
-            assert.equal(validationError, 'Incorrect username or password', 'Could not find failed login message.');
+            assert.equal(validationError, 'Invalid username or password', 'Could not find failed login message.');
         });
 
         it('logs the user in when there is a valid response', function() {
@@ -91,9 +91,9 @@ describe('User', function() {
             loginView.$el.modal('show');
             assert.ok(loginView.$el.is(':visible'), 'Modal is not visible');
 
-            loginView.$el.find('#id_username').val(username);
-            loginView.$el.find('#id_password').val(username);
-            loginView.$el.find('#login-button').click();
+            loginView.$el.find('#username').val(username);
+            loginView.$el.find('#password').val(username);
+            loginView.$el.find('#primary-button').click();
 
             assert.notOk(loginView.$el.is(':visible'), 'Modal should no longer be visible.');
             assert.equal(App.user.get('username'), username, 'Could not get username.');
@@ -115,11 +115,11 @@ describe('User', function() {
             loginView.$el.modal('show');
             assert.ok(loginView.$el.is(':visible'), 'Modal is not visible');
 
-            loginView.$el.find('#id_username').val(username);
-            loginView.$el.find('#id_password').val(username);
+            loginView.$el.find('#username').val(username);
+            loginView.$el.find('#password').val(username);
             var e = $.Event('keyup');
             e.keyCode = ENTER_KEYCODE;
-            loginView.$el.find('#id_password').trigger(e);
+            loginView.$el.find('#password').trigger(e);
 
             assert.notOk(loginView.$el.is(':visible'), 'Modal should no longer be visible.');
 
@@ -145,7 +145,7 @@ describe('User', function() {
 
             var e = $.Event('keyup');
             e.keyCode = 22;
-            loginView.$el.find('#id_password').trigger(e);
+            loginView.$el.find('#password').trigger(e);
 
             assert.ok(loginView.$el.is(':visible'), 'Modal still be visible.');
         });

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -3,6 +3,7 @@
 var _ = require('underscore'),
     $ = require('jquery'),
     Marionette = require('../../shim/backbone.marionette'),
+    router = require('../router').router,
     models = require('./models'),
     loginModalTmpl = require('./templates/loginModal.html'),
     signUpModalTmpl = require('./templates/signUpModal.html'),
@@ -155,9 +156,7 @@ var LoginModalView = ModalBaseView.extend({
     signUp: function() {
         this.$el.modal('hide');
         this.$el.on('hidden.bs.modal', function() {
-            new SignUpModalView({
-                model: new models.SignUpFormModel({})
-            }).render();
+            router.navigate('/sign-up', { trigger: true });
         });
     },
 
@@ -185,6 +184,9 @@ var SignUpModalView = ModalBaseView.extend({
 
     initialize: function(options) {
         ModalBaseView.prototype.initialize(this, options);
+        this.$el.on('hidden.bs.modal', function() {
+            router.navigate('', { trigger: true });
+        });
     },
 
     setFields: function() {

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -7,7 +7,8 @@ var _ = require('underscore'),
     models = require('./models'),
     loginModalTmpl = require('./templates/loginModal.html'),
     signUpModalTmpl = require('./templates/signUpModal.html'),
-    forgotModalTmpl = require('./templates/forgotModal.html');
+    forgotModalTmpl = require('./templates/forgotModal.html'),
+    itsiSignUpModalTmpl = require('./templates/itsiSignUpModal.html');
 
 var ENTER_KEYCODE = 13;
 
@@ -222,8 +223,58 @@ var ForgotModalView = ModalBaseView.extend({
     }
 });
 
+var ItsiSignUpModalView = ModalBaseView.extend({
+    template: itsiSignUpModalTmpl,
+
+    ui: {
+        'username': '#username',
+        'first_name': '#first_name',
+        'last_name': '#last_name',
+        'agreed': '#agreed'
+    },
+
+    initialize: function(options) {
+        ModalBaseView.prototype.initialize(this, options);
+        this.$el.on('hidden.bs.modal', function() {
+            router.navigate('', { trigger: true });
+        });
+    },
+
+    setFields: function() {
+        this.model.set({
+            username: $(this.ui.username.selector).val(),
+            first_name: $(this.ui.first_name.selector).val(),
+            last_name: $(this.ui.last_name.selector).val(),
+            agreed: $(this.ui.agreed.selector).prop('checked')
+        }, { silent: true });
+    },
+
+    // Override to provide custom success handler
+    primaryAction: function() {
+        var formData = this.$el.find('form').serialize();
+        this.model
+            .fetch({
+                method: 'POST',
+                data: formData
+            })
+            .done(_.bind(this.handleSuccess, this))
+            .fail(_.bind(this.handleServerFailure, this));
+    },
+
+    // User account has been created and user has been logged in.
+    // Dismiss modal and update App user state.
+    handleSuccess: function(response) {
+        this.$el.modal('hide');
+        this.app.user.set({
+            'username': response.username,
+            'guest': false
+        });
+    }
+});
+
 module.exports = {
     LoginModalView: LoginModalView,
     SignUpModalView: SignUpModalView,
-    ForgotModalView: ForgotModalView
+    ForgotModalView: ForgotModalView,
+    ItsiSignUpModalView: ItsiSignUpModalView
 };

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -10,35 +10,37 @@ var _ = require('underscore'),
 
 var ENTER_KEYCODE = 13;
 
-var LoginModalView = Marionette.ItemView.extend({
-    template: loginModalTmpl,
+var ModalBaseView = Marionette.ItemView.extend({
     className: 'modal modal-large fade',
+
     ui: {
-        'loginButton': '#login-button',
-        'continueAsGuest': '#continue-as-guest',
-        // The id names come from the default Django login form
-        'username': '#id_username',
-        'password': '#id_password',
-        'signUp': '.sign-up',
-        'forgot': '.forgot',
-        'loginModal': '#login-modal'
+        primary_button: '#primary-button',
+        dismiss_button: '#dismiss-button'
     },
 
     events: {
-        'click @ui.loginButton': 'validate',
-        'keyup @ui.loginModal': 'handleKeyUpEvent',
-        'click @ui.continueAsGuest': 'continueAsGuest',
-        'click @ui.signUp': 'signUp',
-        'click @ui.forgot': 'forgot'
+        'keyup input': 'handleKeyUpEvent',
+        'click @ui.primary_button': 'validate',
+        'click @ui.dismiss_button': 'dismissAction'
     },
 
-    initialize: function(options) {
-        this.app = options.app;
-        this.listenTo(this.model, 'change', this.render);
-        var self = this;
-        this.$el.on('hidden.bs.modal', function() {
-            self.destroy();
-        });
+    modalViewOptions: ['app'],
+
+    // Combine base and child `ui` and `event` hashes,
+    // import `app` if specified,
+    // initialize common routines and handlers.
+    initialize: function(child, options) {
+        child.ui = _.extend(child.ui, this.ui);
+        child.events = _.extend(child.events, this.events);
+
+        child.mergeOptions(options, child.modalViewOptions);
+
+        child.listenTo(child.model, 'change', child.render);
+        child.$el.on('hidden.bs.modal', _.bind(this.onModalHidden, child));
+    },
+
+    onModalHidden: function() {
+        this.destroy();
     },
 
     onRender: function() {
@@ -49,6 +51,74 @@ var LoginModalView = Marionette.ItemView.extend({
         if (e.keyCode === ENTER_KEYCODE) {
             this.validate();
         }
+    },
+
+    // Primary Action might be "log in" or "sign up" or "reset password".
+    // By default this serializes all form data and POSTs to child's `url`.
+    // Override if other behavior is required.
+    primaryAction: function() {
+        var formData = this.$el.find('form').serialize();
+        this.model
+            .fetch({
+                method: 'POST',
+                data: formData
+            })
+            .done(_.bind(this.handleServerSuccess, this))
+            .fail(_.bind(this.handleServerFailure, this));
+    },
+
+    handleServerSuccess: function() {
+        this.model.set({
+            'success': true,
+            'client_errors': null,
+            'server_errors': null
+        });
+    },
+
+    // Default failure handler, will display any `errors` received from server.
+    handleServerFailure: function(response) {
+        var server_errors = ["Server communication error"];
+        if (response.responseJSON.errors) {
+            server_errors = response.responseJSON.errors;
+        }
+        this.model.set({
+            'success': false,
+            'client_errors': null,
+            'server_errors': server_errors
+        });
+    },
+
+    // Dismiss Action can be "cancel" or "continue as guest". Noop by default.
+    // Override if other behavior is required.
+    dismissAction: function() { },
+
+    // Performs Primary Action if model is in valid state.
+    // `setFields` must be defined on child.
+    validate: function() {
+        this.setFields();
+        if (this.model.isValid()) {
+            this.primaryAction();
+        }
+    }
+});
+
+var LoginModalView = ModalBaseView.extend({
+    template: loginModalTmpl,
+
+    ui: {
+        username: '#username',
+        password: '#password',
+        signUp:   '.sign-up',
+        forgot:   '.forgot'
+    },
+
+    events: {
+        'click @ui.signUp': 'signUp',
+        'click @ui.forgot': 'forgot'
+    },
+
+    initialize: function(options) {
+        ModalBaseView.prototype.initialize(this, options);
     },
 
     setFields: function() {
@@ -58,26 +128,30 @@ var LoginModalView = Marionette.ItemView.extend({
         }, { silent: true });
     },
 
-    validate: function() {
-        this.setFields();
-
-        var errors = this.model.validate(this.model.attributes);
-
-        if (!errors) {
-            this.login();
-        }
-    },
-
-    login: function() {
+    // Login
+    primaryAction: function() {
         this.app.user
-            .login({
-                username: this.model.get('username'),
-                password: this.model.get('password')
-            })
+            .login(this.model.attributes)
             .done(_.bind(this.handleSuccess, this))
-            .fail(_.bind(this.handleFail, this));
+            .fail(_.bind(this.handleFailure, this));
     },
 
+    handleSuccess: function() {
+        this.$el.modal('hide');
+        this.app.user.set('guest', false);
+    },
+
+    handleFailure: function(response) {
+        this.handleServerFailure(response);
+        this.app.user.set('guest', true);
+    },
+
+    // Continue as Guest
+    dismissAction: function() {
+        this.app.user.set('guest', true);
+    },
+
+    // Sign Up
     signUp: function() {
         this.$el.modal('hide');
         this.$el.on('hidden.bs.modal', function() {
@@ -87,6 +161,7 @@ var LoginModalView = Marionette.ItemView.extend({
         });
     },
 
+    // Forgot
     forgot: function() {
         this.$el.modal('hide');
         this.$el.on('hidden.bs.modal', function() {
@@ -94,61 +169,22 @@ var LoginModalView = Marionette.ItemView.extend({
                 model: new models.ForgotFormModel({})
             }).render();
         });
-    },
-
-    continueAsGuest: function() {
-        this.app.user.set('guest', true);
-    },
-
-    handleSuccess: function() {
-        this.$el.modal('hide');
-        this.app.user.set('guest', false);
-    },
-
-    handleFail: function() {
-        this.model.set('loginError', true);
-        this.app.user.set('guest', true);
     }
 });
 
-
-var SignUpModalView = Marionette.ItemView.extend({
+var SignUpModalView = ModalBaseView.extend({
     template: signUpModalTmpl,
 
-    className: 'modal modal-large fade',
-
     ui: {
-        'signUpButton': '#sign-up-button',
-        // The id names come from the default Django login form
         'username': '#username',
         'email': '#email',
         'password1': '#password1',
         'password2': '#password2',
-        'agreed': '#agreed',
-        'signUpModal': '#sign-up-modal'
+        'agreed': '#agreed'
     },
 
-    events: {
-        'click @ui.signUpButton': 'validate',
-        'keyup @ui.signUpModal': 'handleKeyUpEvent'
-    },
-
-    initialize: function() {
-        this.listenTo(this.model, 'change', this.render);
-        var self = this;
-        this.$el.on('hidden.bs.modal', function() {
-            self.destroy();
-        });
-    },
-
-    onRender: function() {
-        this.$el.modal('show');
-    },
-
-    handleKeyUpEvent: function(e) {
-        if (e.keyCode === ENTER_KEYCODE) {
-            this.validate();
-        }
+    initialize: function(options) {
+        ModalBaseView.prototype.initialize(this, options);
     },
 
     setFields: function() {
@@ -159,83 +195,20 @@ var SignUpModalView = Marionette.ItemView.extend({
             password2: $(this.ui.password2.selector).val(),
             agreed: $(this.ui.agreed.selector).prop('checked')
         }, { silent: true });
-    },
-
-    validate: function() {
-        this.setFields();
-
-        var errors = this.model.validate(this.model.attributes);
-        if (!errors) {
-            this.signUp();
-        }
-    },
-
-    signUp: function() {
-        var formData = this.$el.find('form').serialize();
-        this.model
-            .fetch({
-                method: 'POST',
-                data: formData
-            })
-            .done(_.bind(this.handleSuccess, this))
-            .fail(_.bind(this.handleFail, this));
-    },
-
-    handleSuccess: function() {
-        this.model.set({
-            'success': true,
-            'clientErrors': null,
-            'serverErrors': null
-        });
-    },
-
-    handleFail: function(response) {
-        this.model.getServerErrors(response.responseJSON);
     }
 });
 
-var ForgotModalView = Marionette.ItemView.extend({
+var ForgotModalView = ModalBaseView.extend({
     template: forgotModalTmpl,
 
-    className: 'modal modal-large fade',
-
     ui: {
-        'forgotModal': '#forgot-modal',
-        'retrieveButton': '#retrieve-button',
         'email': '#email',
         'username': '#username',
-        'password': '#password',
-        'form': 'form'
+        'password': '#password'
     },
 
-    events: {
-        'click @ui.retrieveButton': 'validate',
-        'keyup @ui.forgotModal': 'handleKeyUpEvent',
-        'submit @ui.form': 'cancelFormSubmit'
-    },
-
-    onRender: function() {
-        this.$el.modal('show');
-    },
-
-    // Used to prevent the form from being submitted by the default mechanism
-    // when hitting enter.
-    cancelFormSubmit: function(e) {
-        e.preventDefault();
-    },
-
-    initialize: function() {
-        this.listenTo(this.model, 'change', this.render);
-        var self = this;
-        this.$el.on('hidden.bs.modal', function() {
-            self.destroy();
-        });
-    },
-
-    handleKeyUpEvent: function(e) {
-        if (e.keyCode === ENTER_KEYCODE) {
-            this.validate();
-        }
+    initialize: function(options) {
+        ModalBaseView.prototype.initialize(this, options);
     },
 
     setFields: function() {
@@ -244,38 +217,6 @@ var ForgotModalView = Marionette.ItemView.extend({
             username: $(this.ui.username.selector).prop('checked'),
             password: $(this.ui.password.selector).prop('checked')
         }, { silent: true });
-    },
-
-    validate: function() {
-        this.setFields();
-
-        var errors = this.model.validate(this.model.attributes);
-        if (!errors) {
-            this.attemptReset();
-        }
-    },
-
-    attemptReset: function() {
-        var formData = this.$el.find('form').serialize();
-        this.model
-            .fetch({
-                method: 'POST',
-                data: formData
-            })
-            .done(_.bind(this.handleSuccess, this))
-            .fail(_.bind(this.handleFail, this));
-    },
-
-    handleSuccess: function() {
-        this.model.set({
-            'success': true,
-            'clientErrors': null,
-            'serverErrors': null
-        });
-    },
-
-    handleFail: function(response) {
-        this.model.getServerErrors(response.responseJSON);
     }
 });
 

--- a/src/mmw/sass/base/_login.scss
+++ b/src/mmw/sass/base/_login.scss
@@ -1,0 +1,16 @@
+#continue-as-divider {
+  margin: 1.2rem 0;
+  font-size: 0.6rem;
+  text-align: center;
+}
+
+#guest-buttons {
+  .btn {
+    float: left;
+    width: 48%;
+  }
+
+  .btn + .btn {
+    margin-left: 4%;
+  }
+}

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -43,6 +43,7 @@
  */
 @import
   "base/header",
+  "base/login",
   "base/map";
 
 /**


### PR DESCRIPTION
Adds a login and registration front-end for users logging in with ITSI.

**Before You Begin**

Please check if the `MMW_ITSI_SECRET_KEY` variable is set on your `app` VM:

    vagrant ssh app -c 'cat /etc/mmw.d/env/MMW_ITSI_SECRET_KEY'

If it isn't, you must reprovision the `app` VM with the `MMW_ITSI_SECRET_KEY` variable set, like so:

    MMW_ITSI_SECRET_KEY=*** vagrant provision app

The secret key is available in the wiki.

**Testing Instructions**

 1. Open [http://localhost:8000/](http://localhost:8000/). You should see a new login page that matches the latest mockups.
 2. Click on "ITSI". You should be taken to the ITSI portal.
 3. Log in with either the `tstudent2` or `mmwterence` account to ITSI (credentials are available in the wiki). You should be redirected to the registration front-end, and the `username`, `first_name`, and `last_name` fields should be pre-populated.
 4. Check "I agree to something" and click "Sign Up". If there aren't any validation errors, the registration modal should dismiss and you should be logged in, apparent from the username in the top right hand corner.
 5. Refresh the page to check that you are still logged in as this newly created user.
 6. Log out of this account. Click "Login", and again click "ITSI". You will be redirected to the ITSI portal again, but since you recently logged in there you should be redirected right back to our app which should automatically log you in.

**Alternate Paths**

 * Try going to [`/register`](http://localhost:8000/register) directly and registering.
 * Try dismissing the modal during registration.
 * Try signing up as an already existing username.

**Notes**

 * The mockup has a line from edge to edge behind the "Or continue as" text which I don't know how to add:  
![screen shot 2015-06-02 at 4 28 32 pm](https://cloud.githubusercontent.com/assets/1430060/7946427/93c1ce52-0944-11e5-817c-8de6eb240a54.png)
 * We pass back the username, first and last names received from ITSI to the registration modal via the query string. Is this a security / aesthetic issue? Should we use cookies or some other "under the hood" mechanism which is uglier in code but cleaner in the UI?
 * Unlike regular sign-up / login, the ITSI login requires full page refreshes and is not an XHR-only operation. This should be kept in mind when creating mechanisms to save temporary work in case the user decides to create an account using ITSI mid-way through an unsaved project.
 * We now have a handful of modal views that are very similar in basic operation. Perhaps we should refactor the commonalities into a utility class and derive from that instead.
 * I needed to add some styling for the login modal updates. I decided to add it under `sass/base/_login.scss` and not `sass/pages/_login.scss` because the login is a modal, not a page, and would be available throughout the app, not just in a particular view. If this was not the right place to add it, please let me know and I will correct it.

Connects #180 