### PR TITLE
Associate model output with scenario window

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -156,18 +156,12 @@ def run_tr55(census, model_input):
     A thin Celery wrapper around our TR55 implementation.
     """
 
-    # TODO Remove after testing.
-    time.sleep(3)
-
     et_max = 0.207
-    precip_mod = filter(lambda mod: mod['name'] == 'precipitation',
-                        model_input['modifications'])[0]
-    precip = precip_mod['value']
+    precip = model_input['precip']
 
     def simulate_day(cell, cell_count):
-
-        (soil_type, land_use) = cell.lower().split(':')
+        soil_type, land_use = cell.lower().split(':')
         et = et_max * lookup_ki(land_use)
         return simulate_cell_day((precip, et), cell, cell_count)
 
-    return simulate_modifications(census, fn=simulate_day)
+    return {'runoff': simulate_modifications(census, fn=simulate_day)}

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -23,7 +23,8 @@ class TaskRunnerTestCase(TestCase):
                     'name': 'precipitation',
                     'value': 1.2
                 }
-            ]
+            ],
+            'precip': 1.0
         }
 
         created = now()

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -17,7 +17,15 @@ from rest_framework.test import APIClient
 class TaskRunnerTestCase(TestCase):
     @override_settings(CELERY_ALWAYS_EAGER=True)
     def test_tr55_job_runs_in_chain(self):
-        model_input = 'TEST'
+        model_input = {
+            'modifications': [
+                {
+                    'name': 'precipitation',
+                    'value': 1.2
+                }
+            ]
+        }
+
         created = now()
         job = Job.objects.create(created_at=created, result='', error='',
                                  traceback='', user=None, status='started')

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -196,7 +196,7 @@ def start_tr55(request, format=None):
     user = request.user if request.user.is_authenticated() else None
     created = now()
     # TODO Validate input data.
-    model_input = request.POST
+    model_input = json.loads(request.POST['model_input'])
     job = Job.objects.create(created_at=created, result='', error='',
                              traceback='', user=user, status='started')
 

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -69,7 +69,7 @@ function setupAnalyzeView(data, server) {
     var sandbox = new SandboxRegion(),
         view = new views.AnalyzeWindow({
             id: 'analyze-output-wrapper',
-            model: new models.LayerCollection({})
+            model: new models.AnalyzeTaskModel()
         }),
         jobId = "abc",
         startResponse = JSON.stringify({

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -23,24 +23,23 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
     template: windowTmpl,
 
     initialize: function() {
-        var self = this;
 
+        var self = this;
         if (!this.model.get('result')) {
-            this.model.fetch({ method: 'POST' })
-                .done(function() {
-                    self.model.pollForResults()
-                        .done(_.bind(self.showDetailsRegion, self))
-                        .fail(function() {
-                            console.log('Failed to get analyze results');
-                            // TODO: Show an error message across the whole
-                            // analyze window
-                        });
-                })
-                .fail(function() {
+            var taskHelper = {
+                pollSuccess: function() {
+                    self.showDetailsRegion();
+                },
+
+                pollFailure: function() {
+                    console.log('Failed to get analyze results');
+                },
+
+                startFailure: function() {
                     console.log('Failed to start analyze job');
-                    // TODO: Show an error message across the whole
-                    // analyze window
-                });
+                }
+            };
+            this.model.start(taskHelper);
         } else {
             this.lock = $.Deferred();
             this.lock.done(function() {

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -1,3 +1,4 @@
+
 "use strict";
 
 var $ = require('jquery'),
@@ -24,6 +25,8 @@ var ModelingController = {
                 id: projectId
             });
 
+            App.currProject = project;
+
             project
                 .fetch()
                 .done(function(data) {
@@ -40,21 +43,24 @@ var ModelingController = {
                     } else {
                         project.get('scenarios').makeFirstScenarioActive();
                     }
-
+                    project.getResultsIfNeeded();
                 });
         } else {
             project = new models.ProjectModel({
                 name: 'Untitled Project',
                 created_at: Date.now(),
                 area_of_interest: App.map.get('areaOfInterest'),
-                scenarios: new models.ScenariosCollection([
-                    new models.ScenarioModel({
-                        name: 'Current Conditions',
-                        is_current_conditions: true,
-                        active: true
-                    })
-                ])
+                scenarios: new models.ScenariosCollection()
             });
+
+            App.currProject = project;
+
+            var currentConditionsScenario = new models.ScenarioModel({
+                name: 'Current Conditions',
+                is_current_conditions: true,
+                active: true
+            });
+            project.get('scenarios').add(currentConditionsScenario);
 
             project.on('change:id', function(model) {
                 router.navigate(project.getReferenceUrl());
@@ -62,8 +68,9 @@ var ModelingController = {
 
             initScenarioEvents(project);
             initViews(project);
-        }
 
+            project.getResultsIfNeeded();
+        }
     },
 
     modelCleanUp: function() {

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -114,6 +114,7 @@ var PrecipitationView = ControlView.extend({
     onRender: function() {
         var model = this.modificationModel,
             value = model && model.get('value') || 0;
+
         this.ui.slider.val(value);
         this.ui.displayValue.text(this.getDisplayValue(value));
     }

--- a/src/mmw/js/src/modeling/templates/currentConditionsToolbarTabContent.html
+++ b/src/mmw/js/src/modeling/templates/currentConditionsToolbarTabContent.html
@@ -1,2 +1,0 @@
-<div class="controls"></div>
-Current Conditions

--- a/src/mmw/js/src/modeling/templates/resultsTabPanel.html
+++ b/src/mmw/js/src/modeling/templates/resultsTabPanel.html
@@ -1,1 +1,6 @@
-<a href="#{{ name }}" aria-controls="home" role="tab" data-toggle="tab">{{ displayName }}</a>
+<a href="#{{ name }}" aria-controls="home" role="tab" data-toggle="tab">
+    {% if polling %}
+        <i class="fa fa-refresh fa-spin"></i>
+    {% endif %}
+    {{ displayName }}
+</a>

--- a/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
+++ b/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
@@ -1,14 +1,5 @@
 <div class="inline controls"></div>
 
-<div class="dropdown" data-toggle="tooltip" data-placement="bottom" title="Advanced"> <!-- Advanced Settings -->
-    <button class="btn btn-sm btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
-    <i class="fa fa-cog"></i>
-    </button>
-    <ul class="dropdown-menu menu-right" role="menu">
-        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Advanced Inputs</a></li>
-    </ul>
-</div>
-
 <div id="modification-btn-wrapper"> <!-- Modifications Dropdown -->
     <div class="dropdown"> <!-- Dropdown Button -->
         <button class="btn btn-sm btn-default inverted" type="button" data-toggle="dropdown" aria-expanded="true">

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -19,6 +19,11 @@ describe('Modeling', function() {
         if ($('#sandbox').length === 0) {
             $('<div>', {id: 'sandbox'}).appendTo('body');
         }
+
+        // ScenarioModel.initialize() expects
+        // App.currProject to be set, and uses it to determine the
+        // taskModel and modelPackage to use.
+        App.currProject = new models.ProjectModel();
     });
 
     beforeEach(function() {

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -10,3 +10,4 @@ django-registration-redux==1.1
 python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
+tr55==0.1.0

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -186,12 +186,6 @@ header{
       float: right;
     }
 
-    #advanced{
-      position: absolute;
-      top: 0;
-      right: 0;
-    }
-
     .inline {
       display: inline-block;
       margin-right: 5px;


### PR DESCRIPTION
Reprovision the worker VM. (Although running `sudo service celeryd restart` and `pip install -r src/mmw/requirements/base.txt` (to install tr55) on the worker VM will probably suffice.)

Make sure that the analyze view still loads table/chart as before.

In the model view, in Current Conditions, set the value of the precipitation slider. This should start the spinner icon on the Runoff tab. After polling ~6 times, the bar chart should display with the total level of runoff/et/inf matching the selected precipitation value, and the spinner should stop.

Try changing the precipitation value once, and then again about a second later. On the console, you should see that the first job was cancelled. If the user submits several jobs within the time it takes to run the model, there will be multiple jobs in the queue ahead of the final job, delaying the final job, potentially past the time limit set in the TaskModel. I think we should create a separate issue to deal with cancelling jobs on the backend.

Try making a new scenario, and change the precip values in both scenarios so they are polling concurrently. This should work. Adding modifications will fire off the job, but the modifications will have no effect because we don't have the Geotrellis task running on the backend yet.

Connects #200 