### PR TITLE
Implement project privacy access and UI

### DIFF
--- a/src/mmw/apps/home/tests.py
+++ b/src/mmw/apps/home/tests.py
@@ -3,4 +3,108 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-# Create your tests here.
+from django.contrib.auth.models import User
+
+from django.test import TestCase
+
+from rest_framework.test import APIClient
+
+
+class RouteAccessTestCase(TestCase):
+    def setUp(self):
+        self.c = APIClient()
+
+        self.test_user = User.objects.create_user(username='test',
+                                                  email='test@azavea.com',
+                                                  password='test')
+
+        self.another_user = User.objects.create_user(username='foo',
+                                                     email='test@azavea.com',
+                                                     password='bar')
+        self.project = {
+            "area_of_interest": ("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20))"
+                                 ",((15 5, 40 10, 10 20, 5 10, 15 5)))"),
+            "name": "My Project",
+            "model_package": "tr-55"
+        }
+
+        self.scenario = {
+            "name": "Current Conditions",
+            "is_current_conditions": True,
+            "modifications": "[]"
+        }
+
+        self.c.login(username='test', password='test')
+
+    def test_any_user_can_get_model_route_without_project_id(self):
+        response = self.c.get('/model/')
+
+        self.assertEqual(response.status_code, 200)
+
+        self.c.logout()
+
+        response = self.c.get('/model/')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_project_owner_can_get_model_route_with_project_id(self):
+        project_id = self.create_private_project()
+
+        response = self.c.get('/model/' + project_id + '/')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_logged_in_user_can_get_model_route_for_public_project(self):
+        project_id = self.create_public_project()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.get('/model/' + project_id + '/')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_logged_in_user_cant_get_model_route_for_private_project(self):
+        project_id = self.create_private_project()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.get('/model/' + project_id + '/')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_anon_user_can_get_model_route_for_public_project(self):
+        project_id = self.create_public_project()
+
+        self.c.logout()
+
+        response = self.c.get('/model/' + project_id + '/')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_anon_user_cant_get_model_route_for_private_project(self):
+        project_id = self.create_private_project()
+
+        self.c.logout()
+
+        response = self.c.get('/model/' + project_id + '/')
+
+        self.assertEqual(response.status_code, 404)
+
+    def create_public_project(self):
+        self.project['is_private'] = False
+        response = self.c.post('/api/modeling/projects/', self.project,
+                               format='json')
+
+        project_id = str(response.data['id'])
+
+        return project_id
+
+    def create_private_project(self):
+        response = self.c.post('/api/modeling/projects/', self.project,
+                               format='json')
+
+        project_id = str(response.data['id'])
+
+        return project_id

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from django.http import Http404
 from django.contrib.auth.models import User
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template.context_processors import csrf
@@ -33,16 +34,19 @@ def home_page(request):
 def model(request, proj_id=None):
     """
     If proj_id was specified, check that the user owns
-    the project. It not, return a 404. Otherwise, just
-    load the index template and the let the front-end
-    handle the route and request the project through
-    the API.
+    the project or if the project is public.
+    If not, return a 404. Otherwise, just load the index
+    template and the let the front-end handle the route
+    and request the project through the API.
     """
     csrf_token = {}
     csrf_token.update(csrf(request))
 
     if proj_id:
-        get_object_or_404(Project, user=request.user.id, id=proj_id)
+        project = get_object_or_404(Project, id=proj_id)
+
+        if project.user != request.user and project.is_private:
+            raise Http404
 
     return render_to_response('home/home.html', csrf_token)
 

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -137,7 +137,6 @@ def run_tr55(model_input, landscape):
     """
     A thin Celery wrapper around our TR55 implementation.
     """
