### PR TITLE
Add support for creating worker AMIs

### DIFF
--- a/deployment/ansible/inventory/packer-worker-server
+++ b/deployment/ansible/inventory/packer-worker-server
@@ -1,0 +1,8 @@
+[mmw-worker]
+localhost ansible_ssh_user=ubuntu
+
+[workers]
+mmw-worker
+
+[packer:children]
+workers

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/app.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/app.yml
@@ -6,6 +6,9 @@
 
 - name: Ensure that app_home exists
   file: path="{{ app_home }}"
+        owner="{{ ansible_ssh_user }}"
+        group=mmw
+        mode=0755
         state=directory
 
 - name: Synchronize Django application into app_home

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -27,6 +27,27 @@
                 "Environment": "{{user `stack_type`}}"
             },
             "associate_public_ip_address": true
+        },
+        {
+            "name": "mmw-worker",
+            "type": "amazon-ebs",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_ubuntu_ami`}}",
+            "instance_type": "m3.large",
+            "ssh_username": "ubuntu",
+            "ami_name": "mmw-worker-{{timestamp}}",
+            "run_tags": {
+                "PackerBuilder": "amazon-ebs"
+            },
+            "tags": {
+                "Name": "mmw-worker",
+                "Version": "{{user `version`}}",
+                "Branch": "{{user `branch`}}",
+                "Created": "{{ isotime }}",
+                "Service": "Worker",
+                "Environment": "{{user `stack_type`}}"
+            },
+            "associate_public_ip_address": true
         }
     ],
     "provisioners": [
@@ -46,6 +67,15 @@
             "inventory_file": "ansible/inventory/packer-app-server",
             "only": [
                 "mmw-app"
+            ]
+        },
+        {
+            "type": "ansible-local",
+            "playbook_file": "ansible/workers.yml",
+            "playbook_dir": "ansible",
+            "inventory_file": "ansible/inventory/packer-worker-server",
+            "only": [
+                "mmw-worker"
             ]
         }
     ]


### PR DESCRIPTION
Packer is used to drive the EBS backed AMI generation process, making use of our existing Ansible roles and playbooks. The same credential setup process for launching stacks is reused for AMI creation.

Connects #291 and builds on top of #313. Also, tagging @kdeloach and @lliss.