### PR TITLE
Fix tests not running on Jenkins

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/tasks/static-files.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/static-files.yml
@@ -16,16 +16,8 @@
     chdir: "{{ app_home }}"
   sudo: False
 
-- name: Create minified JS vendor bundle (staging/production)
-  command: "./bundle.sh --vendor --minify"
-  args:
-    chdir: "{{ app_home }}"
-  environment: app_config
-  sudo: False
-  when: "['development'] | is_not_in(group_names)"
-
-- name: Create primary JS bundles (staging/production)
-  command: "./bundle.sh --tests"
+- name: Create JS bundles (staging/production)
+  command: "./bundle.sh --vendor --tests"
   args:
     chdir: "{{ app_home }}"
   environment: app_config


### PR DESCRIPTION
The tests were failing because of a missing dependency related to
sinon. It appears that because of the way that sinon is written, its
internal utility functions are optimized away during minification.

Fixed this by removing minification of staging/production bundles.

Test that this works by running `VAGRANT_ENV=TEST vagrant provision
app` and verifiying that all the JS tests pass via
`./scripts/testem.sh`. You could also just inspect the PR builder
output on Jenkins to confirm that JS tests were run.

Connects #289