### PR TITLE
Revert model_package back to a string

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -15,12 +15,7 @@ var ModelPackageControlsCollection = Backbone.Collection.extend({
     model: ModelPackageControlModel
 });
 
-var ModelPackageModel = Backbone.Model.extend({
-    defaults: {
-        name: '',
-        controls: null  // ModelPackageControlsCollection
-    }
-});
+var ModelPackageModel = Backbone.Model.extend();
 
 var Tr55TaskModel = coreModels.TaskModel.extend({});
 
@@ -37,7 +32,7 @@ var ProjectModel = Backbone.Model.extend({
         name: '',
         created_at: null,          // Date
         area_of_interest: null,    // GeoJSON
-        model_package: null,       // ModelPackageModel
+        model_package: '',         // Package name
         taskModel: null,           // TaskModel
         scenarios: null            // ScenariosCollection
     },
@@ -48,14 +43,7 @@ var ProjectModel = Backbone.Model.extend({
         // they want to use in their project. For
         // now, the only option is TR55, so it is
         // hard-coded here.
-        this.set('model_package', new ModelPackageModel({
-            name: 'tr-55',
-            controls: new ModelPackageControlsCollection([
-                new ModelPackageControlModel({ name: 'landcover' }),
-                new ModelPackageControlModel({ name: 'conservation_practice' }),
-                new ModelPackageControlModel({ name: 'precipitation' })
-            ])
-        }));
+        this.set('model_package', 'tr-55');
         this.set('taskModel', new Tr55TaskModel());
     },
 
@@ -256,7 +244,20 @@ var ScenariosCollection = Backbone.Collection.extend({
     }
 });
 
+function getControlsForModelPackage(modelPackageName) {
+    switch (modelPackageName) {
+        case 'tr-55':
+            return new ModelPackageControlsCollection([
+                new ModelPackageControlModel({ name: 'landcover' }),
+                new ModelPackageControlModel({ name: 'conservation_practice' }),
+                new ModelPackageControlModel({ name: 'precipitation' })
+            ]);
+    }
+    throw 'Model package not supported ' + modelPackageName;
+}
+
 module.exports = {
+    getControlsForModelPackage: getControlsForModelPackage,
     ResultModel: ResultModel,
     ResultCollection: ResultCollection,
     ModelPackageModel: ModelPackageModel,

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -474,7 +474,7 @@ var ToolbarTabContentsView = Marionette.CollectionView.extend({
     childView: ToolbarTabContentView,
     childViewOptions: function(model) {
         var controls = model.get('is_current_conditions') ? null :
-            this.options.model_package.get('controls');
+            models.getControlsForModelPackage(this.options.model_package);
         return {
             collection: controls
         };


### PR DESCRIPTION
This corrects an earlier mistake I made when I changed this property
from a string to an instance of a Backbone model. There's no point in
defining static controls on the project model because they cannot be modified
and should never be persisted.

To test:
1. Save a project.
2. The project and all its scenarios should save, and the address bar
should update to contain the saved project ID.
3. Reloading the page should display your saved data.