### PR TITLE
Allow multiple projects with same name

### DIFF
--- a/src/mmw/apps/modeling/migrations/0005_auto_20150608_1502.py
+++ b/src/mmw/apps/modeling/migrations/0005_auto_20150608_1502.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0004_auto_20150529_1700'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='project',
+            unique_together=set([]),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -45,9 +45,6 @@ class District(models.Model):
 
 
 class Project(models.Model):
-    class Meta:
-        unique_together = ('name', 'user')
-
     TR55 = 'tr-55'
     MODEL_PACKAGES = ((TR55, 'Simple Model'),)
 


### PR DESCRIPTION
Removes unique constraint between user and project name.

**Testing Instructions**

 * Checkout branch and run all migrations.
 * Login as a user.
 * Select an area, click forward from analyze and land in the model view.
 * Use the Marionette.Inspector as instructed in #230, find the Project object, download it into the console (usually automatically declared as `mn1`) and run the following:

```javascript
mn1.set('model_package', 'tr-55');
```

> That last step is necessary because the front-end currently stores `model_package` as a complex object, but the back-end expects a simple string, so we manually fix it.

 * Save the project, using either the UI or just `mn1.saveAll();` in the console. Refresh the page to make sure it saved.
 * Create a second project and follow the same steps, make sure to save it as the exact same name as the first one.

Connects #229 