### PR TITLE
Add support for creating tile server AMIs

### DIFF
--- a/deployment/ansible/group_vars/packer
+++ b/deployment/ansible/group_vars/packer
@@ -2,6 +2,7 @@
 django_settings_module: "mmw.settings.production"
 
 app_deploy_branch: "{{ lookup('env', 'GIT_COMMIT') | default('origin/develop', true) }}"
+tiler_deploy_branch: "{{ lookup('env', 'GIT_COMMIT') | default('origin/develop', true) }}"
 
 postgresql_password: "{{ lookup('env', 'MMW_DB_PASSWORD') | default('mmw', true) }}"
 

--- a/deployment/ansible/inventory/packer-tile-server
+++ b/deployment/ansible/inventory/packer-tile-server
@@ -1,0 +1,8 @@
+[mmw-tiler]
+localhost ansible_ssh_user=ubuntu
+
+[tile-servers]
+mmw-tiler
+
+[packer:children]
+tile-servers

--- a/deployment/ansible/roles/model-my-watershed.tiler/tasks/app.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/tasks/app.yml
@@ -6,6 +6,9 @@
 
 - name: Ensure that tiler_home exists
   file: path="{{ tiler_home }}"
+        owner="{{ ansible_ssh_user }}"
+        group=mmw
+        mode=0755
         state=directory
 
 - name: Synchronize tiler code into into tiler_home
@@ -14,5 +17,5 @@
                compress=no
                recursive=yes
                set_remote_user=no
-               src=/opt/model-my-watershed/src/tiler
+               src=/opt/model-my-watershed/src/tiler/
                dest="{{ tiler_home }}/"

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -29,6 +29,27 @@
             "associate_public_ip_address": true
         },
         {
+            "name": "mmw-tiler",
+            "type": "amazon-ebs",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_ubuntu_ami`}}",
+            "instance_type": "m3.large",
+            "ssh_username": "ubuntu",
+            "ami_name": "mmw-tiler-{{timestamp}}",
+            "run_tags": {
+                "PackerBuilder": "amazon-ebs"
+            },
+            "tags": {
+                "Name": "mmw-tiler",
+                "Version": "{{user `version`}}",
+                "Branch": "{{user `branch`}}",
+                "Created": "{{ isotime }}",
+                "Service": "Tiler",
+                "Environment": "{{user `stack_type`}}"
+            },
+            "associate_public_ip_address": true
+        },
+        {
             "name": "mmw-worker",
             "type": "amazon-ebs",
             "region": "{{user `aws_region`}}",
@@ -67,6 +88,15 @@
             "inventory_file": "ansible/inventory/packer-app-server",
             "only": [
                 "mmw-app"
+            ]
+        },
+        {
+            "type": "ansible-local",
+            "playbook_file": "ansible/tile-servers.yml",
+            "playbook_dir": "ansible",
+            "inventory_file": "ansible/inventory/packer-tile-server",
+            "only": [
+                "mmw-tiler"
             ]
         },
         {


### PR DESCRIPTION
Packer is used to drive the EBS backed AMI generation process, making use of our existing Ansible roles and playbooks. The same credential setup process for launching stacks is reused for AMI creation.

Connects #292 and builds on top of #313. Also, tagging @kdeloach and @lliss.