### PR TITLE
Draw correct map features from a loaded scenario

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -112,6 +112,16 @@ var ModificationModel = coreModels.GeoModel.extend({
 var ModificationsCollection = Backbone.Collection.extend({
     model: ModificationModel
 });
+// Static method to create an instance of this collection.
+// This lets us create a collection from an array of raw objects (web app)
+// or from an array of models (unit tests).
+ModificationsCollection.create = function(data) {
+    if (data instanceof ModificationsCollection) {
+        return data;
+    } else {
+        return new ModificationsCollection(data);
+    }
+};
 
 var ScenarioModel = Backbone.Model.extend({
     urlRoot: '/api/modeling/scenarios/',
@@ -123,15 +133,9 @@ var ScenarioModel = Backbone.Model.extend({
         active: false
     },
 
-    initialize: function() {
-        // TODO: When #278 is resolved, we should be doing something like this
-        // to setup or restore modifications.
-        // var mods = this.get('modifications') === null ? [] : JSON.parse(this.get('modifications'));
-        var mods = this.get('modifications');
-
-        if (mods === null || typeof mods === 'string') {
-            this.set('modifications', new ModificationsCollection());
-        }
+    initialize: function(attrs, options) {
+        Backbone.Model.prototype.initialize.apply(this, arguments);
+        this.set('modifications', ModificationsCollection.create(attrs.modifications));
     },
 
     getSlug: function() {
@@ -153,6 +157,11 @@ var ScenarioModel = Backbone.Model.extend({
             modificationsColl.remove(existing);
         }
         modificationsColl.add(modification);
+    },
+
+    parse: function(response, options) {
+        var modificationsColl = this.get('modifications');
+        modificationsColl.reset(response.modifications);
     }
 });
 

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -88,10 +88,13 @@ describe('Modeling', function() {
         describe('ToolbarTabContentView', function() {
             it('updates the modification count when there is a change to a scenario\'s modifications', function() {
                 var modsCollection = new models.ModificationsCollection(),
-                    model = new models.ScenarioModel({ name: 'New Scenario', modifications: modsCollection }),
+                    model = new models.ScenarioModel({
+                        name: 'New Scenario',
+                        modifications: modsCollection
+                    }),
                     view = new views.ToolbarTabContentView({
                         model: model,
-                        collection: getTR55ModelPackage().get('controls')
+                        collection: models.getControlsForModelPackage('tr-55')
                     }),
                     modsModel1 = new models.ModificationModel(modificationsSample1),
                     modsModel2 = new models.ModificationModel(modificationsSample2);
@@ -107,10 +110,13 @@ describe('Modeling', function() {
                 var modsModel1 = new models.ModificationModel(modificationsSample1),
                     modsModel2 = new models.ModificationModel(modificationsSample2),
                     modsCollection = new models.ModificationsCollection([ modsModel1, modsModel2 ]),
-                    model = new models.ScenarioModel({ name: 'New Scenario', modifications: modsCollection }),
+                    model = new models.ScenarioModel({
+                        name: 'New Scenario',
+                        modifications: modsCollection
+                    }),
                     view = new views.ToolbarTabContentView({
                         model: model,
-                        collection: getTR55ModelPackage().get('controls')
+                        collection: models.getControlsForModelPackage('tr-55')
                     });
 
                 $('#sandbox').html(view.render().el);
@@ -428,15 +434,4 @@ function getTestProject() {
         });
 
     return project;
-}
-
-function getTR55ModelPackage() {
-    return new models.ModelPackageModel({
-        name: 'tr-55',
-        controls: new models.ModelPackageControlsCollection([
-            new models.ModelPackageControlModel({ name: 'landcover' }),
-            new models.ModelPackageControlModel({ name: 'conservation_practice' }),
-            new models.ModelPackageControlModel({ name: 'precipitation' })
-        ])
-    });
 }

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -411,7 +411,6 @@ var ToolbarTabContentView = Marionette.CompositeView.extend({
 
     initialize: function() {
         var modificationsColl = this.model.get('modifications');
-        this.listenTo(modificationsColl, 'add remove', this.updateMap);
         this.listenTo(modificationsColl, 'add remove', this.render);
     },
 
@@ -431,11 +430,14 @@ var ToolbarTabContentView = Marionette.CompositeView.extend({
 
     onRender: function() {
         this.$el.toggleClass('active', this.model.get('active'));
+        this.updateMap();
     },
 
     updateMap: function() {
-        var modificationsColl = this.model.get('modifications');
-        App.getMapView().updateModifications(modificationsColl);
+        if (this.model.get('active')) {
+            var modificationsColl = this.model.get('modifications');
+            App.getMapView().updateModifications(modificationsColl);
+        }
     },
 
     deleteModification: function(e) {


### PR DESCRIPTION
The problem regarding modifications not being present (null) when
loading a saved project has been fixed by #320.

This fixes a related bug where map features would not be drawn for the correct
tab upon loading a saved scenario.

Connects #331