### PR TITLE
Add support for creating application server AMIs

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -13,11 +13,7 @@ $ pip install -r requirements.txt
 
 Next, install [Packer](https://packer.io/) using the steps detailed on Packer's [website](https://packer.io/downloads.html).
 
-## Create Identity and Access Management (IAM) Roles
-
-TBD
-
-## Create and Download an EC2 Keypair
+## Create Identity and Access Management (IAM) roles
 
 TBD
 
@@ -31,19 +27,25 @@ $ aws configure --profile mmw-stg
 
 You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Boto, Packer, and the AWS CLI.
 
-## Edit the Configuration File
+## Edit the configuration file
 
 A configuration file is required to launch the stack. An example file (`default.yml.example`) is available in the current directory.
 
-## Launch and Manage Stacks
+## Launch and manage stacks
 
-Launching stacks is managed with `mmw_stack.py`. This command provides an interface for automatically generating AMIs and launching Model My Watershed stacks.
+Stack launching is managed with `mmw_stack.py`. This command provides an interface for automatically generating AMIs and launching Model My Watershed stacks.
 
 ### Generating AMIs
 
-TBD
+Before launching the Model My Watershed stack, AMIs for each service need to be generated:
 
-### Launch Stack
+
+```bash
+$ ./mmw_stack.py create-ami --aws-profile mmw-stg --mmw-profile staging \
+                            --machine-type mmw-{app,monitoring,tiler,worker}
+```
+
+### Launching Stacks
 
 After successfully creating AMIs, you can launch a Model My Watershed stack with the `launch-stacks` subcommand. To view all options for the `launch-stacks` subcommand, you can use the `--help` option.
 

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -10,6 +10,12 @@ statsite_port: 8125
 apache_port: 8080
 graphite_web_port: "{{ apache_port }}"
 
+itsi_client_id: "model-my-watershed"
+
+postgresql_username: mmw
+postgresql_password: mmw
+postgresql_database: mmw
+
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*-1.pgdg14.04+1"
 postgresql_support_repository_channel: "main"

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -4,9 +4,6 @@ django_settings_module: "mmw.settings.development"
 redis_bind_address: "0.0.0.0"
 
 postgresql_listen_addresses: "*"
-postgresql_username: mmw
-postgresql_password: mmw
-postgresql_database: mmw
 postgresql_log_min_duration_statement: 500
 postgresql_hba_mapping:
   - { type: "host", database: "all", user: "all", address: "33.33.34.1/24", method: "md5" }
@@ -25,5 +22,4 @@ celery_number_of_workers: 2
 celery_processes_per_worker: 1
 
 itsi_base_url: "https://learn.staging.concord.org/"
-itsi_client_id: "model-my-watershed"
 itsi_secret_key: "{{ lookup('env', 'MMW_ITSI_SECRET_KEY') }}"

--- a/deployment/ansible/group_vars/packer
+++ b/deployment/ansible/group_vars/packer
@@ -1,2 +1,22 @@
 ---
 django_settings_module: "mmw.settings.production"
+
+app_deploy_branch: "{{ lookup('env', 'GIT_COMMIT') | default('origin/develop', true) }}"
+
+postgresql_password: "{{ lookup('env', 'MMW_DB_PASSWORD') | default('mmw', true) }}"
+
+ntp_servers:
+  - 0.amazon.pool.ntp.org
+  - 1.amazon.pool.ntp.org
+  - 2.amazon.pool.ntp.org
+  - 3.amazon.pool.ntp.org
+
+redis_host: "cache.service.mmw.internal"
+postgresql_host: "database.service.mmw.internal"
+relp_host: "monitoring.service.mmw.internal"
+graphite_host: "monitoring.service.mmw.internal"
+statsite_host: "monitoring.service.mmw.internal"
+tiler_host: "tile.service.mmw.internal"
+
+itsi_base_url: "https://learn.staging.concord.org/"
+itsi_secret_key: "{{ lookup('env', 'MMW_ITSI_SECRET_KEY') }}"

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -4,9 +4,6 @@ django_settings_module: "mmw.settings.test"
 redis_bind_address: "0.0.0.0"
 
 postgresql_listen_addresses: "*"
-postgresql_username: mmw
-postgresql_password: mmw
-postgresql_database: mmw
 postgresql_hba_mapping:
   - { type: "host", database: "all", user: "all", address: "33.33.34.1/24", method: "md5" }
 
@@ -20,3 +17,6 @@ statsite_host: "{{ services_ip }}"
 
 celery_number_of_workers: 2
 celery_processes_per_worker: 1
+
+itsi_base_url: "https://learn.staging.concord.org/"
+itsi_secret_key: "{{ lookup('env', 'MMW_ITSI_SECRET_KEY') }}"

--- a/deployment/ansible/inventory/packer-app-server
+++ b/deployment/ansible/inventory/packer-app-server
@@ -1,0 +1,8 @@
+[mmw-app]
+localhost ansible_ssh_user=ubuntu
+
+[app-servers]
+mmw-app
+
+[packer:children]
+app-servers

--- a/deployment/ansible/roles/model-my-watershed.app/tasks/app.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/app.yml
@@ -6,6 +6,9 @@
 
 - name: Ensure that app_home exists
   file: path="{{ app_home }}"
+        owner="{{ ansible_ssh_user }}"
+        group=mmw
+        mode=0755
         state=directory
 
 - name: Synchronize Django application into app_home

--- a/deployment/mmw_stack.py
+++ b/deployment/mmw_stack.py
@@ -5,6 +5,7 @@ import argparse
 import os
 
 from cfn.stacks import build_stacks, get_config
+from packer.driver import run_packer
 
 
 current_file_dir = os.path.dirname(os.path.realpath(__file__))
@@ -12,6 +13,13 @@ current_file_dir = os.path.dirname(os.path.realpath(__file__))
 
 def launch_stacks(mmw_config, aws_profile, **kwargs):
     build_stacks(mmw_config, aws_profile, **kwargs)
+
+
+def create_ami(mmw_config, aws_profile, machine_type, **kwargs):
+    run_packer(machine_type,
+               aws_profile=aws_profile,
+               region=mmw_config['Region'],
+               stack_type=mmw_config['StackType'])
 
 
 def main():
@@ -32,11 +40,16 @@ def main():
     subparsers = parser.add_subparsers(title='Model My Watershed Stack '
                                              'Commands')
 
-    # Launch MMW Stack
     mmw_stacks = subparsers.add_parser('launch-stacks',
                                        help='Launch MMW Stack',
                                        parents=[common_parser])
     mmw_stacks.set_defaults(func=launch_stacks)
+
+    mmw_ami = subparsers.add_parser('create-ami', help='Create AMI for Model '
+                                                       'My Watershed Stack',
+                                    parents=[common_parser])
+    mmw_ami.add_argument('--machine-type', help='Type of AMI to build')
+    mmw_ami.set_defaults(func=create_ami)
 
     args = parser.parse_args()
     mmw_config = get_config(args.mmw_config_path, args.mmw_profile)

--- a/deployment/packer/driver.py
+++ b/deployment/packer/driver.py
@@ -1,0 +1,98 @@
+"""Helper functions to handle AMI creation with packer"""
+
+import boto
+import os
+import subprocess
+
+import logging
+import urllib2
+import csv
+
+
+LOGGER = logging.getLogger('mmw')
+
+UBUNTU_RELEASE_URL = 'http://cloud-images.ubuntu.com/query/trusty/server/released.current.txt'  # NOQA
+UBUNTU_RELEASE_FIELD_NAMES = ['version', 'version_type', 'release_status',
+                              'date', 'storage', 'arch', 'region', 'id',
+                              'kernel', 'unknown_col', 'virtualization_type']
+
+
+def get_recent_ubuntu_ami(region):
+    """Gets AMI ID for current release in region"""
+    response = urllib2.urlopen(UBUNTU_RELEASE_URL).readlines()
+    reader = csv.DictReader(response, fieldnames=UBUNTU_RELEASE_FIELD_NAMES,
+                            delimiter='\t')
+
+    def ami_filter(ami):
+        """Helper function to filter AMIs"""
+        return (ami['region'] == region and
+                ami['arch'] == 'amd64' and
+                ami['storage'] == 'ebs-ssd' and
+                ami['virtualization_type'] == 'hvm')
+
+    return [row for row in reader if ami_filter(row)][0]['id']
+
+
+def update_ansible_roles():
+    """Function that executes ansible-galaxy to ensure all roles are
+       up-to-date before Packer runs."""
+    ansible_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        'ansible')
+    ansible_roles_path = os.path.join(ansible_dir, 'roles')
+    ansible_command = ['ansible-galaxy',
+                       'install',
+                       '-f',
+                       '-r', 'roles.txt',
+                       '-p', ansible_roles_path]
+    subprocess.check_call(ansible_command, cwd=ansible_dir)
+
+
+def run_packer(machine_type, aws_profile, region, stack_type):
+    """Function to run packer
+
+    Args:
+      machine_type (str): type of machine to build
+      aws_profile (str): aws profile name to use for authentication
+      stack_type (str): type of stack this machine is for
+    """
+
+    # Get AWS credentials based on profile
+    aws_dir = os.path.expanduser('~/.aws')
+    boto_config_path = os.path.join(aws_dir, 'config')
+    aws_creds_path = os.path.join(aws_dir, 'credentials')
+    boto.config.read([boto_config_path, aws_creds_path])
+    aws_access_key_id = boto.config.get(aws_profile,
+                                        'aws_access_key_id')
+    aws_secret_access_key = boto.config.get(aws_profile,
+                                            'aws_secret_access_key')
+
+    # Get most recent Ubuntu release AMI
+    aws_ubuntu_ami = get_recent_ubuntu_ami(region)
+
+    update_ansible_roles()
+
+    env = os.environ.copy()
+    env['AWS_ACCESS_KEY'] = aws_access_key_id
+    env['AWS_SECRET_ACCESS_KEY'] = aws_secret_access_key
+
+    packer_template_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        'template.js')
+
+    LOGGER.info('Creating %s AMI in %s region', machine_type, region)
+
+    packer_command = ['packer', 'build',
+                      '-var', 'version={}'.format(env.get('GIT_COMMIT',
+                                                          'origin/develop')),
+                      '-var', 'branch={}'.format(env.get('GIT_BRANCH',
+                                                         'origin/develop')),
+                      '-var', 'aws_region={}'.format(region),
+                      '-var', 'aws_ubuntu_ami={}'.format(aws_ubuntu_ami),
+                      '-var', 'stack_type={}'.format(stack_type),
+                      '-only', machine_type,
+                      packer_template_path]
+
+    LOGGER.debug('Running Packer Command: %s', ' '.join(packer_command))
+
+    subprocess.check_call(packer_command, env=env)

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -1,0 +1,52 @@
+{
+    "variables": {
+        "version": "",
+        "branch": "",
+        "aws_region": "",
+        "aws_ubuntu_ami": "",
+        "stack_type": ""
+    },
+    "builders": [
+        {
+            "name": "mmw-app",
+            "type": "amazon-ebs",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_ubuntu_ami`}}",
+            "instance_type": "m3.large",
+            "ssh_username": "ubuntu",
+            "ami_name": "mmw-app-{{timestamp}}",
+            "run_tags": {
+                "PackerBuilder": "amazon-ebs"
+            },
+            "tags": {
+                "Name": "mmw-app",
+                "Version": "{{user `version`}}",
+                "Branch": "{{user `branch`}}",
+                "Created": "{{ isotime }}",
+                "Service": "Application",
+                "Environment": "{{user `stack_type`}}"
+            },
+            "associate_public_ip_address": true
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "inline": [
+                "sleep 5",
+                "sudo apt-get update -qq",
+                "sudo apt-get install python-pip python-dev -y",
+                "sudo pip install ansible==1.9.0.1"
+            ]
+        },
+        {
+            "type": "ansible-local",
+            "playbook_file": "ansible/app-servers.yml",
+            "playbook_dir": "ansible",
+            "inventory_file": "ansible/inventory/packer-app-server",
+            "only": [
+                "mmw-app"
+            ]
+        }
+    ]
+}

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,4 +1,4 @@
-ansible==1.9.1
+ansible==1.9.0.1
 majorkirby>=0.2.0,<0.2.99
 troposphere==1.0.0
 boto==2.38.0


### PR DESCRIPTION
Packer is used to drive the EBS backed AMI generation process, making use of our existing Ansible roles and playbooks. The same credential setup process for launching stacks is reused for AMI creation.

Connects #293 and builds on top of #288. Also, tagging @kdeloach and @lliss.