### PR TITLE
Fix bar chart in Chrome

### DIFF
--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -16,7 +16,6 @@
   vertical-align: bottom;
 
   .bar{
-    width: 9%;
     margin: 0 2%;
     display: inline-block;
     fill: $brand-primary;


### PR DESCRIPTION
Width is always specified in SVG. Firefox prefers SVG width over CSS, so the chart looks correct there, but Chrome prefers CSS width thus making all the bars in the chart have the same 9% width.

If there is history to the 9% number I would love to be filled in. It seems to have always been there since the file was originally added to the repository.

**Testing Notes**

Open the `/analyze` view in different browsers and make sure the bar charts look reasonable.

Connects #299 