### PR TITLE
Add turf-buffer and turf-random to vendor bundle

### DIFF
--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -105,7 +105,7 @@ CONCAT_VENDOR_CSS_COMMAND="cat \
 JS_DEPS=(jquery backbone backbone.marionette \
          bootstrap bootstrap-select \
          leaflet leaflet-draw lodash underscore \
-         d3 nunjucks turf-area \
+         d3 nunjucks turf-area turf-buffer turf-random \
          zeroclipboard)
 BROWSERIFY_EXT=""
 BROWSERIFY_REQ=""


### PR DESCRIPTION
Should reduce the primary bundle size from 1.9MB to 600KB.