### PR TITLE
Add support for creating monitoring server AMIs

### DIFF
--- a/deployment/ansible/inventory/packer-monitoring-server
+++ b/deployment/ansible/inventory/packer-monitoring-server
@@ -1,0 +1,8 @@
+[mmw-monitoring]
+localhost ansible_ssh_user=ubuntu
+
+[monitoring-servers]
+mmw-monitoring
+
+[packer:children]
+monitoring-servers

--- a/deployment/packer/driver.py
+++ b/deployment/packer/driver.py
@@ -48,6 +48,27 @@ def update_ansible_roles():
     subprocess.check_call(ansible_command, cwd=ansible_dir)
 
 
+def get_git_sha():
+    """Function that executes Git to determine the current SHA"""
+    git_command = ['git',
+                   'describe',
+                   '--tags',
+                   '--always',
+                   '--dirty']
+
+    return subprocess.check_output(git_command).rstrip()
+
+
+def get_git_branch():
+    """Function that executes Git to determine the current branch"""
+    git_command = ['git',
+                   'rev-parse',
+                   '--abbrev-ref',
+                   'HEAD']
+
+    return subprocess.check_output(git_command).rstrip()
+
+
 def run_packer(machine_type, aws_profile, region, stack_type):
     """Function to run packer
 
@@ -84,9 +105,9 @@ def run_packer(machine_type, aws_profile, region, stack_type):
 
     packer_command = ['packer', 'build',
                       '-var', 'version={}'.format(env.get('GIT_COMMIT',
-                                                          'origin/develop')),
+                                                          get_git_sha())),
                       '-var', 'branch={}'.format(env.get('GIT_BRANCH',
-                                                         'origin/develop')),
+                                                         get_git_branch())),
                       '-var', 'aws_region={}'.format(region),
                       '-var', 'aws_ubuntu_ami={}'.format(aws_ubuntu_ami),
                       '-var', 'stack_type={}'.format(stack_type),

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -14,7 +14,7 @@
             "source_ami": "{{user `aws_ubuntu_ami`}}",
             "instance_type": "m3.large",
             "ssh_username": "ubuntu",
-            "ami_name": "mmw-app-{{timestamp}}",
+            "ami_name": "mmw-app-{{timestamp}}-{{user `version`}}",
             "run_tags": {
                 "PackerBuilder": "amazon-ebs"
             },
@@ -35,7 +35,7 @@
             "source_ami": "{{user `aws_ubuntu_ami`}}",
             "instance_type": "m3.large",
             "ssh_username": "ubuntu",
-            "ami_name": "mmw-tiler-{{timestamp}}",
+            "ami_name": "mmw-tiler-{{timestamp}}-{{user `version`}}",
             "run_tags": {
                 "PackerBuilder": "amazon-ebs"
             },
@@ -56,7 +56,7 @@
             "source_ami": "{{user `aws_ubuntu_ami`}}",
             "instance_type": "m3.large",
             "ssh_username": "ubuntu",
-            "ami_name": "mmw-worker-{{timestamp}}",
+            "ami_name": "mmw-worker-{{timestamp}}-{{user `version`}}",
             "run_tags": {
                 "PackerBuilder": "amazon-ebs"
             },

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -69,6 +69,27 @@
                 "Environment": "{{user `stack_type`}}"
             },
             "associate_public_ip_address": true
+        },
+        {
+            "name": "mmw-monitoring",
+            "type": "amazon-ebs",
+            "region": "{{user `aws_region`}}",
+            "source_ami": "{{user `aws_ubuntu_ami`}}",
+            "instance_type": "m3.large",
+            "ssh_username": "ubuntu",
+            "ami_name": "mmw-monitoring-{{timestamp}}-{{user `version`}}",
+            "run_tags": {
+                "PackerBuilder": "amazon-ebs"
+            },
+            "tags": {
+                "Name": "mmw-monitoring",
+                "Version": "{{user `version`}}",
+                "Branch": "{{user `branch`}}",
+                "Created": "{{ isotime }}",
+                "Service": "Monitoring",
+                "Environment": "{{user `stack_type`}}"
+            },
+            "associate_public_ip_address": true
         }
     ],
     "provisioners": [
@@ -106,6 +127,15 @@
             "inventory_file": "ansible/inventory/packer-worker-server",
             "only": [
                 "mmw-worker"
+            ]
+        },
+        {
+            "type": "ansible-local",
+            "playbook_file": "ansible/monitoring-servers.yml",
+            "playbook_dir": "ansible",
+            "inventory_file": "ansible/inventory/packer-monitoring-server",
+            "only": [
+                "mmw-monitoring"
             ]
         }
     ]


### PR DESCRIPTION
Packer is used to drive the EBS backed AMI generation process, making use of our existing Ansible roles and playbooks. The same credential setup process for launching stacks is reused for AMI creation.

In addition, this pull request includes a commit for determining the Git SHA and branch when not provided by environment variables.

Connects #290. Also, tagging @lliss and @kdeloach.