-    print(landscape)
     # TODO Remove this.
     # hard coded values for test
     landscape = {

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -5,10 +5,13 @@ from __future__ import division
 
 from apps.core.models import Job
 from apps.modeling import views
+from django.contrib.auth.models import User
 
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.timezone import now
+
+from rest_framework.test import APIClient
 
 
 class TaskRunnerTestCase(TestCase):
@@ -31,3 +34,404 @@ class TaskRunnerTestCase(TestCase):
         self.assertEqual(str(found_job.status),
                          'complete',
                          'Job found but incomplete.')
+
+
+class APIAccessTestCase(TestCase):
+    def setUp(self):
+        self.c = APIClient()
+        self.test_user = User.objects.create_user(username='test',
+                                                  email='test@azavea.com',
+                                                  password='test')
+
+        self.another_user = User.objects.create_user(username='foo',
+                                                     email='test@azavea.com',
+                                                     password='bar')
+        self.project = {
+            "area_of_interest": ("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20))"
+                                 ",((15 5, 40 10, 10 20, 5 10, 15 5)))"),
+            "name": "My Project",
+            "model_package": "tr-55"
+        }
+
+        self.scenario = {
+            "name": "Current Conditions",
+            "is_current_conditions": True,
+            "modifications": "[]"
+        }
+
+        self.c.login(username='test', password='test')
+
+    def test_project_owner_can_get_private_project(self):
+        self.create_private_project()
+
+        response = self.c.get('/api/modeling/projects/')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_project_owner_can_get_public_project(self):
+        self.create_public_project()
+
+        response = self.c.get('/api/modeling/projects/')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_project_owner_can_put_private_project(self):
+        project_id = self.create_private_project()
+
+        response = self.c.put('/api/modeling/projects/' + project_id,
+                              self.project, format='json')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_project_owner_can_put_public_project(self):
+        project_id = self.create_public_project()
+
+        response = self.c.put('/api/modeling/projects/' + project_id,
+                              self.project, format='json')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_project_owner_can_delete_private_project(self):
+        project_id = self.create_private_project()
+
+        response = self.c.delete('/api/modeling/projects/' + project_id,
+                                 self.project, format='json')
+
+        self.assertEqual(response.status_code, 204)
+
+    def test_project_owner_can_delete_public_project(self):
+        project_id = self.create_public_project()
+
+        response = self.c.delete('/api/modeling/projects/' + project_id,
+                                 self.project, format='json')
+
+        self.assertEqual(response.status_code, 204)
+
+    def test_logged_in_user_can_get_public_project(self):
+        project_id = self.create_public_project()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.get('/api/modeling/projects/' + str(project_id))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_logged_in_user_cant_put_public_project(self):
+        project_id = self.create_public_project()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.put('/api/modeling/projects/' + project_id,
+                              self.project, format='json')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_user_cant_delete_public_project(self):
+        project_id = self.create_public_project()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.delete('/api/modeling/projects/' + project_id,
+                                 self.project, format='json')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_user_cant_get_private_project(self):
+        project_id = self.create_private_project()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.get('/api/modeling/projects/' + project_id,
+                              self.project, format='json')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_user_cant_put_private_project(self):
+        project_id = self.create_private_project()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.put('/api/modeling/projects/' + project_id,
+                              self.project, format='json')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_user_cant_delete_private_project(self):
+        project_id = self.create_private_project()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.delete('/api/modeling/projects/' + project_id,
+                                 self.project, format='json')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_anon_user_cant_get_private_project(self):
+        project_id = self.create_private_project()
+
+        self.c.logout()
+
+        response = self.c.get('/api/modeling/projects/' + project_id,
+                              self.project, format='json')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_anon_user_cant_put_private_project(self):
+        project_id = self.create_private_project()
+
+        self.c.logout()
+
+        response = self.c.put('/api/modeling/projects/' + project_id,
+                              self.project, format='json')
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_anon_user_cant_delete_private_project(self):
+        project_id = self.create_private_project()
+
+        self.c.logout()
+
+        response = self.c.delete('/api/modeling/projects/' + project_id,
+                                 self.project, format='json')
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_anon_user_can_get_public_project(self):
+        project_id = self.create_public_project()
+
+        self.c.logout()
+
+        response = self.c.get('/api/modeling/projects/' + project_id,
+                              self.project, format='json')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_anon_user_cant_put_public_project(self):
+        project_id = self.create_public_project()
+
+        self.c.logout()
+
+        response = self.c.put('/api/modeling/projects/' + project_id,
+                              self.project, format='json')
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_anon_user_cant_delete_public_project(self):
+        project_id = self.create_public_project()
+
+        self.c.logout()
+
+        response = self.c.delete('/api/modeling/projects/' + project_id,
+                                 self.project, format='json')
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_project_owner_can_get_private_scenario(self):
+        scenario_id = self.create_private_scenario()
+
+        response = self.c.get('/api/modeling/scenarios/' + scenario_id)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_project_owner_can_get_public_scenario(self):
+        scenario_id = self.create_public_scenario()
+
+        response = self.c.get('/api/modeling/scenarios/' + scenario_id)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_project_owner_can_put_private_scenario(self):
+        scenario_id = self.create_private_scenario()
+
+        response = self.c.put('/api/modeling/scenarios/' + scenario_id,
+                              self.scenario, format='json')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_project_owner_can_put_public_scenario(self):
+        scenario_id = self.create_public_scenario()
+
+        response = self.c.put('/api/modeling/scenarios/' + scenario_id,
+                              self.scenario, format='json')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_project_owner_can_delete_private_scenario(self):
+        scenario_id = self.create_private_scenario()
+
+        response = self.c.delete('/api/modeling/scenarios/' + scenario_id)
+
+        self.assertEqual(response.status_code, 204)
+
+    def test_project_owner_can_delete_public_scenario(self):
+        scenario_id = self.create_public_scenario()
+
+        response = self.c.delete('/api/modeling/scenarios/' + scenario_id)
+
+        self.assertEqual(response.status_code, 204)
+
+    def test_logged_in_user_can_get_public_scenario(self):
+        scenario_id = self.create_public_scenario()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.get('/api/modeling/scenarios/' + str(scenario_id))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_logged_in_user_cant_put_public_scenario(self):
+        scenario_id = self.create_public_scenario()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.put('/api/modeling/scenarios/' + str(scenario_id),
+                              self.scenario, format='json')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_user_cant_delete_public_scenario(self):
+        scenario_id = self.create_public_scenario()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.delete('/api/modeling/scenarios/' + str(scenario_id))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_user_cant_get_private_scenario(self):
+        scenario_id = self.create_private_scenario()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.get('/api/modeling/scenarios/' + str(scenario_id))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_user_cant_put_private_scenario(self):
+        scenario_id = self.create_private_scenario()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.put('/api/modeling/scenarios/' + str(scenario_id),
+                              self.scenario, format='json')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_user_cant_delete_private_scenario(self):
+        scenario_id = self.create_private_scenario()
+
+        self.c.logout()
+        self.c.login(username='foo', password='bar')
+
+        response = self.c.delete('/api/modeling/scenarios/' + str(scenario_id),
+                                 self.scenario, format='json')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_anon_user_cant_get_private_scenario(self):
+        scenario_id = self.create_private_scenario()
+
+        self.c.logout()
+
+        response = self.c.get('/api/modeling/scenarios/' + str(scenario_id))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_anon_user_cant_put_private_scenario(self):
+        scenario_id = self.create_private_scenario()
+
+        self.c.logout()
+
+        response = self.c.put('/api/modeling/scenarios/' + str(scenario_id),
+                              self.scenario, format='json')
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_anon_user_cant_delete_private_scenario(self):
+        scenario_id = self.create_private_scenario()
+
+        self.c.logout()
+
+        response = self.c.delete('/api/modeling/scenarios/' + str(scenario_id),
+                                 self.scenario, format='json')
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_anon_user_can_get_public_scenario(self):
+        scenario_id = self.create_public_scenario()
+
+        self.c.logout()
+
+        response = self.c.get('/api/modeling/scenarios/' + str(scenario_id))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_anon_user_cant_put_public_scenario(self):
+        scenario_id = self.create_public_scenario()
+
+        self.c.logout()
+
+        response = self.c.put('/api/modeling/scenarios/' + str(scenario_id),
+                              self.scenario, format='json')
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_anon_user_cant_delete_public_scenario(self):
+        scenario_id = self.create_public_scenario()
+
+        self.c.logout()
+
+        response = self.c.delete('/api/modeling/scenarios/' + str(scenario_id),
+                                 self.scenario, format='json')
+
+        self.assertEqual(response.status_code, 403)
+
+    def create_public_project(self):
+        self.project['is_private'] = False
+        response = self.c.post('/api/modeling/projects/', self.project,
+                               format='json')
+
+        project_id = str(response.data['id'])
+
+        return project_id
+
+    def create_private_project(self):
+        response = self.c.post('/api/modeling/projects/', self.project,
+                               format='json')
+
+        project_id = str(response.data['id'])
+
+        return project_id
+
+    def create_public_scenario(self):
+        project_id = self.create_public_project()
+        self.scenario['project'] = project_id
+
+        response = self.c.post('/api/modeling/scenarios/', self.scenario,
+                               format='json')
+
+        scenario_id = str(response.data['id'])
+
+        return scenario_id
+
+    def create_private_scenario(self):
+        project_id = self.create_private_project()
+        self.scenario['project'] = project_id
+
+        response = self.c.post('/api/modeling/scenarios/', self.scenario,
+                               format='json')
+
+        scenario_id = str(response.data['id'])
+
+        return scenario_id

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -32,9 +32,14 @@ var MapModel = Backbone.Model.extend({
                       this.get('areaOfInterest').geometry :
                       this.get('areaOfInterest');
 
-            if (aoi.type === 'Polygon') {
+            if (aoi.type !== 'MultiPolygon') {
+                if (aoi.type === 'Polygon') {
+                    aoi.coordinates = [aoi.coordinates];
+                } else if (aoi.type === 'FeatureCollection') {
+                    aoi.coordinates = [aoi.features[0].geometry.coordinates];
+                }
+
                 aoi.type = 'MultiPolygon';
-                aoi.coordinates = [aoi.coordinates];
             }
 
             this.set('areaOfInterest', aoi);

--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -8,12 +8,14 @@
         <i class="fa fa-caret-down"></i>
         </button>
         <ul class="dropdown-menu menu-right" role="menu">
+            {% if id %}
+                <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="share-project">Share</a></li>
+                <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="project-privacy">{% if is_private %}Make Public{% else %}Make Private{% endif %}</a></li>
+                <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="delete-project">Delete</a></li>
+                <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="add-tag">Add Tags</a></li>
+            {% endif %}
             <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="rename-project">Rename</a></li>
-            <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="share-project">Share</a></li>
-            <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="project-privacy">{% if is_private %} Make Public {% else %} Make Private {% endif %}</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" id="print-project">Print</a></li>
-            <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="delete-project">Delete</a></li>
-            <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="add-tag">Add Tags</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" id="save-project">Save</a></li>
         </ul>
     </div>

--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -10,6 +10,7 @@
         <ul class="dropdown-menu menu-right" role="menu">
             <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="rename-project">Rename</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="share-project">Share</a></li>
+            <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="project-privacy">{% if is_private %} Make Public {% else %} Make Private {% endif %}</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" id="print-project">Print</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="delete-project">Delete</a></li>
             <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="add-tag">Add Tags</a></li>

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -126,6 +126,51 @@ describe('Modeling', function() {
                 assert.equal($('#sandbox #mod-conservationpractice tr td:nth-child(2)').text(), '106.4 km2');
             });
         });
+
+        describe('ProjectMenuView', function() {
+            it('displays a limited list of options in the drop down menu until the project is saved', function() {
+                var project = getTestProject(),
+                    view = new views.ProjectMenuView({ model: project });
+
+                $('#sandbox').html(view.render().el);
+
+                assert.equal($('#sandbox li').length, 3);
+            });
+
+            it('displays all the options in the drop down menu if the project is saved', function() {
+                var project = getTestProject(),
+                    view = new views.ProjectMenuView({ model: project }),
+                    projectResponse = '{"id":21,"user":{"id":1,"username":"test","email":"test@azavea.com"},"scenarios":[],"name":"Test Project","area_of_interest":{},"is_private":true,"model_package":"tr-55","created_at":"2015-06-03T20:09:11.988948Z","modified_at":"2015-06-03T20:09:11.988988Z"}';
+
+                this.server.respondWith('POST', '/api/modeling/projects/',
+                            [ 200, { 'Content-Type': 'application/json' }, projectResponse ]);
+
+                project.save();
+
+                $('#sandbox').html(view.render().el);
+
+                assert.equal($('#sandbox li').length, 7);
+            });
+
+            it('changes the privacy menu item depending on the is_private attribute of the project', function() {
+                var project = getTestProject(),
+                    view = new views.ProjectMenuView({ model: project });
+
+                project.set({
+                    id: 1,
+                    is_private: true
+                });
+
+                $('#sandbox').html(view.render().el);
+
+                assert.equal($('#sandbox #project-privacy').text(), 'Make Public');
+
+                project.set('is_private', false);
+                $('#sandbox').html(view.render().el);
+
+                assert.equal($('#sandbox #project-privacy').text(), 'Make Private');
+            });
+        });
     });
 
     describe('Models', function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -64,17 +64,21 @@ var ProjectMenuView = Marionette.ItemView.extend({
         share: '#share-project',
         remove: '#delete-project',
         print: '#print-project',
-        save: '#save-project'
-
+        save: '#save-project',
+        privacy: '#project-privacy'
     },
+
     events: {
         'click @ui.rename': 'renameProject',
         'click @ui.remove': 'deleteProject',
         'click @ui.share': 'shareProject',
         'click @ui.print': 'printProject',
-        'click @ui.save': 'saveProject'
+        'click @ui.save': 'saveProject',
+        'click @ui.privacy': 'setProjectPrivacy'
     },
+
     template: projectMenuTmpl,
+
     modelEvents: {
         'change': 'render'
     },
@@ -142,6 +146,32 @@ var ProjectMenuView = Marionette.ItemView.extend({
 
     saveProject: function() {
         this.model.saveAll();
+    },
+
+    setProjectPrivacy: function() {
+        var self = this,
+            currentSettings = this.model.get('is_private') ? 'private' : 'public',
+            newSettings = currentSettings === 'private' ? 'public' : 'private',
+            primaryText = 'This project is currently ' + currentSettings + '. ' +
+                      'Are you sure you want to make it ' + newSettings + '? ',
+            additionalText = currentSettings === 'private' ?
+                    'Anyone with the URL will be able to access it.' :
+                    'Only you will be able to access it.',
+            question = primaryText + additionalText,
+            modal = new coreViews.ConfirmModal({
+                model: new Backbone.Model({
+                    question: question,
+                    confirmLabel: 'Confirm',
+                    cancelLabel: 'Cancel'
+                })
+            });
+
+        modal.render();
+        modal.on('confirmation', function() {
+            self.model.set('is_private', !self.model.get('is_private'));
+            // TODO: Save just the project. Change after #226 is implemented.
+            self.model.saveAll();
+        });
     }
 });
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -726,5 +726,6 @@ module.exports = {
     ScenariosView: ScenariosView,
     ScenarioTabPanelsView: ScenarioTabPanelsView,
     ScenarioDropDownMenuView: ScenarioDropDownMenuView,
-    ToolbarTabContentView: ToolbarTabContentView
+    ToolbarTabContentView: ToolbarTabContentView,
+    ProjectMenuView: ProjectMenuView
 };


### PR DESCRIPTION
Implements the access rights for private projects and a UI modal to change the settings. See commit messages for details.

Here's the basic rule structure for accessing projects:

- Project owners can GET/PUT/DELETE owned public and private projects
- Logged in users can GET public projects.
- Logged in users can't PUT/DELETE public or private projects.
- Anonymous users can GET public projects.
- Anonymous users can't PUT/DELETE public or private projects.

**To Test:**
- Create a new project or load an existing one.
- Use the "Privacy" option in the project drop down menu to toggle the project privacy settings.
- Try accessing the project when logged in with a different user and when not being logged in. See the basic access rules above for expected behavior.
- Run the tests

Connects to #301.