### PR TITLE
Custom serializer for modifications.

### DIFF
--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -8,6 +8,8 @@ from rest_framework_gis import serializers as gis_serializers
 
 from apps.modeling.models import Project, Scenario
 
+import json
+
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
@@ -15,9 +17,20 @@ class UserSerializer(serializers.ModelSerializer):
         fields = ('id', 'username', 'email')
 
 
+class ModificationsField(serializers.BaseSerializer):
+
+    def to_representation(self, obj):
+        return json.loads(obj)
+
+    def to_internal_value(self, obj):
+        return json.dumps(obj)
+
+
 class ScenarioSerializer(serializers.ModelSerializer):
     class Meta:
         model = Scenario
+
+    modifications = ModificationsField()
 
 
 class ProjectSerializer(gis_serializers.GeoModelSerializer):


### PR DESCRIPTION
The standard serializer prepends `u` to the field names when the object
is transformed into a string.  This patch prevents that from happening.

**To test:**
   * Follow the instructions given in https://github.com/WikiWatershed/model-my-watershed/pull/230, except now you must type `mn1.set('model_package', 'tr-55')` after typing `mn1.get('scenarios').at(1).set('name', 'TEST SCENARIO')` and before typing `mn1.saveAll()`.
   * In "developer tools", click on `network`, then `xhr`, then on the item on the left with `/api/modeling/projects` in it, then on the `response` tab.
   * Paste the response into `pro.jslint.com`.
   * Copy the value associated with the modifications key to the clipboard.  Type `JSON.parse("")` into the Javascript console and paste the modification information between the pair of double quotes.  When you press enter, you should get a valid Javascript object.

Fixes WikiWatershed/model-my-watershed#278