### PR TITLE
Remove stray drawtools.

### DIFF
--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -329,6 +329,27 @@ describe('Core', function() {
             assert.equal(spy.callCount, 0);
         });
 
+        it('does not navigated to the route associated with a prepare function that returns false', function() {
+            var controller = getController(),
+                router = new AppRouter(),
+                otherController = getOtherController(router),
+                spy = sinon.spy(controller, 'foo'),
+                otherSpy = sinon.spy(otherController, 'bazCleanUp');
+
+            router.addRoute(/^foo/, controller, 'foo');
+            router.addRoute(/^baz/, otherController, 'baz');
+
+            Backbone.history.start();
+
+            router.navigate('baz', { trigger: true });
+            router.navigate('foo', { trigger: true });
+
+            // if bazCleanup was never run then evidently the baz
+            // route was never navigated to.
+            assert.equal(spy.callCount, 1);
+            assert.equal(otherSpy.callCount, 0);
+        });
+
         it('does not execute route A\'s cleanUp function when navigating to route B if route A\'s prepare ' +
            'function returned false (i.e. route A was never navigated to)', function() {
 
@@ -387,6 +408,24 @@ function createTransitionRegionWithAnimatedHeightView(displayHeight, hiddenHeigh
         testParentView: testParentView,
         testSubView: testSubView
     };
+}
+
+function getOtherController(router) {
+    var controller = {
+        bazPrepare: function() {
+            console.log('bazPrepare');
+            router.navigate('bar', { trigger: true });
+            return false;
+        },
+        baz: function() {
+            console.log('baz');
+        },
+        bazCleanUp: function() {
+            console.log('bazCleanUp');
+        }
+    };
+
+    return controller;
 }
 
 function getController() {

--- a/src/mmw/js/src/router.js
+++ b/src/mmw/js/src/router.js
@@ -73,21 +73,26 @@ var AppRouter = PatchedRouter.extend({
             });
         }
 
+        var self = this;
         this._sequence = this._sequence.then(function() {
             var result = prepare.apply(null, args);
             // Assume result is a promise if an object is returned.
             if (_.isObject(result)) {
+                self._previousRouteName = routeName;
                 return result.then(function() {
                     cb.apply(null, args);
                 });
-            // Only execute the route callback if prepare
-            // did not return false.
             } else if (result !== false) {
+                // Only execute the route callback if prepare
+                // did not return false.
+                self._previousRouteName = routeName;
                 cb.apply(null, args);
+            } else {
+                // Don't execute the route function
+                // and cancel the route transition
+                return false;
             }
         });
-
-        this._previousRouteName = routeName;
     },
 
     getSuffixMethod: function(context, suffix) {


### PR DESCRIPTION
Modify the router's `.execute` method to make sure that when the prepare method uses `router.navigate` and returns `false`, that that route is not navigated to.  A test has been added for this case, also.

**To Test**
   * Follow the instructions given in the bug report https://github.com/WikiWatershed/model-my-watershed/issues/314
   * The draw tools and geocode search box should no longer stay after you have chosen an AoI.

Fixes #314