### PR TITLE
Prevent multiply-stacked outline layers.

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -172,13 +172,15 @@ var PlaceMarkerView = Marionette.ItemView.extend({
 });
 
 function changeOutlineLayer(endpoint, tableId, model) {
-    var map = App.getLeafletMap();
+    var map = App.getLeafletMap(),
+        ofg = model.get('outlineFeatureGroup');
 
+    // Go about the business of adding the ouline and UTFgrid layers.
     if (endpoint && tableId != undefined) {
         var ol = new L.TileLayer(endpoint + '.png'),
-            grid = new L.UtfGrid(endpoint + '.grid.json?callback={cb}', { resolution: 4 }),
-            ofg = model.get('outlineFeatureGroup');
+            grid = new L.UtfGrid(endpoint + '.grid.json?callback={cb}', { resolution: 4 });
 
+        ofg.clearLayers();
         ofg.addLayer(ol);
         ofg.addLayer(grid);
 


### PR DESCRIPTION
This patch prevents there ever being more than one outline layer visible on the screen at once.

To test: click on `Select by Boundary` and choose `Congressional Districts`.  Do the same again.  Previously, the saturation on the outlines would have increased, now it does not.

Fixes #253