### PR TITLE
Calculate area of Area of Interest.

### DIFF
--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -8,10 +8,6 @@ var $ = require('jquery'),
     views = require('./views'),
     models = require('./models');
 
-var createTaskModel = _.memoize(function(aoi) {
-    return new models.AnalyzeTaskModel();
-});
-
 var AnalyzeController = {
     analyzePrepare: function() {
         if (!App.map.get('areaOfInterest')) {
@@ -21,12 +17,11 @@ var AnalyzeController = {
     },
 
     analyze: function() {
-        var aoi = JSON.stringify(App.map.get('areaOfInterest'));
-
-        var analyzeWindow = new views.AnalyzeWindow({
-            id: 'analyze-output-wrapper',
-            model: createTaskModel(aoi)
-        });
+        var aoi = JSON.stringify(App.map.get('areaOfInterest')),
+            analyzeWindow = new views.AnalyzeWindow({
+                id: 'analyze-output-wrapper',
+                model: createTaskModel(aoi)
+            });
 
         App.rootView.footerRegion.show(analyzeWindow);
     },
@@ -35,6 +30,16 @@ var AnalyzeController = {
         App.rootView.footerRegion.empty();
     }
 };
+
+// Pass in the serialized Area of Interest for
+// caching purposes (_.memoize returns the same
+// results for any object), and deserialize
+// the AoI for use on the model.
+var createTaskModel = _.memoize(function(aoi) {
+    return new models.AnalyzeTaskModel({
+        area_of_interest: JSON.parse(aoi)
+    });
+});
 
 module.exports = {
     AnalyzeController: AnalyzeController

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -5,11 +5,10 @@ var Backbone = require('../../shim/backbone'),
     App = require('../app'),
     coreModels = require('../core/models');
 
-var AnalyzeModel = Backbone.Model.extend({
-    defaults: {
-        area: 10,
-        place: 'Philadelphia'
-    }
+var AnalyzeModel = coreModels.GeoModel.extend({
+    defaults: _.extend({
+        place: 'Selected Area'
+    }, coreModels.GeoModel.prototype.defaults)
 });
 
 var LayerModel = Backbone.Model.extend({
@@ -29,12 +28,10 @@ var LayerCategoryCollection = Backbone.Collection.extend({
 });
 
 var AnalyzeTaskModel = coreModels.TaskModel.extend({
-    defaults: _.extend(
-        {
+    defaults: _.extend( {
             taskName: 'analyze',
             taskType: 'modeling'
-        },
-        coreModels.TaskModel.prototype.defaults
+        }, coreModels.TaskModel.prototype.defaults
     )
 });
 

--- a/src/mmw/js/src/analyze/templates/header.html
+++ b/src/mmw/js/src/analyze/templates/header.html
@@ -3,7 +3,7 @@
 </div>
 <div class="title">
     <h2 class="light">{{ place }}</h2>
-    <label class="light">{{ area }} acres</label>
+    <label class="light">{{ area|round|toLocaleString }} {{ units }}</label>
 </div>
 <div class="cta-wrapper">
     <a data-url="/model" class="btn btn-lg btn-cta"><i class="fa fa-arrow-right"></i></a>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -61,7 +61,9 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
 
     showHeaderRegion: function() {
         this.headerRegion.show(new HeaderView({
-            model: new models.AnalyzeModel({})
+            model: new models.AnalyzeModel({
+                shape: this.model.get('area_of_interest')
+            })
         }));
     },
 

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -2,7 +2,8 @@
 
 var Backbone = require('../../shim/backbone'),
     Marionette = require('../../shim/backbone.marionette'),
-    $ = require('jquery');
+    $ = require('jquery'),
+    turfArea = require('turf-area');
 
 var MapModel = Backbone.Model.extend({
     defaults: {
@@ -83,7 +84,37 @@ var TaskModel = Backbone.Model.extend({
     }
 });
 
+var GeoModel = Backbone.Model.extend({
+    M_IN_KM: 1000000,
+
+    defaults: {
+        name: '',
+        shape: null,        // GeoJSON
+        area: '0',
+        units: 'm<sup>2</sup>',
+    },
+
+    initialize: function() {
+        this.setDisplayArea();
+    },
+
+    setDisplayArea: function() {
+        if (!this.get('shape')) { return; }
+
+        var areaInMeters = turfArea(this.get('shape'));
+
+        // If the area is less than 1 km, use m
+        if (areaInMeters < this.M_IN_KM) {
+            this.set('area', areaInMeters);
+        } else {
+            this.set('area', areaInMeters / this.M_IN_KM);
+            this.set('units', 'km<sup>2</sup>');
+        }
+    }
+});
+
 module.exports = {
     MapModel: MapModel,
-    TaskModel: TaskModel
+    TaskModel: TaskModel,
+    GeoModel: GeoModel
 };

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -110,101 +110,106 @@ describe('Core', function() {
         });
     });
 
-    describe('MapView', function() {
-        it('adds layers to the map when the map model attribute areaOfInterest is set', function() {
-            var mapView = App._mapView,
-                featureGroup = mapView._areaOfInterestLayer;
 
-            assert.equal(featureGroup.getLayers().length, 0);
-            App.map.set('areaOfInterest', TEST_SHAPE);
-            assert.equal(featureGroup.getLayers().length, 1);
-            App.map.set('areaOfInterest', null);
-            assert.equal(featureGroup.getLayers().length, 0);
+    describe('Views', function() {
+        describe('MapView', function() {
+            it('adds layers to the map when the map model attribute areaOfInterest is set', function() {
+                var mapView = App._mapView,
+                    featureGroup = mapView._areaOfInterestLayer;
 
-            App._mapView._leafletMap.remove();
-        });
+                assert.equal(featureGroup.getLayers().length, 0);
+                App.map.set('areaOfInterest', TEST_SHAPE);
+                assert.equal(featureGroup.getLayers().length, 1);
+                App.map.set('areaOfInterest', null);
+                assert.equal(featureGroup.getLayers().length, 0);
 
-        it('updates the position of the map when the map model location attributes are set', function() {
-            var model = new models.MapModel(),
-                view = new views.MapView({
-                    model: model
-                }),
-                latLng = [40, -75],
-                zoom = 18;
+                App._mapView._leafletMap.remove();
+            });
 
-            view._leafletMap.setView([0, 0], 0);
+            it('updates the position of the map when the map model location attributes are set', function() {
+                var model = new models.MapModel(),
+                    view = new views.MapView({
+                        model: model
+                    }),
+                    latLng = [40, -75],
+                    zoom = 18;
 
-            model.set({ lat: latLng[0], lng: latLng[1], zoom: zoom });
+                view._leafletMap.setView([0, 0], 0);
 
-            assert.equal(view._leafletMap.getCenter().lat, latLng[0]);
-            assert.equal(view._leafletMap.getCenter().lng, latLng[1]);
-            assert.equal(view._leafletMap.getZoom(), zoom);
+                model.set({ lat: latLng[0], lng: latLng[1], zoom: zoom });
 
-            view._leafletMap.remove();
-        });
+                assert.equal(view._leafletMap.getCenter().lat, latLng[0]);
+                assert.equal(view._leafletMap.getCenter().lng, latLng[1]);
+                assert.equal(view._leafletMap.getZoom(), zoom);
 
-        it('silently sets the map model location attributes when the map position is updated', function() {
-            var model = new models.MapModel(),
-                view = new views.MapView({
-                    model: model
-                }),
-                latLng = [40, -75],
-                zoom = 18;
+                view._leafletMap.remove();
+            });
 
-            view._leafletMap.setView(latLng, zoom);
+            it('silently sets the map model location attributes when the map position is updated', function() {
+                var model = new models.MapModel(),
+                    view = new views.MapView({
+                        model: model
+                    }),
+                    latLng = [40, -75],
+                    zoom = 18;
 
-            assert.equal(model.get('lat'), 40);
-            assert.equal(model.get('lng'), -75);
-            assert.equal(model.get('zoom'), zoom);
+                view._leafletMap.setView(latLng, zoom);
 
-            view._leafletMap.remove();
-        });
+                assert.equal(model.get('lat'), 40);
+                assert.equal(model.get('lng'), -75);
+                assert.equal(model.get('zoom'), zoom);
 
-        it('adds the class "half" to the map view when the map model attribute halfSize is set to true', function(){
-            var model = new models.MapModel(),
-                view = new views.MapView({
-                    model: model
-                });
+                view._leafletMap.remove();
+            });
 
-            model.set('halfSize', true);
-            assert.isTrue($('#map').hasClass('half'));
+            it('adds the class "half" to the map view when the map model attribute halfSize is set to true', function(){
+                var model = new models.MapModel(),
+                    view = new views.MapView({
+                        model: model
+                    });
 
-            view._leafletMap.remove();
-            $('#map').removeClass('half');
-        });
+                model.set('halfSize', true);
+                assert.isTrue($('#map').hasClass('half'));
+
+                view._leafletMap.remove();
+                $('#map').removeClass('half');
+            });
 
 
-        it('removes the class "half" to the map view when the map model attribute halfSize is set to false', function(){
-            var model = new models.MapModel(),
-                view = new views.MapView({
-                    model: model
-                });
+            it('removes the class "half" to the map view when the map model attribute halfSize is set to false', function(){
+                var model = new models.MapModel(),
+                    view = new views.MapView({
+                        model: model
+                    });
 
-            model.set('halfSize', false);
-            assert.isFalse($('#map').hasClass('half'));
+                model.set('halfSize', false);
+                assert.isFalse($('#map').hasClass('half'));
 
-            view._leafletMap.remove();
+                view._leafletMap.remove();
+            });
         });
     });
 
-    describe('GeoModel', function() {
-        describe('#setDisplayArea', function() {
-            it('calculates and sets the area attribute to sq. m. if the area is less than 1 sq. km.', function() {
-                var model = new models.GeoModel({
-                    shape: polygon270m
+    describe('Models', function() {
+        describe('GeoModel', function() {
+            describe('#setDisplayArea', function() {
+                it('calculates and sets the area attribute to sq. m. if the area is less than 1 sq. km.', function() {
+                    var model = new models.GeoModel({
+                        shape: polygon270m
+                    });
+
+                    assert.equal(Math.round(model.get('area')), 270);
+                    assert.equal(model.get('units'), 'm<sup>2</sup>');
                 });
 
-                assert.equal(Math.round(model.get('area')), 270);
-                assert.equal(model.get('units'), 'm<sup>2</sup>');
-            });
+                it('calculates and sets the area attribute to sq. km. if the area is greater than 1,000 sq. m.', function() {
+                    var model = new models.GeoModel({
+                        shape: polygon7Km
+                    });
 
-            it('calculates and sets the area attribute to sq. km. if the area is greater than 1,000 sq. m.', function() {
-                var model = new models.GeoModel({
-                    shape: polygon7Km
+                    assert.equal(Math.round(model.get('area')), 7);
+                    assert.equal(model.get('units'), 'km<sup>2</sup>');
                 });
-
-                assert.equal(Math.round(model.get('area')), 7);
-                assert.equal(model.get('units'), 'km<sup>2</sup>');
             });
         });
     });

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -187,6 +187,28 @@ describe('Core', function() {
         });
     });
 
+    describe('GeoModel', function() {
+        describe('#setDisplayArea', function() {
+            it('calculates and sets the area attribute to sq. m. if the area is less than 1 sq. km.', function() {
+                var model = new models.GeoModel({
+                    shape: polygon270m
+                });
+
+                assert.equal(Math.round(model.get('area')), 270);
+                assert.equal(model.get('units'), 'm<sup>2</sup>');
+            });
+
+            it('calculates and sets the area attribute to sq. km. if the area is greater than 1,000 sq. m.', function() {
+                var model = new models.GeoModel({
+                    shape: polygon7Km
+                });
+
+                assert.equal(Math.round(model.get('area')), 7);
+                assert.equal(model.get('units'), 'km<sup>2</sup>');
+            });
+        });
+    });
+
     describe('Regions', function() {
         describe('TransitionRegion', function() {
             it('calls view.animateIn and executes the correct animation when show is called', function(done) {
@@ -406,3 +428,7 @@ function getController() {
 
     return controller;
 }
+
+var polygon7Km = { "type": "FeatureCollection", "features": [ { "type": "Feature", "properties": { "stroke": "#555555", "stroke-width": 2, "stroke-opacity": 1, "fill": "#555555", "fill-opacity": 0.5 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -75.17231941223145, 39.96955588282636 ], [ -75.17798423767088, 39.94560797785181 ], [ -75.15000343322754, 39.945213161909656 ], [ -75.14073371887207, 39.96784559630992 ], [ -75.1606035232544, 39.971134570861665 ], [ -75.17231941223145, 39.96955588282636 ] ] ] } } ] };
+
+var polygon270m =  { "type": "Feature", "properties": {}, "geometry": { "type": "Polygon", "coordinates": [ [ [ -75.16355395317078, 39.97186634617687 ], [ -75.16357004642487, 39.97174712489007 ], [ -75.16333937644957, 39.97173890272471 ], [ -75.1633071899414, 39.97184167972083 ], [ -75.1634681224823, 39.97187045725201 ], [ -75.16355395317078, 39.97186634617687 ] ] ] } };

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -2,7 +2,6 @@
 
 var Backbone = require('../../shim/backbone'),
     _ = require('lodash'),
-    turfArea = require('turf-area'),
     App = require('../app'),
     coreModels = require('../core/models');
 
@@ -114,36 +113,12 @@ var ProjectModel = Backbone.Model.extend({
     }
 });
 
-var ModificationModel = Backbone.Model.extend({
-    defaults: {
-        name: '',
-        value: '',
-        shape: null,         // GeoJSON
-        area: '0',
-        units: 'meter(s)'
-    },
-
-    initialize: function() {
-        this.setDisplayArea();
-    },
-
-    setDisplayArea: function() {
-        if (!this.get('shape')) {
-            return;
-        }
-
-        var areaInMeters = turfArea(this.get('shape'));
-
-        // For areas less than an acre, use sq ft,
-        // otherwise use acres
-        if (areaInMeters < 4046.86) {
-            this.set('area', areaInMeters * 10.7639);
-            this.set('units', 'sq. ft.');
-        } else {
-            this.set('area', areaInMeters * 0.000247105);
-            this.set('units', 'acres');
-        }
-    }
+var ModificationModel = coreModels.GeoModel.extend({
+    defaults: _.extend({
+            name: '',
+            type: ''
+        }, coreModels.GeoModel.prototype.defaults
+    )
 });
 
 var ModificationsCollection = Backbone.Collection.extend({

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -115,9 +115,9 @@ describe('Modeling', function() {
 
                 $('#sandbox').html(view.render().el);
                 assert.equal($('#sandbox #mod-landcover tr td:first-child').text(), 'LIR');
-                assert.equal($('#sandbox #mod-landcover tr td:nth-child(2)').text(), '10,977 acres');
+                assert.equal($('#sandbox #mod-landcover tr td:nth-child(2)').text(), '44.4 km2');
                 assert.equal($('#sandbox #mod-conservationpractice tr td:first-child').text(), 'Rain Garden');
-                assert.equal($('#sandbox #mod-conservationpractice tr td:nth-child(2)').text(), '26,292.2 acres');
+                assert.equal($('#sandbox #mod-conservationpractice tr td:nth-child(2)').text(), '106.4 km2');
             });
         });
     });
@@ -184,25 +184,12 @@ describe('Modeling', function() {
             });
         });
 
-        describe('ModificationModel', function() {
-            describe('#setDisplayArea', function() {
-                it('calculates and sets the area attribute to square feet if the area is less than one acre', function() {
-                    var model = new models.ModificationModel({
-                        shape: lessThanOneAcrePolygon
-                    });
+        describe('ModificatioModel', function() {
+            it('inherits defaults from coreModels.GeoModel', function() {
+                var model = new models.ModificationModel({});
 
-                    assert.equal(Math.round(model.get('area')), 6234);
-                    assert.equal(model.get('units'), 'sq. ft.');
-                });
-
-                it('calculates and sets the area attribute to acres if the area is greater than one acre', function() {
-                    var model = new models.ModificationModel({
-                        shape: greaterThanOneAcrePolygon
-                    });
-
-                    assert.equal(Math.round(model.get('area')), 7);
-                    assert.equal(model.get('units'), 'acres');
-                });
+                assert.equal(model.get('units'), 'm<sup>2</sup>');
+                assert.equal(model.get('area'), 0);
             });
         });
 


### PR DESCRIPTION
* Display the area of the Area of Interest in
the Analyze View header.
* Replace the default value of the analyze place
attribute with "Selected Area"
* Move area conversion method from
Modeling.ModificationModel to Core.GeoModel, and
subclass Modeling.ModificationModel and
Analyze.AnalyzeModel from Core.GeoModel.
* Switch to use metric system instead of English
system in area calculation and display per @chitchens.
* Move ModificationModel tests from Modeling
tests to Core tests.
* Add test to Modeling tests to ensure
Modeling.ModificationModel is inheriting
properly from Core.GeoModel.

**To test**:

- Draw an area to analyze.
- Note that, in the analyze window header, the area is now in sq m or sq km and that the name is "Selected Area" and not Philadelphia.
- Try the other AoI methods and verify that the analyze header changes when a new area is selected.
- Run the tests.

Connects to #264