### PR TITLE
Duplicate scenario

### DIFF
--- a/src/mmw/js/src/geocode/tests.js
+++ b/src/mmw/js/src/geocode/tests.js
@@ -167,30 +167,34 @@ describe('Geocoder', function() {
     });
 
     describe('SuggestionModel', function() {
-        it('#setMapViewToLocation sets map model\'s position attributes to the geocode result position', function() {
-            var testSuggestion = getTestSuggestions(1),
-                model = new models.SuggestionModel(testSuggestion[0]),
-                testGeocode = getTestGeocodes(1),
-                zoomLevel = 15;
+        describe('#setMapViewLocation', function() {
+            it('sets map model\'s position attributes to the geocode result position', function() {
+                var testSuggestion = getTestSuggestions(1),
+                    model = new models.SuggestionModel(testSuggestion[0]),
+                    testGeocode = getTestGeocodes(1),
+                    zoomLevel = 15;
 
-            model.set('location', new models.LocationModel(testGeocode[0]));
-            model.setMapViewToLocation(zoomLevel);
+                model.set('location', new models.LocationModel(testGeocode[0]));
+                model.setMapViewToLocation(zoomLevel);
 
-            assert.equal(App.map.get('lat'), model.get('location').get('y'));
-            assert.equal(App.map.get('lng'), model.get('location').get('x'));
-            assert.equal(App.map.get('zoom'), zoomLevel);
+                assert.equal(App.map.get('lat'), model.get('location').get('y'));
+                assert.equal(App.map.get('lng'), model.get('location').get('x'));
+                assert.equal(App.map.get('zoom'), zoomLevel);
+            });
         });
 
-        it('#select fetchs location information for the selected model', function(done) {
-            var testSuggestion = getTestSuggestions(1),
-                model = new models.SuggestionModel(testSuggestion[0]),
-                testGeocode = JSON.stringify(getTestGeocodes(1));
+        describe('#select', function() {
+            it('fetchs location information for the selected model', function(done) {
+                var testSuggestion = getTestSuggestions(1),
+                    model = new models.SuggestionModel(testSuggestion[0]),
+                    testGeocode = JSON.stringify(getTestGeocodes(1));
 
-            this.server.respondWith([200, { 'Content-Type': 'application/json' }, testGeocode]);
+                this.server.respondWith([200, { 'Content-Type': 'application/json' }, testGeocode]);
 
-            model.select().done(function() {
-                assert.instanceOf(model.get('location'), Backbone.Model);
-                done();
+                model.select().done(function() {
+                    assert.instanceOf(model.get('location'), Backbone.Model);
+                    done();
+                });
             });
         });
     });

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -143,7 +143,7 @@ var ProjectModel = Backbone.Model.extend({
             return model.get('name') === newName;
         });
         if (match) {
-            alert('This name is already in use.');
+            window.alert('This name is already in use.');
             return;
         } else if (model.get('name') !== newName) {
             model.set('name', newName);

--- a/src/mmw/js/src/modeling/templates/scenarioTabPanel.html
+++ b/src/mmw/js/src/modeling/templates/scenarioTabPanel.html
@@ -5,11 +5,12 @@
         <i class="fa fa-caret-down"></i>
         </button>
         <ul class="dropdown-menu menu-right" role="menu">
-            <li role="presentation"><a role="menuitem" tabindex="-1" class="share">Share</a></li>
-            <li role="presentation"><a role="menuitem" tabindex="-1" class="print">Print</a></li>
+            <li role="presentation"><a role="menuitem" tabindex="-1" data-action="share">Share</a></li>
+            <li role="presentation"><a role="menuitem" tabindex="-1" data-action="print">Print</a></li>
             {% if not is_current_conditions %}
-            <li role="presentation"><a role="menuitem" tabindex="-1" class="rename">Rename</a></li>
-            <li role="presentation"><a role="menuitem" tabindex="-1" class="delete">Delete</a></li>
+            <li role="presentation"><a role="menuitem" tabindex="-1" data-action="rename">Rename</a></li>
+            <li role="presentation"><a role="menuitem" tabindex="-1" data-action="duplicate">Duplicate</a></li>
+            <li role="presentation"><a role="menuitem" tabindex="-1" data-action="delete">Delete</a></li>
             {% endif %}
         </ul>
     </div>

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -31,22 +31,81 @@ describe('Modeling', function() {
     });
 
     describe('ModificationModel', function() {
-        it('#setDisplayArea calculates and sets the area attribute to square feet if the area is less than one acre', function() {
-            var model = new models.ModificationModel({
-                geojson: lessThanOneAcrePolygon
+        describe('#setDisplayArea', function() {
+            it('calculates and sets the area attribute to square feet if the area is less than one acre', function() {
+                var model = new models.ModificationModel({
+                    geojson: lessThanOneAcrePolygon
+                });
+
+                assert.equal(Math.round(model.get('area')), 6234);
+                assert.equal(model.get('units'), 'sq. ft.');
             });
 
-            assert.equal(Math.round(model.get('area')), 6234);
-            assert.equal(model.get('units'), 'sq. ft.');
+            it('calculates and sets the area attribute to acres if the area is greater than one acre', function() {
+                var model = new models.ModificationModel({
+                    geojson: greaterThanOneAcrePolygon
+                });
+
+                assert.equal(Math.round(model.get('area')), 7);
+                assert.equal(model.get('units'), 'acres');
+            });
+        });
+    });
+
+    describe('ScenarioCollection', function() {
+        describe('#duplicateScenario', function() {
+            it('duplicates an existing scenario and add the new scenario to the collection', function() {
+                var collection = getTestScenarioCollection(),
+                    scenario = collection.at(0);
+
+                assert.equal(collection.length, 1);
+
+                collection.duplicateScenario(scenario.cid);
+                assert.equal(collection.length, 2);
+                assert.deepEqual(collection.at(0).get('modifications'), collection.at(1).get('modifications'));
+                assert.equal(collection.at(1).get('name'), 'Copy of ' + collection.at(0).get('name'));
+            });
         });
 
-        it('#setDisplayArea calculates and sets the area attribute to acres if the area is greater than one acre', function() {
-            var model = new models.ModificationModel({
-                geojson: greaterThanOneAcrePolygon
+        describe('#makeScenarioName', function() {
+            it('creates a new unique scenario name based off baseName', function() {
+                var collection = getTestScenarioCollection();
+
+                var newName = collection.makeNewScenarioName('Copy of ' + collection.at(0).get('name'));
+                assert.equal(newName, 'Copy of ' + collection.at(0).get('name'));
+
+                collection.add({ name: newName });
+                var newName2 = collection.makeNewScenarioName('Copy of ' + collection.at(0).get('name'));
+                assert.equal(newName2, 'Copy of ' + collection.at(0).get('name') + ' 1');
+
+                collection.add({ name: newName2 });
+                var newName3 = collection.makeNewScenarioName('Copy of ' + collection.at(0).get('name'));
+                assert.equal(newName3, 'Copy of ' + collection.at(0).get('name') + ' 2');
             });
 
-            assert.equal(Math.round(model.get('area')), 7);
-            assert.equal(model.get('units'), 'acres');
+            it('doesn\'t append a number to the first duplicate of baseName if it doesn\'t take a number to make the name unique', function() {
+                var collection = getTestScenarioCollection();
+
+                var newName = collection.makeNewScenarioName('Copy of ' + collection.at(0).get('name'));
+                assert.equal(newName, 'Copy of Foo Bar');
+            });
+
+            it('correctly generates unique names for baseNames with trailing numbers', function() {
+                var collection = getTestScenarioCollection();
+
+                collection.at(0).set('name', 'Foo Bar 1');
+
+                var newName = collection.makeNewScenarioName('Copy of ' + collection.at(0).get('name'));
+                assert.equal(newName, 'Copy of ' + collection.at(0).get('name'));
+
+                collection.add({ name: newName });
+                var newName2 = collection.makeNewScenarioName('Copy of ' + collection.at(0).get('name'));
+                assert.equal(newName2, 'Copy of ' + collection.at(0).get('name') + ' 1');
+
+                collection.add({ name: newName2 });
+                var newName3 = collection.makeNewScenarioName('Copy of ' + collection.at(0).get('name'));
+                assert.equal(newName3, 'Copy of ' + collection.at(0).get('name') + ' 2');
+            });
         });
     });
 });
@@ -54,3 +113,20 @@ describe('Modeling', function() {
 var lessThanOneAcrePolygon = { "type": "Feature", "properties": {}, "geometry": { "type": "Polygon", "coordinates": [ [ [ -75.17049014568327, 39.95056149048882 ], [ -75.17032116651535, 39.950538872524845 ], [ -75.17038553953171, 39.9502037145458 ], [ -75.17057061195372, 39.95022633262059 ], [ -75.17049014568327, 39.95056149048882 ] ] ] } };
 
 var greaterThanOneAcrePolygon = { "type": "FeatureCollection", "features": [ { "type": "Feature", "properties": {}, "geometry": { "type": "Polygon", "coordinates": [ [ [ -75.17273247241974, 39.950349703806005 ], [ -75.1707261800766, 39.95009473644421 ], [ -75.17104804515839, 39.94857313726802 ], [ -75.17302215099335, 39.94882399784062 ], [ -75.17273247241974, 39.950349703806005 ] ] ] } } ] };
+
+function getTestScenarioCollection() {
+    var collection = new models.ScenariosCollection([
+            new models.ScenarioModel({
+                name: 'Foo Bar',
+                modifications: new models.ModificationsCollection([
+                    new models.ModificationModel({
+                        name: 'Mod 1',
+                        geojson: _.cloneDeep(greaterThanOneAcrePolygon)
+                    })
+                ]),
+                active: true
+            })
+        ]);
+
+    return collection;
+}

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -217,7 +217,7 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
 
     showShareModal: function() {
         if (App.user.get('guest')) {
-            alert('Guest cannot share scenarios. Please log in or register.');
+            window.alert('Guest cannot share scenarios. Please log in or register.');
             return;
         }
         var share = new coreViews.ShareModal({

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -153,20 +153,24 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
     },
 
     ui: {
-        share: '.share',
-        destroyConfirm: '.delete',
-        rename: '.rename',
-        print: '.print',
+        share: '[data-action="share"]',
+        destroyConfirm: '[data-action="delete"]',
+        rename: '[data-action="rename"]',
+        print: '[data-action="print"]',
+        duplicate: '[data-action="duplicate"]',
         nameField: '.tab-name'
     },
+
     events: {
         'click @ui.rename': 'renameScenario',
         'click @ui.destroyConfirm': 'destroyConfirm',
         'click @ui.share': 'showShareModal',
         'click @ui.print': function() {
             window.print();
-        }
+        },
+        'click @ui.duplicate': 'duplicateScenario'
     },
+
     renameScenario: function() {
         var self = this;
 
@@ -225,6 +229,10 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
         });
         share.render();
         share.$el.modal('show');
+    },
+
+    duplicateScenario: function() {
+        this.model.collection.duplicateScenario(this.model.cid);
     }
 });
 


### PR DESCRIPTION
Adds a "Duplicate" option to the scenario tab context menu that duplicates the selected scenario.

**To Test** (EDITED):
- Create a new project.
- Add a scenario. Keep the default name.
- Draw some modifications for that scenario.
- On that scenario, select "Duplicate". A new scenario should be added with the name "Copy of New Scenario 1". It should also have the modifications from "New Scenario 1".
- Duplicate "New Scenario 1" again. A new scenario should be added with the name "Copy of New Scenario 1 1" (a la Google Sheets). It should also have the modifications from "New Scenario 1".

- Create a new project.
- Add a scenario. Rename it to something with a trailing number.
- Perform the steps from above. Make sure the names are unique and the modifications get carried over.

Connects to #228