### PR TITLE
Modification SVG Fill Patterns

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -33,4 +33,6 @@
     <script type="text/javascript" src="{% static 'js/vendor.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/main.js' %}"></script>
     {% endblock javascript %}
+
+    {% include 'patterns.html' %}
 </body>

--- a/src/mmw/apps/core/templates/patterns.html
+++ b/src/mmw/apps/core/templates/patterns.html
@@ -1,0 +1,3503 @@
+<svg>
+    <defs>
+        <!-- LAND COVER TYPES -->
+        <!-- Low Intensity Residential-->
+        <pattern height="72" id="fill-lir" overflow="visible" patternUnits="userSpaceOnUse" viewBox="79.59 -151.59 72 72" width="72">
+            <g>
+                <polygon fill="#329b9c" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                <g>
+                    <polygon fill="none" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-156.105" y2="-78.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-84.105" y2="-6.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- High Intensity Residential-->
+        <pattern height="72" id="fill-hir" overflow="visible" patternUnits="userSpaceOnUse" viewBox="72.212 -144.212 72 72" width="72">
+            <g>
+                <polygon fill="#39afa1" points="72.212,-72.212 144.212,-72.212 144.212,-144.212 72.212,-144.212"/>
+                <g>
+                    <polygon fill="none" points="72.212,-72.212 144.212,-72.212 144.212,-144.212 72.212,-144.212"/>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="216.212" y1="-144.212" y2="-216.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="216.212" x2="144.212" y1="-144.212" y2="-216.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="210.212" x2="141.21" y1="-144.212" y2="-213.214"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="204.212" x2="141.206" y1="-144.212" y2="-207.218"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="198.212" x2="141.202" y1="-144.212" y2="-201.222"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="192.212" x2="141.198" y1="-144.212" y2="-195.226"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="186.212" x2="141.195" y1="-144.212" y2="-189.229"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="180.212" x2="141.191" y1="-144.212" y2="-183.234"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="174.212" x2="141.187" y1="-144.212" y2="-177.236"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="168.212" x2="141.185" y1="-144.212" y2="-171.24"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="162.212" x2="141.181" y1="-144.212" y2="-165.244"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="156.212" x2="141.177" y1="-144.212" y2="-159.248"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="150.212" x2="141.173" y1="-144.212" y2="-153.252"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="141.169" y1="-144.212" y2="-147.256"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="144.212" y1="-144.212" y2="-216.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="78.212" x2="147.213" y1="-144.212" y2="-213.214"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="84.212" x2="147.217" y1="-144.212" y2="-207.218"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="90.212" x2="147.221" y1="-144.212" y2="-201.222"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="96.212" x2="147.225" y1="-144.212" y2="-195.225"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="102.212" x2="147.228" y1="-144.212" y2="-189.229"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="108.212" x2="147.231" y1="-144.212" y2="-183.234"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="114.212" x2="147.235" y1="-144.212" y2="-177.236"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="120.212" x2="147.239" y1="-144.212" y2="-171.24"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="126.212" x2="147.242" y1="-144.212" y2="-165.244"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="132.212" x2="147.246" y1="-144.212" y2="-159.248"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="138.212" x2="147.25" y1="-144.212" y2="-153.252"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="147.255" y1="-144.212" y2="-147.255"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="72.212" y1="-144.212" y2="-216.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="138.212" x2="69.21" y1="-144.212" y2="-213.214"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="132.212" x2="69.206" y1="-144.212" y2="-207.218"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="126.212" x2="69.202" y1="-144.212" y2="-201.222"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="120.212" x2="69.198" y1="-144.212" y2="-195.226"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="114.212" x2="69.195" y1="-144.212" y2="-189.229"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="108.212" x2="69.191" y1="-144.212" y2="-183.234"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="102.212" x2="69.187" y1="-144.212" y2="-177.236"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="96.212" x2="69.185" y1="-144.212" y2="-171.24"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="90.212" x2="69.181" y1="-144.212" y2="-165.244"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="84.212" x2="69.177" y1="-144.212" y2="-159.248"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="78.212" x2="69.173" y1="-144.212" y2="-153.252"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="69.169" y1="-144.212" y2="-147.256"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="0.212" x2="72.212" y1="-144.212" y2="-216.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="6.212" x2="75.213" y1="-144.212" y2="-213.214"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="12.212" x2="75.217" y1="-144.212" y2="-207.218"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="18.212" x2="75.221" y1="-144.212" y2="-201.222"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="24.212" x2="75.225" y1="-144.212" y2="-195.225"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="30.212" x2="75.228" y1="-144.212" y2="-189.229"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="36.212" x2="75.231" y1="-144.212" y2="-183.234"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="42.212" x2="75.235" y1="-144.212" y2="-177.236"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="48.212" x2="75.239" y1="-144.212" y2="-171.24"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="54.212" x2="75.242" y1="-144.212" y2="-165.244"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="60.212" x2="75.246" y1="-144.212" y2="-159.248"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="66.212" x2="75.25" y1="-144.212" y2="-153.252"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="75.255" y1="-144.212" y2="-147.255"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="0.212" y1="-144.212" y2="-216.212"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="216.212" y1="-72.212" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.21" x2="210.212" y1="-75.211" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.206" x2="204.212" y1="-81.207" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.202" x2="198.212" y1="-87.203" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.198" x2="192.212" y1="-93.199" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.195" x2="186.212" y1="-99.195" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.191" x2="180.212" y1="-105.193" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.187" x2="174.212" y1="-111.188" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.185" x2="168.212" y1="-117.184" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.181" x2="162.212" y1="-123.181" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.177" x2="156.212" y1="-129.177" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.173" x2="150.212" y1="-135.173" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.169" x2="144.212" y1="-141.169" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="216.212" x2="144.212" y1="-72.212" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="210.212" x2="141.21" y1="-72.212" y2="-141.214"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="204.212" x2="141.206" y1="-72.212" y2="-135.218"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="198.212" x2="141.202" y1="-72.212" y2="-129.222"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="192.212" x2="141.198" y1="-72.212" y2="-123.226"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="186.212" x2="141.195" y1="-72.212" y2="-117.229"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="180.212" x2="141.191" y1="-72.212" y2="-111.234"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="174.212" x2="141.187" y1="-72.212" y2="-105.236"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="168.212" x2="141.185" y1="-72.212" y2="-99.24"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="162.212" x2="141.181" y1="-72.212" y2="-93.244"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="156.212" x2="141.177" y1="-72.212" y2="-87.248"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="150.212" x2="141.173" y1="-72.212" y2="-81.252"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="141.169" y1="-72.212" y2="-75.256"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="144.212" y1="-72.212" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.21" x2="138.212" y1="-75.211" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.206" x2="132.212" y1="-81.207" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.202" x2="126.212" y1="-87.203" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.198" x2="120.212" y1="-93.199" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.195" x2="114.212" y1="-99.195" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.191" x2="108.212" y1="-105.193" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.187" x2="102.212" y1="-111.188" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.185" x2="96.212" y1="-117.184" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.181" x2="90.212" y1="-123.181" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.177" x2="84.212" y1="-129.177" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.173" x2="78.212" y1="-135.173" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.169" x2="72.212" y1="-141.169" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="78.212" x2="147.213" y1="-72.212" y2="-141.214"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="84.212" x2="147.217" y1="-72.212" y2="-135.218"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="90.212" x2="147.221" y1="-72.212" y2="-129.222"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="96.212" x2="147.225" y1="-72.212" y2="-123.225"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="102.212" x2="147.228" y1="-72.212" y2="-117.229"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="108.212" x2="147.231" y1="-72.212" y2="-111.234"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="114.212" x2="147.235" y1="-72.212" y2="-105.236"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="120.212" x2="147.239" y1="-72.212" y2="-99.24"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="126.212" x2="147.242" y1="-72.212" y2="-93.244"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="132.212" x2="147.246" y1="-72.212" y2="-87.248"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="138.212" x2="147.25" y1="-72.212" y2="-81.252"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="147.255" y1="-72.212" y2="-75.255"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="72.212" y1="-72.212" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="138.212" x2="69.21" y1="-72.212" y2="-141.214"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="132.212" x2="69.206" y1="-72.212" y2="-135.218"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="126.212" x2="69.202" y1="-72.212" y2="-129.222"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="120.212" x2="69.198" y1="-72.212" y2="-123.226"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="114.212" x2="69.195" y1="-72.212" y2="-117.229"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="108.212" x2="69.191" y1="-72.212" y2="-111.234"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="102.212" x2="69.187" y1="-72.212" y2="-105.236"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="96.212" x2="69.185" y1="-72.212" y2="-99.24"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="90.212" x2="69.181" y1="-72.212" y2="-93.244"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="84.212" x2="69.177" y1="-72.212" y2="-87.248"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="78.212" x2="69.173" y1="-72.212" y2="-81.252"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="69.169" y1="-72.212" y2="-75.256"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.213" x2="78.212" y1="-75.211" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.217" x2="84.212" y1="-81.207" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.221" x2="90.212" y1="-87.203" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.225" x2="96.212" y1="-93.199" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.228" x2="102.212" y1="-99.195" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.231" x2="108.212" y1="-105.193" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.235" x2="114.212" y1="-111.188" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.239" x2="120.212" y1="-117.185" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.242" x2="126.212" y1="-123.181" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.246" x2="132.212" y1="-129.177" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.25" x2="138.212" y1="-135.173" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.255" x2="144.212" y1="-141.17" y2="-144.212"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="0.212" x2="72.212" y1="-72.212" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="6.212" x2="75.213" y1="-72.212" y2="-141.214"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="12.212" x2="75.217" y1="-72.212" y2="-135.218"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="18.212" x2="75.221" y1="-72.212" y2="-129.222"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="24.212" x2="75.225" y1="-72.212" y2="-123.225"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="30.212" x2="75.228" y1="-72.212" y2="-117.229"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="36.212" x2="75.231" y1="-72.212" y2="-111.234"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="42.212" x2="75.235" y1="-72.212" y2="-105.236"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="48.212" x2="75.239" y1="-72.212" y2="-99.24"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="54.212" x2="75.242" y1="-72.212" y2="-93.244"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="60.212" x2="75.246" y1="-72.212" y2="-87.248"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="66.212" x2="75.25" y1="-72.212" y2="-81.252"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="75.255" y1="-72.212" y2="-75.255"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="0.212" y1="-72.212" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.213" x2="6.212" y1="-75.211" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.217" x2="12.212" y1="-81.207" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.221" x2="18.212" y1="-87.203" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.225" x2="24.212" y1="-93.199" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.228" x2="30.212" y1="-99.195" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.231" x2="36.212" y1="-105.193" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.235" x2="42.212" y1="-111.188" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.239" x2="48.212" y1="-117.185" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.242" x2="54.212" y1="-123.181" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.246" x2="60.212" y1="-129.177" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.25" x2="66.212" y1="-135.173" y2="-144.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.255" x2="72.212" y1="-141.17" y2="-144.212"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="216.212" y1="-0.212" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.21" x2="210.212" y1="-3.211" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.206" x2="204.212" y1="-9.207" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.202" x2="198.212" y1="-15.203" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.198" x2="192.212" y1="-21.199" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.195" x2="186.212" y1="-27.195" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.191" x2="180.212" y1="-33.193" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.187" x2="174.212" y1="-39.188" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.185" x2="168.212" y1="-45.184" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.181" x2="162.212" y1="-51.181" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.177" x2="156.212" y1="-57.177" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.173" x2="150.212" y1="-63.173" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="141.169" x2="144.212" y1="-69.169" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="216.212" x2="144.212" y1="-0.212" y2="-72.212"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="144.212" y1="-0.212" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.21" x2="138.212" y1="-3.211" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.206" x2="132.212" y1="-9.207" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.202" x2="126.212" y1="-15.203" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.198" x2="120.212" y1="-21.199" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.195" x2="114.212" y1="-27.195" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.191" x2="108.212" y1="-33.193" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.187" x2="102.212" y1="-39.188" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.185" x2="96.212" y1="-45.184" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.181" x2="90.212" y1="-51.181" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.177" x2="84.212" y1="-57.177" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.173" x2="78.212" y1="-63.173" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="69.169" x2="72.212" y1="-69.169" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="144.212" x2="72.212" y1="-0.212" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.213" x2="78.212" y1="-3.211" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.217" x2="84.212" y1="-9.207" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.221" x2="90.212" y1="-15.203" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.225" x2="96.212" y1="-21.199" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.228" x2="102.212" y1="-27.195" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.231" x2="108.212" y1="-33.193" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.235" x2="114.212" y1="-39.188" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.239" x2="120.212" y1="-45.185" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.242" x2="126.212" y1="-51.181" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.246" x2="132.212" y1="-57.177" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.25" x2="138.212" y1="-63.173" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="147.255" x2="144.212" y1="-69.17" y2="-72.212"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="0.212" x2="72.212" y1="-0.212" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="72.212" x2="0.212" y1="-0.212" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.213" x2="6.212" y1="-3.211" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.217" x2="12.212" y1="-9.207" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.221" x2="18.212" y1="-15.203" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.225" x2="24.212" y1="-21.199" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.228" x2="30.212" y1="-27.195" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.231" x2="36.212" y1="-33.193" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.235" x2="42.212" y1="-39.188" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.239" x2="48.212" y1="-45.185" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.242" x2="54.212" y1="-51.181" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.246" x2="60.212" y1="-57.177" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.25" x2="66.212" y1="-63.173" y2="-72.212"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-linejoin="bevel" stroke-width="0.3" x1="75.255" x2="72.212" y1="-69.17" y2="-72.212"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- Commercial-->
+        <pattern height="43.199" id="fill-commercial" overflow="visible" patternUnits="userSpaceOnUse" viewBox="57.763 -49.576 57.601 43.199" width="57.601">
+            <g>
+                <polygon fill="#40c2a8" points="57.763,-6.377 115.364,-6.377 115.364,-49.576 57.763,-49.576"/>
+                <g>
+                    <polygon fill="none" points="57.763,-6.377 115.363,-6.377 115.363,-49.576 57.763,-49.576"/>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="115.352" x2="172.977" y1="-7.176" y2="-7.176"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="115.352" x2="172.977" y1="-14.376" y2="-14.376"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="115.352" x2="172.977" y1="-21.577" y2="-21.577"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="115.352" x2="172.977" y1="-28.776" y2="-28.776"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="115.352" x2="172.977" y1="-35.977" y2="-35.977"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="115.352" x2="172.977" y1="-43.178" y2="-43.178"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="111.726" x2="111.726" y1="-14.387" y2="-21.574"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="97.327" x2="97.327" y1="-14.387" y2="-21.574"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="82.927" x2="82.927" y1="-14.387" y2="-21.574"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.526" x2="68.526" y1="-14.387" y2="-21.574"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="111.726" x2="111.726" y1="-28.762" y2="-35.949"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="97.327" x2="97.327" y1="-28.762" y2="-35.949"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="82.927" x2="82.927" y1="-28.762" y2="-35.949"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.526" x2="68.526" y1="-28.762" y2="-35.949"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="111.726" x2="111.726" y1="-43.199" y2="-50.573"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="97.327" x2="97.327" y1="-43.199" y2="-50.573"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="82.927" x2="82.927" y1="-43.199" y2="-50.573"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.526" x2="68.526" y1="-43.199" y2="-50.573"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="104.513" x2="104.513" y1="-35.949" y2="-43.137"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="90.114" x2="90.114" y1="-35.949" y2="-43.137"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.714" x2="75.714" y1="-35.949" y2="-43.137"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.313" x2="61.313" y1="-35.949" y2="-43.137"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="104.513" x2="104.513" y1="-21.574" y2="-28.762"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="90.114" x2="90.114" y1="-21.574" y2="-28.762"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.714" x2="75.714" y1="-21.574" y2="-28.762"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.313" x2="61.313" y1="-21.574" y2="-28.762"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="104.513" x2="104.513" y1="-7.199" y2="-14.387"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="90.114" x2="90.114" y1="-7.199" y2="-14.387"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.714" x2="75.714" y1="-7.199" y2="-14.387"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.313" x2="61.313" y1="-7.199" y2="-14.387"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.751" x2="115.376" y1="-7.176" y2="-7.176"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.751" x2="115.376" y1="-14.376" y2="-14.376"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.751" x2="115.376" y1="-21.577" y2="-21.577"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.751" x2="115.376" y1="-28.776" y2="-28.776"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.751" x2="115.376" y1="-35.977" y2="-35.977"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.751" x2="115.376" y1="-43.178" y2="-43.178"/>
+                        <path d="M61.327-48.74c1.084,0,1.961,0.878,1.961,1.962 c0,1.083-0.877,1.963-1.961,1.963s-1.963-0.88-1.963-1.963C59.364-47.862,60.243-48.74,61.327-48.74z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M75.726-48.74c1.086,0,1.963,0.878,1.963,1.962 c0,1.083-0.877,1.963-1.963,1.963c-1.084,0-1.961-0.88-1.961-1.963C73.765-47.862,74.642-48.74,75.726-48.74z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M90.126-48.74c1.084,0,1.963,0.878,1.963,1.962 c0,1.083-0.879,1.963-1.963,1.963s-1.961-0.88-1.961-1.963C88.165-47.862,89.042-48.74,90.126-48.74z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M104.526-48.74c1.084,0,1.963,0.878,1.963,1.962 c0,1.083-0.879,1.963-1.963,1.963s-1.961-0.88-1.961-1.963C102.565-47.862,103.442-48.74,104.526-48.74z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M68.526-41.54c1.084,0,1.961,0.878,1.961,1.962 c0,1.083-0.877,1.962-1.961,1.962s-1.961-0.879-1.961-1.962C66.565-40.662,67.442-41.54,68.526-41.54z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M82.927-41.54c1.084,0,1.961,0.878,1.961,1.962 c0,1.083-0.877,1.962-1.961,1.962s-1.963-0.879-1.963-1.962C80.964-40.662,81.843-41.54,82.927-41.54z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M97.327-41.54c1.084,0,1.961,0.878,1.961,1.962 c0,1.083-0.877,1.962-1.961,1.962s-1.963-0.879-1.963-1.962C95.364-40.662,96.243-41.54,97.327-41.54z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M111.726-41.54c1.084,0,1.963,0.878,1.963,1.962 c0,1.083-0.879,1.962-1.963,1.962s-1.961-0.879-1.961-1.962C109.765-40.662,110.642-41.54,111.726-41.54z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M61.327-34.34c1.084,0,1.961,0.877,1.961,1.961 s-0.877,1.963-1.961,1.963s-1.963-0.879-1.963-1.963S60.243-34.34,61.327-34.34z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M75.726-34.34c1.086,0,1.963,0.877,1.963,1.961 s-0.877,1.963-1.963,1.963c-1.084,0-1.961-0.879-1.961-1.963S74.642-34.34,75.726-34.34z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M90.126-34.34c1.084,0,1.963,0.877,1.963,1.961 s-0.879,1.963-1.963,1.963s-1.961-0.879-1.961-1.963S89.042-34.34,90.126-34.34z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M104.526-34.34c1.084,0,1.963,0.877,1.963,1.961 s-0.879,1.963-1.963,1.963s-1.961-0.879-1.961-1.963S103.442-34.34,104.526-34.34z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M68.526-27.139c1.084,0,1.961,0.877,1.961,1.961 s-0.877,1.963-1.961,1.963s-1.961-0.879-1.961-1.963S67.442-27.139,68.526-27.139z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M82.927-27.139c1.084,0,1.961,0.877,1.961,1.961 s-0.877,1.963-1.961,1.963s-1.963-0.879-1.963-1.963S81.843-27.139,82.927-27.139z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M97.327-27.139c1.084,0,1.961,0.877,1.961,1.961 s-0.877,1.963-1.961,1.963s-1.963-0.879-1.963-1.963S96.243-27.139,97.327-27.139z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M111.726-27.139c1.084,0,1.963,0.877,1.963,1.961 s-0.879,1.963-1.963,1.963s-1.961-0.879-1.961-1.963S110.642-27.139,111.726-27.139z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M61.327-19.939c1.084,0,1.961,0.879,1.961,1.963 c0,1.082-0.877,1.961-1.961,1.961s-1.963-0.879-1.963-1.961C59.364-19.061,60.243-19.939,61.327-19.939z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M75.726-19.939c1.086,0,1.963,0.879,1.963,1.963 c0,1.082-0.877,1.961-1.963,1.961c-1.084,0-1.961-0.879-1.961-1.961C73.765-19.061,74.642-19.939,75.726-19.939z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M90.126-19.939c1.084,0,1.963,0.879,1.963,1.963 c0,1.082-0.879,1.961-1.963,1.961s-1.961-0.879-1.961-1.961C88.165-19.061,89.042-19.939,90.126-19.939z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M104.526-19.939c1.084,0,1.963,0.879,1.963,1.963 c0,1.082-0.879,1.961-1.963,1.961s-1.961-0.879-1.961-1.961C102.565-19.061,103.442-19.939,104.526-19.939z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M68.526-12.74c1.084,0,1.961,0.878,1.961,1.962 c0,1.083-0.877,1.963-1.961,1.963s-1.961-0.88-1.961-1.963C66.565-11.862,67.442-12.74,68.526-12.74z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M82.927-12.74c1.084,0,1.961,0.878,1.961,1.962 c0,1.083-0.877,1.963-1.961,1.963s-1.963-0.88-1.963-1.963C80.964-11.862,81.843-12.74,82.927-12.74z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M97.327-12.74c1.084,0,1.961,0.878,1.961,1.962 c0,1.083-0.877,1.963-1.961,1.963s-1.963-0.88-1.963-1.963C95.364-11.862,96.243-12.74,97.327-12.74z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M111.726-12.74c1.084,0,1.963,0.878,1.963,1.962 c0,1.083-0.879,1.963-1.963,1.963s-1.961-0.88-1.961-1.963C109.765-11.862,110.642-12.74,111.726-12.74z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="61.327" x2="61.327" y1="-46.778" y2="-46.778"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="75.726" x2="75.726" y1="-46.778" y2="-46.778"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="90.126" x2="90.126" y1="-46.778" y2="-46.778"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="104.526" x2="104.526" y1="-46.778" y2="-46.778"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="68.526" x2="68.526" y1="-39.578" y2="-39.578"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="82.927" x2="82.927" y1="-39.578" y2="-39.578"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="97.327" x2="97.327" y1="-39.578" y2="-39.578"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="111.726" x2="111.726" y1="-39.578" y2="-39.578"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="61.327" x2="61.327" y1="-32.379" y2="-32.379"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="75.726" x2="75.726" y1="-32.379" y2="-32.379"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="90.126" x2="90.126" y1="-32.379" y2="-32.379"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="104.526" x2="104.526" y1="-32.379" y2="-32.379"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="68.526" x2="68.526" y1="-25.178" y2="-25.178"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="82.927" x2="82.927" y1="-25.178" y2="-25.178"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="97.327" x2="97.327" y1="-25.178" y2="-25.178"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="111.726" x2="111.726" y1="-25.178" y2="-25.178"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="61.327" x2="61.327" y1="-17.977" y2="-17.977"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="75.726" x2="75.726" y1="-17.977" y2="-17.977"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="90.126" x2="90.126" y1="-17.977" y2="-17.977"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="104.526" x2="104.526" y1="-17.977" y2="-17.977"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="68.526" x2="68.526" y1="-10.778" y2="-10.778"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="82.927" x2="82.927" y1="-10.778" y2="-10.778"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="97.327" x2="97.327" y1="-10.778" y2="-10.778"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" x1="111.726" x2="111.726" y1="-10.778" y2="-10.778"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="57.775" y1="-7.176" y2="-7.176"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="57.775" y1="-14.376" y2="-14.376"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="57.775" y1="-21.577" y2="-21.577"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="57.775" y1="-28.776" y2="-28.776"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="57.775" y1="-35.977" y2="-35.977"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="57.775" y1="-43.178" y2="-43.178"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="111.726" x2="111.726" y1="0" y2="-7.374"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="97.327" x2="97.327" y1="0" y2="-7.374"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="82.927" x2="82.927" y1="0" y2="-7.374"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.526" x2="68.526" y1="0" y2="-7.374"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- Forest -->
+        <pattern height="54.001" id="fill-forest" overflow="visible" patternUnits="userSpaceOnUse" viewBox="2.932 -56.828 46.766 54.001" width="46.766">
+            <g>
+                <polygon fill="#53e9b4" points="2.932,-2.826 49.698,-2.826 49.698,-56.828 2.932,-56.828"/>
+                <g>
+                    <polygon fill="none" points="2.932,-2.826 49.697,-2.826 49.697,-56.828 2.932,-56.828"/>
+                    <g>
+                        <path d="M43.996-24.401c0.414,0.717,0.168,1.635-0.549,2.049 c-0.717,0.414-1.635,0.168-2.049-0.549c-0.414-0.718-0.168-1.636,0.549-2.05C42.664-25.365,43.582-25.119,43.996-24.401z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M42.746-32.748c-0.414,0.717-1.332,0.963-2.049,0.547 c-0.717-0.414-0.963-1.33-0.549-2.049c0.414-0.718,1.332-0.963,2.049-0.549C42.914-34.385,43.16-33.468,42.746-32.748z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M34.496-19.651c-0.414,0.717-1.332,0.963-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C34.664-21.287,34.91-20.369,34.496-19.651z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M26.947-26.451c0.414,0.719,0.168,1.636-0.549,2.05 c-0.719,0.415-1.637,0.169-2.051-0.55c-0.412-0.719-0.168-1.635,0.551-2.051C25.615-27.414,26.533-27.168,26.947-26.451z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M29.746-32.651c-0.414,0.717-1.332,0.964-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C29.914-34.287,30.16-33.369,29.746-32.651z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M35.359-37.328c-0.83,0-1.5-0.67-1.5-1.5c0-0.825,0.67-1.5,1.5-1.5 c0.828,0,1.5,0.675,1.5,1.5C36.859-37.998,36.188-37.328,35.359-37.328z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M9.455-26.5c-0.414,0.719-0.168,1.635,0.549,2.049 c0.717,0.416,1.635,0.17,2.049-0.549c0.414-0.718,0.168-1.635-0.549-2.049C10.787-27.463,9.869-27.218,9.455-26.5z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M10.084-34.074c0.414,0.718,1.33,0.963,2.049,0.55 c0.717-0.416,0.963-1.332,0.549-2.052c-0.414-0.717-1.332-0.963-2.049-0.549C9.914-35.709,9.67-34.793,10.084-34.074z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M15.348-19.248c0.414,0.717,1.332,0.963,2.051,0.547 c0.717-0.414,0.963-1.33,0.549-2.047c-0.414-0.72-1.332-0.965-2.049-0.551C15.18-20.885,14.936-19.968,15.348-19.248z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M20.932-36.326c0.828,0,1.5-0.672,1.5-1.5c0-0.827-0.672-1.5-1.5-1.5 c-0.828,0-1.5,0.673-1.5,1.5C19.432-36.998,20.104-36.326,20.932-36.326z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M43.951-52.828c-0.414-0.717-1.332-0.963-2.049-0.547 c-0.717,0.414-0.963,1.33-0.549,2.047c0.414,0.721,1.332,0.966,2.049,0.551C44.119-51.19,44.365-52.107,43.951-52.828z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M28.246-52.901c-0.414-0.718-1.332-0.964-2.049-0.55 c-0.717,0.414-0.963,1.332-0.549,2.05c0.414,0.717,1.332,0.964,2.049,0.549C28.414-51.267,28.66-52.185,28.246-52.901z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M34.109-49.328c-0.83,0-1.5,0.675-1.5,1.5c0,0.83,0.67,1.5,1.5,1.5 c0.828,0,1.5-0.67,1.5-1.5C35.609-48.653,34.938-49.328,34.109-49.328z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M8.697-53.201c0.414-0.719,1.332-0.965,2.049-0.549 c0.717,0.414,0.963,1.33,0.549,2.049s-1.332,0.965-2.049,0.55C8.529-51.565,8.283-52.482,8.697-53.201z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M18.77-47.328c0.828,0,1.5,0.675,1.5,1.5c0,0.83-0.672,1.5-1.5,1.5 s-1.5-0.67-1.5-1.5C17.27-46.653,17.941-47.328,18.77-47.328z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M43.201-6.576c0.414-0.719,0.168-1.635-0.549-2.049 c-0.717-0.416-1.635-0.17-2.049,0.549s-0.168,1.636,0.549,2.05C41.869-5.611,42.787-5.857,43.201-6.576z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M35.408-12.576c-0.414-0.719-1.332-0.965-2.049-0.549 c-0.719,0.414-0.965,1.33-0.549,2.049c0.412,0.719,1.33,0.965,2.049,0.55C35.576-10.94,35.822-11.857,35.408-12.576z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M28.295-5.951c0.414-0.719,0.168-1.635-0.549-2.051 c-0.717-0.414-1.635-0.168-2.049,0.551c-0.414,0.719-0.168,1.636,0.549,2.05C26.963-4.986,27.881-5.232,28.295-5.951z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M9.426-6.576C9.012-7.295,9.258-8.211,9.977-8.625 c0.717-0.416,1.635-0.17,2.049,0.549s0.168,1.636-0.549,2.05C10.758-5.611,9.84-5.857,9.426-6.576z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M17.721-11.576c0.414-0.719,1.332-0.965,2.049-0.549 c0.717,0.414,0.963,1.33,0.549,2.049c-0.414,0.719-1.332,0.965-2.049,0.55C17.553-9.94,17.307-10.857,17.721-11.576z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M50.447-21.826c-0.828,0-1.5,0.673-1.5,1.5c0,0.828,0.672,1.5,1.5,1.5 c0.828,0,1.5-0.672,1.5-1.5C51.947-21.153,51.275-21.826,50.447-21.826z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M50.432-49.328c0.828,0,1.5,0.675,1.5,1.5c0,0.83-0.672,1.5-1.5,1.5 c-0.828,0-1.5-0.67-1.5-1.5C48.932-48.653,49.604-49.328,50.432-49.328z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M28.746-42.151c-0.414,0.717-1.332,0.964-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C28.914-43.787,29.16-42.869,28.746-42.151z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M20.246-29.151c-0.414,0.717-1.332,0.964-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C20.414-30.787,20.66-29.869,20.246-29.151z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M36.48-27.276c-0.414,0.717-1.33,0.963-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C36.65-28.912,36.895-27.994,36.48-27.276z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M27.496-15.651c-0.414,0.717-1.332,0.963-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C27.664-17.287,27.91-16.369,27.496-15.651z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M10.996-15.151c-0.414,0.717-1.332,0.963-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C11.164-16.787,11.41-15.869,10.996-15.151z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M43.057-15.076c-0.414,0.719-1.332,0.965-2.049,0.55 c-0.719-0.414-0.965-1.331-0.551-2.05c0.416-0.719,1.332-0.965,2.051-0.551C43.225-16.711,43.471-15.793,43.057-15.076z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M11.246-42.151c-0.414,0.717-1.332,0.964-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C11.414-43.787,11.66-42.869,11.246-42.151z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M19.746-54.901c-0.414,0.717-1.332,0.964-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C19.914-56.537,20.16-55.619,19.746-54.901z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M37.496-55.401c-0.414,0.717-1.332,0.964-2.049,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C37.664-57.037,37.91-56.119,37.496-55.401z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M42.432-42.576c0.828,0,1.5-0.672,1.5-1.5c0-0.826-0.672-1.5-1.5-1.5 c-0.828,0-1.5,0.674-1.5,1.5C40.932-43.248,41.604-42.576,42.432-42.576z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M49.697-56.076c-0.828,0-1.5-0.672-1.5-1.5c0-0.826,0.672-1.5,1.5-1.5 c0.828,0,1.5,0.674,1.5,1.5C51.197-56.748,50.525-56.076,49.697-56.076z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M50.73-29.026c-0.416,0.717-1.332,0.964-2.051,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C50.898-30.662,51.145-29.744,50.73-29.026z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M50.416-9.326c-0.828,0-1.5-0.672-1.5-1.5c0-0.827,0.672-1.5,1.5-1.5 s1.5,0.673,1.5,1.5C51.916-9.998,51.244-9.326,50.416-9.326z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M48.416-37.576c0.83,0,1.5-0.672,1.5-1.5c0-0.827-0.67-1.5-1.5-1.5 c-0.828,0-1.5,0.673-1.5,1.5C46.916-38.248,47.588-37.576,48.416-37.576z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    </g>
+                    <g>
+                        <path d="M3.682-21.826c-0.828,0-1.5,0.673-1.5,1.5c0,0.828,0.672,1.5,1.5,1.5 c0.828,0,1.5-0.672,1.5-1.5C5.182-21.153,4.51-21.826,3.682-21.826z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M3.666-49.328c0.828,0,1.5,0.675,1.5,1.5c0,0.83-0.672,1.5-1.5,1.5 s-1.5-0.67-1.5-1.5C2.166-48.653,2.838-49.328,3.666-49.328z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M2.932-56.076c-0.828,0-1.5-0.672-1.5-1.5c0-0.826,0.672-1.5,1.5-1.5 c0.828,0,1.5,0.674,1.5,1.5C4.432-56.748,3.76-56.076,2.932-56.076z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M3.965-29.026c-0.416,0.717-1.332,0.964-2.051,0.549 c-0.717-0.414-0.963-1.332-0.549-2.049c0.414-0.718,1.332-0.964,2.049-0.55C4.133-30.662,4.379-29.744,3.965-29.026z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M3.65-9.326c-0.828,0-1.5-0.672-1.5-1.5c0-0.827,0.672-1.5,1.5-1.5 c0.828,0,1.5,0.673,1.5,1.5C5.15-9.998,4.479-9.326,3.65-9.326z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M1.65-37.576c0.83,0,1.5-0.672,1.5-1.5c0-0.827-0.67-1.5-1.5-1.5 c-0.828,0-1.5,0.673-1.5,1.5C0.15-38.248,0.822-37.576,1.65-37.576z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    </g>
+                    <g>
+                        <path d="M19.746-0.9c-0.414,0.717-1.332,0.964-2.049,0.549C16.98-0.766,16.734-1.684,17.148-2.4c0.414-0.719,1.332-0.963,2.049-0.551C19.914-2.535,20.16-1.619,19.746-0.9z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M37.496-1.4c-0.414,0.717-1.332,0.964-2.049,0.549C34.73-1.266,34.484-2.184,34.898-2.9c0.414-0.719,1.332-0.963,2.049-0.551C37.664-3.035,37.91-2.119,37.496-1.4z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                        <path d="M49.697-2.076c-0.828,0-1.5-0.672-1.5-1.5c0-0.825,0.672-1.5,1.5-1.5 c0.828,0,1.5,0.675,1.5,1.5C51.197-2.748,50.525-2.076,49.697-2.076z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    </g>
+                    <g>
+                        <path d="M2.932-2.076c-0.828,0-1.5-0.672-1.5-1.5c0-0.825,0.672-1.5,1.5-1.5 c0.828,0,1.5,0.675,1.5,1.5C4.432-2.748,3.76-2.076,2.932-2.076z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- Turf Grass -->
+        <pattern height="93" id="fill-turf_grass" overflow="visible" patternUnits="userSpaceOnUse" viewBox="86.002 -93 85.499 93" width="85.499">
+            <g>
+                <polygon fill="#4aeab3" points="86.002,0 171.501,0 171.501,-93 86.002,-93"/>
+                <g>
+                    <polygon fill="none" points="86.002,0 171.501,0 171.501,-93 86.002,-93"/>
+                    <g>
+                        <path d="M171.501-3.71C190.788-2.984,212.001-3,240.5-4c4.337-0.152,11.31,0.305,16.5,0.29" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.501-10.564C196.001-8,217.234-11.789,234.5-10c3.666,0.379,12.75-0.463,22.5-0.564" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.501-17.486c21.5,1.486,27.297-1.404,58.999,1.236c9,0.75,23.491-1.422,26.495-1.236" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.498-22.898c14.414-0.719,30.656-2.348,49.627-0.401c9.758,1,22.621,0.14,35.875,0.401" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.501-36.715c18.065,0.271,22.285,1.929,55.999,0.215c14.75-0.75,22.5-1,29.5-0.215" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.504-42.939c12.848-0.506,24.497,1.439,45.622-0.11c16.544-1.216,29.924,1.422,39.875,0.11" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.502-56.375c20.499,0.375,17.512,0.747,44.999-0.125c31.499-1,40.007,0.135,40.496,0.125" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.501-63.66c20.94,0.315,17.606-1.033,50.249,0.91c2.06,0.122,26.25-2.25,35.254-0.91" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.502-68.9c14.338-0.972,31.999-1.6,50.623-0.649c9.513,0.483,20.375-0.449,34.876,0.649" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.503-75.9C192.443-76.43,224-75.5,245-76.25c1.408-0.051,10.491,0.277,11.997,0.35" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.501-83.405C201.501-81.5,236.5-84.5,251-83.5c1.763,0.121,4.101,0.043,5.999,0.095" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.502-89.533c10.684-0.154,21.464,1.098,38.499,0.033C234-91,251.78-89.622,257-89.533" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.501-50.289C193.646-49.66,218-48.5,229.25-49.5c13.841-1.23,26.949-0.814,27.754-0.789" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M171.501-29.715c18.065,0.271,22,1.215,46,0.215c21.481-0.895,30.499-1,39.499-0.215" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                    </g>
+                    <g>
+                        <path d="M86.002-3.71C105.289-2.984,126.502-3,155.001-4c4.337-0.152,11.31,0.305,16.5,0.29" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.002-10.564C110.502-8,131.735-11.789,149.001-10c3.666,0.379,12.75-0.463,22.5-0.564" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.002-17.486c21.5,1.486,27.297-1.404,58.999,1.236c9,0.75,23.491-1.422,26.495-1.236" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M85.999-22.898c14.414-0.719,30.656-2.348,49.627-0.401c9.758,1,22.621,0.14,35.875,0.401" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.002-36.715c18.065,0.271,22.285,1.929,55.999,0.215c14.75-0.75,22.5-1,29.5-0.215" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.005-42.939c12.848-0.506,24.497,1.439,45.622-0.11c16.544-1.216,29.924,1.422,39.875,0.11" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.003-56.375c20.499,0.375,17.512,0.747,44.999-0.125c31.499-1,40.007,0.135,40.496,0.125" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.002-63.66c20.94,0.315,17.606-1.033,50.249,0.91c2.06,0.122,26.25-2.25,35.254-0.91" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.003-68.9c14.338-0.972,31.999-1.6,50.623-0.649c9.513,0.483,20.375-0.449,34.876,0.649" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.004-75.9c20.94-0.529,52.497,0.4,73.497-0.35c1.408-0.051,10.491,0.277,11.997,0.35" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.002-83.405c30,1.905,64.999-1.095,79.499-0.095c1.763,0.121,4.101,0.043,5.999,0.095" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.003-89.533c10.684-0.154,21.464,1.098,38.499,0.033c23.999-1.5,41.779-0.122,46.999-0.033" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.002-50.289c22.146,0.629,46.499,1.789,57.749,0.789c13.841-1.23,26.949-0.814,27.754-0.789" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M86.002-29.715c18.065,0.271,22,1.215,46,0.215c21.481-0.895,30.499-1,39.499-0.215" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                    </g>
+                    <g>
+                        <path d="M0.503-3.71C19.79-2.984,41.003-3,69.502-4c4.337-0.152,11.31,0.305,16.5,0.29" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.503-10.564C25.003-8,46.236-11.789,63.502-10c3.666,0.379,12.75-0.463,22.5-0.564" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.503-17.486C22.003-16,27.8-18.893,59.502-16.25c9,0.75,23.491-1.422,26.495-1.236" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.5-22.898c14.414-0.719,30.656-2.348,49.627-0.401c9.758,1,22.621,0.14,35.875,0.401" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.503-36.715c18.065,0.271,22.285,1.929,55.999,0.215c14.75-0.75,22.5-1,29.5-0.215" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.506-42.939c12.848-0.506,24.497,1.439,45.622-0.11c16.544-1.216,29.924,1.422,39.875,0.11" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.504-56.375C21.003-56,18.016-55.628,45.503-56.5c31.499-1,40.007,0.135,40.496,0.125" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.503-63.66c20.94,0.315,17.606-1.033,50.249,0.91c2.06,0.122,26.25-2.25,35.254-0.91" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.504-68.9c14.338-0.972,31.999-1.6,50.623-0.649C60.64-69.066,71.502-70,86.003-68.9" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.505-75.9c20.94-0.529,52.497,0.4,73.497-0.35c1.408-0.051,10.491,0.277,11.997,0.35" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.503-83.405c30,1.905,64.999-1.095,79.499-0.095c1.763,0.121,4.101,0.043,5.999,0.095" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.504-89.533c10.684-0.154,21.464,1.098,38.499,0.033c23.999-1.5,41.779-0.122,46.999-0.033" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.503-50.289C22.648-49.66,47.002-48.5,58.252-49.5c13.841-1.23,26.949-0.814,27.754-0.789" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                        <path d="M0.503-29.715c18.065,0.271,22,1.215,46,0.215c21.481-0.895,30.499-1,39.499-0.215" fill="none" stroke="#231F20" stroke-dasharray="0.1,3,0.1,3,0.1,6" stroke-linecap="round" stroke-miterlimit="10"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- Pasture -->
+        <pattern height="65.25" id="fill-pasture" overflow="visible" patternUnits="userSpaceOnUse" viewBox="4.71 -70.865 65.25 65.25" width="65.25">
+            <g>
+                <polygon fill="#51dec2" points="4.71,-5.615 69.96,-5.615 69.96,-70.865 4.71,-70.865"/>
+                <g>
+                    <polygon fill="none" points="4.71,-5.615 69.96,-5.615 69.96,-70.865 4.71,-70.865"/>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.255" x2="66.729" y1="-67.208" y2="-71.505"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="74.71" x2="69.186" y1="-70.365" y2="-74.662"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="51.899" x2="48.21" y1="-68.141" y2="-73.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="54.643" x2="49.541" y1="-71.055" y2="-75.85"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.843" x2="60.21" y1="-70.087" y2="-75.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="60.96" x2="63.71" y1="-68.865" y2="-75.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="32.71" x2="27.018" y1="-69.365" y2="-73.748"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="36.71" x2="30.007" y1="-70.365" y2="-76.407"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="13.96" x2="13.71" y1="-70.115" y2="-71.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="18.934" x2="23.21" y1="-68.288" y2="-74.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="21.762" x2="26.041" y1="-65.46" y2="-71.288"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="43.46" x2="43.96" y1="-68.365" y2="-74.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="40.71" x2="39.21" y1="-67.615" y2="-74.365"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="7.005" x2="1.479" y1="-67.208" y2="-71.505"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="9.46" x2="3.936" y1="-70.365" y2="-74.662"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="27.197" x2="23.96" y1="-28.659" y2="-34.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="41.134" x2="48.71" y1="-49.062" y2="-51.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="42.21" x2="49.96" y1="-46.115" y2="-47.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="34.71" x2="37.46" y1="-66.365" y2="-61.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="31.21" x2="34.233" y1="-65.865" y2="-60.079"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="50.71" x2="45.96" y1="-61.115" y2="-64.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="51.96" x2="48.21" y1="-63.615" y2="-67.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="54.591" x2="55.492" y1="-51.92" y2="-58.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="50.692" x2="52.242" y1="-52.82" y2="-59.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="18.934" x2="23.21" y1="-68.288" y2="-74.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="21.762" x2="26.041" y1="-65.46" y2="-71.288"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="25.237" x2="28.673" y1="-54.256" y2="-60.355"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="28.942" x2="31.585" y1="-52.746" y2="-59.227"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="37.71" x2="32.46" y1="-50.115" y2="-53.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="40.21" x2="34.46" y1="-53.365" y2="-55.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="51.899" x2="48.21" y1="-68.141" y2="-73.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="54.643" x2="49.541" y1="-71.055" y2="-75.85"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.843" x2="60.21" y1="-70.087" y2="-75.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="32.71" x2="27.018" y1="-69.365" y2="-73.748"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="36.71" x2="30.007" y1="-70.365" y2="-76.407"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="26.21" x2="26.71" y1="-63.865" y2="-65.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="42.46" x2="43.46" y1="-65.865" y2="-66.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="43.46" x2="43.96" y1="-68.365" y2="-74.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="40.71" x2="39.21" y1="-67.615" y2="-74.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.992" x2="59.242" y1="-55.615" y2="-55.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="37.21" x2="37.46" y1="-56.115" y2="-57.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="55.21" x2="56.46" y1="-67.615" y2="-67.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="38.46" x2="37.46" y1="-65.615" y2="-67.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="42.71" x2="43.96" y1="-52.865" y2="-52.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="44.947" x2="40.522" y1="-61.084" y2="-58.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="47.686" x2="41.328" y1="-58.686" y2="-55.756"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="40.21" x2="41.46" y1="-61.365" y2="-61.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="46.992" x2="48.242" y1="-54.615" y2="-54.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="23.335" x2="24.96" y1="-59.865" y2="-59.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="31.703" x2="31.835" y1="-14.067" y2="-21.066"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="35.703" x2="34.96" y1="-13.992" y2="-20.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="48.354" x2="54.835" y1="-33.348" y2="-35.99"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="49.862" x2="56.346" y1="-29.645" y2="-32.286"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="31.833" x2="36.604" y1="-29.197" y2="-25.555"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="28.798" x2="34.707" y1="-27.186" y2="-23.434"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="23.207" x2="16.432" y1="-46.993" y2="-48.75"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="23.96" x2="17.186" y1="-50.615" y2="-52.372"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="24.401" x2="21.164" y1="-26.809" y2="-33.016"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="13.447" x2="14.785" y1="-15.51" y2="-22.38"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="17.373" x2="18.71" y1="-14.744" y2="-21.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="5.276" x2="11.46" y1="-12.584" y2="-15.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="8.21" x2="7.033" y1="-22.115" y2="-28.109"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="12.283" x2="10.96" y1="-21.991" y2="-28.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="61.076" x2="63.492" y1="-49.816" y2="-57.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="65.242" x2="65.985" y1="-49.865" y2="-56.361"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.737" x2="53.733" y1="-42.075" y2="-47.816"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="60.483" x2="58.742" y1="-43.407" y2="-48.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="31.658" x2="32.46" y1="-33.412" y2="-40.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="34.643" x2="36.341" y1="-32.604" y2="-39.395"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.52" x2="51.175" y1="-10.491" y2="-13.451"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="58.96" x2="52.869" y1="-13.365" y2="-17.075"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="22.358" x2="23.96" y1="-18.092" y2="-24.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="24.442" x2="27.544" y1="-15.818" y2="-22.094"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="42.21" x2="38.71" y1="-19.865" y2="-26.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="44.846" x2="40.896" y1="-21.036" y2="-26.814"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="54.71" x2="48.46" y1="-21.365" y2="-23.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="55.21" x2="48.96" y1="-25.865" y2="-26.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="60.934" x2="59.242" y1="-23.038" y2="-29.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="63.656" x2="60.184" y1="-25.521" y2="-31.6"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="61.852" x2="55.514" y1="-58.771" y2="-61.744"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="63.548" x2="57.21" y1="-62.393" y2="-65.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="51.96" x2="47.71" y1="-42.615" y2="-37.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="49.21" x2="44.395" y1="-43.365" y2="-38.958"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="35.242" x2="39.21" y1="-44.865" y2="-39.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="37.643" x2="41.96" y1="-48.064" y2="-42.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="27.137" x2="20.177" y1="-37.139" y2="-36.393"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="26.21" x2="19.367" y1="-40.365" y2="-38.898"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="11.462" x2="17.062" y1="-42.364" y2="-46.562"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="13.862" x2="19.46" y1="-39.165" y2="-43.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="18.703" x2="18.132" y1="-55.104" y2="-62.081"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="22.46" x2="21.518" y1="-55.615" y2="-63.036"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="24.882" x2="29.832" y1="-45.943" y2="-50.893"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="27.71" x2="32.66" y1="-43.115" y2="-48.064"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="13.21" x2="8.643" y1="-51.865" y2="-56.07"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="15.485" x2="9.96" y1="-54.317" y2="-58.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="60.832" x2="67.807" y1="-20.205" y2="-19.6"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="60.96" x2="67.46" y1="-16.865" y2="-15.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="40.96" x2="41.71" y1="-28.865" y2="-35.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="44.96" x2="44.46" y1="-28.865" y2="-34.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="16.673" x2="13.809" y1="-6.725" y2="-11.695"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="11.171" x2="16.925" y1="-37.842" y2="-33.852"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="8.893" x2="14.646" y1="-34.555" y2="-30.564"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="8.848" x2="13.21" y1="-63.85" y2="-68.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="11.276" x2="15.21" y1="-62.178" y2="-65.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="65.46" x2="69.778" y1="-27.865" y2="-33.375"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="68.108" x2="72.427" y1="-25.646" y2="-31.157"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="63.207" x2="56.432" y1="-34.243" y2="-36"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="64.21" x2="57.436" y1="-38.115" y2="-39.872"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="20.46" x2="13.552" y1="-25.115" y2="-24.686"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="20.96" x2="14.005" y1="-27.865" y2="-28.66"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="64.971" x2="68.899" y1="-61.318" y2="-67.111"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="68.278" x2="72.21" y1="-59.073" y2="-64.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="68.46" x2="64.75" y1="-36.365" y2="-40.705"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="71.843" x2="68.147" y1="-36.871" y2="-42.814"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.255" x2="66.729" y1="-67.208" y2="-71.505"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="60.96" x2="63.71" y1="-68.865" y2="-75.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="68.653" x2="74.835" y1="-16.117" y2="-19.398"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="21.289" x2="25.71" y1="-15.084" y2="-12.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="18.548" x2="24.906" y1="-12.686" y2="-9.756"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="40.835" x2="45.585" y1="-13.74" y2="-18.49"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="43.983" x2="48.302" y1="-11.271" y2="-16.782"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.438" x2="67.21" y1="-45.1" y2="-47.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="75.272" x2="69.162" y1="-47.692" y2="-51.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="34.71" x2="35.96" y1="-9.365" y2="-9.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="33.96" x2="33.71" y1="-12.365" y2="-11.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="38.71" x2="39.46" y1="-17.865" y2="-17.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="49.71" x2="50.96" y1="-15.615" y2="-15.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="56.46" x2="57.21" y1="-20.115" y2="-20.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="65.46" x2="66.21" y1="-23.615" y2="-22.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="66.96" x2="66.46" y1="-11.365" y2="-12.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="10.71" x2="11.46" y1="-19.115" y2="-19.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="16.96" x2="16.96" y1="-36.365" y2="-37.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="10.21" x2="8.71" y1="-40.365" y2="-40.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="14.46" x2="14.96" y1="-60.115" y2="-58.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="22.96" x2="22.21" y1="-43.365" y2="-42.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="53.96" x2="54.71" y1="-39.865" y2="-39.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="43.992" x2="44.492" y1="-42.615" y2="-43.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="30.21" x2="30.96" y1="-24.365" y2="-23.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="27.96" x2="29.21" y1="-33.365" y2="-34.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="13.96" x2="13.71" y1="-70.115" y2="-71.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="42.96" x2="42.46" y1="-39.365" y2="-38.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.255" x2="66.729" y1="-1.958" y2="-6.255"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="74.71" x2="69.186" y1="-5.115" y2="-9.412"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="51.899" x2="48.21" y1="-2.891" y2="-8.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="54.643" x2="49.541" y1="-5.805" y2="-10.6"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.843" x2="60.21" y1="-4.837" y2="-10.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="60.96" x2="63.71" y1="-3.615" y2="-10.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="32.71" x2="27.018" y1="-4.115" y2="-8.498"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="36.71" x2="30.007" y1="-5.115" y2="-11.157"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="13.96" x2="13.71" y1="-4.865" y2="-6.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="18.934" x2="23.21" y1="-3.038" y2="-8.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="21.762" x2="26.041" y1="-0.21" y2="-6.038"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="63.242" x2="63.742" y1="-65.115" y2="-66.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="43.46" x2="43.96" y1="-3.115" y2="-9.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="40.71" x2="39.21" y1="-2.365" y2="-9.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="50.46" x2="51.21" y1="-19.365" y2="-20.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="37.46" x2="38.71" y1="-31.115" y2="-31.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="68.21" x2="68.96" y1="-56.615" y2="-55.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="12.96" x2="9.559" y1="-7.365" y2="-11.695"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="66.21" x2="67.46" y1="-43.865" y2="-44.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="27.96" x2="28.96" y1="-15.615" y2="-16.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="40.96" x2="41.21" y1="-10.115" y2="-11.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="15.71" x2="16.21" y1="-14.115" y2="-12.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="7.96" x2="7.96" y1="-9.365" y2="-9.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="10.96" x2="10.96" y1="-12.615" y2="-12.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="17.71" x2="17.71" y1="-7.115" y2="-7.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="27.96" x2="27.96" y1="-14.115" y2="-14.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="21.71" x2="21.71" y1="-20.865" y2="-20.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="19.21" x2="19.21" y1="-30.615" y2="-30.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="8.46" x2="8.46" y1="-29.615" y2="-29.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="25.21" x2="25.21" y1="-41.615" y2="-41.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="30.46" x2="30.46" y1="-37.365" y2="-37.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="38.21" x2="38.21" y1="-28.865" y2="-28.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="32.71" x2="32.71" y1="-45.865" y2="-45.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="37.46" x2="37.46" y1="-48.615" y2="-48.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="23.46" x2="23.46" y1="-52.865" y2="-52.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="46.71" x2="46.71" y1="-30.365" y2="-30.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="46.46" x2="46.46" y1="-21.865" y2="-21.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="62.96" x2="62.96" y1="-13.115" y2="-13.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="54.96" x2="54.96" y1="-9.615" y2="-9.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="65.71" x2="65.71" y1="-32.865" y2="-32.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="64.21" x2="64.21" y1="-43.865" y2="-43.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="58.71" x2="58.71" y1="-50.615" y2="-50.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="62.21" x2="62.21" y1="-60.615" y2="-60.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="54.71" x2="54.71" y1="-65.365" y2="-65.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="33.21" x2="33.21" y1="-66.615" y2="-66.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="44.21" x2="44.21" y1="-69.115" y2="-69.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="29.96" x2="29.96" y1="-21.365" y2="-21.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="15.46" x2="15.46" y1="-68.365" y2="-68.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="5.46" x2="5.46" y1="-57.115" y2="-57.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="8.46" x2="8.46" y1="-49.865" y2="-49.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="13.71" x2="13.71" y1="-46.115" y2="-46.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="14.46" x2="14.46" y1="-49.865" y2="-49.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="55.46" x2="55.46" y1="-28.115" y2="-28.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="52.71" x2="52.71" y1="-37.865" y2="-37.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="50.96" x2="50.96" y1="-46.115" y2="-46.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="32.46" x2="32.46" y1="-30.365" y2="-30.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="28.96" x2="28.96" y1="-61.115" y2="-61.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="28.96" x2="28.96" y1="-69.115" y2="-69.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="23.585" x2="23.585" y1="-65.115" y2="-65.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="31.335" x2="31.335" y1="-42.615" y2="-42.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="65.71" x2="65.71" y1="-67.615" y2="-67.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="9.21" x2="9.21" y1="-61.615" y2="-61.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="38.46" x2="38.46" y1="-35.365" y2="-35.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="37.96" x2="37.96" y1="-20.365" y2="-20.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="39.21" x2="39.21" y1="-13.615" y2="-13.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="54.46" x2="54.46" y1="-61.365" y2="-61.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="53.71" x2="53.71" y1="-50.365" y2="-50.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="67.46" x2="67.46" y1="-52.865" y2="-52.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="56.96" x2="56.96" y1="-23.115" y2="-23.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="57.71" x2="57.71" y1="-24.865" y2="-24.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="57.96" x2="57.96" y1="-16.115" y2="-16.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="44.71" x2="44.71" y1="-25.365" y2="-25.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="53.71" x2="53.71" y1="-32.865" y2="-32.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="64.21" x2="64.21" y1="-29.615" y2="-29.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="65.71" x2="65.71" y1="-36.865" y2="-36.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="round" stroke-width="0.75" x1="5.71" x2="5.71" y1="-21.865" y2="-21.865"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.21" x2="4.528" y1="-27.865" y2="-33.375"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="2.858" x2="7.177" y1="-25.646" y2="-31.157"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="3.028" x2="6.96" y1="-59.073" y2="-64.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="6.593" x2="2.897" y1="-36.871" y2="-42.814"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="7.005" x2="1.479" y1="-67.208" y2="-71.505"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="3.403" x2="9.585" y1="-16.117" y2="-19.398"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="7.188" x2="1.96" y1="-45.1" y2="-47.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="10.022" x2="3.912" y1="-47.692" y2="-51.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="7.005" x2="1.479" y1="-1.958" y2="-6.255"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="9.46" x2="3.936" y1="-5.115" y2="-9.412"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="18.934" x2="23.21" y1="-3.038" y2="-8.865"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="21.762" x2="26.041" y1="-0.21" y2="-6.038"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="51.899" x2="48.21" y1="-2.891" y2="-8.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="54.643" x2="49.541" y1="-5.805" y2="-10.6"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="57.843" x2="60.21" y1="-4.837" y2="-10.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="32.71" x2="27.018" y1="-4.115" y2="-8.498"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="36.71" x2="30.007" y1="-5.115" y2="-11.157"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="43.46" x2="43.96" y1="-3.115" y2="-9.615"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="40.71" x2="39.21" y1="-2.365" y2="-9.115"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.255" x2="66.729" y1="-1.958" y2="-6.255"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="60.96" x2="63.71" y1="-3.615" y2="-10.365"/>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="13.96" x2="13.71" y1="-4.865" y2="-6.365"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="7.005" x2="1.479" y1="-1.958" y2="-6.255"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- Grassland -->
+        <pattern height="57.6" id="fill-grassland" overflow="visible" patternUnits="userSpaceOnUse" viewBox="0 -57.6 57.6 57.6" width="57.6">
+            <g>
+                <polygon fill="#54d2d0" points="0,0 57.6,0 57.6,-57.6 0,-57.6"/>
+                <g>
+                    <polygon fill="none" points="0,0 57.6,0 57.6,-57.6 0,-57.6"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.5" x2="55.5" y1="-3.6" y2="-3.6"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.1" x2="41.1" y1="-3.6" y2="-3.6"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.7" x2="26.7" y1="-3.6" y2="-3.6"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.3" x2="12.3" y1="-3.6" y2="-3.6"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.3" x2="48.3" y1="-10.801" y2="-10.801"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.9" x2="33.9" y1="-10.801" y2="-10.801"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.5" x2="19.5" y1="-10.801" y2="-10.801"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="2.1" x2="5.1" y1="-10.801" y2="-10.801"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.5" x2="55.5" y1="-18" y2="-18"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.1" x2="41.1" y1="-18" y2="-18"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.7" x2="26.7" y1="-18" y2="-18"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.3" x2="12.3" y1="-18" y2="-18"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.3" x2="48.3" y1="-25.2" y2="-25.2"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.9" x2="33.9" y1="-25.2" y2="-25.2"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.5" x2="19.5" y1="-25.2" y2="-25.2"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="2.1" x2="5.1" y1="-25.2" y2="-25.2"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.5" x2="55.5" y1="-32.4" y2="-32.4"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.1" x2="41.1" y1="-32.4" y2="-32.4"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.7" x2="26.7" y1="-32.4" y2="-32.4"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.3" x2="12.3" y1="-32.4" y2="-32.4"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.3" x2="48.3" y1="-39.6" y2="-39.6"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.9" x2="33.9" y1="-39.6" y2="-39.6"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.5" x2="19.5" y1="-39.6" y2="-39.6"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="2.1" x2="5.1" y1="-39.6" y2="-39.6"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.5" x2="55.5" y1="-46.801" y2="-46.801"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.1" x2="41.1" y1="-46.801" y2="-46.801"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.7" x2="26.7" y1="-46.801" y2="-46.801"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.3" x2="12.3" y1="-46.801" y2="-46.801"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.3" x2="48.3" y1="-54" y2="-54"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.9" x2="33.9" y1="-54" y2="-54"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.5" x2="19.5" y1="-54" y2="-54"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="2.1" x2="5.1" y1="-54" y2="-54"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54" x2="54" y1="-2.1" y2="-5.1"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.6" x2="39.6" y1="-2.1" y2="-5.1"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.2" x2="25.2" y1="-2.1" y2="-5.1"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.8" x2="10.8" y1="-2.1" y2="-5.1"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.8" x2="46.8" y1="-9.301" y2="-12.301"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.4" x2="32.4" y1="-9.301" y2="-12.301"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18" x2="18" y1="-9.301" y2="-12.301"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="3.6" x2="3.6" y1="-9.301" y2="-12.301"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54" x2="54" y1="-16.5" y2="-19.5"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.6" x2="39.6" y1="-16.5" y2="-19.5"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.2" x2="25.2" y1="-16.5" y2="-19.5"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.8" x2="10.8" y1="-16.5" y2="-19.5"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.8" x2="46.8" y1="-23.7" y2="-26.7"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.4" x2="32.4" y1="-23.7" y2="-26.7"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18" x2="18" y1="-23.7" y2="-26.7"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="3.6" x2="3.6" y1="-23.7" y2="-26.7"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54" x2="54" y1="-30.9" y2="-33.9"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.6" x2="39.6" y1="-30.9" y2="-33.9"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.2" x2="25.2" y1="-30.9" y2="-33.9"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.8" x2="10.8" y1="-30.9" y2="-33.9"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.8" x2="46.8" y1="-38.1" y2="-41.1"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.4" x2="32.4" y1="-38.1" y2="-41.1"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18" x2="18" y1="-38.1" y2="-41.1"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="3.6" x2="3.6" y1="-38.1" y2="-41.1"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54" x2="54" y1="-45.301" y2="-48.301"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.6" x2="39.6" y1="-45.301" y2="-48.301"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.2" x2="25.2" y1="-45.301" y2="-48.301"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.8" x2="10.8" y1="-45.301" y2="-48.301"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.8" x2="46.8" y1="-52.5" y2="-55.5"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.4" x2="32.4" y1="-52.5" y2="-55.5"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18" x2="18" y1="-52.5" y2="-55.5"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="3.6" x2="3.6" y1="-52.5" y2="-55.5"/>
+                </g>
+            </g>
+        </pattern>
+        <!-- Row Crops -->
+        <pattern height="72" id="fill-row_crop" overflow="visible" patternUnits="userSpaceOnUse" viewBox="14.586 -72 68.398 72" width="68.398">
+            <g>
+                <polygon fill="#52c6dd" points="14.586,-72 82.984,-72 82.984,0 14.586,0"/>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="92.172" x2="81.547" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="92.172" x2="81.547" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="87.922" x2="81.357" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="96.297" x2="81.422" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="91.422" x2="80.797" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="85.297" x2="81.047" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="87.984" x2="81.297" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="91.922" x2="81.297" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="84.047" x2="81.109" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="81.047" x2="94.422" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="81.109" x2="84.047" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="81.109" x2="108.422" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="84.172" x2="81.234" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="87.607" x2="81.047" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="81.609" x2="84.547" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="89.047" x2="81.359" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="84.297" x2="81.359" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="84.547" x2="81.609" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="81.359" x2="88.922" y1="-2.625" y2="-2.625"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="24.648" x2="24.898" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.959" x2="31.209" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.898" x2="32.334" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.459" x2="38.709" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.523" x2="41.773" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.398" x2="42.523" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.959" x2="48.209" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.084" x2="53.834" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.084" x2="59.334" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.148" x2="66.398" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.273" x2="70.523" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.273" x2="72.273" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.834" x2="73.084" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.834" x2="76.023" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.584" x2="76.834" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.709" x2="79.959" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.648" x2="83.584" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.773" x2="13.148" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.773" x2="26.023" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.023" x2="27.273" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.398" x2="28.648" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.398" x2="29.648" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.273" x2="39.523" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.398" x2="40.648" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.773" x2="49.023" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.773" x2="50.023" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.648" x2="50.898" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.148" x2="58.398" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.148" x2="57.398" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.273" x2="56.523" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.523" x2="55.773" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.523" x2="54.773" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.023" x2="67.273" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.023" x2="68.273" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.898" x2="69.148" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.773" x2="79.023" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.523" x2="77.773" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.586" x2="18.836" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.961" x2="35.148" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.523" x2="39.273" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.834" x2="40.084" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.898" x2="43.148" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.398" x2="43.898" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.959" x2="48.209" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.834" x2="52.084" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.084" x2="59.334" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.148" x2="66.398" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.273" x2="70.523" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.273" x2="72.273" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.834" x2="73.084" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.834" x2="76.023" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.584" x2="76.834" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.709" x2="79.959" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.648" x2="81.334" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="81.898" x2="83.648" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.648" x2="14.898" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.023" x2="16.273" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17.023" x2="17.273" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.648" x2="40.898" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.773" x2="42.023" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.773" x2="49.023" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.773" x2="50.023" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.648" x2="50.898" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.148" x2="58.398" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.148" x2="57.398" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.273" x2="56.523" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.523" x2="55.773" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.523" x2="54.773" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.898" x2="65.584" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.023" x2="67.273" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.023" x2="68.273" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.898" x2="69.148" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.773" x2="79.023" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.523" x2="77.773" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="24.648" x2="24.898" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.959" x2="31.209" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.898" x2="32.334" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.459" x2="45.709" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.523" x2="48.773" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.523" x2="49.523" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.084" x2="53.334" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.209" x2="58.959" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64.209" x2="64.459" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.709" x2="65.023" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.273" x2="72.273" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.834" x2="76.023" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.584" x2="76.834" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.709" x2="79.959" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.648" x2="83.584" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.773" x2="13.148" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.773" x2="26.023" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.023" x2="27.273" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.398" x2="28.648" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.398" x2="29.648" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.273" x2="46.523" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.398" x2="47.648" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.898" x2="54.148" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.898" x2="55.148" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.773" x2="56.023" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63.273" x2="63.523" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.273" x2="62.523" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.398" x2="61.648" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.648" x2="60.898" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.648" x2="59.898" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.398" x2="72.834" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.773" x2="79.023" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.523" x2="77.773" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.398" x2="20.648" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.709" x2="26.959" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.648" x2="28.084" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.209" x2="34.459" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.273" x2="37.523" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.148" x2="38.273" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.334" x2="44.584" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.459" x2="50.209" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.459" x2="55.709" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.584" x2="56.273" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.148" x2="66.398" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.273" x2="70.523" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.273" x2="72.273" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.834" x2="73.084" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.834" x2="76.023" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.584" x2="76.834" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.709" x2="79.959" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.648" x2="83.584" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.523" x2="12.959" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.523" x2="21.773" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.773" x2="23.023" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="24.148" x2="24.398" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.148" x2="25.398" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.023" x2="35.273" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.148" x2="36.398" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.148" x2="45.398" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.148" x2="46.398" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.023" x2="47.273" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.523" x2="54.773" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.523" x2="53.773" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.648" x2="52.898" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.898" x2="52.148" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.898" x2="51.148" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.023" x2="67.273" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.023" x2="68.273" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.898" x2="69.148" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.773" x2="79.023" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.523" x2="77.773" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.773" x2="29.023" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.084" x2="35.334" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.023" x2="36.459" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.584" x2="42.834" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.523" x2="47.273" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.834" x2="48.084" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.959" x2="59.209" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.773" x2="61.523" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.086" x2="62.336" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.211" x2="66.461" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.211" x2="68.211" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.773" x2="69.023" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.773" x2="75.898" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.459" x2="76.709" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.584" x2="79.834" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.523" x2="83.459" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.898" x2="13.023" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.898" x2="30.148" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="31.148" x2="31.398" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.523" x2="32.773" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.523" x2="33.773" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.398" x2="43.648" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.523" x2="44.773" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.648" x2="48.898" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.648" x2="49.898" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.523" x2="53.461" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.086" x2="54.648" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.961" x2="63.211" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63.961" x2="64.211" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64.836" x2="65.086" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.648" x2="78.898" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.398" x2="77.648" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.898" x2="24.148" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.209" x2="30.459" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.148" x2="31.584" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.709" x2="37.959" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.773" x2="41.023" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.648" x2="41.773" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.209" x2="47.459" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.084" x2="51.334" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.334" x2="58.584" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64.834" x2="59.148" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.398" x2="65.648" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.523" x2="69.773" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.523" x2="71.523" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.084" x2="72.334" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.084" x2="81.023" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="81.584" x2="81.834" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.023" x2="12.398" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.023" x2="25.273" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.273" x2="26.523" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.648" x2="27.898" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.648" x2="28.898" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.523" x2="38.773" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.648" x2="39.898" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.023" x2="48.273" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.023" x2="49.273" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.898" x2="50.148" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.398" x2="57.648" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.398" x2="56.648" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.523" x2="55.773" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.773" x2="55.023" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.773" x2="54.023" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.273" x2="66.523" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.273" x2="67.523" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.148" x2="68.398" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="82.523" x2="82.773" y1="-55.25" y2="-55.25"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.898" x2="12.648" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.898" x2="22.148" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.398" x2="23.273" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.959" x2="38.209" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.023" x2="41.273" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.898" x2="42.023" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.459" x2="47.709" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.334" x2="51.584" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.584" x2="58.834" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.084" x2="59.398" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.648" x2="65.898" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.773" x2="70.023" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.773" x2="71.773" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.334" x2="72.584" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.334" x2="75.523" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.084" x2="76.334" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.209" x2="79.459" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.148" x2="83.084" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17.961" x2="18.211" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.336" x2="19.586" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.336" x2="20.586" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.773" x2="39.023" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.898" x2="40.148" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.273" x2="48.523" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.273" x2="49.523" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.148" x2="50.398" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.648" x2="57.898" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.648" x2="56.898" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.773" x2="56.023" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.023" x2="55.273" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.023" x2="54.273" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.523" x2="66.773" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.523" x2="67.773" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.398" x2="68.648" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.273" x2="78.523" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.023" x2="77.273" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.461" x2="20.711" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.773" x2="27.023" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.648" x2="29.148" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.209" x2="38.459" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.273" x2="41.523" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.084" x2="42.273" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.646" x2="51.896" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.521" x2="55.771" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.209" x2="61.398" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.773" x2="74.023" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.586" x2="12.898" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.586" x2="21.836" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.836" x2="23.086" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="24.211" x2="24.461" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.211" x2="25.461" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.023" x2="39.273" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.148" x2="40.398" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.459" x2="52.709" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.459" x2="53.709" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.334" x2="54.584" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.834" x2="61.084" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.959" x2="60.209" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.209" x2="59.459" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.209" x2="58.459" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.648" x2="74.898" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.648" x2="83.334" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="24.398" x2="24.648" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.273" x2="45.398" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.709" x2="48.459" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.023" x2="49.273" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.148" x2="53.398" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.148" x2="55.148" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.709" x2="55.959" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.773" x2="64.148" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.334" x2="76.584" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.459" x2="79.709" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="83.334" x2="80.398" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.523" x2="12.898" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.523" x2="25.773" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.773" x2="27.023" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.148" x2="28.398" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.148" x2="29.398" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.898" x2="50.148" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.898" x2="51.148" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.773" x2="52.023" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.523" x2="78.773" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.273" x2="77.523" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.086" x2="60.336" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.086" x2="62.086" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.648" x2="62.898" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.711" x2="58.961" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.648" x2="71.398" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.336" x2="65.086" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.398" x2="63.961" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.836" x2="57.586" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.773" x2="54.523" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.898" x2="53.773" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.336" x2="48.086" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.461" x2="44.211" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.211" x2="36.961" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.711" x2="36.398" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.148" x2="29.898" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.023" x2="25.773" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.023" x2="24.023" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.461" x2="23.211" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.461" x2="20.273" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.711" x2="19.461" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.586" x2="16.336" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="15.648" x2="12.711" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.523" x2="83.148" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.523" x2="70.273" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.273" x2="69.023" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.898" x2="67.648" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.898" x2="66.648" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.023" x2="56.773" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.898" x2="55.648" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.523" x2="47.273" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.523" x2="46.273" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.648" x2="45.398" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.148" x2="37.898" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.148" x2="38.898" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.023" x2="39.773" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.773" x2="40.523" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.773" x2="41.523" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.273" x2="29.023" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.273" x2="28.023" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.398" x2="27.148" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17.523" x2="17.273" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.773" x2="18.523" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.709" x2="77.459" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.148" x2="76.334" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.023" x2="59.773" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.461" x2="56.211" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.398" x2="53.148" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.898" x2="52.398" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.336" x2="48.086" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.211" x2="36.961" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.711" x2="36.398" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.148" x2="29.898" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.648" x2="26.023" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="82.896" x2="82.646" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="81.646" x2="81.396" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.271" x2="80.021" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.271" x2="79.021" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.648" x2="55.398" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.523" x2="54.273" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.523" x2="47.273" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.523" x2="46.273" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.648" x2="45.398" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.148" x2="37.898" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.148" x2="38.898" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.023" x2="39.773" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.773" x2="40.523" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.773" x2="41.523" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.273" x2="29.023" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.273" x2="28.023" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.398" x2="27.148" y1="-34.125" y2="-34.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.648" x2="71.398" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.336" x2="65.086" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.398" x2="63.961" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.836" x2="50.586" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.773" x2="47.523" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.211" x2="42.961" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.336" x2="39.086" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.086" x2="31.836" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.586" x2="31.273" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.461" x2="20.273" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.711" x2="19.461" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.586" x2="16.336" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.711" x2="15.648" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.523" x2="83.148" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.523" x2="70.273" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.273" x2="69.023" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.898" x2="67.648" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.898" x2="66.648" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.023" x2="49.773" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.898" x2="48.648" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.398" x2="42.148" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.398" x2="41.148" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.523" x2="40.273" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.023" x2="32.773" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.023" x2="33.773" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.898" x2="34.648" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.648" x2="35.398" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.648" x2="36.398" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.898" x2="25.023" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.148" x2="22.898" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17.523" x2="17.273" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.773" x2="18.523" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.898" x2="75.648" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.586" x2="69.336" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.648" x2="68.211" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.086" x2="61.836" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.023" x2="58.773" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.148" x2="58.023" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.961" x2="51.711" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.086" x2="47.836" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.836" x2="40.586" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.711" x2="40.023" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.773" x2="83.336" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.773" x2="74.523" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.523" x2="73.273" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.148" x2="71.898" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.148" x2="70.898" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.273" x2="61.023" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.148" x2="59.898" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.148" x2="50.898" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.148" x2="49.898" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.273" x2="49.023" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.773" x2="41.523" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.773" x2="42.523" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.648" x2="43.398" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.398" x2="44.148" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.398" x2="45.148" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.523" x2="67.273" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.211" x2="60.961" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.273" x2="59.836" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.711" x2="53.461" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.023" x2="50.773" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.461" x2="48.211" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.336" x2="37.086" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.209" x2="33.959" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.084" x2="29.834" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.084" x2="28.084" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.523" x2="27.273" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.523" x2="20.398" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.836" x2="19.586" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.711" x2="16.461" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="15.773" x2="12.836" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.398" x2="83.273" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.398" x2="66.148" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.148" x2="64.898" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63.773" x2="63.523" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.773" x2="62.523" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.898" x2="52.648" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.773" x2="51.523" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.648" x2="47.398" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.648" x2="46.398" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.834" x2="45.773" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.023" x2="41.648" y1="-24.125" y2="-24.125"/>
+                    <polyline fill="none" points="36.523,-24.125 36.523,-24.125 34.773,-24.125" stroke="#231F20" stroke-width="0.3"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.334" x2="33.084" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.334" x2="32.084" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="31.459" x2="31.209" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17.648" x2="17.398" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.898" x2="18.648" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.336" x2="77.086" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.023" x2="70.773" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64.086" x2="69.648" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63.523" x2="63.273" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.461" x2="60.211" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.586" x2="59.461" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.023" x2="53.773" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.148" x2="49.898" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.898" x2="42.648" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.836" x2="35.586" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="31.711" x2="31.461" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.711" x2="29.711" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.148" x2="28.898" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.148" x2="23.834" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.273" x2="23.023" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.148" x2="19.898" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.209" x2="12.648" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.211" x2="84.773" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.211" x2="75.961" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.961" x2="74.711" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.586" x2="73.336" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.586" x2="72.336" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.711" x2="62.461" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.586" x2="61.336" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.211" x2="52.961" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.211" x2="51.961" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.336" x2="51.086" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.836" x2="43.586" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.836" x2="44.586" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.711" x2="45.461" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.461" x2="46.211" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.461" x2="47.211" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.086" x2="36.398" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.961" x2="34.711" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.961" x2="33.711" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.086" x2="32.836" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.084" x2="20.834" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.334" x2="22.084" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.398" x2="83.648" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.398" x2="74.148" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.898" x2="73.023" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.336" x2="58.086" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.273" x2="55.023" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.398" x2="54.273" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.836" x2="48.586" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.711" x2="42.961" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.711" x2="37.461" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="31.211" x2="36.898" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.648" x2="30.398" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.523" x2="26.273" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.523" x2="24.523" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.961" x2="23.711" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.961" x2="20.773" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.211" x2="19.961" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17.086" x2="16.836" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="13.211" x2="16.148" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.334" x2="78.084" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.959" x2="76.709" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.959" x2="75.709" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.523" x2="57.273" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.398" x2="56.148" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.023" x2="47.773" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.023" x2="46.773" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.148" x2="45.898" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.648" x2="38.398" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.648" x2="39.398" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.523" x2="40.273" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.273" x2="41.023" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.273" x2="42.023" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.773" x2="29.523" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.773" x2="28.523" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.898" x2="27.648" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.023" x2="17.773" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.273" x2="19.023" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.834" x2="75.584" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.523" x2="69.273" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.648" x2="64.523" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.086" x2="57.836" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.023" x2="54.773" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.211" x2="54.023" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.648" x2="44.398" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.523" x2="38.773" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.086" x2="34.898" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.523" x2="22.273" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.709" x2="83.398" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.709" x2="74.459" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.459" x2="73.209" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.084" x2="71.834" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.084" x2="70.834" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.273" x2="57.023" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.148" x2="55.898" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.836" x2="43.586" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.836" x2="42.586" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.961" x2="41.711" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.461" x2="35.211" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.336" x2="36.086" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.086" x2="36.836" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.086" x2="37.836" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.648" x2="21.398" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.648" x2="12.961" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.898" x2="71.648" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.023" x2="50.898" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.836" x2="49.586" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.273" x2="47.023" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.148" x2="42.898" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.148" x2="41.148" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.586" x2="40.336" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.523" x2="32.148" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.961" x2="19.711" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.836" x2="16.586" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="15.898" x2="12.961" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.773" x2="83.398" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.773" x2="70.523" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.523" x2="69.273" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.148" x2="67.898" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.148" x2="66.898" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.398" x2="46.148" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.398" x2="45.148" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.523" x2="44.273" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17.773" x2="17.523" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.209" x2="35.959" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.209" x2="34.209" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.648" x2="33.398" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.584" x2="37.334" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.398" x2="74.148" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.898" x2="73.023" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.336" x2="58.086" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.273" x2="55.023" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.711" x2="37.461" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.648" x2="30.398" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.523" x2="26.273" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.523" x2="24.523" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.961" x2="23.711" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.961" x2="20.773" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.211" x2="19.961" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17.086" x2="16.836" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.148" x2="13.211" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="79.334" x2="83.648" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.334" x2="78.084" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.959" x2="76.709" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.959" x2="75.709" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.523" x2="57.273" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.398" x2="56.148" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.648" x2="38.398" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.648" x2="39.398" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.523" x2="40.273" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.023" x2="54.273" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.898" x2="31.211" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.773" x2="29.523" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.773" x2="28.523" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.898" x2="27.648" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.023" x2="17.773" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.273" x2="19.023" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.834" x2="75.584" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.523" x2="69.273" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.648" x2="67.148" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.086" x2="57.836" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.023" x2="54.773" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.211" x2="54.023" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.648" x2="44.398" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.523" x2="38.773" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.086" x2="34.898" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.523" x2="22.273" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.961" x2="20.523" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.709" x2="83.398" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.709" x2="74.459" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.459" x2="73.209" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.084" x2="71.834" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.084" x2="70.834" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.273" x2="57.023" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.148" x2="55.898" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.836" x2="43.586" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.836" x2="42.586" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.961" x2="41.711" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.461" x2="35.211" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.336" x2="36.086" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.086" x2="36.836" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.086" x2="37.836" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.648" x2="21.398" y1="-2.625" y2="-2.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.898" x2="65.584" y1="-70.375" y2="-70.375"/>
+                    <path d="M44.211-34.125h-1.75H44.211z" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.773" x2="46.773" y1="-31.875" y2="-31.875"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.25" x2="15.186" y1="-70.375" y2="-70.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="13.5" x2="15.25" y1="-66.375" y2="-66.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.25" x2="15.186" y1="-64.125" y2="-64.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.25" x2="15.186" y1="-58.625" y2="-58.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.125" x2="15.061" y1="-56.375" y2="-56.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="11.75" x2="14.686" y1="-49.625" y2="-49.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="7.25" x2="14.936" y1="-47.625" y2="-47.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.936" x2="12" y1="-42.625" y2="-42.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="4.125" x2="14.75" y1="-38.125" y2="-38.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="4.125" x2="14.75" y1="-31.875" y2="-31.875"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.375" x2="14.938" y1="-26.375" y2="-26.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="0" x2="14.875" y1="-24.125" y2="-24.125"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.812" x2="16.375" y1="-6.625" y2="-6.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="11" x2="15.25" y1="-17.375" y2="-17.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.311" x2="15" y1="-15.375" y2="-15.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="4.375" x2="15" y1="-10.375" y2="-10.375"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.936" x2="15.25" y1="-4.625" y2="-4.625"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.311" x2="15" y1="-2.625" y2="-2.625"/>
+                </g>
+            </g>
+        </pattern>
+        <!-- Wetlands -->
+        <pattern height="72" id="fill-wetland" overflow="visible" patternUnits="userSpaceOnUse" viewBox="6.5 -72.625 72 72" width="72">
+            <g>
+                <polygon fill="#4ebaea" points="6.5,-0.625 78.5,-0.625 78.5,-72.625 6.5,-72.625"/>
+                <g>
+                    <polygon fill="none" points="6.5,-0.625 78.5,-0.625 78.5,-72.625 6.5,-72.625"/>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36" x2="36" y1="-73.75" y2="-72"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.5" x2="35.062" y1="-73.75" y2="-72.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.5" x2="37.031" y1="-73.75" y2="-72.625"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77" x2="83.875" y1="-49.375" y2="-49.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78.312" x2="85.188" y1="-36" y2="-36"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="78" x2="84.875" y1="-12.75" y2="-12.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.125" x2="84" y1="-4.125" y2="-4.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.438" x2="81.812" y1="-66" y2="-66"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.562" x2="30.438" y1="-70" y2="-70"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.562" x2="43.438" y1="-66.5" y2="-66.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.688" x2="69.562" y1="-68.25" y2="-68.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.562" x2="72.438" y1="-62.625" y2="-62.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.562" x2="61.438" y1="-59.375" y2="-59.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.062" x2="48.938" y1="-56.75" y2="-56.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.062" x2="35.938" y1="-53.5" y2="-53.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.562" x2="47.438" y1="-49.25" y2="-49.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.062" x2="58.938" y1="-45" y2="-45"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.812" x2="53.688" y1="-41.125" y2="-41.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.562" x2="67.438" y1="-53.375" y2="-53.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.312" x2="67.188" y1="-37.875" y2="-37.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.062" x2="24.938" y1="-62.75" y2="-62.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="7.062" x2="13.938" y1="-59.5" y2="-59.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="13.062" x2="19.938" y1="-53.5" y2="-53.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="5" x2="11.875" y1="-49.375" y2="-49.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.188" x2="19.062" y1="-44.875" y2="-44.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.312" x2="34.188" y1="-42.125" y2="-42.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.812" x2="42.688" y1="-37.875" y2="-37.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.312" x2="36.188" y1="-30.75" y2="-30.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.812" x2="48.688" y1="-31.875" y2="-31.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.312" x2="17.188" y1="-32" y2="-32"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="6.312" x2="13.188" y1="-36" y2="-36"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="6" x2="12.875" y1="-12.75" y2="-12.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18" x2="24.875" y1="-16.75" y2="-16.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.625" x2="26.5" y1="-23.375" y2="-23.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.5" x2="19.375" y1="-7.375" y2="-7.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="5.125" x2="12" y1="-4.125" y2="-4.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.812" x2="41.688" y1="-22" y2="-22"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.312" x2="55.188" y1="-26.5" y2="-26.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.5" x2="54.375" y1="-18.625" y2="-18.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.5" x2="65.375" y1="-21.875" y2="-21.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.5" x2="72.375" y1="-16.625" y2="-16.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41" x2="47.875" y1="-11.5" y2="-11.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.5" x2="40.375" y1="-8.5" y2="-8.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.562" x2="39.438" y1="-1.75" y2="-1.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45" x2="51.875" y1="-4.25" y2="-4.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60" x2="66.875" y1="-7.25" y2="-7.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.188" x2="77.062" y1="-54.125" y2="-54.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.312" x2="78.188" y1="-41.25" y2="-41.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72" x2="78.875" y1="-18.625" y2="-18.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.812" x2="79.688" y1="-26.625" y2="-26.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27" x2="27" y1="-70" y2="-68.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40" x2="40" y1="-66.5" y2="-64.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.125" x2="66.125" y1="-68.25" y2="-66.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69" x2="69" y1="-62.625" y2="-60.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58" x2="58" y1="-59.375" y2="-57.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.5" x2="45.5" y1="-56.75" y2="-55"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.5" x2="32.5" y1="-53.5" y2="-51.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44" x2="44" y1="-49.25" y2="-47.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.5" x2="55.5" y1="-45" y2="-43.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.25" x2="50.25" y1="-41.125" y2="-39.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64" x2="64" y1="-53.375" y2="-51.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63.75" x2="63.75" y1="-37.875" y2="-36.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.5" x2="21.5" y1="-62.75" y2="-61"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.5" x2="10.5" y1="-59.5" y2="-57.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.5" x2="16.5" y1="-53.5" y2="-51.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.438" x2="8.438" y1="-49.375" y2="-47.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="15.625" x2="15.625" y1="-44.875" y2="-43.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.75" x2="30.75" y1="-42.125" y2="-40.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.25" x2="39.25" y1="-37.875" y2="-36.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.75" x2="32.75" y1="-30.75" y2="-29"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.25" x2="45.25" y1="-31.875" y2="-30.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.25" x2="76.25" y1="-26.625" y2="-24.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="13.75" x2="13.75" y1="-32" y2="-30.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.75" x2="9.75" y1="-36" y2="-34.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.438" x2="9.438" y1="-12.75" y2="-11"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.438" x2="21.438" y1="-16.75" y2="-15"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.063" x2="23.063" y1="-23.375" y2="-21.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="15.938" x2="15.938" y1="-7.375" y2="-5.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.563" x2="8.563" y1="-4.125" y2="-2.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.25" x2="38.25" y1="-22" y2="-20.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.75" x2="51.75" y1="-26.5" y2="-24.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.938" x2="50.938" y1="-18.625" y2="-16.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.938" x2="61.938" y1="-21.875" y2="-20.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.938" x2="68.938" y1="-16.625" y2="-14.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.438" x2="44.438" y1="-11.5" y2="-9.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.938" x2="36.938" y1="-8.5" y2="-6.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36" x2="36" y1="-1.75" y2="0"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.438" x2="48.438" y1="-4.25" y2="-2.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63.438" x2="63.438" y1="-7.25" y2="-5.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.625" x2="73.625" y1="-54.125" y2="-52.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.75" x2="74.75" y1="-41.25" y2="-39.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.438" x2="75.438" y1="-18.625" y2="-16.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.5" x2="26.062" y1="-70" y2="-68.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.5" x2="39.062" y1="-66.5" y2="-65.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.625" x2="65.188" y1="-68.25" y2="-67.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.5" x2="68.062" y1="-62.625" y2="-61.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="57.5" x2="57.062" y1="-59.375" y2="-58.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45" x2="44.562" y1="-56.75" y2="-55.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32" x2="31.562" y1="-53.5" y2="-52.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.5" x2="43.062" y1="-49.25" y2="-48.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55" x2="54.562" y1="-45" y2="-43.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.75" x2="49.312" y1="-41.125" y2="-40"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63.5" x2="63.062" y1="-53.375" y2="-52.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63.25" x2="62.812" y1="-37.875" y2="-36.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21" x2="20.562" y1="-62.75" y2="-61.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10" x2="9.562" y1="-59.5" y2="-58.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16" x2="15.562" y1="-53.5" y2="-52.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="7.938" x2="7.5" y1="-49.375" y2="-48.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="15.125" x2="14.688" y1="-44.875" y2="-43.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.25" x2="29.812" y1="-42.125" y2="-41"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.75" x2="38.312" y1="-37.875" y2="-36.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.25" x2="31.812" y1="-30.75" y2="-29.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.75" x2="44.312" y1="-31.875" y2="-30.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="13.25" x2="12.812" y1="-32" y2="-30.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.25" x2="8.812" y1="-36" y2="-34.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.938" x2="8.5" y1="-12.75" y2="-11.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.938" x2="20.5" y1="-16.75" y2="-15.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.563" x2="22.125" y1="-23.375" y2="-22.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="15.438" x2="15" y1="-7.375" y2="-6.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.063" x2="7.625" y1="-4.125" y2="-3"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.75" x2="37.312" y1="-22" y2="-20.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.25" x2="50.812" y1="-26.5" y2="-25.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.438" x2="50" y1="-18.625" y2="-17.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.438" x2="61" y1="-21.875" y2="-20.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.438" x2="68" y1="-16.625" y2="-15.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.938" x2="43.5" y1="-11.5" y2="-10.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.438" x2="36" y1="-8.5" y2="-7.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.5" x2="35.062" y1="-1.75" y2="-0.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.938" x2="47.5" y1="-4.25" y2="-3.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.938" x2="62.5" y1="-7.25" y2="-6.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.125" x2="72.688" y1="-54.125" y2="-53"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.25" x2="73.812" y1="-41.25" y2="-40.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.938" x2="74.5" y1="-18.625" y2="-17.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.75" x2="75.312" y1="-26.625" y2="-25.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.906" x2="25.281" y1="-70" y2="-69.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.906" x2="38.281" y1="-66.5" y2="-65.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.031" x2="64.406" y1="-68.25" y2="-67.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.906" x2="67.281" y1="-62.625" y2="-62"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.906" x2="56.281" y1="-59.375" y2="-58.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.406" x2="43.781" y1="-56.75" y2="-56.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="31.406" x2="30.781" y1="-53.5" y2="-52.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.906" x2="42.281" y1="-49.25" y2="-48.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="54.406" x2="53.781" y1="-45" y2="-44.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.156" x2="48.531" y1="-41.125" y2="-40.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.906" x2="62.281" y1="-53.375" y2="-52.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.656" x2="62.031" y1="-37.875" y2="-37.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.406" x2="19.781" y1="-62.75" y2="-62.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.406" x2="8.781" y1="-59.5" y2="-58.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="15.406" x2="14.781" y1="-53.5" y2="-52.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="7.345" x2="6.72" y1="-49.375" y2="-48.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.531" x2="13.906" y1="-44.875" y2="-44.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.656" x2="29.031" y1="-42.125" y2="-41.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.156" x2="37.531" y1="-37.875" y2="-37.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="31.656" x2="31.031" y1="-30.75" y2="-30.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.156" x2="43.531" y1="-31.875" y2="-31.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.656" x2="12.031" y1="-32" y2="-31.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.656" x2="8.031" y1="-36" y2="-35.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.345" x2="7.72" y1="-12.75" y2="-12.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.345" x2="19.72" y1="-16.75" y2="-16.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.97" x2="21.345" y1="-23.375" y2="-22.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.845" x2="14.22" y1="-7.375" y2="-6.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="7.47" x2="6.845" y1="-4.125" y2="-3.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.156" x2="36.531" y1="-22" y2="-21.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.656" x2="50.031" y1="-26.5" y2="-25.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.845" x2="49.22" y1="-18.625" y2="-18"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.845" x2="60.22" y1="-21.875" y2="-21.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.845" x2="67.22" y1="-16.625" y2="-16"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.345" x2="42.72" y1="-11.5" y2="-10.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.845" x2="35.22" y1="-8.5" y2="-7.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.906" x2="34.281" y1="-1.75" y2="-1.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="47.345" x2="46.72" y1="-4.25" y2="-3.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.345" x2="61.72" y1="-7.25" y2="-6.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="72.531" x2="71.906" y1="-54.125" y2="-53.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.656" x2="73.031" y1="-41.25" y2="-40.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.345" x2="73.72" y1="-18.625" y2="-18"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.156" x2="74.531" y1="-26.625" y2="-26"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.5" x2="28.031" y1="-70" y2="-68.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.5" x2="41.031" y1="-66.5" y2="-65.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.625" x2="67.156" y1="-68.25" y2="-67.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.5" x2="70.031" y1="-62.625" y2="-61.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.5" x2="59.031" y1="-59.375" y2="-58.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46" x2="46.531" y1="-56.75" y2="-55.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33" x2="33.531" y1="-53.5" y2="-52.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.5" x2="45.031" y1="-49.25" y2="-48.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56" x2="56.531" y1="-45" y2="-43.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.75" x2="51.281" y1="-41.125" y2="-40"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64.5" x2="65.031" y1="-53.375" y2="-52.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64.25" x2="64.781" y1="-37.875" y2="-36.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22" x2="22.531" y1="-62.75" y2="-61.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="11" x2="11.531" y1="-59.5" y2="-58.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17" x2="17.531" y1="-53.5" y2="-52.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.938" x2="9.47" y1="-49.375" y2="-48.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.125" x2="16.656" y1="-44.875" y2="-43.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="31.25" x2="31.781" y1="-42.125" y2="-41"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.75" x2="40.281" y1="-37.875" y2="-36.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.25" x2="33.781" y1="-30.75" y2="-29.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.75" x2="46.281" y1="-31.875" y2="-30.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.938" x2="76.47" y1="-18.625" y2="-17.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.75" x2="77.281" y1="-26.625" y2="-25.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.25" x2="14.781" y1="-32" y2="-30.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.25" x2="10.781" y1="-36" y2="-34.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.938" x2="10.47" y1="-12.75" y2="-11.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.938" x2="22.47" y1="-16.75" y2="-15.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="23.563" x2="24.095" y1="-23.375" y2="-22.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.438" x2="16.97" y1="-7.375" y2="-6.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.063" x2="9.595" y1="-4.125" y2="-3"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.75" x2="39.281" y1="-22" y2="-20.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.25" x2="52.781" y1="-26.5" y2="-25.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.438" x2="51.97" y1="-18.625" y2="-17.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.438" x2="62.97" y1="-21.875" y2="-20.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.438" x2="69.97" y1="-16.625" y2="-15.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.938" x2="45.47" y1="-11.5" y2="-10.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.438" x2="37.97" y1="-8.5" y2="-7.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.5" x2="37.031" y1="-1.75" y2="-0.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.938" x2="49.47" y1="-4.25" y2="-3.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63.938" x2="64.47" y1="-7.25" y2="-6.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.125" x2="74.656" y1="-54.125" y2="-53"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.25" x2="75.781" y1="-41.25" y2="-40.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.062" x2="28.75" y1="-70" y2="-69.312"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="41.062" x2="41.75" y1="-66.5" y2="-65.812"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.188" x2="67.875" y1="-68.25" y2="-67.562"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.062" x2="70.75" y1="-62.625" y2="-61.938"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.062" x2="59.75" y1="-59.375" y2="-58.688"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.562" x2="47.25" y1="-56.75" y2="-56.062"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.562" x2="34.25" y1="-53.5" y2="-52.812"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.062" x2="45.75" y1="-49.25" y2="-48.562"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.562" x2="57.25" y1="-45" y2="-44.312"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.312" x2="52" y1="-41.125" y2="-40.438"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="65.062" x2="65.75" y1="-53.375" y2="-52.688"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64.812" x2="65.5" y1="-37.875" y2="-37.188"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.562" x2="23.25" y1="-62.75" y2="-62.062"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="11.562" x2="12.25" y1="-59.5" y2="-58.812"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17.562" x2="18.25" y1="-53.5" y2="-52.812"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.5" x2="10.188" y1="-49.375" y2="-48.688"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.812" x2="76.5" y1="-41.25" y2="-40.562"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.688" x2="17.375" y1="-44.875" y2="-44.188"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="31.812" x2="32.5" y1="-42.125" y2="-41.438"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.312" x2="41" y1="-37.875" y2="-37.188"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.812" x2="34.5" y1="-30.75" y2="-30.062"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.312" x2="47" y1="-31.875" y2="-31.188"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="76.5" x2="77.188" y1="-18.625" y2="-17.938"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.312" x2="78" y1="-26.625" y2="-25.938"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.812" x2="15.5" y1="-32" y2="-31.312"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.812" x2="11.5" y1="-36" y2="-35.312"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="10.5" x2="11.188" y1="-12.75" y2="-12.062"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.5" x2="23.188" y1="-16.75" y2="-16.062"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="24.125" x2="24.813" y1="-23.375" y2="-22.688"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="17" x2="17.688" y1="-7.375" y2="-6.688"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.625" x2="10.313" y1="-4.125" y2="-3.438"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.312" x2="40" y1="-22" y2="-21.312"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.812" x2="53.5" y1="-26.5" y2="-25.812"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52" x2="52.688" y1="-18.625" y2="-17.938"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="63" x2="63.688" y1="-21.875" y2="-21.188"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70" x2="70.688" y1="-16.625" y2="-15.938"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.5" x2="46.188" y1="-11.5" y2="-10.812"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38" x2="38.688" y1="-8.5" y2="-7.812"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.062" x2="37.75" y1="-1.75" y2="-1.062"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.5" x2="50.188" y1="-4.25" y2="-3.562"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64.5" x2="65.188" y1="-7.25" y2="-6.562"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.688" x2="75.375" y1="-54.125" y2="-53.438"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.253" x2="28.878" y1="-70.378" y2="-70.378"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.253" x2="41.878" y1="-66.878" y2="-66.878"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="64.378" x2="68.003" y1="-68.628" y2="-68.628"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.253" x2="70.878" y1="-63.003" y2="-63.003"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.253" x2="59.878" y1="-59.753" y2="-59.753"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.753" x2="47.378" y1="-57.128" y2="-57.128"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.753" x2="34.378" y1="-53.878" y2="-53.878"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.253" x2="45.878" y1="-49.628" y2="-49.628"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.753" x2="57.378" y1="-45.378" y2="-45.378"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.503" x2="52.128" y1="-41.503" y2="-41.503"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.253" x2="65.878" y1="-53.753" y2="-53.753"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.003" x2="65.628" y1="-38.253" y2="-38.253"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.753" x2="23.378" y1="-63.128" y2="-63.128"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.753" x2="12.378" y1="-59.878" y2="-59.878"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.753" x2="18.378" y1="-53.878" y2="-53.878"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="6.691" x2="10.316" y1="-49.753" y2="-49.753"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="13.878" x2="17.503" y1="-45.253" y2="-45.253"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.003" x2="32.628" y1="-42.503" y2="-42.503"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.503" x2="41.128" y1="-38.253" y2="-38.253"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="31.003" x2="34.628" y1="-31.128" y2="-31.128"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="43.503" x2="47.128" y1="-32.253" y2="-32.253"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.003" x2="15.628" y1="-32.378" y2="-32.378"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.003" x2="11.628" y1="-36.378" y2="-36.378"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="7.691" x2="11.316" y1="-13.128" y2="-13.128"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.691" x2="23.316" y1="-17.128" y2="-17.128"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.316" x2="24.941" y1="-23.753" y2="-23.753"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.191" x2="17.816" y1="-7.753" y2="-7.753"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="6.816" x2="10.441" y1="-4.503" y2="-4.503"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.503" x2="40.128" y1="-22.378" y2="-22.378"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="50.003" x2="53.628" y1="-26.878" y2="-26.878"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.191" x2="52.816" y1="-19.003" y2="-19.003"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.191" x2="63.816" y1="-22.253" y2="-22.253"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.191" x2="70.816" y1="-17.003" y2="-17.003"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="42.691" x2="46.316" y1="-11.878" y2="-11.878"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="35.191" x2="38.816" y1="-8.878" y2="-8.878"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.253" x2="37.878" y1="-2.128" y2="-2.128"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.691" x2="50.316" y1="-4.628" y2="-4.628"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.691" x2="65.316" y1="-7.628" y2="-7.628"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="71.878" x2="75.503" y1="-54.503" y2="-54.503"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.003" x2="76.628" y1="-41.628" y2="-41.628"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.691" x2="77.316" y1="-19.003" y2="-19.003"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.503" x2="78.128" y1="-27.003" y2="-27.003"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="13.875" x2="18.25" y1="-3.75" y2="-3.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.75" x2="24.125" y1="-8.5" y2="-8.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="45.375" x2="54.125" y1="-6.625" y2="-6.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="13.25" x2="17.625" y1="-14" y2="-14"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26" x2="30.375" y1="-18" y2="-18"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.375" x2="65.75" y1="-3.625" y2="-3.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.25" x2="71.625" y1="-8.375" y2="-8.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.75" x2="65.125" y1="-13.875" y2="-13.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.062" x2="12.438" y1="-27.75" y2="-27.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.688" x2="42.438" y1="-25.875" y2="-25.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.312" x2="18.688" y1="-37.25" y2="-37.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.688" x2="54.062" y1="-22.875" y2="-22.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.562" x2="59.938" y1="-27.625" y2="-27.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="49.062" x2="53.438" y1="-33.125" y2="-33.125"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.938" x2="25.312" y1="-44.5" y2="-44.5"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="26.812" x2="31.188" y1="-49.25" y2="-49.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.438" x2="61.188" y1="-47.375" y2="-47.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.312" x2="24.688" y1="-54.75" y2="-54.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="33.062" x2="37.438" y1="-58.75" y2="-58.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="68.438" x2="72.812" y1="-44.375" y2="-44.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="5.438" x2="9.812" y1="-66" y2="-66"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="11.312" x2="15.688" y1="-70.75" y2="-70.75"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.938" x2="45.688" y1="-68.875" y2="-68.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.938" x2="57.312" y1="-65.875" y2="-65.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.812" x2="63.188" y1="-70.625" y2="-70.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.875" x2="13.25" y1="-40.875" y2="-40.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.25" x2="74.625" y1="-10.625" y2="-10.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="70.062" x2="74.438" y1="-71.375" y2="-71.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.062" x2="50.438" y1="-60.375" y2="-60.375"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27" x2="33.438" y1="-38.875" y2="-38.875"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.188" x2="78.562" y1="-23" y2="-23"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.562" x2="77.938" y1="-33.25" y2="-33.25"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.625" x2="79" y1="-44.875" y2="-44.875"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="0" x2="6.875" y1="-18.625" y2="-18.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="0.812" x2="7.688" y1="-26.625" y2="-26.625"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="2.188" x2="6.562" y1="-23" y2="-23"/>
+                        <line fill="none" stroke="#231F20" stroke-width="0.3" x1="2.625" x2="7" y1="-44.875" y2="-44.875"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- CONSERVATION PRACTICES -->
+        <!-- No Till farming -->
+        <pattern height="74.8" id="fill-no_till_agriculture" overflow="visible" patternUnits="userSpaceOnUse" viewBox="72.15 -74.8 72 74.8" width="72">
+            <g>
+                <polygon fill="#53e9b4" points="72.15,-74.8 144.15,-74.8 144.15,0 72.15,0"/>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-0.85" y2="-0.85"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-2.55" y2="-2.55"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-4.25" y2="-4.25"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-5.95" y2="-5.95"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-7.65" y2="-7.65"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-9.35" y2="-9.35"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-11.05" y2="-11.05"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-12.75" y2="-12.75"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-14.45" y2="-14.45"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-16.15" y2="-16.15"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-17.85" y2="-17.85"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-19.55" y2="-19.55"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-21.25" y2="-21.25"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-22.949" y2="-22.949"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-24.649" y2="-24.649"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-26.349" y2="-26.349"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-28.049" y2="-28.049"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-29.749" y2="-29.749"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-31.449" y2="-31.449"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-33.149" y2="-33.149"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-34.849" y2="-34.849"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-36.549" y2="-36.549"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-38.249" y2="-38.249"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-39.949" y2="-39.949"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-41.649" y2="-41.649"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-43.349" y2="-43.349"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-45.049" y2="-45.049"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-46.749" y2="-46.749"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-48.449" y2="-48.449"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-50.149" y2="-50.149"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-51.849" y2="-51.849"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-53.549" y2="-53.549"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-55.249" y2="-55.249"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-56.949" y2="-56.949"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-58.649" y2="-58.649"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-60.349" y2="-60.349"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-62.049" y2="-62.049"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-63.749" y2="-63.749"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-65.449" y2="-65.449"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-67.149" y2="-67.149"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-68.849" y2="-68.849"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-70.549" y2="-70.549"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-72.249" y2="-72.249"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-73.949" y2="-73.949"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-0.85" y2="-0.85"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-2.55" y2="-2.55"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-4.25" y2="-4.25"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-5.95" y2="-5.95"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-7.65" y2="-7.65"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-9.35" y2="-9.35"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-11.05" y2="-11.05"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-12.75" y2="-12.75"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-14.45" y2="-14.45"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-16.15" y2="-16.15"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-17.85" y2="-17.85"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-19.55" y2="-19.55"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-21.25" y2="-21.25"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-22.949" y2="-22.949"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-24.649" y2="-24.649"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-26.349" y2="-26.349"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-28.049" y2="-28.049"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-29.749" y2="-29.749"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-31.449" y2="-31.449"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-33.149" y2="-33.149"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-34.849" y2="-34.849"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-36.549" y2="-36.549"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-38.249" y2="-38.249"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-39.949" y2="-39.949"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-41.649" y2="-41.649"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-43.349" y2="-43.349"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-45.049" y2="-45.049"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-46.749" y2="-46.749"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-48.449" y2="-48.449"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-50.149" y2="-50.149"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-51.849" y2="-51.849"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-53.549" y2="-53.549"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-55.249" y2="-55.249"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-56.949" y2="-56.949"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-58.649" y2="-58.649"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-60.349" y2="-60.349"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-62.049" y2="-62.049"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-63.749" y2="-63.749"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-65.449" y2="-65.449"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-67.149" y2="-67.149"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-68.849" y2="-68.849"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-70.549" y2="-70.549"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-72.249" y2="-72.249"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="144.15" y1="-73.949" y2="-73.949"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-0.85" y2="-0.85"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-2.55" y2="-2.55"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-4.25" y2="-4.25"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-5.95" y2="-5.95"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-7.65" y2="-7.65"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-9.35" y2="-9.35"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-11.05" y2="-11.05"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-12.75" y2="-12.75"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-14.45" y2="-14.45"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-16.15" y2="-16.15"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-17.85" y2="-17.85"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-19.55" y2="-19.55"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-21.25" y2="-21.25"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-22.949" y2="-22.949"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-24.649" y2="-24.649"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-26.349" y2="-26.349"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-28.049" y2="-28.049"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-29.749" y2="-29.749"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-31.449" y2="-31.449"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-33.149" y2="-33.149"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-34.849" y2="-34.849"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-36.549" y2="-36.549"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-38.249" y2="-38.249"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-39.949" y2="-39.949"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-41.649" y2="-41.649"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-43.349" y2="-43.349"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-45.049" y2="-45.049"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-46.749" y2="-46.749"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-48.449" y2="-48.449"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-50.149" y2="-50.149"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-51.849" y2="-51.849"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-53.549" y2="-53.549"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-55.249" y2="-55.249"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-56.949" y2="-56.949"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-58.649" y2="-58.649"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-60.349" y2="-60.349"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-62.049" y2="-62.049"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-63.749" y2="-63.749"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-65.449" y2="-65.449"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-67.149" y2="-67.149"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-68.849" y2="-68.849"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-70.549" y2="-70.549"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-72.249" y2="-72.249"/>
+                    <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="72.15" y1="-73.949" y2="-73.949"/>
+                </g>
+            </g>
+        </pattern>
+        <!-- Cluster Housing -->
+        <pattern height="72" id="fill-cluster_housing" overflow="visible" patternUnits="userSpaceOnUse" viewBox="4.145 -78.23 72 72" width="72">
+            <g>
+                <polygon fill="#4aeab3" points="4.145,-78.23 76.145,-78.23 76.145,-6.23 4.145,-6.23"/>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.844" x2="71.324" y1="-1.534" y2="-7.609"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.588" x2="66.107" y1="-8.603" y2="-2.529"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.145" x2="50.77" y1="-0.73" y2="-7.313"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.887" x2="51.264" y1="-6.635" y2="-0.051"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.574" x2="42.299" y1="-2.393" y2="-9.176"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.359" x2="38.637" y1="-9.668" y2="-2.885"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.018" x2="20.922" y1="-2.919" y2="-9.655"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.996" x2="17.092" y1="-10.2" y2="-3.464"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.93" x2="10.914" y1="-3.305" y2="-10.009"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.998" x2="11.016" y1="-9.434" y2="-2.729"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.162" x2="59.596" y1="-8.939" y2="-3.521"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.143" x2="56.711" y1="-4.789" y2="-10.205"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.877" x2="82.395" y1="-51.929" y2="-54.48"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="3.877" x2="10.395" y1="-51.929" y2="-54.48"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.336" x2="5.775" y1="-38.085" y2="-31.569"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="7.637" x2="10.197" y1="-30.839" y2="-37.354"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.355" x2="79.521" y1="-72.569" y2="-69.252"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.469" x2="74.305" y1="-71.014" y2="-74.33"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.404" x2="78.701" y1="-58.14" y2="-62.715"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="77.395" x2="72.098" y1="-64.23" y2="-59.654"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="75.877" x2="82.395" y1="-51.929" y2="-54.48"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="81.666" x2="75.146" y1="-56.342" y2="-53.79"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.07" x2="79.898" y1="-43.322" y2="-41.78"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.34" x2="73.512" y1="-43.731" y2="-45.273"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="73.109" x2="79.895" y1="-21.954" y2="-20.23"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.387" x2="73.604" y1="-22.168" y2="-23.893"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="74.145" x2="80.793" y1="-11.98" y2="-14.173"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="80.164" x2="73.518" y1="-16.072" y2="-13.879"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.844" x2="71.324" y1="-73.534" y2="-79.609"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.588" x2="66.107" y1="-80.603" y2="-74.529"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.145" x2="50.77" y1="-72.73" y2="-79.313"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.887" x2="51.264" y1="-78.635" y2="-72.051"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.574" x2="42.299" y1="-74.393" y2="-81.176"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.359" x2="38.637" y1="-81.668" y2="-74.885"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.93" x2="28.486" y1="-74.547" y2="-77.28"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.705" x2="34.148" y1="-75.438" y2="-72.705"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.018" x2="20.922" y1="-74.919" y2="-81.655"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.996" x2="17.092" y1="-82.2" y2="-75.464"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.93" x2="10.914" y1="-75.305" y2="-82.009"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.998" x2="11.016" y1="-81.434" y2="-74.729"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.588" x2="66.107" y1="-8.603" y2="-2.529"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.844" x2="71.324" y1="-1.534" y2="-7.609"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.162" x2="59.596" y1="-8.939" y2="-3.521"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.143" x2="56.711" y1="-4.789" y2="-10.205"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.887" x2="51.264" y1="-6.635" y2="-0.051"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.145" x2="50.77" y1="-0.73" y2="-7.313"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.359" x2="38.637" y1="-9.668" y2="-2.885"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.574" x2="42.299" y1="-2.393" y2="-9.176"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.996" x2="17.092" y1="-10.2" y2="-3.464"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.018" x2="20.922" y1="-2.919" y2="-9.655"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.998" x2="11.016" y1="-9.434" y2="-2.729"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.93" x2="10.914" y1="-3.305" y2="-10.009"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.588" x2="19.107" y1="-31.103" y2="-25.029"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="20.844" x2="24.324" y1="-24.034" y2="-30.109"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="52.643" x2="48.211" y1="-63.289" y2="-68.705"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.662" x2="51.096" y1="-67.439" y2="-62.021"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.387" x2="42.764" y1="-65.135" y2="-58.551"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.645" x2="42.27" y1="-59.23" y2="-65.813"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.93" x2="60.486" y1="-17.047" y2="-19.78"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.705" x2="66.148" y1="-17.938" y2="-15.205"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.125" x2="65.221" y1="-35.01" y2="-28.273"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.145" x2="69.049" y1="-27.73" y2="-34.464"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="56.713" x2="58.729" y1="-40.356" y2="-33.652"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="60.645" x2="58.629" y1="-34.23" y2="-40.934"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="37.164" x2="40.645" y1="-45.655" y2="-51.73"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.908" x2="35.43" y1="-52.724" y2="-46.65"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.662" x2="27.096" y1="-52.439" y2="-47.021"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="28.643" x2="24.211" y1="-48.289" y2="-53.705"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.887" x2="17.264" y1="-50.635" y2="-44.051"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.145" x2="16.77" y1="-44.73" y2="-51.313"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="66.859" x2="65.137" y1="-52.668" y2="-45.885"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.074" x2="68.799" y1="-45.393" y2="-52.176"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="51.037" x2="57.48" y1="-49.036" y2="-46.304"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="58.262" x2="51.818" y1="-48.146" y2="-50.879"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.213" x2="36.229" y1="-18.856" y2="-12.152"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="38.145" x2="36.129" y1="-12.73" y2="-19.434"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.113" x2="46.182" y1="-17.78" y2="-16.806"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.461" x2="53.393" y1="-14.826" y2="-15.8"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.258" x2="51.695" y1="-29.998" y2="-23.176"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.645" x2="55.207" y1="-22.73" y2="-29.552"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.367" x2="30.623" y1="-32.929" y2="-27.015"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="32.312" x2="36.059" y1="-25.944" y2="-31.858"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="36.037" x2="29.619" y1="-41.526" y2="-38.728"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="30.42" x2="36.836" y1="-36.894" y2="-39.692"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.518" x2="24.422" y1="-35.919" y2="-42.655"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="22.496" x2="20.592" y1="-43.2" y2="-36.464"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.061" x2="46.045" y1="-39.306" y2="-46.009"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="44.129" x2="46.145" y1="-45.434" y2="-38.73"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="34.346" x2="28.758" y1="-62.471" y2="-58.256"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="29.961" x2="35.551" y1="-56.659" y2="-60.873"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="25.082" x2="23.139" y1="-62.288" y2="-69.011"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="21.217" x2="23.16" y1="-68.456" y2="-61.731"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="14.541" x2="14.135" y1="-68.809" y2="-61.819"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="16.131" x2="16.537" y1="-61.702" y2="-68.692"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="27.395" x2="23.141" y1="-20.952" y2="-15.394"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="24.729" x2="28.984" y1="-14.177" y2="-19.737"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.602" x2="14.752" y1="-16.542" y2="-21.589"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="13.311" x2="18.158" y1="-20.205" y2="-15.155"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="59.645" x2="64.047" y1="-53.73" y2="-59.172"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.49" x2="58.09" y1="-60.43" y2="-54.987"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="62.674" x2="63.459" y1="-63.896" y2="-70.852"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.471" x2="60.688" y1="-71.076" y2="-64.119"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="39.705" x2="46.148" y1="-28.938" y2="-26.205"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="46.93" x2="40.486" y1="-28.047" y2="-30.78"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.162" x2="59.596" y1="-80.939" y2="-75.521"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.143" x2="56.711" y1="-76.789" y2="-82.205"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="1.355" x2="7.521" y1="-72.569" y2="-69.252"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.469" x2="2.305" y1="-71.014" y2="-74.33"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="1.404" x2="6.701" y1="-58.14" y2="-62.715"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="5.395" x2="0.098" y1="-64.23" y2="-59.654"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="3.877" x2="10.395" y1="-51.929" y2="-54.48"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="9.666" x2="3.146" y1="-56.342" y2="-53.79"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="1.07" x2="7.898" y1="-43.322" y2="-41.78"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.34" x2="1.512" y1="-43.731" y2="-45.273"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="1.109" x2="7.895" y1="-21.954" y2="-20.23"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.387" x2="1.604" y1="-22.168" y2="-23.893"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="2.145" x2="8.793" y1="-11.98" y2="-14.173"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.164" x2="1.518" y1="-16.072" y2="-13.879"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.588" x2="66.107" y1="-80.603" y2="-74.529"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.844" x2="71.324" y1="-73.534" y2="-79.609"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="55.162" x2="59.596" y1="-80.939" y2="-75.521"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="61.143" x2="56.711" y1="-76.789" y2="-82.205"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="48.887" x2="51.264" y1="-78.635" y2="-72.051"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="53.145" x2="50.77" y1="-72.73" y2="-79.313"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.359" x2="38.637" y1="-81.668" y2="-74.885"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="40.574" x2="42.299" y1="-74.393" y2="-81.176"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="18.996" x2="17.092" y1="-82.2" y2="-75.464"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="19.018" x2="20.922" y1="-74.919" y2="-81.655"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="8.998" x2="11.016" y1="-81.434" y2="-74.729"/>
+                    <line fill="none" stroke="#231F20" stroke-width="0.3" x1="12.93" x2="10.914" y1="-75.305" y2="-82.009"/>
+                </g>
+            </g>
+        </pattern>
+        <!-- Rain Garden -->
+        <pattern height="72" id="fill-rain_garden" overflow="visible" patternUnits="userSpaceOnUse" viewBox="51.688 -85.483 72 72" width="72">
+            <g>
+                <polygon fill="#51dec2" points="51.688,-85.483 123.688,-85.483 123.688,-13.483 51.688,-13.483"/>
+                <g>
+                    <path d="M119.938-9.983c2.25-0.5,7,0,6,1.75s4,7,4.5,5.5s-2-4.5,0.75-4.75s5.75,3,7.5,3.25s5.5-1.5,3.25-3s-2.75-4.5-5.5-4.25s-7-0.25-6-3" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M120.938-12.483c1.75,0.5,5.5,0.25,6,1.75s2.75,2.75,2.75,1.5s-1.75-2.75-1.75-2.75s-4-3.5-2-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.688-5.233c1.5,1.5,3.5,2.75,5.5,3.75s5,2,5.25,0.75s-2.75-3.25-1-3.25s3.25,2,6.5,1.75s9.25-4,7.25-4.75s-3.75-3.5-5.5-4.5s-2.75-1-4-1s-4-1.25-2-2" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                </g>
+                <g>
+                    <path d="M47.938-9.983c2.25-0.5,7,0,6,1.75s4,7,4.5,5.5s-2-4.5,0.75-4.75s5.75,3,7.5,3.25s5.5-1.5,3.25-3s-2.75-4.5-5.5-4.25s-7-0.25-6-3" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M75.438-14.483c1.25,0.5,4.25,3,3.25,4.75s-0.5,3.25,1,3.5s6.25-2,5.75-3.25s-1.75-3.25,0-4.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M97.438-16.733c1.75,1,1.75,2,0.5,3.25s-6.5,1.25-5.75,2.5s5,4,7.75,4s3-3.5,4.75-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M105.688-12.233c0.75-0.5,0.75-1,0.5-3" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M107.938-19.233c0,1.5-0.375,5.601-0.375,6.875c0,1.375,0.5,1.875,0.5,1.875" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M48.938-12.483c1.75,0.5,5.5,0.25,6,1.75s2.75,2.75,2.75,1.5s-1.75-2.75-1.75-2.75s-4-3.5-2-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M77.688-15.233c1.75,0.5,3.75,1,3.5,2.75s0.25,4,0.75,2.75s0-4,1.5-5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M100.438-19.983c1.25,2.25,1.5,6.25-0.25,7.5s-3,3-1.5,2.75s4-0.75,4.75-3s2.25-8.75,0.75-9.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M109.688-19.983c-1,1.5-1,4.5,0.25,5.75s2.5,0.75,2.75,2.25s1.5,3.25,2.5,3.25s2.5-2,3.25-2.75c1-1,2.5-1,2.5-1c1.75,0.5,5.5,0.25,6,1.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.688-5.233c1.5,1.5,3.5,2.75,5.5,3.75s5,2,5.25,0.75s-2.75-3.25-1-3.25s3.25,2,6.5,1.75s9.25-4,7.25-4.75s-3.75-3.5-5.5-4.5s-2.75-1-4-1s-4-1.25-2-2" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M73.938-13.983c1,2,2.25,3.25,2.5,5s-0.5,4.75,2,4.75c0.634,0,1.316-0.049,2.014-0.156" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M82.5-4.89c1.375-0.469,2.688-1.219,3.688-2.344c2-2.25,0.25-2.75,0.5-4s6-4,7-3.25s-1.25,0-2.25,1.75s-4.25,6.25,1,6.5s6.25,1.25,6.5,2.25s5,0.75,5-0.5s1.5-6,2-4.75s2,3.5,5,5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M112.938-14.733c1.25,1.25,1.5,3.75,2.75,3s2.75-2.25,3.5-2.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                </g>
+                <g>
+                    <path d="M37.688-19.983c-1,1.5-1,4.5,0.25,5.75s2.5,0.75,2.75,2.25s1.5,3.25,2.5,3.25s2.5-2,3.25-2.75c1-1,2.5-1,2.5-1c1.75,0.5,5.5,0.25,6,1.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                </g>
+                <g>
+                    <path d="M118.438-16.733c3.863-2.44,6.032-7.021,10.5-8.5c-0.151,1.054-0.104,2.299,0.616,2.848c1.178,0.9,2.416,0.625,3.884,0.152c0.969-3.206,3.09-7.295,6.977-6.402c1.391,0.319,1.32,1.988,2.145,2.776c0.854,0.816,2.232,1.673,3.267,0.964c1.189-0.816,2.373-1.207,3.634-1.792c0.728-0.338,0.198-1.305,0.972-1.566c1.88-0.637,2.174,1.36,3.507,2.021c-0.106,1.858-0.029,3.673,0.512,5.497c0.694,2.336,3.374,1.622,4.988,0.503c-0.314-0.261,0.625-1.75,0.5-3.375c0.513-3.658-1.721-6.91,2.098-8.367c3.719-1.418,7.868-0.392,11.874-0.953c1.155-0.162,2.447-0.378,3.434-0.963c1.359-0.809,2.558-1.909,4.095-2.342c0.199,0.784,1.378,0.199,1.459,1.005c0.22,2.177,1.654,3.67,2.755,5.354c0.194,0.298,0.514,1.065,1.174,1.377c0.872,0.413,0.74,2.107,1.112,3.264" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.063-23.108c1.508-0.742,3.13-1.227,4.5-2.25c0.087-0.859,0.825-1.39,1.026-2.243c0.047-0.199,0.381-0.256,0.396-0.291c0.706-1.565,2.286-2.378,3.824-1.71c0.374,0.162,0.177,0.871,0.753,0.744c0,0.251,0.082,0.605-0.042,0.69c-1.252,0.86-1.343,2.354-1.07,3.527c0.189,0.815,1.123,1.553,2.112,0.782c-0.23-2.832,1.053-5.251,3.33-6.889c1.202-0.863,2.723-0.696,4.17-0.611c-0.07,0.557,0.369,0.094,0.5,0.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.438-26.733c1.75-0.25,3.75-2.5,5.25-4s3-2.5,4.5-2.25s1,3.25,3.25,0.25s3.75-2,5.25-1.75s5,2,6.25,0.5s-2-6,0.25-6.25s3.25,3.25,5.25,4.5s3,2.75,4.25,0.75s3.25-3.75,5.5-3s3,0.75,5,0.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M140.945-43.604c-0.965,0.061-1.905,0.12-2.757,0.12c-3.5,0-4,2.5-1.5,3s4.5,2.5,6.5,4s-1.5,1-3.5,0s-3,0-5.5,2s-1.5-0.5-3-1s-3,0.5-4.5,2s-3.5,0.5-7.5-0.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M120.438-37.233c1.5,0.75,3.25,2.25,5.25,1.25s3.25-2.5,4.5-2s2.5,2.25,4,1.25s3.25-0.75,1.5-2.5s-5.25-3-4-4s3.75-3.25,6.5-3.25s15-2.25,14.5,0.25s-1.75,8.25,0,7.25s3.25-2.75,4.75-2.75s2.75-0.25,3.25-2.75s3-3.75,4-2.75s2.5,2.25,2.25,0.5s0.5-4.5,4-4.25c0.481,0.034,1.071,0.078,1.739,0.133" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M120.938-16.233c1-1.25,2.75-3,4.5-4.75s2.75-1.25,3,0.25s0.75,2.5,2.25,2.25s5.5-3,6-5.25s1.75-3.75,3-2.75s2,4,4.25,4s7.5-4.75,7.75-3s-0.5,4,0.25,6.5s2.5,2.5,5,1.5s4.5-2,4.75-3.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M119.938-81.983c2.25-0.5,7,0,6,1.75s4,7,4.5,5.5s-2-4.5,0.75-4.75s5.75,3,7.5,3.25s5.5-1.5,3.25-3s-2.75-4.5-5.5-4.25s-7-0.25-6-3" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.188-40.733c1.75,1,2,2,4,1.25s2.5-1,2.5-1c2,1,3.5,1.5,3.25,0.5c-0.858-3.431-5.773-3.014-5-4.25c1.25-2,5.25-2.25,6.75-4.25s-0.5-3.75,1.75-4.75s5.5,1,6.25,2.25s4.5,2.25,7.5,1.5s7.25-2,6.75,0.5s-1.25,5.75,0.25,4.5s5.25-8.5,7.5-8.25s3.25,0,6.25-0.25s9.5,0.5,9.25-2s-4.75-8.25-1-8.25c1.704,0,3.615,0.568,5.24,1.517" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M120.938-84.483c1.75,0.5,5.5,0.25,6,1.75s2.75,2.75,2.75,1.5s-1.75-2.75-1.75-2.75s-4-3.5-2-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.188-49.483c1.25,0.5,3.25,2.25,4,1.25s-8-3-0.5-4.75s6.25-1,7.25-3.5s-6.5-3.25-4.5-4.5s9.331-2.959,11.75-1.75c3,1.5,1.5,3.75,1.75,4.5s-1,4.75,2.5,6s5,2.5,8,0.75s7-3.25,7-2s-0.25,2,2.5,0.25s7.25-3.25,9.75-3s5-0.5,4-2.25s-3.75-2.75-5-4.75s0.75-3.25,3.25-3.5s12,0.75,13.75,2.25s2.25,5.5,2.25,8s-1,3.25,1.75,5.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.438-55.483c2.25,0.5,4.25,0,5.25-0.5s-2.5-3-4.75-3.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.938-64.733c3.75-0.5,7.25-1.5,9.75-1s7.75-0.5,9.75,3" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.188-68.733c3.5,0.5,10.75,2,12.5,2c0.554,0,1.784,0,3.247,0.056" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.688-77.233c1.5,1.5,3.5,2.75,5.5,3.75s5,2,5.25,0.75s-2.75-3.25-1-3.25s3.25,2,6.5,1.75s9.25-4,7.25-4.75s-3.75-3.5-5.5-4.5s-2.75-1-4-1s-4-1.25-2-2" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.188-71.233c1.75,0.5,10.25,2.75,14.25,2.5s10.75-0.5,11.75,0.25s0.25,2,0.5,3.25s1,2.25,2.25,1s3.75-2,5-1.5s3.5,1.25,3.25,0s-2.75-3.25-1.5-5.5s7-6.5,6.5-4.25s-1.25,5.25,0.5,4.5s5-2,8-1.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.438-73.983c3,1.5,9.5,4,16,3.75s6.25-1.75,4.75-1.75s0.25-2.5,2.25-2.5s4.5,1.5,4.75,3.25s1,3,2.25,2.75s1-1,2.75-4s2.5-3,4-4.75s1.5,0,2.25,0.25s6.25-0.75,6.25,0.5s-3.75,3-2,3s9.75-1.5,11.5-0.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                </g>
+                <g>
+                    <path d="M46.438-16.733c3.863-2.44,6.032-7.021,10.5-8.5c-0.151,1.054-0.104,2.299,0.616,2.848c1.178,0.9,2.416,0.625,3.884,0.152c0.969-3.206,3.09-7.295,6.977-6.402c1.391,0.319,1.32,1.988,2.145,2.776c0.854,0.816,2.232,1.673,3.267,0.964c1.189-0.816,2.373-1.207,3.634-1.792c0.728-0.338,0.198-1.305,0.972-1.566c1.88-0.637,2.174,1.36,3.507,2.021c-0.106,1.858-0.029,3.673,0.512,5.497c0.694,2.336,3.374,1.622,4.988,0.503c-0.314-0.261,0.625-1.75,0.5-3.375c0.513-3.658-1.721-6.91,2.098-8.367c3.719-1.418,7.868-0.392,11.874-0.953c1.155-0.162,2.447-0.378,3.434-0.963c1.359-0.809,2.558-1.909,4.095-2.342c0.199,0.784,1.378,0.199,1.459,1.005c0.22,2.177,1.654,3.67,2.755,5.354c0.194,0.298,0.514,1.065,1.174,1.377c0.872,0.413,0.74,2.107,1.112,3.264" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M128.938-25.233c-4.468,1.479-6.637,6.06-10.5,8.5c-1.516,0.958-2.624,1.114-3.934,0.757c-1.233-0.338-0.398-2.072-0.547-3.259c-0.183-1.469,1.57-0.876,2.175-1.882c0.603-1.006,0.806-1.491,0.556-2.741" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M49.063-23.108c1.508-0.742,3.13-1.227,4.5-2.25c0.087-0.859,0.825-1.39,1.026-2.243c0.047-0.199,0.381-0.256,0.396-0.291c0.706-1.565,2.286-2.378,3.824-1.71c0.374,0.162,0.177,0.871,0.753,0.744c0,0.251,0.082,0.605-0.042,0.69c-1.252,0.86-1.343,2.354-1.07,3.527c0.189,0.815,1.123,1.553,2.112,0.782c-0.23-2.832,1.053-5.251,3.33-6.889c1.202-0.863,2.723-0.696,4.17-0.611c-0.07,0.557,0.369,0.094,0.5,0.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.063-23.108c1.508-0.742,3.13-1.227,4.5-2.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M120.063-21.608c-0.845,0.455-1.071,1.446-1.593,2.185c-0.111,0.158-0.455,0.185-0.407,0.565c-0.535-0.122-0.975,0.413-1.494,0.23c-0.334-0.118-0.396-0.521-0.214-0.684c0.358-0.324,0.262-0.893,0.482-0.946c0.729-0.182,0.267-1.142,0.976-1.101c0.363-1.485,0.5-3.031,0.117-4.465c-0.501-1.876-1.628-3.489-2.367-5.285" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M114.688-32.483c-1.75-2.25-3-3.5-3.25-4.75s-0.5-2.25-1.75-2.25s-2.25,1.5-4.25,2.5s-9.25,2.25-11.25,2s-6-1-7-0.25s-1.75,4.25-1.75,6.25s0.25,4.75,0,5.75s-1.75,2.75-2-0.5s-0.5-4.75-2.25-6.5s-4.75-2.75-5-1.5s0.75,2.25,0.25,2.75s-2.25,1.25-3.25,1s-1.5-1-2.25-1.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M49.438-26.733c1.75-0.25,3.75-2.5,5.25-4s3-2.5,4.5-2.25s1,3.25,3.25,0.25s3.75-2,5.25-1.75s5,2,6.25,0.5s-2-6,0.25-6.25s3.25,3.25,5.25,4.5s3,2.75,4.25,0.75s3.25-3.75,5.5-3s3,0.75,5,0.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M97.438-37.483c1.5-0.25,6.25-1,7.5-2.25s-1.75-5-0.25-5.5s5.5,0.25,7,1.5s2.75,5,3.25,7.25s3.75,4.75,4.25,6.5s0,4.5,0.5,5s1-1.5,1.75-1.75c1.677-0.56,3.75-2.5,5.25-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M126.688-33.483c-1.5,1.5-3.5,0.5-7.5-0.5c0,0-2.25-1-2.5-6.5s-3.75-6.75-6.25-7.5s-12.75-2-13.5-0.5s3.75,3.5,4.5,5s-0.25,3.75-2,3.5s-1.75-2.75-3.25-3.5s-5.5-1-5.75,1.25s-4.25,2.25-4.25,2.25c-2.5-0.5-3,4-5,4s-2.5-4.5-4.5-6.5c-1-1-2.75-1.25-4.688-1.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M68.945-43.604c-0.965,0.061-1.905,0.12-2.757,0.12c-3.5,0-4,2.5-1.5,3s4.5,2.5,6.5,4s-1.5,1-3.5,0s-3,0-5.5,2s-1.5-0.5-3-1s-3,0.5-4.5,2s-3.5,0.5-7.5-0.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M48.438-37.233c1.5,0.75,3.25,2.25,5.25,1.25s3.25-2.5,4.5-2s2.5,2.25,4,1.25s3.25-0.75,1.5-2.5s-5.25-3-4-4s3.75-3.25,6.5-3.25s15-2.25,14.5,0.25s-1.75,8.25,0,7.25s3.25-2.75,4.75-2.75s2.75-0.25,3.25-2.75s3-3.75,4-2.75s2.5,2.25,2.25,0.5s0.5-4.5,4-4.25c0.481,0.034,1.071,0.078,1.739,0.133" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M102.683-50.672c4.182,0.404,9.73,1.15,11.756,2.438c2.75,1.75,4.5,6,4.75,8.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M120.438-37.233c1.5,0.75,3.25,2.25,5.25,1.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M64.438-11.483c-2.75,0.25-7-0.25-6-3s7.5-4.5,8.25-6s2.75-1.75,3.75,0.25s3.75,5.25,5,5.75s4.25,3,3.25,4.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M85.438-9.483c-0.5-1.25-1.75-3.25,0-4.5s10.25-3.75,12-2.75s1.75,2,0.5,3.25s-6.5,1.25-5.75,2.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M48.938-16.233c1-1.25,2.75-3,4.5-4.75s2.75-1.25,3,0.25s0.75,2.5,2.25,2.25s5.5-3,6-5.25s1.75-3.75,3-2.75s2,4,4.25,4s7.5-4.75,7.75-3s-0.5,4,0.25,6.5s2.5,2.5,5,1.5s4.5-2,4.75-3.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M120.938-16.233c1-1.25,2.75-3,4.5-4.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M55.938-11.983c0,0-4-3.5-2-4s4,0,6-1.25s5.25-3.25,6-4.75s1.75-2.5,2.5-1.5s2,2,3.75,2.5s3-1,3.75,0.75s0,4.5,1.75,5s3.75,1,3.5,2.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M81.938-9.733c0.5-1.25,0-4,1.5-5s6.25-2.75,7-4c0.691-1.152,3.931-1.879,6.001-1.986" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M98.188-20.733c0.23,0.176,1.937,0.188,2.25,0.75c1.25,2.25,1.5,6.25-0.25,7.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M103.438-12.733c0.75-2.25,2.25-8.75,0.75-9.5s-4.75-1.5-2.75-3.5s5.75-3.75,6.75-3.25s4.5,3.5,3.75,5.25s-1.25,2.25-2.25,3.75s-1,4.5,0.25,5.75s2.5,0.75,2.75,2.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M89.938-22.733c0-1.25-0.5-2.5,0.25-4.5s2.75-3,3-1.5s-1.5,4.75,0,5s2.5,0.5,3.25-1s-1.25-3.25,0-4.25s6.25-2.75,7.75-2.25s2.75-0.25,3.75-0.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M109.688-31.733c1-0.25,2.25,1.5,2.5,3s2.25,2.75,2.5,3.75s-2.25,5-2.75,6.25s-0.25,2.75,1,4s1.5,3.75,2.75,3s2.75-2.25,3.5-2.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M105.688-12.233c0.75-0.5,0.75-1,0.5-3s0.75-6.75,0-7.75s-1.5-3,0-2.5c0.824,0.274,2.514-0.086,2.75,1.375c0.192,1.197-1,4.199-1,4.875c0,1.5-0.375,5.601-0.375,6.875" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M47.938-81.983c2.25-0.5,7,0,6,1.75s4,7,4.5,5.5s-2-4.5,0.75-4.75s5.75,3,7.5,3.25s5.5-1.5,3.25-3s-2.75-4.5-5.5-4.25s-7-0.25-6-3" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M75.438-86.483c1.25,0.5,4.25,3,3.25,4.75s-0.5,3.25,1,3.5s6.25-2,5.75-3.25s-1.75-3.25,0-4.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M97.438-88.733c1.75,1,1.75,2,0.5,3.25s-6.5,1.25-5.75,2.5s5,4,7.75,4s3-3.5,4.75-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M105.688-84.233c0.75-0.5,0.75-1,0.5-3" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M107.938-91.233c0,1.5-0.375,5.601-0.375,6.875c0,1.375,0.5,1.875,0.5,1.875" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.188-40.733c1.75,1,2,2,4,1.25s2.5-1,2.5-1c2,1,3.5,1.5,3.25,0.5c-0.858-3.431-5.773-3.014-5-4.25c1.25-2,5.25-2.25,6.75-4.25s-0.5-3.75,1.75-4.75s5.5,1,6.25,2.25s4.5,2.25,7.5,1.5s7.25-2,6.75,0.5s-1.25,5.75,0.25,4.5s5.25-8.5,7.5-8.25s3.25,0,6.25-0.25s9.5,0.5,9.25-2s-4.75-8.25-1-8.25c1.704,0,3.615,0.568,5.24,1.517" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M114.099-59.437c0.574,0.75,0.965,1.578,1.09,2.453c0.5,3.5,0.25,5.75,2.25,7" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.188-40.733c1.75,1,2,2,4,1.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M118.688-49.233c1,1,2,3,2,4s-0.5,2.25,0.25,3.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M48.938-84.483c1.75,0.5,5.5,0.25,6,1.75s2.75,2.75,2.75,1.5s-1.75-2.75-1.75-2.75s-4-3.5-2-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M77.688-87.233c1.75,0.5,3.75,1,3.5,2.75s0.25,4,0.75,2.75s0-4,1.5-5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M100.438-91.983c1.25,2.25,1.5,6.25-0.25,7.5s-3,3-1.5,2.75s4-0.75,4.75-3s2.25-8.75,0.75-9.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M109.688-91.983c-1,1.5-1,4.5,0.25,5.75s2.5,0.75,2.75,2.25s1.5,3.25,2.5,3.25s2.5-2,3.25-2.75c1-1,2.5-1,2.5-1c1.75,0.5,5.5,0.25,6,1.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M49.188-49.483c1.25,0.5,3.25,2.25,4,1.25s-8-3-0.5-4.75s6.25-1,7.25-3.5s-6.5-3.25-4.5-4.5s9.331-2.959,11.75-1.75c3,1.5,1.5,3.75,1.75,4.5s-1,4.75,2.5,6s5,2.5,8,0.75s7-3.25,7-2s-0.25,2,2.5,0.25s7.25-3.25,9.75-3s5-0.5,4-2.25s-3.75-2.75-5-4.75s0.75-3.25,3.25-3.5s12,0.75,13.75,2.25s2.25,5.5,2.25,8s-1,3.25,1.75,5.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.188-49.483c1.25,0.5,3.25,2.25,4,1.25s-8-3-0.5-4.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M49.438-55.483c2.25,0.5,4.25,0,5.25-0.5s-2.5-3-4.75-3.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M49.938-64.733c3.75-0.5,7.25-1.5,9.75-1s7.75-0.5,9.75,3" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.438-55.483c2.25,0.5,4.25,0,5.25-0.5s-2.5-3-4.75-3.75s-3.75-4.5,0-5s7.25-1.5,9.75-1" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M120.188-55.733c-1.25-0.75-2-2.25-2-4s-2-7.5-5-7.75s-20.25-2-20.75,0.25s3.25,4.5,4,5.5s0.5,3.25-0.75,3.5s-4,1-3.75-0.5s-1-3.25-2.5-1.5c-0.75,0.875-2.657,1.5-3.75,2.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M83.938-56.733c-1.75,1.75-4.75,3-6.75,3s-6.25-0.5-6-2.75s0.25-3.25-0.25-4.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.188-68.733c3.5,0.5,10.75,2,12.5,2c0.554,0,1.784,0,3.247,0.056" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M69.925-66.378c2,0.249,3.748,0.673,4.264,1.395c1.25,1.75-0.25,4.75-0.75,6.25s-1,2.75,0.5,2.75s6.75,0.25,6-1.25s-3.25-2.25-2.5-3.75s7-2.5,8.25-2.25s3.75,1.25,4.75,0.25s-0.75-1.5-0.25-3.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.188-68.733c3.5,0.5,10.75,2,12.5,2" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M91.188-67.983c2-1,3.25-2.25,7.75-2s17.5,1.25,18,2.25s2,1.75,2.5,0.5s1.25-1.5,1.25-1.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.688-77.233c1.5,1.5,3.5,2.75,5.5,3.75s5,2,5.25,0.75s-2.75-3.25-1-3.25s3.25,2,6.5,1.75s9.25-4,7.25-4.75s-3.75-3.5-5.5-4.5s-2.75-1-4-1s-4-1.25-2-2" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M73.938-85.983c1,2,2.25,3.25,2.5,5s-0.5,4.75,2,4.75c0.634,0,1.316-0.049,2.014-0.156" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M82.5-76.89c1.375-0.469,2.688-1.219,3.688-2.344c2-2.25,0.25-2.75,0.5-4s6-4,7-3.25s-1.25,0-2.25,1.75s-4.25,6.25,1,6.5s6.25,1.25,6.5,2.25s5,0.75,5-0.5s1.5-6,2-4.75s2,3.5,5,5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.688-77.233c1.5,1.5,3.5,2.75,5.5,3.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M119.938-81.983c2.25-0.5,7,0,6,1.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M109.688-81.483c0.75,1,3.25,2.25,4,3.25s2.25,2.5,3,0.75s-0.25-3.5,1.5-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.938-77.983c-1.5-1.5-3.25-2.25-3.25-1.25s2.75,1.75,1.75,3.25s-5,2.5-6.5,1.75s-1.75-1.25-1.75-1.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.188-71.233c1.75,0.5,10.25,2.75,14.25,2.5s10.75-0.5,11.75,0.25s0.25,2,0.5,3.25s1,2.25,2.25,1s3.75-2,5-1.5s3.5,1.25,3.25,0s-2.75-3.25-1.5-5.5s7-6.5,6.5-4.25s-1.25,5.25,0.5,4.5s5-2,8-1.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.188-71.233c1.75,0.5,10.25,2.75,14.25,2.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M120.438-71.483c-1.5-0.5-3.61-0.197-3.25,1c0.75,2.5-3.25-0.25-6-0.75s-6-0.75-7-0.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.438-73.983c3,1.5,9.5,4,16,3.75s6.25-1.75,4.75-1.75s0.25-2.5,2.25-2.5s4.5,1.5,4.75,3.25s1,3,2.25,2.75s1-1,2.75-4s2.5-3,4-4.75s1.5,0,2.25,0.25s6.25-0.75,6.25,0.5s-3.75,3-2,3s9.75-1.5,11.5-0.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M122.438-73.983c3,1.5,9.5,4,16,3.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M121.938-74.233c-2-0.875-4.25,2.25-7,1.75s-4.75-1-6.25-1.25s-2.25-0.25-2.25-0.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M64.688-12.483c-1.25,0-4-1.25-2-2c2.75-2,9.5-2.25,11.25,0.5c1,2,2.25,3.25,2.5,5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M86.688-11.233c0.25-1.25,6-4,7-3.25s-1.25,0-2.25,1.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M112.938-86.733c1.25,1.25,1.5,3.75,2.75,3s2.75-2.25,3.5-2.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                </g>
+                <g>
+                    <path d="M56.938-25.233c-4.468,1.479-6.637,6.06-10.5,8.5c-1.516,0.958-2.624,1.114-3.934,0.757c-1.233-0.338-0.398-2.072-0.547-3.259c-0.183-1.469,1.57-0.876,2.175-1.882c0.603-1.006,0.806-1.491,0.556-2.741" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M49.063-23.108c1.508-0.742,3.13-1.227,4.5-2.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M25.438-37.483c1.5-0.25,6.25-1,7.5-2.25s-1.75-5-0.25-5.5s5.5,0.25,7,1.5s2.75,5,3.25,7.25s3.75,4.75,4.25,6.5s0,4.5,0.5,5s1-1.5,1.75-1.75c1.677-0.56,3.75-2.5,5.25-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M54.688-33.483c-1.5,1.5-3.5,0.5-7.5-0.5c0,0-2.25-1-2.5-6.5s-3.75-6.75-6.25-7.5s-12.75-2-13.5-0.5s3.75,3.5,4.5,5s-0.25,3.75-2,3.5s-1.75-2.75-3.25-3.5s-5.5-1-5.75,1.25s-4.25,2.25-4.25,2.25c-2.5-0.5-3,4-5,4s-2.5-4.5-4.5-6.5c-1-1-2.75-1.25-4.688-1.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M48.438-37.233c1.5,0.75,3.25,2.25,5.25,1.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M48.938-16.233c1-1.25,2.75-3,4.5-4.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.188-40.733c1.75,1,2,2,4,1.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M37.688-91.983c-1,1.5-1,4.5,0.25,5.75s2.5,0.75,2.75,2.25s1.5,3.25,2.5,3.25s2.5-2,3.25-2.75c1-1,2.5-1,2.5-1c1.75,0.5,5.5,0.25,6,1.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M49.188-49.483c1.25,0.5,3.25,2.25,4,1.25s-8-3-0.5-4.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M49.438-55.483c2.25,0.5,4.25,0,5.25-0.5s-2.5-3-4.75-3.75s-3.75-4.5,0-5s7.25-1.5,9.75-1" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.188-68.733c3.5,0.5,10.75,2,12.5,2" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.688-77.233c1.5,1.5,3.5,2.75,5.5,3.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M47.938-81.983c2.25-0.5,7,0,6,1.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.188-71.233c1.75,0.5,10.25,2.75,14.25,2.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M50.438-73.983c3,1.5,9.5,4,16,3.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                </g>
+                <g>
+                    <path d="M64.438-83.483c-2.75,0.25-7-0.25-6-3s7.5-4.5,8.25-6s2.75-1.75,3.75,0.25s3.75,5.25,5,5.75s4.25,3,3.25,4.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M85.438-81.483c-0.5-1.25-1.75-3.25,0-4.5s10.25-3.75,12-2.75s1.75,2,0.5,3.25s-6.5,1.25-5.75,2.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M55.938-83.983c0,0-4-3.5-2-4s4,0,6-1.25s5.25-3.25,6-4.75s1.75-2.5,2.5-1.5s2,2,3.75,2.5s3-1,3.75,0.75s0,4.5,1.75,5s3.75,1,3.5,2.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M81.938-81.733c0.5-1.25,0-4,1.5-5s6.25-2.75,7-4c0.691-1.152,3.931-1.879,6.001-1.986" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M98.188-92.733c0.23,0.176,1.937,0.188,2.25,0.75c1.25,2.25,1.5,6.25-0.25,7.5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M103.438-84.733c0.75-2.25,2.25-8.75,0.75-9.5s-4.75-1.5-2.75-3.5s5.75-3.75,6.75-3.25s4.5,3.5,3.75,5.25s-1.25,2.25-2.25,3.75s-1,4.5,0.25,5.75s2.5,0.75,2.75,2.25" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M109.688-103.733c1-0.25,2.25,1.5,2.5,3s2.25,2.75,2.5,3.75s-2.25,5-2.75,6.25s-0.25,2.75,1,4s1.5,3.75,2.75,3s2.75-2.25,3.5-2.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M105.688-84.233c0.75-0.5,0.75-1,0.5-3s0.75-6.75,0-7.75s-1.5-3,0-2.5c0.824,0.274,2.514-0.086,2.75,1.375c0.192,1.197-1,4.199-1,4.875c0,1.5-0.375,5.601-0.375,6.875" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M64.688-84.483c-1.25,0-4-1.25-2-2c2.75-2,9.5-2.25,11.25,0.5c1,2,2.25,3.25,2.5,5" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                    <path d="M86.688-83.233c0.25-1.25,6-4,7-3.25s-1.25,0-2.25,1.75" fill="none" stroke="#231F20" stroke-width="0.3"/>
+                </g>
+            </g>
+        </pattern>
+        <!-- Pervious Pavers -->
+        <pattern height="72" id="fill-porous_paving" overflow="visible" patternUnits="userSpaceOnUse" viewBox="29.713 -73.775 72 72" width="72">
+            <g>
+                <polygon fill="#54d2d0" points="29.713,-73.775 101.713,-73.775 101.713,-1.775 29.713,-1.775"/>
+                <g>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="59.15" x2="59.15" y1="-0.15" y2="-3.65"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="100.713" x2="123.4" y1="-64.15" y2="-64.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="107.9" x2="100.713" y1="-59.9" y2="-59.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="100.713" x2="124.65" y1="-48.4" y2="-48.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="100.713" x2="131.4" y1="-39.15" y2="-39.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="100.713" x2="132.65" y1="-23.4" y2="-23.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="100.713" x2="103.4" y1="-14.65" y2="-14.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="100.713" x2="137.4" y1="-20.4" y2="-20.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="110.9" x2="100.713" y1="-31.9" y2="-31.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="100.713" x2="110.9" y1="-7.4" y2="-7.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="100.713" x2="124.9" y1="-10.4" y2="-10.4"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="28.713" x2="51.4" y1="-64.15" y2="-64.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="41.65" x2="85.4" y1="-69.9" y2="-69.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="45.9" x2="45.9" y1="-64.15" y2="-69.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="64.15" x2="95.65" y1="-68.15" y2="-68.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="50.15" x2="89.65" y1="-66.4" y2="-66.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="78.65" x2="98.9" y1="-56.9" y2="-56.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="91.9" x2="91.9" y1="-56.9" y2="-60.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="100.4" x2="94.15" y1="-59.9" y2="-59.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="35.9" x2="28.713" y1="-59.9" y2="-59.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="34.65" x2="58.9" y1="-56.9" y2="-56.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="67.9" x2="100.9" y1="-64.15" y2="-64.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="48.65" x2="72.9" y1="-59.9" y2="-59.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="81.15" x2="102.713" y1="-51.65" y2="-51.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="80.9" x2="102.713" y1="-50.4" y2="-50.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="36.9" x2="55.65" y1="-51.65" y2="-51.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="36.65" x2="49.15" y1="-50.4" y2="-50.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="51.4" x2="75.65" y1="-54.65" y2="-54.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="63.15" x2="83.4" y1="-48.4" y2="-48.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="76.4" x2="76.4" y1="-48.4" y2="-51.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="28.713" x2="52.65" y1="-48.4" y2="-48.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="33.65" x2="33.65" y1="-48.4" y2="-51.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="87.65" x2="100.15" y1="-48.4" y2="-48.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="59.4" x2="63.15" y1="-51.65" y2="-51.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="28.713" x2="59.4" y1="-39.15" y2="-39.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="49.65" x2="93.4" y1="-44.9" y2="-44.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="53.9" x2="53.9" y1="-39.15" y2="-44.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="72.15" x2="102.713" y1="-43.15" y2="-43.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="58.15" x2="97.65" y1="-41.4" y2="-41.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="86.65" x2="102.713" y1="-31.9" y2="-31.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="99.9" x2="99.9" y1="-31.9" y2="-35.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="85.65" x2="83.65" y1="-34.9" y2="-34.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="43.9" x2="37.65" y1="-34.9" y2="-34.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="42.65" x2="66.9" y1="-31.9" y2="-31.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="76.4" x2="102.713" y1="-39.15" y2="-39.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="56.65" x2="80.9" y1="-34.9" y2="-34.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="89.15" x2="102.713" y1="-26.65" y2="-26.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="88.9" x2="102.713" y1="-25.4" y2="-25.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="44.9" x2="63.65" y1="-26.65" y2="-26.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="44.65" x2="57.15" y1="-25.4" y2="-25.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="59.4" x2="83.65" y1="-29.65" y2="-29.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="71.15" x2="91.4" y1="-23.4" y2="-23.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="84.4" x2="84.4" y1="-23.4" y2="-26.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="28.713" x2="60.65" y1="-23.4" y2="-23.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="41.65" x2="41.65" y1="-23.4" y2="-26.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="95.65" x2="102.713" y1="-23.4" y2="-23.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="67.4" x2="71.15" y1="-26.65" y2="-26.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="28.713" x2="31.4" y1="-14.65" y2="-14.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="28.713" x2="65.4" y1="-20.4" y2="-20.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="44.15" x2="75.65" y1="-18.65" y2="-18.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="31.463" x2="69.65" y1="-16.9" y2="-16.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="58.65" x2="78.9" y1="-7.4" y2="-7.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="71.9" x2="71.9" y1="-7.4" y2="-10.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="81.4" x2="75.15" y1="-10.4" y2="-10.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="38.9" x2="28.713" y1="-31.9" y2="-31.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="28.713" x2="38.9" y1="-7.4" y2="-7.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="48.4" x2="81.4" y1="-14.65" y2="-14.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="28.713" x2="52.9" y1="-10.4" y2="-10.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="88.65" x2="102.713" y1="-14.65" y2="-14.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="67.15" x2="91.15" y1="-5.15" y2="-5.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="92.15" x2="102.713" y1="-10.4" y2="-10.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="31.4" x2="55.65" y1="-5.15" y2="-5.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="59.15" x2="59.15" y1="-0.15" y2="-3.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="92.15" x2="102.713" y1="-18.9" y2="-18.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="94.9" x2="98.65" y1="-5.15" y2="-5.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="45.9" x2="66.15" y1="-72.15" y2="-72.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="59.15" x2="59.15" y1="-72.15" y2="-75.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="32.4" x2="36.15" y1="-69.65" y2="-69.65"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="9.15" x2="30.713" y1="-51.65" y2="-51.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="8.9" x2="30.713" y1="-50.4" y2="-50.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="0.15" x2="30.713" y1="-43.15" y2="-43.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="14.65" x2="30.713" y1="-31.9" y2="-31.9"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="4.4" x2="30.713" y1="-39.15" y2="-39.15"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="17.15" x2="30.713" y1="-26.65" y2="-26.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="16.9" x2="30.713" y1="-25.4" y2="-25.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="23.65" x2="30.713" y1="-23.4" y2="-23.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="16.65" x2="30.713" y1="-14.65" y2="-14.65"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="20.15" x2="30.713" y1="-10.4" y2="-10.4"/>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="20.15" x2="30.713" y1="-18.9" y2="-18.9"/>
+                </g>
+                <g>
+                    <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="59.15" x2="59.15" y1="-72.15" y2="-75.65"/>
+                </g>
+            </g>
+        </pattern>
+        <!-- Detention Basin -->
+        <pattern height="71.606" id="fill-veg_infil_basin" overflow="visible" patternUnits="userSpaceOnUse" viewBox="0.305 -71.606 71.606 71.606" width="71.606">
+            <g>
+                <polygon fill="#52c6dd" points="0.305,-71.606 71.911,-71.606 71.911,0 0.305,0"/>
+                <g>
+                    <path d="M70.606-52.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C70.737-52.273,70.677-52.242,70.606-52.242z" fill="#231F20"/>
+                    <path d="M11.356-53.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C11.487-53.523,11.417-53.492,11.356-53.492z" fill="#231F20"/>
+                    <path d="M22.106-58.242c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C22.237-58.273,22.167-58.242,22.106-58.242z" fill="#231F20"/>
+                    <path d="M28.106-63.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.171c0.11-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C28.237-63.773,28.167-63.742,28.106-63.742z" fill="#231F20"/>
+                    <path d="M45.856-51.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C45.987-51.273,45.927-51.242,45.856-51.242z" fill="#231F20"/>
+                    <path d="M37.856-53.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.04,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C37.987-53.523,37.927-53.492,37.856-53.492z" fill="#231F20"/>
+                    <path d="M32.356-56.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.101,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C32.487-56.523,32.427-56.492,32.356-56.492z" fill="#231F20"/>
+                    <path d="M33.856-67.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C33.987-68.023,33.927-67.992,33.856-67.992z" fill="#231F20"/>
+                    <path d="M36.606-70.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C36.737-70.773,36.667-70.742,36.606-70.742z" fill="#231F20"/>
+                    <path d="M3.856-40.492c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C3.987-40.523,3.927-40.492,3.856-40.492z" fill="#231F20"/>
+                    <path d="M13.856-36.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C13.987-36.773,13.917-36.742,13.856-36.742z" fill="#231F20"/>
+                    <path d="M7.856-38.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C7.987-38.773,7.927-38.742,7.856-38.742z" fill="#231F20"/>
+                    <path d="M22.606-35.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C22.727-35.523,22.667-35.492,22.606-35.492z" fill="#231F20"/>
+                    <path d="M71.907-51.242c-0.061,0-0.13-0.031-0.17-0.08c-0.051-0.041-0.08-0.111-0.08-0.17c0-0.07,0.029-0.131,0.08-0.181c0.09-0.09,0.25-0.09,0.35,0c0.05,0.05,0.07,0.12,0.07,0.181c0,0.059-0.021,0.119-0.061,0.17C72.037-51.273,71.977-51.242,71.907-51.242z" fill="#231F20"/>
+                    <path d="M50.856-50.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C50.977-50.273,50.917-50.242,50.856-50.242z" fill="#231F20"/>
+                    <path d="M56.356-50.242c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C56.477-50.273,56.417-50.242,56.356-50.242z" fill="#231F20"/>
+                    <path d="M69.606-42.992c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.06,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C69.737-43.023,69.677-42.992,69.606-42.992z" fill="#231F20"/>
+                    <path d="M67.856-42.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C67.987-42.773,67.927-42.742,67.856-42.742z" fill="#231F20"/>
+                    <path d="M65.356-41.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C65.487-41.273,65.427-41.242,65.356-41.242z" fill="#231F20"/>
+                    <path d="M54.106-37.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C54.227-37.523,54.167-37.492,54.106-37.492z" fill="#231F20"/>
+                    <path d="M49.106-37.242c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C49.237-37.273,49.177-37.242,49.106-37.242z" fill="#231F20"/>
+                    <path d="M64.737-50.242c-0.07,0-0.131-0.031-0.181-0.07c-0.05-0.051-0.069-0.11-0.069-0.18c0-0.07,0.02-0.141,0.069-0.181c0.09-0.09,0.25-0.09,0.351,0c0.05,0.05,0.08,0.11,0.08,0.181c0,0.059-0.03,0.129-0.08,0.18C64.856-50.273,64.797-50.242,64.737-50.242z" fill="#231F20"/>
+                    <path d="M68.106-50.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C68.237-50.773,68.167-50.742,68.106-50.742z" fill="#231F20"/>
+                    <path d="M64.356-47.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C64.477-47.273,64.417-47.242,64.356-47.242z" fill="#231F20"/>
+                    <path d="M65.987-47.123c-0.07,0-0.131-0.02-0.181-0.07c-0.05-0.039-0.069-0.109-0.069-0.18s0.02-0.13,0.069-0.18c0.09-0.08,0.25-0.09,0.351,0c0.05,0.05,0.08,0.119,0.08,0.18c0,0.07-0.03,0.131-0.08,0.18C66.106-47.143,66.047-47.123,65.987-47.123z" fill="#231F20"/>
+                    <path d="M22.106-33.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C22.227-33.773,22.167-33.742,22.106-33.742z" fill="#231F20"/>
+                    <path d="M25.856-29.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C25.987-29.773,25.927-29.742,25.856-29.742z" fill="#231F20"/>
+                    <path d="M29.856-26.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C29.987-27.023,29.917-26.992,29.856-26.992z" fill="#231F20"/>
+                    <path d="M37.356-23.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.12-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C37.487-23.773,37.427-23.742,37.356-23.742z" fill="#231F20"/>
+                    <path d="M43.356-22.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C43.477-22.273,43.417-22.242,43.356-22.242z" fill="#231F20"/>
+                    <path d="M50.106-21.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C50.237-21.523,50.177-21.492,50.106-21.492z" fill="#231F20"/>
+                    <path d="M56.856-22.242c-0.06,0-0.119-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C56.987-22.273,56.927-22.242,56.856-22.242z" fill="#231F20"/>
+                    <path d="M61.106-24.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C61.237-24.523,61.177-24.492,61.106-24.492z" fill="#231F20"/>
+                    <path d="M57.856-27.242c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C57.987-27.273,57.927-27.242,57.856-27.242z" fill="#231F20"/>
+                    <path d="M53.856-31.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C53.977-31.523,53.917-31.492,53.856-31.492z" fill="#231F20"/>
+                    <path d="M51.106-35.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C51.227-35.773,51.167-35.742,51.106-35.742z" fill="#231F20"/>
+                    <path d="M64.856-22.492c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.02,0.129-0.069,0.17C64.987-22.523,64.917-22.492,64.856-22.492z" fill="#231F20"/>
+                    <path d="M70.106-20.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C70.237-21.023,70.177-20.992,70.106-20.992z" fill="#231F20"/>
+                    <path d="M1.856-20.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C1.987-20.773,1.927-20.742,1.856-20.742z" fill="#231F20"/>
+                    <path d="M5.356-21.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C5.477-22.023,5.417-21.992,5.356-21.992z" fill="#231F20"/>
+                    <path d="M9.356-22.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C9.487-23.023,9.417-22.992,9.356-22.992z" fill="#231F20"/>
+                    <path d="M13.356-24.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C13.487-25.023,13.427-24.992,13.356-24.992z" fill="#231F20"/>
+                    <path d="M16.606-27.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C16.737-27.523,16.677-27.492,16.606-27.492z" fill="#231F20"/>
+                    <path d="M18.856-29.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C18.987-29.523,18.927-29.492,18.856-29.492z" fill="#231F20"/>
+                    <path d="M1.856-50.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C1.987-50.523,1.927-50.492,1.856-50.492z" fill="#231F20"/>
+                    <path d="M3.856-51.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C3.977-51.273,3.917-51.242,3.856-51.242z" fill="#231F20"/>
+                    <path d="M5.856-51.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.101,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C5.987-51.773,5.927-51.742,5.856-51.742z" fill="#231F20"/>
+                    <path d="M7.606-52.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C7.737-52.523,7.667-52.492,7.606-52.492z" fill="#231F20"/>
+                    <path d="M13.856-54.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C13.987-54.273,13.927-54.242,13.856-54.242z" fill="#231F20"/>
+                    <path d="M16.356-55.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.17C16.477-55.523,16.417-55.492,16.356-55.492z" fill="#231F20"/>
+                    <path d="M18.356-56.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C18.477-56.523,18.417-56.492,18.356-56.492z" fill="#231F20"/>
+                    <path d="M23.356-58.742c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C23.487-58.773,23.417-58.742,23.356-58.742z" fill="#231F20"/>
+                    <path d="M25.106-60.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C25.237-60.523,25.167-60.492,25.106-60.492z" fill="#231F20"/>
+                    <path d="M19.356-35.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C19.487-35.273,19.427-35.242,19.356-35.242z" fill="#231F20"/>
+                    <path d="M0.606-48.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C0.727-49.023,0.667-48.992,0.606-48.992z" fill="#231F20"/>
+                    <path d="M1.606-46.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C1.727-46.273,1.667-46.242,1.606-46.242z" fill="#231F20"/>
+                    <path d="M1.606-41.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C1.727-41.523,1.667-41.492,1.606-41.492z" fill="#231F20"/>
+                    <path d="M34.106-55.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C34.237-55.273,34.167-55.242,34.106-55.242z" fill="#231F20"/>
+                    <path d="M35.606-54.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C35.737-54.273,35.677-54.242,35.606-54.242z" fill="#231F20"/>
+                    <path d="M26.606-61.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C26.737-61.523,26.677-61.492,26.606-61.492z" fill="#231F20"/>
+                    <path d="M28.106-60.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C28.227-60.523,28.167-60.492,28.106-60.492z" fill="#231F20"/>
+                    <path d="M30.606-59.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C30.737-59.273,30.667-59.242,30.606-59.242z" fill="#231F20"/>
+                    <path d="M32.856-58.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C32.987-58.273,32.927-58.242,32.856-58.242z" fill="#231F20"/>
+                    <path d="M35.606-57.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C35.737-57.273,35.667-57.242,35.606-57.242z" fill="#231F20"/>
+                    <path d="M38.356-55.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C38.487-56.023,38.417-55.992,38.356-55.992z" fill="#231F20"/>
+                    <path d="M41.856-54.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C41.987-55.023,41.917-54.992,41.856-54.992z" fill="#231F20"/>
+                    <path d="M46.106-53.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.171c0.11-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C46.237-54.023,46.177-53.992,46.106-53.992z" fill="#231F20"/>
+                    <path d="M49.606-53.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.17C49.737-53.773,49.667-53.742,49.606-53.742z" fill="#231F20"/>
+                    <path d="M54.356-53.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C54.487-53.523,54.417-53.492,54.356-53.492z" fill="#231F20"/>
+                    <path d="M57.356-53.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C57.477-53.773,57.417-53.742,57.356-53.742z" fill="#231F20"/>
+                    <path d="M60.356-54.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C60.487-54.523,60.427-54.492,60.356-54.492z" fill="#231F20"/>
+                    <path d="M62.856-55.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C62.987-55.523,62.927-55.492,62.856-55.492z" fill="#231F20"/>
+                    <path d="M66.856-56.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C66.987-56.773,66.917-56.742,66.856-56.742z" fill="#231F20"/>
+                    <path d="M69.856-57.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C69.987-57.523,69.927-57.492,69.856-57.492z" fill="#231F20"/>
+                    <path d="M55.856-52.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C55.987-52.273,55.927-52.242,55.856-52.242z" fill="#231F20"/>
+                    <path d="M47.106-52.742c-0.06,0-0.119-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C47.237-52.773,47.177-52.742,47.106-52.742z" fill="#231F20"/>
+                    <path d="M51.356-52.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.261-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C51.487-52.273,51.427-52.242,51.356-52.242z" fill="#231F20"/>
+                    <path d="M59.606-52.242c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.11-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C59.737-52.273,59.677-52.242,59.606-52.242z" fill="#231F20"/>
+                    <path d="M62.106-52.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.08,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C62.237-52.773,62.177-52.742,62.106-52.742z" fill="#231F20"/>
+                    <path d="M65.106-53.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C65.227-53.523,65.167-53.492,65.106-53.492z" fill="#231F20"/>
+                    <path d="M69.356-53.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C69.477-53.523,69.417-53.492,69.356-53.492z" fill="#231F20"/>
+                    <path d="M29.106-62.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C29.237-62.523,29.177-62.492,29.106-62.492z" fill="#231F20"/>
+                    <path d="M31.356-61.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C31.487-61.523,31.427-61.492,31.356-61.492z" fill="#231F20"/>
+                    <path d="M33.356-60.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C33.487-60.523,33.417-60.492,33.356-60.492z" fill="#231F20"/>
+                    <path d="M35.606-59.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C35.737-59.523,35.677-59.492,35.606-59.492z" fill="#231F20"/>
+                    <path d="M38.106-58.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C38.227-58.523,38.167-58.492,38.106-58.492z" fill="#231F20"/>
+                    <path d="M40.356-57.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C40.487-57.523,40.417-57.492,40.356-57.492z" fill="#231F20"/>
+                    <path d="M42.856-56.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.18C42.987-57.023,42.917-56.992,42.856-56.992z" fill="#231F20"/>
+                    <path d="M45.856-56.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C45.987-56.273,45.917-56.242,45.856-56.242z" fill="#231F20"/>
+                    <path d="M48.606-55.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C48.737-56.023,48.667-55.992,48.606-55.992z" fill="#231F20"/>
+                    <path d="M52.106-55.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C52.237-56.023,52.177-55.992,52.106-55.992z" fill="#231F20"/>
+                    <path d="M55.356-56.242c-0.06,0-0.13-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C55.487-56.273,55.427-56.242,55.356-56.242z" fill="#231F20"/>
+                    <path d="M58.106-56.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C58.237-56.523,58.167-56.492,58.106-56.492z" fill="#231F20"/>
+                    <path d="M60.356-57.492c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C60.487-57.523,60.427-57.492,60.356-57.492z" fill="#231F20"/>
+                    <path d="M63.106-58.742c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C63.237-58.773,63.167-58.742,63.106-58.742z" fill="#231F20"/>
+                    <path d="M65.606-59.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C65.737-60.023,65.677-59.992,65.606-59.992z" fill="#231F20"/>
+                    <path d="M69.606-59.992c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C69.737-60.023,69.677-59.992,69.606-59.992z" fill="#231F20"/>
+                    <path d="M70.606-62.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C70.737-62.773,70.677-62.742,70.606-62.742z" fill="#231F20"/>
+                    <path d="M70.356-64.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C70.477-64.523,70.417-64.492,70.356-64.492z" fill="#231F20"/>
+                    <path d="M67.606-62.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C67.737-62.773,67.677-62.742,67.606-62.742z" fill="#231F20"/>
+                    <path d="M64.356-61.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C64.477-61.523,64.417-61.492,64.356-61.492z" fill="#231F20"/>
+                    <path d="M61.356-60.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C61.487-60.273,61.427-60.242,61.356-60.242z" fill="#231F20"/>
+                    <path d="M58.356-58.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C58.487-59.023,58.427-58.992,58.356-58.992z" fill="#231F20"/>
+                    <path d="M54.856-58.242c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.02,0.129-0.069,0.17C54.987-58.273,54.917-58.242,54.856-58.242z" fill="#231F20"/>
+                    <path d="M51.606-57.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C51.737-57.773,51.677-57.742,51.606-57.742z" fill="#231F20"/>
+                    <path d="M48.606-57.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C48.737-57.773,48.667-57.742,48.606-57.742z" fill="#231F20"/>
+                    <path d="M45.606-58.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C45.737-58.523,45.677-58.492,45.606-58.492z" fill="#231F20"/>
+                    <path d="M41.856-59.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C41.977-59.523,41.917-59.492,41.856-59.492z" fill="#231F20"/>
+                    <path d="M39.606-60.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C39.727-60.273,39.667-60.242,39.606-60.242z" fill="#231F20"/>
+                    <path d="M36.356-61.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C36.487-61.523,36.427-61.492,36.356-61.492z" fill="#231F20"/>
+                    <path d="M33.856-62.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C33.977-62.523,33.917-62.492,33.856-62.492z" fill="#231F20"/>
+                    <path d="M31.856-64.242c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C31.987-64.273,31.927-64.242,31.856-64.242z" fill="#231F20"/>
+                    <path d="M30.856-65.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.101,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C30.987-65.273,30.927-65.242,30.856-65.242z" fill="#231F20"/>
+                    <path d="M32.356-66.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C32.487-66.273,32.427-66.242,32.356-66.242z" fill="#231F20"/>
+                    <path d="M33.606-64.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C33.737-65.023,33.667-64.992,33.606-64.992z" fill="#231F20"/>
+                    <path d="M35.606-63.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C35.737-63.523,35.667-63.492,35.606-63.492z" fill="#231F20"/>
+                    <path d="M37.606-62.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C37.737-62.273,37.677-62.242,37.606-62.242z" fill="#231F20"/>
+                    <path d="M40.106-61.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C40.237-61.523,40.167-61.492,40.106-61.492z" fill="#231F20"/>
+                    <path d="M43.106-60.492c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.261-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C43.237-60.523,43.177-60.492,43.106-60.492z" fill="#231F20"/>
+                    <path d="M45.856-59.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C45.987-60.023,45.917-59.992,45.856-59.992z" fill="#231F20"/>
+                    <path d="M48.606-59.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C48.737-59.773,48.677-59.742,48.606-59.742z" fill="#231F20"/>
+                    <path d="M51.856-59.742c-0.069,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.08,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C51.987-59.773,51.927-59.742,51.856-59.742z" fill="#231F20"/>
+                    <path d="M54.606-60.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C54.737-60.523,54.677-60.492,54.606-60.492z" fill="#231F20"/>
+                    <path d="M57.106-61.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C57.237-61.273,57.177-61.242,57.106-61.242z" fill="#231F20"/>
+                    <path d="M59.856-62.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C59.987-62.523,59.927-62.492,59.856-62.492z" fill="#231F20"/>
+                    <path d="M62.356-63.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.101,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C62.477-64.023,62.417-63.992,62.356-63.992z" fill="#231F20"/>
+                    <path d="M65.106-64.992c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C65.227-65.023,65.167-64.992,65.106-64.992z" fill="#231F20"/>
+                    <path d="M68.356-66.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C68.487-66.523,68.427-66.492,68.356-66.492z" fill="#231F20"/>
+                    <path d="M70.356-67.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C70.477-67.773,70.417-67.742,70.356-67.742z" fill="#231F20"/>
+                    <path d="M66.856-68.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C66.987-68.523,66.927-68.492,66.856-68.492z" fill="#231F20"/>
+                    <path d="M65.356-67.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.07-0.08,0.261-0.101,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C65.487-67.523,65.427-67.492,65.356-67.492z" fill="#231F20"/>
+                    <path d="M62.856-66.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.08,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C62.987-66.273,62.917-66.242,62.856-66.242z" fill="#231F20"/>
+                    <path d="M60.606-65.242c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C60.727-65.273,60.667-65.242,60.606-65.242z" fill="#231F20"/>
+                    <path d="M57.606-63.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C57.737-64.023,57.677-63.992,57.606-63.992z" fill="#231F20"/>
+                    <path d="M55.106-63.242c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.261-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C55.237-63.273,55.177-63.242,55.106-63.242z" fill="#231F20"/>
+                    <path d="M52.106-62.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C52.237-62.773,52.177-62.742,52.106-62.742z" fill="#231F20"/>
+                    <path d="M48.856-62.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C48.977-62.773,48.917-62.742,48.856-62.742z" fill="#231F20"/>
+                    <path d="M46.356-62.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C46.487-62.273,46.417-62.242,46.356-62.242z" fill="#231F20"/>
+                    <path d="M42.606-63.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C42.737-63.523,42.667-63.492,42.606-63.492z" fill="#231F20"/>
+                    <path d="M40.606-64.242c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C40.737-64.273,40.677-64.242,40.606-64.242z" fill="#231F20"/>
+                    <path d="M38.106-65.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C38.237-65.273,38.177-65.242,38.106-65.242z" fill="#231F20"/>
+                    <path d="M35.856-66.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C35.987-66.273,35.927-66.242,35.856-66.242z" fill="#231F20"/>
+                    <path d="M35.356-68.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C35.487-69.023,35.427-68.992,35.356-68.992z" fill="#231F20"/>
+                    <path d="M36.856-67.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C36.987-67.773,36.927-67.742,36.856-67.742z" fill="#231F20"/>
+                    <path d="M38.356-66.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C38.487-66.773,38.417-66.742,38.356-66.742z" fill="#231F20"/>
+                    <path d="M40.606-65.992c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C40.737-66.023,40.677-65.992,40.606-65.992z" fill="#231F20"/>
+                    <path d="M43.106-65.492c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.261-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C43.237-65.523,43.177-65.492,43.106-65.492z" fill="#231F20"/>
+                    <path d="M45.856-65.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C45.977-65.273,45.917-65.242,45.856-65.242z" fill="#231F20"/>
+                    <path d="M48.606-65.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C48.737-65.273,48.667-65.242,48.606-65.242z" fill="#231F20"/>
+                    <path d="M51.106-65.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C51.237-65.523,51.177-65.492,51.106-65.492z" fill="#231F20"/>
+                    <path d="M54.606-65.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C54.737-66.023,54.667-65.992,54.606-65.992z" fill="#231F20"/>
+                    <path d="M56.856-66.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C56.987-67.023,56.917-66.992,56.856-66.992z" fill="#231F20"/>
+                    <path d="M59.106-67.992c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C59.237-68.023,59.177-67.992,59.106-67.992z" fill="#231F20"/>
+                    <path d="M61.856-68.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C61.987-69.023,61.927-68.992,61.856-68.992z" fill="#231F20"/>
+                    <path d="M63.606-70.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C63.737-70.273,63.667-70.242,63.606-70.242z" fill="#231F20"/>
+                    <path d="M68.606-70.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C68.737-70.273,68.667-70.242,68.606-70.242z" fill="#231F20"/>
+                    <path d="M59.606-69.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C59.737-70.023,59.677-69.992,59.606-69.992z" fill="#231F20"/>
+                    <path d="M57.106-69.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C57.227-69.273,57.167-69.242,57.106-69.242z" fill="#231F20"/>
+                    <path d="M54.356-68.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C54.487-68.523,54.417-68.492,54.356-68.492z" fill="#231F20"/>
+                    <path d="M51.606-67.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C51.737-68.023,51.667-67.992,51.606-67.992z" fill="#231F20"/>
+                    <path d="M48.606-68.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C48.727-68.273,48.667-68.242,48.606-68.242z" fill="#231F20"/>
+                    <path d="M45.606-68.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.261-0.09,0.351,0.01c0.05,0.04,0.069,0.101,0.069,0.171c0,0.059-0.029,0.129-0.069,0.17C45.737-68.273,45.677-68.242,45.606-68.242z" fill="#231F20"/>
+                    <path d="M42.106-68.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.11-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C42.237-69.023,42.177-68.992,42.106-68.992z" fill="#231F20"/>
+                    <path d="M39.606-69.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C39.737-70.023,39.677-69.992,39.606-69.992z" fill="#231F20"/>
+                    <path d="M37.856-70.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C37.987-71.023,37.927-70.992,37.856-70.992z" fill="#231F20"/>
+                    <path d="M42.606-70.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C42.737-70.523,42.677-70.492,42.606-70.492z" fill="#231F20"/>
+                    <path d="M44.856-69.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C44.987-70.023,44.917-69.992,44.856-69.992z" fill="#231F20"/>
+                    <path d="M47.856-69.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C47.987-69.773,47.917-69.742,47.856-69.742z" fill="#231F20"/>
+                    <path d="M50.356-69.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C50.487-70.023,50.417-69.992,50.356-69.992z" fill="#231F20"/>
+                    <path d="M52.606-70.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C52.737-70.273,52.677-70.242,52.606-70.242z" fill="#231F20"/>
+                    <path d="M55.106-70.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.261-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C55.237-70.773,55.177-70.742,55.106-70.742z" fill="#231F20"/>
+                    <path d="M2.606-49.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C2.727-49.773,2.667-49.742,2.606-49.742z" fill="#231F20"/>
+                    <path d="M41.106-52.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C41.227-52.273,41.167-52.242,41.106-52.242z" fill="#231F20"/>
+                    <path d="M43.356-50.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C43.477-50.513,43.417-50.492,43.356-50.492z" fill="#231F20"/>
+                    <path d="M48.356-50.742c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C48.487-50.773,48.427-50.742,48.356-50.742z" fill="#231F20"/>
+                    <path d="M50.356-49.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C50.487-49.523,50.427-49.492,50.356-49.492z" fill="#231F20"/>
+                    <path d="M47.106-44.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C47.237-45.023,47.167-44.992,47.106-44.992z" fill="#231F20"/>
+                    <path d="M49.856-46.992c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C49.987-47.023,49.927-46.992,49.856-46.992z" fill="#231F20"/>
+                    <path d="M51.856-48.742c-0.069,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C51.987-48.773,51.927-48.742,51.856-48.742z" fill="#231F20"/>
+                    <path d="M32.106-70.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C32.237-70.273,32.167-70.242,32.106-70.242z" fill="#231F20"/>
+                    <path d="M29.856-68.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C29.977-68.523,29.917-68.492,29.856-68.492z" fill="#231F20"/>
+                    <path d="M27.356-67.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C27.477-68.023,27.417-67.992,27.356-67.992z" fill="#231F20"/>
+                    <path d="M23.856-65.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.02,0.129-0.069,0.17C23.987-65.273,23.927-65.242,23.856-65.242z" fill="#231F20"/>
+                    <path d="M20.606-63.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.24-0.101,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C20.737-63.273,20.677-63.242,20.606-63.242z" fill="#231F20"/>
+                    <path d="M17.856-61.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C17.987-61.273,17.917-61.242,17.856-61.242z" fill="#231F20"/>
+                    <path d="M13.856-59.492c-0.06,0-0.119-0.021-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.171c0.12-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C13.977-59.523,13.917-59.492,13.856-59.492z" fill="#231F20"/>
+                    <path d="M9.606-58.492c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C9.737-58.523,9.677-58.492,9.606-58.492z" fill="#231F20"/>
+                    <path d="M5.606-56.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C5.737-57.023,5.667-56.992,5.606-56.992z" fill="#231F20"/>
+                    <path d="M2.356-56.242c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C2.487-56.273,2.427-56.242,2.356-56.242z" fill="#231F20"/>
+                    <path d="M28.856-70.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C28.997-70.273,28.927-70.242,28.856-70.242z" fill="#231F20"/>
+                    <path d="M24.356-68.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C24.487-68.523,24.427-68.492,24.356-68.492z" fill="#231F20"/>
+                    <path d="M21.356-66.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C21.477-66.773,21.417-66.742,21.356-66.742z" fill="#231F20"/>
+                    <path d="M18.106-64.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C18.237-64.523,18.177-64.492,18.106-64.492z" fill="#231F20"/>
+                    <path d="M14.856-63.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.101,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C14.987-63.273,14.927-63.242,14.856-63.242z" fill="#231F20"/>
+                    <path d="M11.106-61.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C11.227-61.523,11.167-61.492,11.106-61.492z" fill="#231F20"/>
+                    <path d="M6.856-60.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C6.987-60.773,6.917-60.742,6.856-60.742z" fill="#231F20"/>
+                    <path d="M3.106-59.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C3.227-59.523,3.167-59.492,3.106-59.492z" fill="#231F20"/>
+                    <path d="M8.606-61.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C8.737-62.023,8.677-61.992,8.606-61.992z" fill="#231F20"/>
+                    <path d="M11.856-64.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C11.977-64.273,11.917-64.242,11.856-64.242z" fill="#231F20"/>
+                    <path d="M15.606-66.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.101,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C15.727-66.273,15.667-66.242,15.606-66.242z" fill="#231F20"/>
+                    <path d="M17.856-67.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C17.987-68.023,17.927-67.992,17.856-67.992z" fill="#231F20"/>
+                    <path d="M20.606-70.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.09,0.351-0.011c0.06,0.061,0.079,0.121,0.079,0.191c0,0.069-0.029,0.129-0.069,0.17C20.727-70.273,20.667-70.242,20.606-70.242z" fill="#231F20"/>
+                    <path d="M21.356-61.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C21.487-61.523,21.427-61.492,21.356-61.492z" fill="#231F20"/>
+                    <path d="M17.356-59.242c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C17.487-59.273,17.417-59.242,17.356-59.242z" fill="#231F20"/>
+                    <path d="M13.856-57.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C13.987-57.273,13.927-57.242,13.856-57.242z" fill="#231F20"/>
+                    <path d="M11.356-56.492c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.101,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C11.487-56.523,11.427-56.492,11.356-56.492z" fill="#231F20"/>
+                    <path d="M7.856-55.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C7.977-55.523,7.917-55.492,7.856-55.492z" fill="#231F20"/>
+                    <path d="M4.606-54.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C4.737-54.773,4.677-54.742,4.606-54.742z" fill="#231F20"/>
+                    <path d="M1.856-54.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.101,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C1.977-54.523,1.917-54.492,1.856-54.492z" fill="#231F20"/>
+                    <path d="M23.356-62.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.171c0.101-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C23.477-63.023,23.417-62.992,23.356-62.992z" fill="#231F20"/>
+                    <path d="M26.356-64.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C26.487-65.023,26.427-64.992,26.356-64.992z" fill="#231F20"/>
+                    <path d="M18.856-68.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.18C18.977-68.273,18.917-68.242,18.856-68.242z" fill="#231F20"/>
+                    <path d="M1.856-61.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C1.987-61.273,1.927-61.242,1.856-61.242z" fill="#231F20"/>
+                    <path d="M4.856-62.242c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.101,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C4.987-62.273,4.927-62.242,4.856-62.242z" fill="#231F20"/>
+                    <path d="M8.106-63.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C8.237-64.023,8.177-63.992,8.106-63.992z" fill="#231F20"/>
+                    <path d="M10.606-65.992c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C10.737-66.023,10.677-65.992,10.606-65.992z" fill="#231F20"/>
+                    <path d="M12.606-67.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C12.727-67.773,12.667-67.742,12.606-67.742z" fill="#231F20"/>
+                    <path d="M14.856-69.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C14.987-69.773,14.927-69.742,14.856-69.742z" fill="#231F20"/>
+                    <path d="M12.356-70.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.101,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.17C12.477-70.273,12.417-70.242,12.356-70.242z" fill="#231F20"/>
+                    <path d="M10.356-68.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C10.487-68.773,10.417-68.742,10.356-68.742z" fill="#231F20"/>
+                    <path d="M8.106-67.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C8.237-67.273,8.167-67.242,8.106-67.242z" fill="#231F20"/>
+                    <path d="M5.856-65.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C5.977-66.023,5.917-65.992,5.856-65.992z" fill="#231F20"/>
+                    <path d="M3.356-64.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C3.477-64.773,3.417-64.742,3.356-64.742z" fill="#231F20"/>
+                    <path d="M1.106-64.242c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C1.237-64.273,1.177-64.242,1.106-64.242z" fill="#231F20"/>
+                    <path d="M1.356-66.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C1.487-66.773,1.417-66.742,1.356-66.742z" fill="#231F20"/>
+                    <path d="M3.356-67.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.07-0.09,0.25-0.101,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C3.487-67.273,3.427-67.242,3.356-67.242z" fill="#231F20"/>
+                    <path d="M5.606-68.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C5.737-68.523,5.667-68.492,5.606-68.492z" fill="#231F20"/>
+                    <path d="M7.106-70.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C7.227-70.273,7.167-70.242,7.106-70.242z" fill="#231F20"/>
+                    <path d="M4.356-70.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.061,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C4.477-70.523,4.417-70.492,4.356-70.492z" fill="#231F20"/>
+                    <path d="M2.856-69.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.07-0.08,0.261-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C2.987-69.273,2.927-69.242,2.856-69.242z" fill="#231F20"/>
+                    <path d="M9.356-52.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C9.487-52.773,9.417-52.742,9.356-52.742z" fill="#231F20"/>
+                    <path d="M12.606-53.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C12.737-54.023,12.677-53.992,12.606-53.992z" fill="#231F20"/>
+                    <path d="M14.856-54.992c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C14.987-55.023,14.927-54.992,14.856-54.992z" fill="#231F20"/>
+                    <path d="M19.606-57.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C19.737-57.523,19.667-57.492,19.606-57.492z" fill="#231F20"/>
+                    <path d="M24.356-59.742c-0.06,0-0.119-0.021-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C24.487-59.773,24.417-59.742,24.356-59.742z" fill="#231F20"/>
+                    <path d="M33.356-66.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C33.487-67.023,33.417-66.992,33.356-66.992z" fill="#231F20"/>
+                    <path d="M29.106-58.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C29.237-58.273,29.167-58.242,29.106-58.242z" fill="#231F20"/>
+                    <path d="M30.606-57.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C30.737-57.273,30.677-57.242,30.606-57.242z" fill="#231F20"/>
+                    <path d="M33.106-55.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C33.237-55.773,33.167-55.742,33.106-55.742z" fill="#231F20"/>
+                    <path d="M36.356-53.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C36.477-54.023,36.417-53.992,36.356-53.992z" fill="#231F20"/>
+                    <path d="M39.356-52.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C39.477-52.773,39.417-52.742,39.356-52.742z" fill="#231F20"/>
+                    <path d="M42.856-51.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C42.987-51.773,42.917-51.742,42.856-51.742z" fill="#231F20"/>
+                    <path d="M47.106-50.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C47.237-51.023,47.167-50.992,47.106-50.992z" fill="#231F20"/>
+                    <path d="M49.606-50.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C49.727-50.773,49.667-50.742,49.606-50.742z" fill="#231F20"/>
+                    <path d="M53.356-49.992c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C53.487-50.023,53.427-49.992,53.356-49.992z" fill="#231F20"/>
+                    <path d="M18.106-32.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C18.237-32.773,18.177-32.742,18.106-32.742z" fill="#231F20"/>
+                    <path d="M16.106-30.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.07-0.09,0.25-0.101,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C16.227-30.773,16.167-30.742,16.106-30.742z" fill="#231F20"/>
+                    <path d="M13.606-28.992c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.171c0.101-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C13.737-29.023,13.667-28.992,13.606-28.992z" fill="#231F20"/>
+                    <path d="M11.356-27.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C11.487-27.773,11.417-27.742,11.356-27.742z" fill="#231F20"/>
+                    <path d="M8.356-26.242c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C8.487-26.273,8.427-26.242,8.356-26.242z" fill="#231F20"/>
+                    <path d="M5.356-24.992c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C5.477-25.023,5.417-24.992,5.356-24.992z" fill="#231F20"/>
+                    <path d="M2.356-24.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C2.487-24.523,2.427-24.492,2.356-24.492z" fill="#231F20"/>
+                    <path d="M17.106-35.742c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C17.237-35.773,17.177-35.742,17.106-35.742z" fill="#231F20"/>
+                    <path d="M47.856-48.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C47.987-49.023,47.917-48.992,47.856-48.992z" fill="#231F20"/>
+                    <path d="M14.606-53.742c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C14.737-53.773,14.667-53.742,14.606-53.742z" fill="#231F20"/>
+                    <path d="M3.856-45.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C3.987-45.273,3.927-45.242,3.856-45.242z" fill="#231F20"/>
+                    <path d="M25.356-35.242c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C25.487-35.273,25.427-35.242,25.356-35.242z" fill="#231F20"/>
+                    <path d="M28.106-35.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C28.237-36.023,28.177-35.992,28.106-35.992z" fill="#231F20"/>
+                    <path d="M45.356-42.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C45.477-43.023,45.417-42.992,45.356-42.992z" fill="#231F20"/>
+                    <path d="M42.856-41.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C42.987-41.273,42.917-41.242,42.856-41.242z" fill="#231F20"/>
+                    <path d="M39.356-39.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C39.487-39.523,39.427-39.492,39.356-39.492z" fill="#231F20"/>
+                    <path d="M36.106-37.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C36.237-38.023,36.177-37.992,36.106-37.992z" fill="#231F20"/>
+                    <path d="M31.356-36.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C31.487-36.273,31.427-36.242,31.356-36.242z" fill="#231F20"/>
+                    <path d="M45.606-47.242c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.261-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C45.737-47.273,45.677-47.242,45.606-47.242z" fill="#231F20"/>
+                    <path d="M43.106-45.492c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.261-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C43.237-45.523,43.177-45.492,43.106-45.492z" fill="#231F20"/>
+                    <path d="M38.856-42.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C38.987-42.523,38.917-42.492,38.856-42.492z" fill="#231F20"/>
+                    <path d="M41.606-43.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C41.737-43.773,41.677-43.742,41.606-43.742z" fill="#231F20"/>
+                    <path d="M35.856-40.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C35.977-41.023,35.917-40.992,35.856-40.992z" fill="#231F20"/>
+                    <path d="M33.106-40.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C33.237-40.273,33.177-40.242,33.106-40.242z" fill="#231F20"/>
+                    <path d="M30.106-39.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.02,0.129-0.069,0.17C30.237-39.773,30.177-39.742,30.106-39.742z" fill="#231F20"/>
+                    <path d="M27.106-39.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C27.237-39.523,27.177-39.492,27.106-39.492z" fill="#231F20"/>
+                    <path d="M23.606-39.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.101,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C23.737-39.273,23.667-39.242,23.606-39.242z" fill="#231F20"/>
+                    <path d="M20.106-39.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.171c0.11-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C20.227-39.273,20.167-39.242,20.106-39.242z" fill="#231F20"/>
+                    <path d="M17.106-39.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C17.237-40.023,17.177-39.992,17.106-39.992z" fill="#231F20"/>
+                    <path d="M14.106-41.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.02,0.129-0.069,0.17C14.237-41.273,14.177-41.242,14.106-41.242z" fill="#231F20"/>
+                    <path d="M10.856-42.242c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C10.987-42.273,10.917-42.242,10.856-42.242z" fill="#231F20"/>
+                    <path d="M7.856-43.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C7.977-43.273,7.917-43.242,7.856-43.242z" fill="#231F20"/>
+                    <path d="M5.856-43.992c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C5.987-44.023,5.927-43.992,5.856-43.992z" fill="#231F20"/>
+                    <path d="M44.856-49.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.18C44.987-50.023,44.917-49.992,44.856-49.992z" fill="#231F20"/>
+                    <path d="M42.856-48.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C42.987-48.273,42.917-48.242,42.856-48.242z" fill="#231F20"/>
+                    <path d="M40.356-46.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.171c0.11-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C40.487-46.773,40.427-46.742,40.356-46.742z" fill="#231F20"/>
+                    <path d="M38.106-45.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C38.237-45.273,38.167-45.242,38.106-45.242z" fill="#231F20"/>
+                    <path d="M35.356-44.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C35.497-44.273,35.427-44.242,35.356-44.242z" fill="#231F20"/>
+                    <path d="M32.356-43.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.101,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C32.487-43.523,32.417-43.492,32.356-43.492z" fill="#231F20"/>
+                    <path d="M29.106-43.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C29.237-43.273,29.177-43.242,29.106-43.242z" fill="#231F20"/>
+                    <path d="M26.106-42.992c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C26.237-43.023,26.167-42.992,26.106-42.992z" fill="#231F20"/>
+                    <path d="M22.856-43.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C22.977-43.273,22.917-43.242,22.856-43.242z" fill="#231F20"/>
+                    <path d="M20.106-43.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C20.227-43.773,20.167-43.742,20.106-43.742z" fill="#231F20"/>
+                    <path d="M17.106-44.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C17.237-44.523,17.177-44.492,17.106-44.492z" fill="#231F20"/>
+                    <path d="M14.356-45.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C14.477-45.523,14.417-45.492,14.356-45.492z" fill="#231F20"/>
+                    <path d="M11.606-46.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C11.727-46.773,11.667-46.742,11.606-46.742z" fill="#231F20"/>
+                    <path d="M9.356-48.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C9.487-48.273,9.427-48.242,9.356-48.242z" fill="#231F20"/>
+                    <path d="M7.106-49.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C7.237-50.023,7.177-49.992,7.106-49.992z" fill="#231F20"/>
+                    <path d="M41.356-50.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C41.477-50.273,41.417-50.242,41.356-50.242z" fill="#231F20"/>
+                    <path d="M39.356-49.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C39.487-49.273,39.417-49.242,39.356-49.242z" fill="#231F20"/>
+                    <path d="M36.856-47.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C36.977-48.023,36.917-47.992,36.856-47.992z" fill="#231F20"/>
+                    <path d="M34.356-47.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.25-0.09,0.351-0.011c0.06,0.061,0.079,0.131,0.079,0.191c0,0.059-0.02,0.129-0.069,0.17C34.477-47.273,34.417-47.242,34.356-47.242z" fill="#231F20"/>
+                    <path d="M31.856-46.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C31.987-46.523,31.927-46.492,31.856-46.492z" fill="#231F20"/>
+                    <path d="M29.106-46.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C29.237-46.523,29.167-46.492,29.106-46.492z" fill="#231F20"/>
+                    <path d="M26.606-46.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C26.727-46.273,26.667-46.242,26.606-46.242z" fill="#231F20"/>
+                    <path d="M22.856-46.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C22.987-46.773,22.927-46.742,22.856-46.742z" fill="#231F20"/>
+                    <path d="M20.606-47.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.07-0.09,0.25-0.101,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.17C20.727-47.773,20.667-47.742,20.606-47.742z" fill="#231F20"/>
+                    <path d="M17.606-48.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C17.737-48.523,17.667-48.492,17.606-48.492z" fill="#231F20"/>
+                    <path d="M15.106-49.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C15.237-49.523,15.177-49.492,15.106-49.492z" fill="#231F20"/>
+                    <path d="M13.106-50.742c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C13.237-50.773,13.177-50.742,13.106-50.742z" fill="#231F20"/>
+                    <path d="M11.356-52.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C11.487-52.523,11.427-52.492,11.356-52.492z" fill="#231F20"/>
+                    <path d="M39.106-51.492c-0.06,0-0.119-0.021-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C39.227-51.523,39.167-51.492,39.106-51.492z" fill="#231F20"/>
+                    <path d="M37.106-50.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C37.237-50.523,37.177-50.492,37.106-50.492z" fill="#231F20"/>
+                    <path d="M35.106-49.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C35.237-49.773,35.167-49.742,35.106-49.742z" fill="#231F20"/>
+                    <path d="M32.606-49.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C32.737-49.273,32.667-49.242,32.606-49.242z" fill="#231F20"/>
+                    <path d="M29.856-48.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C29.987-49.023,29.917-48.992,29.856-48.992z" fill="#231F20"/>
+                    <path d="M27.356-49.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C27.487-49.273,27.417-49.242,27.356-49.242z" fill="#231F20"/>
+                    <path d="M24.856-49.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C24.987-49.773,24.917-49.742,24.856-49.742z" fill="#231F20"/>
+                    <path d="M22.356-50.742c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C22.487-50.773,22.417-50.742,22.356-50.742z" fill="#231F20"/>
+                    <path d="M20.356-51.742c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C20.487-51.773,20.427-51.742,20.356-51.742z" fill="#231F20"/>
+                    <path d="M17.856-53.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C17.977-53.273,17.917-53.242,17.856-53.242z" fill="#231F20"/>
+                    <path d="M16.356-54.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C16.477-54.773,16.417-54.742,16.356-54.742z" fill="#231F20"/>
+                    <path d="M19.356-55.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C19.487-55.273,19.427-55.242,19.356-55.242z" fill="#231F20"/>
+                    <path d="M21.856-53.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C21.977-53.773,21.917-53.742,21.856-53.742z" fill="#231F20"/>
+                    <path d="M23.856-53.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C23.977-53.273,23.917-53.242,23.856-53.242z" fill="#231F20"/>
+                    <path d="M26.356-51.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C26.487-51.773,26.417-51.742,26.356-51.742z" fill="#231F20"/>
+                    <path d="M28.356-51.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.18C28.477-51.773,28.417-51.742,28.356-51.742z" fill="#231F20"/>
+                    <path d="M31.106-52.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C31.237-52.273,31.167-52.242,31.106-52.242z" fill="#231F20"/>
+                    <path d="M33.356-52.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C33.487-52.273,33.417-52.242,33.356-52.242z" fill="#231F20"/>
+                    <path d="M35.606-52.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C35.737-53.023,35.667-52.992,35.606-52.992z" fill="#231F20"/>
+                    <path d="M33.106-54.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C33.237-55.023,33.177-54.992,33.106-54.992z" fill="#231F20"/>
+                    <path d="M30.856-54.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.18C30.987-54.273,30.917-54.242,30.856-54.242z" fill="#231F20"/>
+                    <path d="M27.856-54.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C27.987-54.523,27.927-54.492,27.856-54.492z" fill="#231F20"/>
+                    <path d="M24.856-55.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C24.977-55.273,24.917-55.242,24.856-55.242z" fill="#231F20"/>
+                    <path d="M21.856-56.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C21.987-57.023,21.927-56.992,21.856-56.992z" fill="#231F20"/>
+                    <path d="M29.606-56.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C29.737-56.523,29.667-56.492,29.606-56.492z" fill="#231F20"/>
+                    <path d="M26.856-56.742c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.171c0.101-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C26.987-56.773,26.917-56.742,26.856-56.742z" fill="#231F20"/>
+                    <path d="M24.356-57.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C24.487-58.023,24.417-57.992,24.356-57.992z" fill="#231F20"/>
+                    <path d="M26.356-58.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C26.487-59.023,26.417-58.992,26.356-58.992z" fill="#231F20"/>
+                    <path d="M5.606-39.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.08,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C5.737-39.773,5.677-39.742,5.606-39.742z" fill="#231F20"/>
+                    <path d="M9.106-38.242c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.11-0.07-0.18c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.101,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C9.227-38.273,9.167-38.242,9.106-38.242z" fill="#231F20"/>
+                    <path d="M11.606-37.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C11.727-37.523,11.667-37.492,11.606-37.492z" fill="#231F20"/>
+                    <path d="M15.856-36.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C15.987-36.273,15.917-36.242,15.856-36.242z" fill="#231F20"/>
+                    <path d="M21.106-34.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C21.237-35.023,21.177-34.992,21.106-34.992z" fill="#231F20"/>
+                    <path d="M24.356-34.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C24.487-35.023,24.427-34.992,24.356-34.992z" fill="#231F20"/>
+                    <path d="M30.106-35.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C30.237-35.773,30.167-35.742,30.106-35.742z" fill="#231F20"/>
+                    <path d="M26.856-34.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C26.977-35.023,26.917-34.992,26.856-34.992z" fill="#231F20"/>
+                    <path d="M71.856-51.242c-0.069,0-0.14-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.06,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C71.997-51.273,71.927-51.242,71.856-51.242z" fill="#231F20"/>
+                    <path d="M66.606-51.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.08-0.09,0.271-0.101,0.36,0.01c0.04,0.04,0.069,0.101,0.069,0.171c0,0.059-0.02,0.129-0.069,0.17C66.737-51.773,66.677-51.742,66.606-51.742z" fill="#231F20"/>
+                    <path d="M51.106-47.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C51.237-48.023,51.167-47.992,51.106-47.992z" fill="#231F20"/>
+                    <path d="M48.856-45.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C48.987-45.773,48.927-45.742,48.856-45.742z" fill="#231F20"/>
+                    <path d="M46.606-43.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C46.727-43.773,46.667-43.742,46.606-43.742z" fill="#231F20"/>
+                    <path d="M44.106-41.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C44.237-42.023,44.167-41.992,44.106-41.992z" fill="#231F20"/>
+                    <path d="M41.606-40.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C41.737-40.273,41.667-40.242,41.606-40.242z" fill="#231F20"/>
+                    <path d="M37.856-38.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C37.987-38.773,37.927-38.742,37.856-38.742z" fill="#231F20"/>
+                    <path d="M35.356-37.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C35.487-37.273,35.427-37.242,35.356-37.242z" fill="#231F20"/>
+                    <path d="M33.106-36.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C33.237-36.523,33.177-36.492,33.106-36.492z" fill="#231F20"/>
+                    <path d="M62.356-50.992c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C62.477-51.023,62.417-50.992,62.356-50.992z" fill="#231F20"/>
+                    <path d="M54.606-50.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.07-0.181c0.11-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.17C54.737-50.273,54.677-50.242,54.606-50.242z" fill="#231F20"/>
+                    <path d="M64.606-51.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.17C64.727-52.023,64.667-51.992,64.606-51.992z" fill="#231F20"/>
+                    <path d="M24.356-30.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C24.477-31.023,24.417-30.992,24.356-30.992z" fill="#231F20"/>
+                    <path d="M23.106-32.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C23.237-32.523,23.167-32.492,23.106-32.492z" fill="#231F20"/>
+                    <path d="M27.106-28.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C27.237-28.523,27.177-28.492,27.106-28.492z" fill="#231F20"/>
+                    <path d="M31.106-25.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C31.237-26.023,31.167-25.992,31.106-25.992z" fill="#231F20"/>
+                    <path d="M33.106-25.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C33.237-25.273,33.177-25.242,33.106-25.242z" fill="#231F20"/>
+                    <path d="M35.106-24.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C35.227-24.273,35.167-24.242,35.106-24.242z" fill="#231F20"/>
+                    <path d="M38.856-22.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.11-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C38.987-23.023,38.927-22.992,38.856-22.992z" fill="#231F20"/>
+                    <path d="M41.106-22.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C41.237-22.523,41.167-22.492,41.106-22.492z" fill="#231F20"/>
+                    <path d="M44.606-21.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C44.737-21.773,44.667-21.742,44.606-21.742z" fill="#231F20"/>
+                    <path d="M47.356-21.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C47.487-21.273,47.417-21.242,47.356-21.242z" fill="#231F20"/>
+                    <path d="M49.106-20.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C49.227-21.023,49.167-20.992,49.106-20.992z" fill="#231F20"/>
+                    <path d="M52.606-21.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C52.727-21.273,52.667-21.242,52.606-21.242z" fill="#231F20"/>
+                    <path d="M54.606-21.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C54.737-21.273,54.677-21.242,54.606-21.242z" fill="#231F20"/>
+                    <path d="M56.356-21.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C56.477-21.523,56.417-21.492,56.356-21.492z" fill="#231F20"/>
+                    <path d="M58.606-21.992c-0.069,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C58.737-22.023,58.677-21.992,58.606-21.992z" fill="#231F20"/>
+                    <path d="M61.606-23.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C61.737-23.523,61.667-23.492,61.606-23.492z" fill="#231F20"/>
+                    <path d="M47.356-41.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C47.487-41.773,47.427-41.742,47.356-41.742z" fill="#231F20"/>
+                    <path d="M48.106-39.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C48.237-40.023,48.167-39.992,48.106-39.992z" fill="#231F20"/>
+                    <path d="M48.606-38.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C48.737-38.773,48.677-38.742,48.606-38.742z" fill="#231F20"/>
+                    <path d="M49.856-35.992c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C49.987-36.023,49.927-35.992,49.856-35.992z" fill="#231F20"/>
+                    <path d="M51.106-33.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.17C51.237-33.773,51.177-33.742,51.106-33.742z" fill="#231F20"/>
+                    <path d="M52.606-31.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.07-0.181c0.11-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.17C52.737-31.773,52.677-31.742,52.606-31.742z" fill="#231F20"/>
+                    <path d="M53.856-30.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C53.987-30.523,53.917-30.492,53.856-30.492z" fill="#231F20"/>
+                    <path d="M55.856-28.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C55.987-28.773,55.917-28.742,55.856-28.742z" fill="#231F20"/>
+                    <path d="M58.106-26.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C58.227-26.523,58.167-26.492,58.106-26.492z" fill="#231F20"/>
+                    <path d="M59.356-25.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C59.487-25.273,59.427-25.242,59.356-25.242z" fill="#231F20"/>
+                    <path d="M62.856-22.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.101,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C62.987-23.023,62.927-22.992,62.856-22.992z" fill="#231F20"/>
+                    <path d="M65.606-21.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C65.737-21.523,65.677-21.492,65.606-21.492z" fill="#231F20"/>
+                    <path d="M67.606-20.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C67.737-20.773,67.667-20.742,67.606-20.742z" fill="#231F20"/>
+                    <path d="M70.356-19.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.08,0.25-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C70.477-20.023,70.417-19.992,70.356-19.992z" fill="#231F20"/>
+                    <path d="M38.606-0.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C38.737-1.023,38.667-0.992,38.606-0.992z" fill="#231F20"/>
+                    <path d="M40.106-2.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C40.237-2.773,40.167-2.742,40.106-2.742z" fill="#231F20"/>
+                    <path d="M41.606-5.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C41.737-5.523,41.667-5.492,41.606-5.492z" fill="#231F20"/>
+                    <path d="M42.356-7.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C42.477-7.523,42.417-7.492,42.356-7.492z" fill="#231F20"/>
+                    <path d="M43.106-9.992c-0.069,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.261-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C43.237-10.023,43.177-9.992,43.106-9.992z" fill="#231F20"/>
+                    <path d="M43.856-12.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C43.987-12.273,43.917-12.242,43.856-12.242z" fill="#231F20"/>
+                    <path d="M44.606-14.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C44.737-14.273,44.667-14.242,44.606-14.242z" fill="#231F20"/>
+                    <path d="M44.856-16.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C44.987-16.273,44.927-16.242,44.856-16.242z" fill="#231F20"/>
+                    <path d="M45.106-18.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C45.237-18.773,45.167-18.742,45.106-18.742z" fill="#231F20"/>
+                    <path d="M45.356-20.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C45.477-20.773,45.417-20.742,45.356-20.742z" fill="#231F20"/>
+                    <path d="M21.356-30.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C21.487-30.523,21.427-30.492,21.356-30.492z" fill="#231F20"/>
+                    <path d="M44.106-9.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C44.237-9.273,44.167-9.242,44.106-9.242z" fill="#231F20"/>
+                    <path d="M70.606-11.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C70.737-11.773,70.677-11.742,70.606-11.742z" fill="#231F20"/>
+                    <path d="M70.356-47.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C70.477-47.773,70.417-47.742,70.356-47.742z" fill="#231F20"/>
+                    <path d="M68.106-49.242c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C68.237-49.273,68.177-49.242,68.106-49.242z" fill="#231F20"/>
+                    <path d="M70.606-49.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C70.737-50.023,70.677-49.992,70.606-49.992z" fill="#231F20"/>
+                    <path d="M65.356-46.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C65.487-46.273,65.427-46.242,65.356-46.242z" fill="#231F20"/>
+                    <path d="M66.606-45.492c-0.069,0-0.13-0.031-0.18-0.07c-0.05-0.061-0.07-0.121-0.07-0.18c0-0.061,0.03-0.131,0.07-0.171c0.101-0.1,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C66.737-45.523,66.677-45.492,66.606-45.492z" fill="#231F20"/>
+                    <path d="M68.237-44.242c-0.07,0-0.141-0.031-0.181-0.08c-0.05-0.041-0.069-0.111-0.069-0.17c0-0.07,0.02-0.131,0.069-0.181c0.09-0.09,0.25-0.09,0.351,0c0.05,0.05,0.08,0.11,0.08,0.181c0,0.059-0.03,0.129-0.08,0.17C68.367-44.273,68.297-44.242,68.237-44.242z" fill="#231F20"/>
+                    <path d="M71.106-42.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C71.237-42.273,71.167-42.242,71.106-42.242z" fill="#231F20"/>
+                    <path d="M25.356-33.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C25.487-33.273,25.417-33.242,25.356-33.242z" fill="#231F20"/>
+                    <path d="M27.106-31.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C27.237-31.773,27.167-31.742,27.106-31.742z" fill="#231F20"/>
+                    <path d="M29.106-29.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C29.237-30.023,29.167-29.992,29.106-29.992z" fill="#231F20"/>
+                    <path d="M31.106-28.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C31.237-28.773,31.167-28.742,31.106-28.742z" fill="#231F20"/>
+                    <path d="M33.356-27.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.171c0.11-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C33.487-27.773,33.417-27.742,33.356-27.742z" fill="#231F20"/>
+                    <path d="M36.356-26.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C36.487-26.273,36.427-26.242,36.356-26.242z" fill="#231F20"/>
+                    <path d="M40.106-24.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C40.237-25.023,40.177-24.992,40.106-24.992z" fill="#231F20"/>
+                    <path d="M44.106-24.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C44.237-24.523,44.177-24.492,44.106-24.492z" fill="#231F20"/>
+                    <path d="M48.356-23.992c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C48.487-24.023,48.427-23.992,48.356-23.992z" fill="#231F20"/>
+                    <path d="M51.606-23.992c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C51.737-24.023,51.677-23.992,51.606-23.992z" fill="#231F20"/>
+                    <path d="M54.606-24.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C54.737-24.773,54.677-24.742,54.606-24.742z" fill="#231F20"/>
+                    <path d="M56.856-25.492c-0.06,0-0.13-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C56.987-25.523,56.927-25.492,56.856-25.492z" fill="#231F20"/>
+                    <path d="M54.856-27.492c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.02,0.129-0.069,0.17C54.987-27.523,54.917-27.492,54.856-27.492z" fill="#231F20"/>
+                    <path d="M51.856-26.742c-0.069,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C51.987-26.773,51.927-26.742,51.856-26.742z" fill="#231F20"/>
+                    <path d="M48.606-26.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.02,0.129-0.069,0.17C48.737-26.523,48.677-26.492,48.606-26.492z" fill="#231F20"/>
+                    <path d="M45.356-27.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C45.487-27.273,45.417-27.242,45.356-27.242z" fill="#231F20"/>
+                    <path d="M41.356-28.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C41.487-28.273,41.427-28.242,41.356-28.242z" fill="#231F20"/>
+                    <path d="M37.356-29.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.171c0.12-0.11,0.271-0.1,0.36-0.01c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C37.487-29.273,37.427-29.242,37.356-29.242z" fill="#231F20"/>
+                    <path d="M34.106-30.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C34.237-31.023,34.167-30.992,34.106-30.992z" fill="#231F20"/>
+                    <path d="M32.106-32.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C32.237-33.023,32.167-32.992,32.106-32.992z" fill="#231F20"/>
+                    <path d="M29.356-34.742c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C29.487-34.773,29.427-34.742,29.356-34.742z" fill="#231F20"/>
+                    <path d="M32.856-35.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.02,0.129-0.069,0.17C32.987-35.273,32.927-35.242,32.856-35.242z" fill="#231F20"/>
+                    <path d="M34.606-33.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C34.727-33.523,34.667-33.492,34.606-33.492z" fill="#231F20"/>
+                    <path d="M36.856-32.242c-0.06,0-0.119-0.021-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C36.977-32.273,36.917-32.242,36.856-32.242z" fill="#231F20"/>
+                    <path d="M40.356-30.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C40.487-31.023,40.417-30.992,40.356-30.992z" fill="#231F20"/>
+                    <path d="M43.606-30.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C43.737-30.273,43.667-30.242,43.606-30.242z" fill="#231F20"/>
+                    <path d="M47.106-29.992c-0.06,0-0.13-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C47.237-30.023,47.177-29.992,47.106-29.992z" fill="#231F20"/>
+                    <path d="M49.606-30.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C49.737-30.273,49.677-30.242,49.606-30.242z" fill="#231F20"/>
+                    <path d="M51.856-30.742c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C51.987-30.773,51.917-30.742,51.856-30.742z" fill="#231F20"/>
+                    <path d="M50.356-32.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C50.487-33.023,50.427-32.992,50.356-32.992z" fill="#231F20"/>
+                    <path d="M47.106-32.992c-0.06,0-0.119-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C47.237-33.023,47.177-32.992,47.106-32.992z" fill="#231F20"/>
+                    <path d="M43.856-33.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C43.987-33.523,43.917-33.492,43.856-33.492z" fill="#231F20"/>
+                    <path d="M40.606-34.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C40.737-35.023,40.677-34.992,40.606-34.992z" fill="#231F20"/>
+                    <path d="M37.606-37.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.11-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C37.737-37.273,37.677-37.242,37.606-37.242z" fill="#231F20"/>
+                    <path d="M39.856-38.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C39.987-38.273,39.917-38.242,39.856-38.242z" fill="#231F20"/>
+                    <path d="M41.356-36.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C41.487-37.023,41.417-36.992,41.356-36.992z" fill="#231F20"/>
+                    <path d="M43.856-36.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C43.977-36.273,43.917-36.242,43.856-36.242z" fill="#231F20"/>
+                    <path d="M46.606-36.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C46.727-36.273,46.667-36.242,46.606-36.242z" fill="#231F20"/>
+                    <path d="M48.606-36.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C48.737-36.523,48.677-36.492,48.606-36.492z" fill="#231F20"/>
+                    <path d="M47.356-38.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C47.487-38.773,47.427-38.742,47.356-38.742z" fill="#231F20"/>
+                    <path d="M45.356-38.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C45.487-38.773,45.427-38.742,45.356-38.742z" fill="#231F20"/>
+                    <path d="M42.856-39.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C42.987-40.023,42.927-39.992,42.856-39.992z" fill="#231F20"/>
+                    <path d="M44.356-40.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.25-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C44.477-41.023,44.417-40.992,44.356-40.992z" fill="#231F20"/>
+                    <path d="M46.606-40.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.17C46.737-40.773,46.667-40.742,46.606-40.742z" fill="#231F20"/>
+                    <path d="M71.967-51.242c-0.07,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.07-0.181c0.09-0.09,0.25-0.101,0.35,0c0.05,0.05,0.08,0.11,0.08,0.181c0,0.059-0.03,0.129-0.07,0.17C72.087-51.273,72.027-51.242,71.967-51.242z" fill="#231F20"/>
+                    <path d="M59.606-49.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.08,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C59.737-50.023,59.677-49.992,59.606-49.992z" fill="#231F20"/>
+                    <path d="M67.356-48.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C67.477-49.023,67.417-48.992,67.356-48.992z" fill="#231F20"/>
+                    <path d="M63.856-48.742c-0.06,0-0.13-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C63.987-48.773,63.927-48.742,63.856-48.742z" fill="#231F20"/>
+                    <path d="M62.356-48.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C62.477-48.773,62.427-48.742,62.356-48.742z" fill="#231F20"/>
+                    <path d="M60.106-48.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C60.237-48.773,60.167-48.742,60.106-48.742z" fill="#231F20"/>
+                    <path d="M57.856-49.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.261-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C57.987-49.273,57.927-49.242,57.856-49.242z" fill="#231F20"/>
+                    <path d="M55.356-49.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.02,0.129-0.069,0.17C55.477-49.523,55.417-49.492,55.356-49.492z" fill="#231F20"/>
+                    <path d="M26.606-60.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C26.737-60.773,26.667-60.742,26.606-60.742z" fill="#231F20"/>
+                    <path d="M64.106-45.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C64.237-45.523,64.177-45.492,64.106-45.492z" fill="#231F20"/>
+                    <path d="M61.606-44.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C61.737-45.023,61.667-44.992,61.606-44.992z" fill="#231F20"/>
+                    <path d="M58.606-44.742c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C58.737-44.773,58.667-44.742,58.606-44.742z" fill="#231F20"/>
+                    <path d="M55.856-44.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C55.987-45.023,55.917-44.992,55.856-44.992z" fill="#231F20"/>
+                    <path d="M52.356-45.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C52.487-46.023,52.417-45.992,52.356-45.992z" fill="#231F20"/>
+                    <path d="M53.856-42.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C53.987-43.023,53.927-42.992,53.856-42.992z" fill="#231F20"/>
+                    <path d="M57.106-42.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C57.227-42.523,57.167-42.492,57.106-42.492z" fill="#231F20"/>
+                    <path d="M59.856-42.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.07-0.08,0.261-0.09,0.351,0.01c0.04,0.04,0.069,0.101,0.069,0.171c0,0.059-0.02,0.129-0.069,0.17C59.987-42.523,59.927-42.492,59.856-42.492z" fill="#231F20"/>
+                    <path d="M62.856-42.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C62.987-42.523,62.927-42.492,62.856-42.492z" fill="#231F20"/>
+                    <path d="M65.356-43.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C65.487-43.523,65.427-43.492,65.356-43.492z" fill="#231F20"/>
+                    <path d="M50.356-44.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C50.477-44.273,50.417-44.242,50.356-44.242z" fill="#231F20"/>
+                    <path d="M54.106-47.992c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C54.227-48.023,54.177-47.992,54.106-47.992z" fill="#231F20"/>
+                    <path d="M56.106-47.242c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C56.237-47.273,56.167-47.242,56.106-47.242z" fill="#231F20"/>
+                    <path d="M58.606-46.992c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C58.737-47.023,58.667-46.992,58.606-46.992z" fill="#231F20"/>
+                    <path d="M61.606-47.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C61.737-48.023,61.677-47.992,61.606-47.992z" fill="#231F20"/>
+                    <path d="M61.856-40.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C61.987-40.523,61.927-40.492,61.856-40.492z" fill="#231F20"/>
+                    <path d="M58.106-39.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C58.237-40.023,58.167-39.992,58.106-39.992z" fill="#231F20"/>
+                    <path d="M54.606-40.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C54.737-40.523,54.667-40.492,54.606-40.492z" fill="#231F20"/>
+                    <path d="M50.856-41.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C50.987-41.523,50.917-41.492,50.856-41.492z" fill="#231F20"/>
+                    <path d="M48.106-42.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C48.237-42.773,48.177-42.742,48.106-42.742z" fill="#231F20"/>
+                    <path d="M51.106-38.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C51.237-38.273,51.177-38.242,51.106-38.242z" fill="#231F20"/>
+                    <path d="M57.606-37.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C57.737-37.273,57.677-37.242,57.606-37.242z" fill="#231F20"/>
+                    <path d="M60.856-37.492c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C60.987-37.523,60.917-37.492,60.856-37.492z" fill="#231F20"/>
+                    <path d="M64.606-37.992c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.341,0c0.05,0.04,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.17C64.737-38.023,64.667-37.992,64.606-37.992z" fill="#231F20"/>
+                    <path d="M67.356-39.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C67.487-39.273,67.417-39.242,67.356-39.242z" fill="#231F20"/>
+                    <path d="M70.606-40.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C70.737-40.773,70.677-40.742,70.606-40.742z" fill="#231F20"/>
+                    <path d="M53.356-34.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C53.487-34.773,53.417-34.742,53.356-34.742z" fill="#231F20"/>
+                    <path d="M56.606-34.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.351,0c0.05,0.04,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.17C56.727-34.523,56.667-34.492,56.606-34.492z" fill="#231F20"/>
+                    <path d="M60.106-34.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C60.237-34.523,60.177-34.492,60.106-34.492z" fill="#231F20"/>
+                    <path d="M64.106-34.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C64.237-35.023,64.167-34.992,64.106-34.992z" fill="#231F20"/>
+                    <path d="M67.606-35.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C67.727-36.023,67.667-35.992,67.606-35.992z" fill="#231F20"/>
+                    <path d="M70.856-36.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C70.987-36.773,70.927-36.742,70.856-36.742z" fill="#231F20"/>
+                    <path d="M55.106-31.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C55.237-31.523,55.177-31.492,55.106-31.492z" fill="#231F20"/>
+                    <path d="M58.606-31.242c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C58.727-31.273,58.667-31.242,58.606-31.242z" fill="#231F20"/>
+                    <path d="M61.856-31.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C61.987-31.273,61.927-31.242,61.856-31.242z" fill="#231F20"/>
+                    <path d="M65.606-31.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C65.737-32.023,65.677-31.992,65.606-31.992z" fill="#231F20"/>
+                    <path d="M68.356-32.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C68.487-32.523,68.417-32.492,68.356-32.492z" fill="#231F20"/>
+                    <path d="M70.856-32.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C70.987-33.023,70.927-32.992,70.856-32.992z" fill="#231F20"/>
+                    <path d="M58.856-28.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C58.977-28.773,58.917-28.742,58.856-28.742z" fill="#231F20"/>
+                    <path d="M62.356-28.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C62.477-28.523,62.427-28.492,62.356-28.492z" fill="#231F20"/>
+                    <path d="M64.606-28.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C64.737-28.523,64.667-28.492,64.606-28.492z" fill="#231F20"/>
+                    <path d="M67.106-28.742c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.17C67.237-28.773,67.167-28.742,67.106-28.742z" fill="#231F20"/>
+                    <path d="M69.606-28.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C69.737-29.023,69.677-28.992,69.606-28.992z" fill="#231F20"/>
+                    <path d="M61.106-25.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C61.237-25.773,61.177-25.742,61.106-25.742z" fill="#231F20"/>
+                    <path d="M63.356-24.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C63.487-24.273,63.417-24.242,63.356-24.242z" fill="#231F20"/>
+                    <path d="M65.106-24.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C65.227-24.273,65.167-24.242,65.106-24.242z" fill="#231F20"/>
+                    <path d="M67.606-23.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C67.737-23.773,67.677-23.742,67.606-23.742z" fill="#231F20"/>
+                    <path d="M70.356-24.492c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351-0.011c0.06,0.07,0.079,0.131,0.079,0.191c0,0.059-0.02,0.119-0.069,0.17C70.477-24.523,70.417-24.492,70.356-24.492z" fill="#231F20"/>
+                    <path d="M67.106-21.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C67.237-21.523,67.167-21.492,67.106-21.492z" fill="#231F20"/>
+                    <path d="M56.606-27.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C56.727-28.023,56.667-27.992,56.606-27.992z" fill="#231F20"/>
+                    <path d="M54.856-29.742c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C54.987-29.773,54.917-29.742,54.856-29.742z" fill="#231F20"/>
+                    <path d="M49.856-34.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C49.987-35.023,49.927-34.992,49.856-34.992z" fill="#231F20"/>
+                    <path d="M23.106-34.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C23.237-34.773,23.167-34.742,23.106-34.742z" fill="#231F20"/>
+                    <path d="M2.106-29.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C2.237-29.523,2.167-29.492,2.106-29.492z" fill="#231F20"/>
+                    <path d="M4.856-30.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C4.987-30.523,4.927-30.492,4.856-30.492z" fill="#231F20"/>
+                    <path d="M7.856-31.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C7.977-32.023,7.917-31.992,7.856-31.992z" fill="#231F20"/>
+                    <path d="M10.606-34.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C10.727-34.273,10.667-34.242,10.606-34.242z" fill="#231F20"/>
+                    <path d="M12.856-36.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C12.977-36.273,12.917-36.242,12.856-36.242z" fill="#231F20"/>
+                    <path d="M2.106-33.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C2.237-33.523,2.167-33.492,2.106-33.492z" fill="#231F20"/>
+                    <path d="M4.856-34.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C4.987-34.273,4.917-34.242,4.856-34.242z" fill="#231F20"/>
+                    <path d="M6.856-35.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C6.987-35.523,6.917-35.492,6.856-35.492z" fill="#231F20"/>
+                    <path d="M8.606-36.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C8.737-37.023,8.677-36.992,8.606-36.992z" fill="#231F20"/>
+                    <path d="M2.106-36.992c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C2.227-37.023,2.167-36.992,2.106-36.992z" fill="#231F20"/>
+                    <path d="M4.106-37.992c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C4.237-38.023,4.177-37.992,4.106-37.992z" fill="#231F20"/>
+                    <path d="M63.606-25.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C63.737-25.773,63.677-25.742,63.606-25.742z" fill="#231F20"/>
+                    <path d="M67.106-26.242c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.17C67.237-26.273,67.167-26.242,67.106-26.242z" fill="#231F20"/>
+                    <path d="M70.356-26.742c-0.069,0-0.14-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.08,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C70.487-26.773,70.427-26.742,70.356-26.742z" fill="#231F20"/>
+                    <path d="M3.606-27.242c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C3.737-27.273,3.677-27.242,3.606-27.242z" fill="#231F20"/>
+                    <path d="M6.106-27.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C6.237-28.023,6.177-27.992,6.106-27.992z" fill="#231F20"/>
+                    <path d="M9.356-29.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C9.487-29.273,9.427-29.242,9.356-29.242z" fill="#231F20"/>
+                    <path d="M12.606-31.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C12.737-31.273,12.677-31.242,12.606-31.242z" fill="#231F20"/>
+                    <path d="M14.856-33.742c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C14.987-33.773,14.917-33.742,14.856-33.742z" fill="#231F20"/>
+                    <path d="M20.356-29.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C20.477-29.773,20.417-29.742,20.356-29.742z" fill="#231F20"/>
+                    <path d="M18.356-28.742c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C18.487-28.773,18.427-28.742,18.356-28.742z" fill="#231F20"/>
+                    <path d="M15.606-26.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.101,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C15.727-26.523,15.667-26.492,15.606-26.492z" fill="#231F20"/>
+                    <path d="M14.106-25.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C14.237-25.523,14.167-25.492,14.106-25.492z" fill="#231F20"/>
+                    <path d="M11.856-23.992c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C11.977-24.023,11.917-23.992,11.856-23.992z" fill="#231F20"/>
+                    <path d="M8.356-22.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C8.487-22.523,8.417-22.492,8.356-22.492z" fill="#231F20"/>
+                    <path d="M6.606-21.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C6.737-22.023,6.667-21.992,6.606-21.992z" fill="#231F20"/>
+                    <path d="M3.856-20.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C3.987-21.023,3.927-20.992,3.856-20.992z" fill="#231F20"/>
+                    <path d="M51.606-32.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C51.737-32.523,51.667-32.492,51.606-32.492z" fill="#231F20"/>
+                    <path d="M28.356-27.242c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C28.487-27.273,28.417-27.242,28.356-27.242z" fill="#231F20"/>
+                    <path d="M32.106-25.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.18C32.227-25.273,32.167-25.242,32.106-25.242z" fill="#231F20"/>
+                    <path d="M36.106-23.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C36.237-23.523,36.167-23.492,36.106-23.492z" fill="#231F20"/>
+                    <path d="M42.356-21.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C42.487-21.773,42.427-21.742,42.356-21.742z" fill="#231F20"/>
+                    <path d="M51.606-20.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C51.727-20.523,51.667-20.492,51.606-20.492z" fill="#231F20"/>
+                    <path d="M59.856-22.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C59.987-23.023,59.927-22.992,59.856-22.992z" fill="#231F20"/>
+                    <path d="M2.106-10.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C2.237-10.523,2.177-10.492,2.106-10.492z" fill="#231F20"/>
+                    <path d="M4.606-9.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C4.737-9.273,4.667-9.242,4.606-9.242z" fill="#231F20"/>
+                    <path d="M7.856-7.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C7.987-8.023,7.917-7.992,7.856-7.992z" fill="#231F20"/>
+                    <path d="M10.856-6.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C10.987-7.023,10.917-6.992,10.856-6.992z" fill="#231F20"/>
+                    <path d="M14.106-5.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C14.227-6.023,14.167-5.992,14.106-5.992z" fill="#231F20"/>
+                    <path d="M16.856-5.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C16.987-5.523,16.927-5.492,16.856-5.492z" fill="#231F20"/>
+                    <path d="M19.856-4.742c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C19.987-4.773,19.927-4.742,19.856-4.742z" fill="#231F20"/>
+                    <path d="M23.356-4.242c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C23.487-4.273,23.417-4.242,23.356-4.242z" fill="#231F20"/>
+                    <path d="M27.106-3.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C27.227-3.773,27.167-3.742,27.106-3.742z" fill="#231F20"/>
+                    <path d="M30.356-3.742c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C30.487-3.773,30.427-3.742,30.356-3.742z" fill="#231F20"/>
+                    <path d="M33.356-3.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C33.477-4.023,33.417-3.992,33.356-3.992z" fill="#231F20"/>
+                    <path d="M23.356-31.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C23.487-31.773,23.427-31.742,23.356-31.742z" fill="#231F20"/>
+                    <path d="M22.356-31.742c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C22.487-31.773,22.427-31.742,22.356-31.742z" fill="#231F20"/>
+                    <path d="M56.606-49.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C56.727-49.523,56.667-49.492,56.606-49.492z" fill="#231F20"/>
+                    <path d="M61.106-48.992c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C61.237-49.023,61.177-48.992,61.106-48.992z" fill="#231F20"/>
+                    <path d="M65.106-48.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C65.227-48.773,65.167-48.742,65.106-48.742z" fill="#231F20"/>
+                    <path d="M69.856-49.373c-0.069,0-0.14-0.029-0.18-0.08c-0.04-0.039-0.07-0.1-0.07-0.17c0-0.061,0.03-0.13,0.08-0.18c0.08-0.08,0.25-0.09,0.351,0c0.04,0.05,0.069,0.119,0.069,0.18c0,0.07-0.029,0.131-0.069,0.18C69.997-49.402,69.927-49.373,69.856-49.373z" fill="#231F20"/>
+                    <path d="M29.856-64.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C29.987-64.273,29.927-64.242,29.856-64.242z" fill="#231F20"/>
+                    <path d="M27.606-62.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C27.737-62.523,27.667-62.492,27.606-62.492z" fill="#231F20"/>
+                    <path d="M69.856-12.992c-0.069,0-0.14-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C69.997-13.023,69.927-12.992,69.856-12.992z" fill="#231F20"/>
+                    <path d="M66.856-15.242c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C66.987-15.273,66.927-15.242,66.856-15.242z" fill="#231F20"/>
+                    <path d="M65.106-17.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C65.227-17.523,65.167-17.492,65.106-17.492z" fill="#231F20"/>
+                    <path d="M63.106-20.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C63.237-20.773,63.167-20.742,63.106-20.742z" fill="#231F20"/>
+                    <path d="M28.356-3.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C28.487-3.523,28.417-3.492,28.356-3.492z" fill="#231F20"/>
+                    <path d="M35.606-3.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C35.737-4.023,35.667-3.992,35.606-3.992z" fill="#231F20"/>
+                    <path d="M37.856-4.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C37.987-4.523,37.917-4.492,37.856-4.492z" fill="#231F20"/>
+                    <path d="M40.356-4.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C40.487-4.773,40.417-4.742,40.356-4.742z" fill="#231F20"/>
+                    <path d="M7.606-12.742c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C7.737-12.773,7.677-12.742,7.606-12.742z" fill="#231F20"/>
+                    <path d="M11.356-11.492c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C11.487-11.523,11.427-11.492,11.356-11.492z" fill="#231F20"/>
+                    <path d="M15.106-9.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C15.237-10.023,15.177-9.992,15.106-9.992z" fill="#231F20"/>
+                    <path d="M19.856-8.742c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C19.987-8.773,19.917-8.742,19.856-8.742z" fill="#231F20"/>
+                    <path d="M23.606-7.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C23.727-8.023,23.667-7.992,23.606-7.992z" fill="#231F20"/>
+                    <path d="M27.356-6.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C27.487-7.023,27.417-6.992,27.356-6.992z" fill="#231F20"/>
+                    <path d="M31.356-6.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C31.487-6.773,31.427-6.742,31.356-6.742z" fill="#231F20"/>
+                    <path d="M34.856-6.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C34.987-7.023,34.917-6.992,34.856-6.992z" fill="#231F20"/>
+                    <path d="M39.106-7.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C39.237-7.523,39.177-7.492,39.106-7.492z" fill="#231F20"/>
+                    <path d="M3.856-14.242c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C3.987-14.273,3.927-14.242,3.856-14.242z" fill="#231F20"/>
+                    <path d="M39.856-10.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C39.987-10.773,39.917-10.742,39.856-10.742z" fill="#231F20"/>
+                    <path d="M36.856-10.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C36.987-10.273,36.917-10.242,36.856-10.242z" fill="#231F20"/>
+                    <path d="M32.606-9.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C32.727-9.773,32.667-9.742,32.606-9.742z" fill="#231F20"/>
+                    <path d="M27.856-9.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C27.987-10.023,27.917-9.992,27.856-9.992z" fill="#231F20"/>
+                    <path d="M23.606-10.742c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C23.737-10.773,23.667-10.742,23.606-10.742z" fill="#231F20"/>
+                    <path d="M19.106-12.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C19.237-12.523,19.177-12.492,19.106-12.492z" fill="#231F20"/>
+                    <path d="M15.356-13.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C15.487-14.023,15.417-13.992,15.356-13.992z" fill="#231F20"/>
+                    <path d="M11.606-15.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C11.727-15.773,11.667-15.742,11.606-15.742z" fill="#231F20"/>
+                    <path d="M8.356-17.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C8.487-17.523,8.417-17.492,8.356-17.492z" fill="#231F20"/>
+                    <path d="M5.106-19.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.101,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C5.227-19.523,5.167-19.492,5.106-19.492z" fill="#231F20"/>
+                    <path d="M42.106-14.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C42.237-14.523,42.177-14.492,42.106-14.492z" fill="#231F20"/>
+                    <path d="M38.856-13.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C38.987-14.023,38.917-13.992,38.856-13.992z" fill="#231F20"/>
+                    <path d="M35.356-13.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C35.487-13.273,35.427-13.242,35.356-13.242z" fill="#231F20"/>
+                    <path d="M32.106-13.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.18C32.227-13.273,32.167-13.242,32.106-13.242z" fill="#231F20"/>
+                    <path d="M28.856-13.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C28.987-13.523,28.927-13.492,28.856-13.492z" fill="#231F20"/>
+                    <path d="M25.356-14.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.08-0.09,0.26-0.101,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C25.477-14.273,25.417-14.242,25.356-14.242z" fill="#231F20"/>
+                    <path d="M21.356-15.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C21.477-15.773,21.417-15.742,21.356-15.742z" fill="#231F20"/>
+                    <path d="M17.856-17.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.171c0.101-0.11,0.26-0.1,0.36-0.01c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C17.977-17.273,17.917-17.242,17.856-17.242z" fill="#231F20"/>
+                    <path d="M14.606-18.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C14.737-18.773,14.677-18.742,14.606-18.742z" fill="#231F20"/>
+                    <path d="M10.856-21.492c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C10.987-21.523,10.917-21.492,10.856-21.492z" fill="#231F20"/>
+                    <path d="M42.356-17.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C42.477-17.523,42.417-17.492,42.356-17.492z" fill="#231F20"/>
+                    <path d="M39.356-16.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C39.487-16.523,39.427-16.492,39.356-16.492z" fill="#231F20"/>
+                    <path d="M35.356-15.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C35.487-16.023,35.427-15.992,35.356-15.992z" fill="#231F20"/>
+                    <path d="M31.356-15.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C31.477-16.023,31.417-15.992,31.356-15.992z" fill="#231F20"/>
+                    <path d="M27.856-16.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C27.987-16.773,27.927-16.742,27.856-16.742z" fill="#231F20"/>
+                    <path d="M24.106-17.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C24.237-18.023,24.177-17.992,24.106-17.992z" fill="#231F20"/>
+                    <path d="M20.606-19.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C20.727-19.773,20.667-19.742,20.606-19.742z" fill="#231F20"/>
+                    <path d="M17.106-21.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C17.237-22.023,17.177-21.992,17.106-21.992z" fill="#231F20"/>
+                    <path d="M14.356-23.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C14.477-24.023,14.417-23.992,14.356-23.992z" fill="#231F20"/>
+                    <path d="M41.606-20.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C41.737-20.773,41.667-20.742,41.606-20.742z" fill="#231F20"/>
+                    <path d="M38.856-19.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C38.977-19.773,38.917-19.742,38.856-19.742z" fill="#231F20"/>
+                    <path d="M35.606-19.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C35.727-19.273,35.667-19.242,35.606-19.242z" fill="#231F20"/>
+                    <path d="M31.856-19.492c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C31.987-19.523,31.927-19.492,31.856-19.492z" fill="#231F20"/>
+                    <path d="M28.606-20.242c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C28.737-20.273,28.677-20.242,28.606-20.242z" fill="#231F20"/>
+                    <path d="M24.356-21.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C24.487-21.773,24.427-21.742,24.356-21.742z" fill="#231F20"/>
+                    <path d="M20.106-23.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C20.227-23.773,20.167-23.742,20.106-23.742z" fill="#231F20"/>
+                    <path d="M17.356-25.992c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C17.487-26.023,17.417-25.992,17.356-25.992z" fill="#231F20"/>
+                    <path d="M36.856-21.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.17C36.987-22.023,36.917-21.992,36.856-21.992z" fill="#231F20"/>
+                    <path d="M33.856-21.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C33.987-21.773,33.917-21.742,33.856-21.742z" fill="#231F20"/>
+                    <path d="M29.106-22.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C29.237-22.523,29.177-22.492,29.106-22.492z" fill="#231F20"/>
+                    <path d="M25.356-24.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C25.487-24.523,25.417-24.492,25.356-24.492z" fill="#231F20"/>
+                    <path d="M21.606-26.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C21.727-26.773,21.667-26.742,21.606-26.742z" fill="#231F20"/>
+                    <path d="M22.856-29.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.09,0.351-0.011c0.06,0.061,0.079,0.121,0.079,0.191c0,0.059-0.02,0.129-0.069,0.17C22.977-29.773,22.917-29.742,22.856-29.742z" fill="#231F20"/>
+                    <path d="M25.606-27.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C25.727-27.773,25.667-27.742,25.606-27.742z" fill="#231F20"/>
+                    <path d="M29.106-26.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C29.237-26.273,29.177-26.242,29.106-26.242z" fill="#231F20"/>
+                    <path d="M31.106-25.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C31.237-26.023,31.167-25.992,31.106-25.992z" fill="#231F20"/>
+                    <path d="M41.106-1.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C41.237-1.773,41.167-1.742,41.106-1.742z" fill="#231F20"/>
+                    <path d="M43.356-0.742c-0.06,0-0.119-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.171c0.11-0.11,0.26-0.1,0.351-0.01c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C43.477-0.773,43.417-0.742,43.356-0.742z" fill="#231F20"/>
+                    <path d="M46.356-0.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C46.487-0.523,46.417-0.492,46.356-0.492z" fill="#231F20"/>
+                    <path d="M49.106-0.492c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C49.237-0.523,49.167-0.492,49.106-0.492z" fill="#231F20"/>
+                    <path d="M42.356-3.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C42.487-3.273,42.427-3.242,42.356-3.242z" fill="#231F20"/>
+                    <path d="M44.856-2.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C44.987-2.523,44.917-2.492,44.856-2.492z" fill="#231F20"/>
+                    <path d="M48.106-2.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C48.237-2.523,48.177-2.492,48.106-2.492z" fill="#231F20"/>
+                    <path d="M3.106-9.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C3.237-9.773,3.177-9.742,3.106-9.742z" fill="#231F20"/>
+                    <path d="M5.606-8.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C5.737-8.773,5.677-8.742,5.606-8.742z" fill="#231F20"/>
+                    <path d="M10.856-6.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C10.987-7.023,10.917-6.992,10.856-6.992z" fill="#231F20"/>
+                    <path d="M12.356-6.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.101,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C12.477-6.523,12.417-6.492,12.356-6.492z" fill="#231F20"/>
+                    <path d="M8.856-7.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C8.987-7.523,8.917-7.492,8.856-7.492z" fill="#231F20"/>
+                    <path d="M18.606-4.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C18.737-5.023,18.677-4.992,18.606-4.992z" fill="#231F20"/>
+                    <path d="M21.106-4.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C21.227-4.523,21.167-4.492,21.106-4.492z" fill="#231F20"/>
+                    <path d="M24.356-3.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C24.477-4.023,24.417-3.992,24.356-3.992z" fill="#231F20"/>
+                    <path d="M32.106-3.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.101,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C32.237-3.523,32.177-3.492,32.106-3.492z" fill="#231F20"/>
+                    <path d="M23.106-0.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C23.237-1.023,23.177-0.992,23.106-0.992z" fill="#231F20"/>
+                    <path d="M24.356-3.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C24.477-4.023,24.417-3.992,24.356-3.992z" fill="#231F20"/>
+                    <path d="M28.106-2.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C28.237-2.523,28.167-2.492,28.106-2.492z" fill="#231F20"/>
+                    <path d="M26.606-0.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C26.737-0.773,26.677-0.742,26.606-0.742z" fill="#231F20"/>
+                    <path d="M24.106-2.992c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C24.237-3.023,24.167-2.992,24.106-2.992z" fill="#231F20"/>
+                    <path d="M18.106-0.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C18.237-1.023,18.167-0.992,18.106-0.992z" fill="#231F20"/>
+                    <path d="M20.606-3.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.17C20.727-3.273,20.667-3.242,20.606-3.242z" fill="#231F20"/>
+                    <path d="M17.356-3.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C17.477-4.023,17.417-3.992,17.356-3.992z" fill="#231F20"/>
+                    <path d="M15.606-1.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.09,0.351-0.011c0.06,0.061,0.079,0.121,0.079,0.191c0,0.069-0.029,0.129-0.069,0.17C15.727-2.023,15.667-1.992,15.606-1.992z" fill="#231F20"/>
+                    <path d="M14.356-0.742c-0.06,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.11-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C14.487-0.773,14.417-0.742,14.356-0.742z" fill="#231F20"/>
+                    <path d="M9.106-0.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.17C9.227-1.023,9.167-0.992,9.106-0.992z" fill="#231F20"/>
+                    <path d="M10.856-2.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.101,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C10.987-2.523,10.927-2.492,10.856-2.492z" fill="#231F20"/>
+                    <path d="M12.356-4.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.101,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C12.487-4.773,12.427-4.742,12.356-4.742z" fill="#231F20"/>
+                    <path d="M10.606-5.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C10.737-5.523,10.677-5.492,10.606-5.492z" fill="#231F20"/>
+                    <path d="M9.106-4.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.08,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C9.227-4.523,9.167-4.492,9.106-4.492z" fill="#231F20"/>
+                    <path d="M7.106-2.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C7.237-2.773,7.167-2.742,7.106-2.742z" fill="#231F20"/>
+                    <path d="M5.106-1.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C5.227-1.523,5.167-1.492,5.106-1.492z" fill="#231F20"/>
+                    <path d="M2.606-0.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.25-0.09,0.351-0.011c0.06,0.061,0.079,0.131,0.079,0.191c0,0.059-0.02,0.129-0.069,0.17C2.727-0.523,2.667-0.492,2.606-0.492z" fill="#231F20"/>
+                    <path d="M7.606-6.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C7.727-6.523,7.667-6.492,7.606-6.492z" fill="#231F20"/>
+                    <path d="M5.356-4.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C5.477-5.023,5.417-4.992,5.356-4.992z" fill="#231F20"/>
+                    <path d="M3.606-3.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.101,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C3.737-3.523,3.677-3.492,3.606-3.492z" fill="#231F20"/>
+                    <path d="M1.356-1.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C1.487-2.023,1.427-1.992,1.356-1.992z" fill="#231F20"/>
+                    <path d="M5.106-7.742c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.061-0.07-0.121-0.07-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C5.237-7.773,5.177-7.742,5.106-7.742z" fill="#231F20"/>
+                    <path d="M3.106-5.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C3.227-6.023,3.167-5.992,3.106-5.992z" fill="#231F20"/>
+                    <path d="M1.106-4.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C1.227-5.023,1.167-4.992,1.106-4.992z" fill="#231F20"/>
+                    <path d="M2.856-8.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.079,0.18C2.987-8.523,2.927-8.492,2.856-8.492z" fill="#231F20"/>
+                    <path d="M1.106-7.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C1.237-7.523,1.177-7.492,1.106-7.492z" fill="#231F20"/>
+                    <path d="M1.606-9.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C1.737-9.523,1.677-9.492,1.606-9.492z" fill="#231F20"/>
+                    <path d="M30.606-0.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C30.737-0.523,30.667-0.492,30.606-0.492z" fill="#231F20"/>
+                    <path d="M31.606-2.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C31.737-2.273,31.667-2.242,31.606-2.242z" fill="#231F20"/>
+                    <path d="M35.606-2.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C35.737-2.773,35.667-2.742,35.606-2.742z" fill="#231F20"/>
+                    <path d="M34.106-0.742c-0.06,0-0.119-0.021-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.18C34.227-0.773,34.167-0.742,34.106-0.742z" fill="#231F20"/>
+                    <path d="M34.356-3.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.25-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C34.477-3.523,34.417-3.492,34.356-3.492z" fill="#231F20"/>
+                    <path d="M1.356-11.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C1.477-11.773,1.417-11.742,1.356-11.742z" fill="#231F20"/>
+                    <path d="M40.856-3.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C40.987-4.023,40.917-3.992,40.856-3.992z" fill="#231F20"/>
+                    <path d="M39.106-2.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C39.237-2.273,39.177-2.242,39.106-2.242z" fill="#231F20"/>
+                    <path d="M43.606-10.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C43.737-11.023,43.667-10.992,43.606-10.992z" fill="#231F20"/>
+                    <path d="M44.856-16.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C44.987-16.273,44.927-16.242,44.856-16.242z" fill="#231F20"/>
+                    <path d="M46.106-20.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C46.237-20.273,46.177-20.242,46.106-20.242z" fill="#231F20"/>
+                    <path d="M45.356-17.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C45.477-17.523,45.417-17.492,45.356-17.492z" fill="#231F20"/>
+                    <path d="M47.106-16.992c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C47.237-17.023,47.177-16.992,47.106-16.992z" fill="#231F20"/>
+                    <path d="M49.606-16.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C49.737-16.273,49.677-16.242,49.606-16.242z" fill="#231F20"/>
+                    <path d="M52.106-15.742c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.101-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C52.227-15.773,52.167-15.742,52.106-15.742z" fill="#231F20"/>
+                    <path d="M55.106-15.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C55.237-15.773,55.177-15.742,55.106-15.742z" fill="#231F20"/>
+                    <path d="M57.356-16.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351-0.011c0.06,0.061,0.079,0.131,0.079,0.191c0,0.059-0.02,0.129-0.069,0.17C57.477-16.263,57.417-16.242,57.356-16.242z" fill="#231F20"/>
+                    <path d="M59.606-17.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C59.737-17.273,59.677-17.242,59.606-17.242z" fill="#231F20"/>
+                    <path d="M61.606-18.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C61.737-19.023,61.677-18.992,61.606-18.992z" fill="#231F20"/>
+                    <path d="M63.106-17.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C63.237-17.523,63.177-17.492,63.106-17.492z" fill="#231F20"/>
+                    <path d="M61.106-15.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C61.237-15.523,61.177-15.492,61.106-15.492z" fill="#231F20"/>
+                    <path d="M58.356-13.742c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.18C58.477-13.773,58.417-13.742,58.356-13.742z" fill="#231F20"/>
+                    <path d="M56.106-12.992c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C56.237-13.023,56.167-12.992,56.106-12.992z" fill="#231F20"/>
+                    <path d="M52.106-12.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C52.237-13.023,52.167-12.992,52.106-12.992z" fill="#231F20"/>
+                    <path d="M49.356-13.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.09,0.26-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C49.487-13.523,49.417-13.492,49.356-13.492z" fill="#231F20"/>
+                    <path d="M47.106-13.992c-0.06,0-0.119-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C47.237-14.023,47.177-13.992,47.106-13.992z" fill="#231F20"/>
+                    <path d="M46.106-11.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C46.237-11.523,46.167-11.492,46.106-11.492z" fill="#231F20"/>
+                    <path d="M48.606-10.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C48.727-10.523,48.667-10.492,48.606-10.492z" fill="#231F20"/>
+                    <path d="M51.356-9.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.101,0.271-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C51.487-10.023,51.427-9.992,51.356-9.992z" fill="#231F20"/>
+                    <path d="M54.356-9.992c-0.06,0-0.119-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C54.487-10.023,54.427-9.992,54.356-9.992z" fill="#231F20"/>
+                    <path d="M57.106-10.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C57.237-10.773,57.167-10.742,57.106-10.742z" fill="#231F20"/>
+                    <path d="M60.106-11.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C60.237-11.523,60.177-11.492,60.106-11.492z" fill="#231F20"/>
+                    <path d="M62.606-12.742c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C62.737-12.773,62.677-12.742,62.606-12.742z" fill="#231F20"/>
+                    <path d="M64.856-13.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C64.987-13.773,64.917-13.742,64.856-13.742z" fill="#231F20"/>
+                    <path d="M67.356-11.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C67.487-11.523,67.417-11.492,67.356-11.492z" fill="#231F20"/>
+                    <path d="M65.606-9.742c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C65.737-9.773,65.677-9.742,65.606-9.742z" fill="#231F20"/>
+                    <path d="M62.356-7.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C62.477-8.013,62.417-7.992,62.356-7.992z" fill="#231F20"/>
+                    <path d="M59.356-6.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.08,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C59.487-7.023,59.427-6.992,59.356-6.992z" fill="#231F20"/>
+                    <path d="M56.106-5.992c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.24-0.09,0.341,0c0.05,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.18C56.237-6.023,56.167-5.992,56.106-5.992z" fill="#231F20"/>
+                    <path d="M52.356-5.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C52.487-5.773,52.417-5.742,52.356-5.742z" fill="#231F20"/>
+                    <path d="M48.356-5.992c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C48.487-6.023,48.427-5.992,48.356-5.992z" fill="#231F20"/>
+                    <path d="M44.606-6.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C44.737-6.523,44.677-6.492,44.606-6.492z" fill="#231F20"/>
+                    <path d="M52.606-1.492c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.17C52.727-1.523,52.667-1.492,52.606-1.492z" fill="#231F20"/>
+                    <path d="M56.856-2.742c-0.06,0-0.13-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C56.987-2.773,56.927-2.742,56.856-2.742z" fill="#231F20"/>
+                    <path d="M60.106-3.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C60.237-3.773,60.177-3.742,60.106-3.742z" fill="#231F20"/>
+                    <path d="M48.106-19.242c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C48.237-19.273,48.167-19.242,48.106-19.242z" fill="#231F20"/>
+                    <path d="M50.856-18.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.07-0.181c0.11-0.09,0.26-0.09,0.351,0c0.05,0.04,0.079,0.11,0.079,0.181c0,0.069-0.029,0.129-0.069,0.18C50.987-18.523,50.927-18.492,50.856-18.492z" fill="#231F20"/>
+                    <path d="M53.356-18.242c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C53.487-18.273,53.427-18.242,53.356-18.242z" fill="#231F20"/>
+                    <path d="M56.356-19.492c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.24-0.101,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C56.477-19.523,56.417-19.492,56.356-19.492z" fill="#231F20"/>
+                    <path d="M58.606-20.492c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.101,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.18C58.737-20.523,58.667-20.492,58.606-20.492z" fill="#231F20"/>
+                    <path d="M59.856-21.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C59.987-21.523,59.927-21.492,59.856-21.492z" fill="#231F20"/>
+                    <path d="M53.606-20.992c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C53.737-21.023,53.667-20.992,53.606-20.992z" fill="#231F20"/>
+                    <path d="M50.356-20.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C50.487-20.773,50.427-20.742,50.356-20.742z" fill="#231F20"/>
+                    <path d="M63.856-4.992c-0.06,0-0.119-0.031-0.17-0.07c-0.06-0.061-0.08-0.121-0.08-0.18c0-0.07,0.021-0.131,0.07-0.181c0.12-0.101,0.26-0.09,0.351,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.119-0.069,0.17C63.987-5.023,63.927-4.992,63.856-4.992z" fill="#231F20"/>
+                    <path d="M66.856-6.742c-0.06,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.141,0.08-0.181c0.091-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C66.987-6.773,66.917-6.742,66.856-6.742z" fill="#231F20"/>
+                    <path d="M65.356-3.242c-0.069,0-0.13-0.031-0.18-0.07c-0.04-0.051-0.07-0.11-0.07-0.18c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C65.487-3.273,65.427-3.242,65.356-3.242z" fill="#231F20"/>
+                    <path d="M69.106-5.242c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.11-0.08-0.18c0-0.07,0.03-0.131,0.08-0.181c0.091-0.09,0.25-0.09,0.341,0c0.06,0.05,0.079,0.11,0.079,0.181c0,0.059-0.02,0.129-0.069,0.17C69.237-5.273,69.177-5.242,69.106-5.242z" fill="#231F20"/>
+                    <path d="M69.106-9.242c-0.06,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C69.237-9.273,69.167-9.242,69.106-9.242z" fill="#231F20"/>
+                    <path d="M46.106-21.242c-0.06,0-0.119-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.11-0.101,0.26-0.09,0.36,0c0.04,0.04,0.069,0.11,0.069,0.181c0,0.069-0.029,0.129-0.069,0.18C46.227-21.273,46.167-21.242,46.106-21.242z" fill="#231F20"/>
+                    <path d="M72.106-15.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.271-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C72.237-16.023,72.177-15.992,72.106-15.992z" fill="#231F20"/>
+                    <path d="M69.106-16.992c-0.069,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.101-0.08-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C69.237-17.023,69.177-16.992,69.106-16.992z" fill="#231F20"/>
+                    <path d="M66.106-19.242c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.25-0.09,0.351-0.011c0.06,0.07,0.079,0.131,0.079,0.191c0,0.059-0.02,0.119-0.069,0.17C66.227-19.273,66.167-19.242,66.106-19.242z" fill="#231F20"/>
+                    <path d="M62.106-1.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C62.237-1.523,62.177-1.492,62.106-1.492z" fill="#231F20"/>
+                    <path d="M58.856-0.492c-0.069,0-0.13-0.031-0.17-0.07c-0.05-0.051-0.08-0.121-0.08-0.18c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C58.987-0.523,58.927-0.492,58.856-0.492z" fill="#231F20"/>
+                    <path d="M65.606-0.492c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C65.737-0.523,65.677-0.492,65.606-0.492z" fill="#231F20"/>
+                    <path d="M69.106-2.242c-0.069,0-0.13-0.031-0.17-0.08c-0.05-0.041-0.08-0.111-0.08-0.17c0-0.07,0.03-0.141,0.08-0.181c0.07-0.08,0.25-0.09,0.351,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C69.237-2.273,69.177-2.242,69.106-2.242z" fill="#231F20"/>
+                    <path d="M70.856-0.742c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.051-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.26-0.09,0.36,0c0.05,0.05,0.069,0.12,0.069,0.181c0,0.059-0.02,0.119-0.069,0.17C70.987-0.773,70.927-0.742,70.856-0.742z" fill="#231F20"/>
+                    <path d="M66.237-48.873c-0.07,0-0.131-0.02-0.181-0.07c-0.05-0.049-0.069-0.109-0.069-0.18c0-0.061,0.02-0.13,0.069-0.17c0.101-0.1,0.261-0.09,0.351-0.01c0.05,0.05,0.08,0.119,0.08,0.18c0,0.07-0.03,0.131-0.08,0.18C66.356-48.893,66.297-48.873,66.237-48.873z" fill="#231F20"/>
+                    <path d="M71.237-49.873c-0.07,0-0.131-0.02-0.181-0.07c-0.05-0.039-0.069-0.109-0.069-0.18s0.029-0.13,0.069-0.18c0.09-0.09,0.25-0.09,0.351,0c0.05,0.05,0.08,0.119,0.08,0.18c0,0.07-0.03,0.131-0.08,0.18C71.356-49.893,71.297-49.873,71.237-49.873z" fill="#231F20"/>
+                    <path d="M64.987-47.123c-0.07,0-0.131-0.02-0.181-0.07c-0.05-0.049-0.069-0.109-0.069-0.18c0-0.061,0.02-0.13,0.069-0.17c0.09-0.1,0.25-0.1,0.351-0.01c0.05,0.061,0.08,0.119,0.08,0.18s-0.03,0.131-0.07,0.18C65.106-47.143,65.047-47.123,64.987-47.123z" fill="#231F20"/>
+                </g>
+                <g>
+                    <path d="M0.301-51.242c-0.061,0-0.13-0.031-0.17-0.08c-0.051-0.041-0.08-0.111-0.08-0.17c0-0.07,0.029-0.131,0.08-0.181c0.09-0.09,0.25-0.09,0.35,0c0.05,0.05,0.07,0.12,0.07,0.181c0,0.059-0.021,0.119-0.061,0.17C0.431-51.273,0.37-51.242,0.301-51.242z" fill="#231F20"/>
+                    <path d="M0.25-51.242c-0.069,0-0.14-0.031-0.18-0.08C0.03-51.363,0-51.423,0-51.492c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.36,0c0.05,0.06,0.069,0.12,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C0.391-51.273,0.32-51.242,0.25-51.242z" fill="#231F20"/>
+                    <path d="M0.36-51.242c-0.07,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.07-0.181c0.09-0.09,0.25-0.101,0.35,0c0.05,0.05,0.08,0.11,0.08,0.181c0,0.059-0.03,0.129-0.07,0.17C0.48-51.273,0.421-51.242,0.36-51.242z" fill="#231F20"/>
+                    <path d="M0.5-15.992c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.09-0.09,0.271-0.09,0.36,0c0.04,0.05,0.069,0.11,0.069,0.181c0,0.059-0.029,0.129-0.069,0.17C0.631-16.023,0.57-15.992,0.5-15.992z" fill="#231F20"/>
+                </g>
+            </g>
+        </pattern>
+        <!-- Cisterine -->
+        <pattern height="72" id="fill-green_roof" overflow="visible" patternUnits="userSpaceOnUse" viewBox="0.379 -72.688 72 72" width="72">
+            <g>
+                <polygon fill="#4ebaea" points="0.379,-72.688 72.379,-72.688 72.379,-0.688 0.379,-0.688"/>
+                <g>
+                    <path d="M56.81,0c-0.1,0-0.199-0.04-0.26-0.11c-0.07-0.069-0.109-0.17-0.109-0.271c0-0.1,0.039-0.189,0.109-0.26c0.13-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.26c0,0.101-0.04,0.201-0.11,0.271C57.01-0.04,56.92,0,56.81,0z" fill="#231F20"/>
+                    <path d="M4.13-0.561c-0.1,0-0.2-0.039-0.27-0.119C3.79-0.74,3.75-0.84,3.75-0.939c0-0.101,0.04-0.191,0.11-0.261c0.13-0.14,0.39-0.14,0.529,0C4.46-1.131,4.5-1.04,4.5-0.939c0,0.1-0.04,0.199-0.11,0.27C4.32-0.6,4.229-0.561,4.13-0.561z" fill="#231F20"/>
+                    <path d="M18.94-0.561c-0.101,0-0.2-0.039-0.271-0.119c-0.07-0.07-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.12-0.261c0.12-0.14,0.38-0.149,0.53,0c0.06,0.069,0.1,0.16,0.1,0.261c0,0.1-0.029,0.189-0.1,0.27C19.13-0.6,19.04-0.561,18.94-0.561z" fill="#231F20"/>
+                    <path d="M40.69-0.381c-0.101,0-0.2-0.029-0.271-0.109c-0.07-0.061-0.1-0.16-0.1-0.26s0.029-0.189,0.1-0.26c0.15-0.15,0.39-0.15,0.54-0.01c0.07,0.069,0.1,0.17,0.1,0.27s-0.04,0.199-0.109,0.27C40.89-0.41,40.79-0.381,40.69-0.381z" fill="#231F20"/>
+                </g>
+                <g>
+                    <path d="M13.31-2.811c-0.1,0-0.199-0.039-0.26-0.119c-0.07-0.061-0.109-0.16-0.109-0.26c0-0.101,0.039-0.201,0.109-0.271c0.13-0.13,0.391-0.13,0.53,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S13.42-2.811,13.31-2.811z" fill="#231F20"/>
+                    <path d="M1.5-3C1.4-3,1.3-3.04,1.229-3.11c-0.06-0.069-0.1-0.17-0.1-0.26c0-0.101,0.04-0.2,0.11-0.271c0.13-0.129,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C1.7-3.04,1.6-3,1.5-3z" fill="#231F20"/>
+                    <path d="M10.88-4.311c-0.1,0-0.2-0.039-0.27-0.119C10.55-4.49,10.5-4.59,10.5-4.689c0-0.101,0.04-0.191,0.11-0.261c0.13-0.14,0.39-0.14,0.529,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C11.07-4.35,10.979-4.311,10.88-4.311z" fill="#231F20"/>
+                    <path d="M20.06-5.439c-0.09,0-0.189-0.041-0.26-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.109,0.039-0.199,0.109-0.27c0.141-0.141,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C20.26-5.48,20.16-5.439,20.06-5.439z" fill="#231F20"/>
+                    <path d="M4.13-0.561c-0.1,0-0.2-0.039-0.27-0.119C3.8-0.74,3.75-0.84,3.75-0.939c0-0.101,0.04-0.191,0.11-0.261c0.13-0.13,0.39-0.14,0.529,0C4.47-1.131,4.5-1.04,4.5-0.939c0,0.1-0.04,0.199-0.11,0.27C4.32-0.6,4.229-0.561,4.13-0.561z" fill="#231F20"/>
+                    <path d="M7.5-6.939c-0.1,0-0.2-0.041-0.271-0.111c-0.06-0.069-0.1-0.159-0.1-0.26c0-0.109,0.04-0.199,0.11-0.27c0.12-0.13,0.39-0.141,0.529,0c0.07,0.07,0.11,0.16,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C7.7-6.98,7.6-6.939,7.5-6.939z" fill="#231F20"/>
+                    <path d="M24.94-2.061c-0.101,0-0.2-0.039-0.271-0.119c-0.07-0.061-0.1-0.16-0.1-0.26c0-0.101,0.029-0.191,0.109-0.261c0.12-0.14,0.38-0.14,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.189-0.11,0.27C25.13-2.1,25.04-2.061,24.94-2.061z" fill="#231F20"/>
+                    <path d="M27.38-0.75c-0.11,0-0.2-0.04-0.27-0.12C27.04-0.93,27-1.02,27-1.12c0-0.11,0.04-0.2,0.12-0.271c0.109-0.129,0.38-0.14,0.52,0c0.08,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C27.57-0.79,27.479-0.75,27.38-0.75z" fill="#231F20"/>
+                    <path d="M29.44-5.061c-0.101,0-0.2-0.05-0.271-0.119c-0.06-0.061-0.1-0.16-0.1-0.26c0-0.101,0.04-0.191,0.109-0.261c0.12-0.14,0.38-0.149,0.53,0c0.06,0.069,0.1,0.16,0.1,0.261c0,0.1-0.029,0.199-0.1,0.27S29.54-5.061,29.44-5.061z" fill="#231F20"/>
+                    <path d="M41.25-6c-0.1,0-0.19-0.04-0.26-0.11c-0.07-0.069-0.11-0.159-0.11-0.271c0-0.1,0.04-0.189,0.11-0.26c0.14-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.26c0,0.101-0.04,0.201-0.11,0.271C41.45-6.04,41.35-6,41.25-6z" fill="#231F20"/>
+                    <path d="M49.69-4.689c-0.101,0-0.2-0.041-0.271-0.111c-0.06-0.069-0.11-0.159-0.11-0.26c0-0.1,0.051-0.199,0.12-0.27c0.13-0.13,0.38-0.141,0.521,0c0.08,0.07,0.12,0.17,0.12,0.27c0,0.09-0.04,0.19-0.11,0.26C49.89-4.73,49.79-4.689,49.69-4.689z" fill="#231F20"/>
+                    <path d="M35.44-6.561c-0.101,0-0.2-0.039-0.271-0.109c-0.06-0.07-0.1-0.16-0.1-0.27c0-0.101,0.04-0.201,0.109-0.271c0.13-0.13,0.38-0.13,0.53,0.01c0.06,0.06,0.11,0.16,0.11,0.261c0,0.1-0.051,0.199-0.12,0.27C35.64-6.6,35.54-6.561,35.44-6.561z" fill="#231F20"/>
+                    <path d="M24.94-6.561c-0.101,0-0.2-0.039-0.271-0.119c-0.07-0.061-0.1-0.16-0.1-0.26c0-0.101,0.04-0.201,0.109-0.271c0.12-0.12,0.38-0.14,0.53,0.01c0.06,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S25.04-6.561,24.94-6.561z" fill="#231F20"/>
+                    <path d="M15.56-6.561c-0.1,0-0.189-0.039-0.26-0.119c-0.07-0.061-0.109-0.16-0.109-0.26c0-0.101,0.039-0.191,0.109-0.261c0.13-0.14,0.391-0.149,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S15.66-6.561,15.56-6.561z" fill="#231F20"/>
+                    <path d="M44.25-9.189c-0.09,0-0.19-0.041-0.26-0.111c-0.07-0.06-0.11-0.159-0.11-0.26c0-0.109,0.04-0.199,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.2-0.12,0.26C44.45-9.23,44.35-9.189,44.25-9.189z" fill="#231F20"/>
+                    <path d="M47.06-0.939c-0.1,0-0.189-0.041-0.26-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.1,0.039-0.199,0.109-0.27c0.141-0.141,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C47.26-0.98,47.17-0.939,47.06-0.939z" fill="#231F20"/>
+                    <path d="M18.94-0.561c-0.101,0-0.2-0.039-0.271-0.119c-0.06-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.12-0.261c0.12-0.14,0.38-0.149,0.53,0c0.06,0.069,0.1,0.16,0.1,0.261c0,0.1-0.04,0.199-0.109,0.27C19.13-0.6,19.04-0.561,18.94-0.561z" fill="#231F20"/>
+                    <path d="M32.81-1.87c-0.09,0-0.189-0.04-0.26-0.11S32.44-2.15,32.44-2.25s0.039-0.189,0.109-0.26c0.141-0.15,0.391-0.141,0.53-0.01c0.07,0.08,0.11,0.17,0.11,0.27s-0.04,0.199-0.11,0.27S32.91-1.87,32.81-1.87z" fill="#231F20"/>
+                    <path d="M40.69-0.37c-0.101,0-0.2-0.05-0.271-0.12c-0.06-0.061-0.1-0.16-0.1-0.26s0.04-0.2,0.109-0.27c0.13-0.131,0.38-0.141,0.53,0.01c0.06,0.06,0.1,0.16,0.1,0.26s-0.04,0.199-0.109,0.27C40.89-0.42,40.79-0.37,40.69-0.37z" fill="#231F20"/>
+                    <path d="M51-24.189c-0.1,0-0.19-0.041-0.26-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.2-0.11,0.26C51.2-24.23,51.1-24.189,51-24.189z" fill="#231F20"/>
+                    <path d="M58.69-24.561c-0.101,0-0.2-0.039-0.271-0.119c-0.06-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.12-0.261c0.12-0.13,0.38-0.149,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.051,0.199-0.12,0.27C58.88-24.6,58.79-24.561,58.69-24.561z" fill="#231F20"/>
+                    <path d="M63.19-24c-0.101,0-0.2-0.04-0.271-0.11c-0.07-0.069-0.11-0.17-0.11-0.26c0-0.101,0.04-0.2,0.11-0.271c0.14-0.14,0.39-0.14,0.54,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C63.39-24.04,63.29-24,63.19-24z" fill="#231F20"/>
+                    <path d="M67.31-1.689c-0.1,0-0.199-0.041-0.26-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.1,0.039-0.199,0.109-0.27c0.13-0.13,0.391-0.141,0.53,0c0.07,0.07,0.11,0.16,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C67.51-1.73,67.42-1.689,67.31-1.689z" fill="#231F20"/>
+                    <path d="M52.69-11.439c-0.101,0-0.2-0.041-0.271-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.11-0.27c0.15-0.141,0.39-0.141,0.54,0c0.07,0.07,0.1,0.17,0.1,0.27c0,0.101-0.029,0.19-0.1,0.26C52.89-11.48,52.79-11.439,52.69-11.439z" fill="#231F20"/>
+                    <path d="M70.88-17.439c-0.1,0-0.2-0.041-0.27-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.109,0.04-0.199,0.12-0.27c0.12-0.13,0.39-0.141,0.53,0.01c0.06,0.061,0.1,0.16,0.1,0.26c0,0.101-0.04,0.19-0.11,0.26C71.07-17.48,70.979-17.439,70.88-17.439z" fill="#231F20"/>
+                    <path d="M71.44-4.311c-0.101,0-0.2-0.05-0.271-0.119c-0.06-0.061-0.1-0.16-0.1-0.26c0-0.101,0.04-0.201,0.109-0.271c0.12-0.12,0.38-0.14,0.53,0.01c0.06,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S71.54-4.311,71.44-4.311z" fill="#231F20"/>
+                    <path d="M64.32-19.5c-0.11,0-0.2-0.04-0.271-0.11c-0.07-0.06-0.109-0.159-0.109-0.26s0.039-0.2,0.109-0.271c0.13-0.14,0.4-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.101-0.04,0.2-0.12,0.271C64.51-19.54,64.42-19.5,64.32-19.5z" fill="#231F20"/>
+                    <path d="M62.25-0.75c-0.1,0-0.2-0.04-0.271-0.11c-0.06-0.069-0.1-0.159-0.1-0.26s0.04-0.2,0.11-0.271c0.12-0.129,0.38-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271s-0.04,0.19-0.12,0.26C62.45-0.79,62.35-0.75,62.25-0.75z" fill="#231F20"/>
+                    <path d="M54-19.87c-0.1,0-0.19-0.05-0.26-0.12c-0.07-0.061-0.11-0.16-0.11-0.26s0.04-0.2,0.11-0.27c0.14-0.141,0.39-0.131,0.529,0c0.07,0.069,0.11,0.17,0.11,0.27s-0.04,0.189-0.11,0.27C54.2-19.92,54.1-19.87,54-19.87z" fill="#231F20"/>
+                    <path d="M52.13-5.62c-0.1,0-0.2-0.05-0.27-0.12C51.79-5.801,51.75-5.9,51.75-6s0.04-0.189,0.11-0.27C52-6.4,52.25-6.41,52.39-6.26C52.46-6.189,52.5-6.1,52.5-6s-0.04,0.199-0.11,0.27C52.32-5.67,52.229-5.62,52.13-5.62z" fill="#231F20"/>
+                    <path d="M57.75-17.25c-0.1,0-0.2-0.04-0.26-0.11c-0.07-0.069-0.11-0.159-0.11-0.26s0.04-0.2,0.11-0.271c0.13-0.129,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C57.95-17.29,57.85-17.25,57.75-17.25z" fill="#231F20"/>
+                    <path d="M61.32-16.5c-0.11,0-0.2-0.04-0.271-0.11c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.11,0.039-0.21,0.109-0.271c0.12-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C61.51-16.54,61.42-16.5,61.32-16.5z" fill="#231F20"/>
+                    <path d="M56.81-3c-0.09,0-0.189-0.04-0.26-0.11c-0.07-0.069-0.109-0.17-0.109-0.26c0-0.101,0.039-0.2,0.109-0.271c0.13-0.14,0.391-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C57-3.04,56.91-3,56.81-3z" fill="#231F20"/>
+                    <path d="M61.69-9.189c-0.101,0-0.2-0.041-0.271-0.111c-0.07-0.069-0.11-0.17-0.11-0.26c0-0.1,0.04-0.199,0.12-0.27c0.13-0.13,0.38-0.141,0.521,0c0.08,0.07,0.12,0.17,0.12,0.27c0,0.09-0.04,0.19-0.11,0.26C61.89-9.23,61.79-9.189,61.69-9.189z" fill="#231F20"/>
+                    <path d="M58.32-10.87c-0.11,0-0.2-0.05-0.271-0.12s-0.109-0.16-0.109-0.26s0.039-0.189,0.109-0.27c0.13-0.131,0.38-0.141,0.521,0c0.08,0.08,0.12,0.17,0.12,0.27s-0.04,0.189-0.11,0.26C58.51-10.91,58.41-10.87,58.32-10.87z" fill="#231F20"/>
+                    <path d="M67.5-7.5c-0.1,0-0.2-0.04-0.271-0.11c-0.06-0.06-0.1-0.159-0.1-0.26c0-0.11,0.04-0.2,0.11-0.271c0.13-0.129,0.38-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271s-0.04,0.19-0.12,0.26C67.7-7.54,67.6-7.5,67.5-7.5z" fill="#231F20"/>
+                    <path d="M69.57-12.37c-0.11,0-0.2-0.05-0.271-0.12c-0.07-0.061-0.109-0.16-0.109-0.26s0.039-0.2,0.109-0.27c0.12-0.131,0.4-0.141,0.53,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.12,0.27C69.76-12.42,69.67-12.37,69.57-12.37z" fill="#231F20"/>
+                    <path d="M65.44-13.5c-0.101,0-0.2-0.04-0.271-0.11c-0.07-0.069-0.11-0.17-0.11-0.271c0-0.1,0.051-0.189,0.12-0.26c0.12-0.129,0.38-0.14,0.53,0c0.06,0.07,0.11,0.16,0.11,0.26c0,0.101-0.04,0.201-0.11,0.271C65.64-13.54,65.54-13.5,65.44-13.5z" fill="#231F20"/>
+                    <path d="M2.07-15.75c-0.11,0-0.21-0.04-0.271-0.11c-0.07-0.069-0.109-0.17-0.109-0.26c0-0.101,0.039-0.2,0.109-0.271c0.13-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C2.26-15.79,2.16-15.75,2.07-15.75z" fill="#231F20"/>
+                    <path d="M29.63-9.939c-0.1,0-0.2-0.041-0.27-0.111c-0.061-0.06-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.12-0.27c0.12-0.13,0.38-0.141,0.52,0c0.07,0.061,0.11,0.16,0.11,0.27c0,0.101-0.04,0.2-0.11,0.271C29.82-9.98,29.729-9.939,29.63-9.939z" fill="#231F20"/>
+                    <path d="M15.94-21c-0.101,0-0.2-0.04-0.271-0.11c-0.07-0.069-0.11-0.159-0.11-0.26s0.04-0.2,0.12-0.271c0.13-0.14,0.37-0.14,0.521-0.01c0.08,0.08,0.12,0.18,0.12,0.28c0,0.09-0.04,0.19-0.11,0.26C16.14-21.04,16.04-21,15.94-21z" fill="#231F20"/>
+                    <path d="M5.25-11.439c-0.1,0-0.19-0.041-0.26-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.11-0.27c0.14-0.13,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C5.45-11.48,5.35-11.439,5.25-11.439z" fill="#231F20"/>
+                    <path d="M19.13-18.189c-0.1,0-0.2-0.041-0.27-0.111c-0.07-0.069-0.101-0.159-0.101-0.26c0-0.1,0.04-0.199,0.101-0.27c0.13-0.13,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.09-0.04,0.19-0.11,0.26C19.32-18.23,19.229-18.189,19.13-18.189z" fill="#231F20"/>
+                    <path d="M10.13-21.561c-0.1,0-0.2-0.039-0.27-0.119c-0.07-0.061-0.11-0.16-0.11-0.26c0-0.101,0.05-0.201,0.12-0.271c0.12-0.12,0.38-0.14,0.52,0.01c0.07,0.06,0.12,0.16,0.12,0.261c0,0.1-0.05,0.199-0.12,0.27C10.32-21.6,10.229-21.561,10.13-21.561z" fill="#231F20"/>
+                    <path d="M18.94-24.189c-0.101,0-0.2-0.041-0.271-0.111c-0.07-0.069-0.11-0.17-0.11-0.26c0-0.1,0.04-0.199,0.12-0.27c0.12-0.13,0.38-0.141,0.53,0c0.06,0.07,0.1,0.17,0.1,0.27c0,0.101-0.04,0.19-0.1,0.26C19.13-24.23,19.04-24.189,18.94-24.189z" fill="#231F20"/>
+                    <path d="M21.75-15.939c-0.1,0-0.2-0.041-0.271-0.111c-0.06-0.069-0.1-0.17-0.1-0.26c0-0.1,0.04-0.199,0.11-0.27c0.13-0.13,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C21.95-15.98,21.85-15.939,21.75-15.939z" fill="#231F20"/>
+                    <path d="M21-12.37c-0.1,0-0.2-0.05-0.271-0.12c-0.06-0.07-0.1-0.16-0.1-0.26s0.04-0.189,0.11-0.26c0.12-0.141,0.39-0.15,0.529,0c0.07,0.07,0.11,0.16,0.11,0.26s-0.04,0.189-0.11,0.27C21.2-12.41,21.1-12.37,21-12.37z" fill="#231F20"/>
+                    <path d="M7.5-16.87c-0.1,0-0.2-0.05-0.271-0.12c-0.06-0.07-0.1-0.16-0.1-0.26s0.04-0.2,0.11-0.27c0.12-0.131,0.39-0.141,0.529,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.189-0.11,0.27C7.7-16.91,7.6-16.87,7.5-16.87z" fill="#231F20"/>
+                    <path d="M13.69-12c-0.101,0-0.2-0.04-0.271-0.11c-0.06-0.069-0.11-0.159-0.11-0.271c0-0.1,0.04-0.189,0.12-0.26c0.12-0.129,0.38-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.26c0,0.111-0.051,0.201-0.12,0.271C13.89-12.04,13.79-12,13.69-12z" fill="#231F20"/>
+                    <path d="M15.38-15.381c-0.1,0-0.2-0.039-0.27-0.109c-0.07-0.07-0.11-0.16-0.11-0.26s0.05-0.2,0.12-0.27c0.12-0.131,0.38-0.141,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.03,0.189-0.11,0.27C15.57-15.42,15.479-15.381,15.38-15.381z" fill="#231F20"/>
+                    <path d="M30.56-22.5c-0.09,0-0.189-0.04-0.26-0.11c-0.07-0.069-0.109-0.159-0.109-0.271c0-0.1,0.039-0.189,0.109-0.26c0.15-0.14,0.391-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.26c0,0.101-0.04,0.201-0.11,0.271C30.76-22.54,30.66-22.5,30.56-22.5z" fill="#231F20"/>
+                    <path d="M36.38-15c-0.1,0-0.2-0.04-0.27-0.11C36.05-15.17,36-15.27,36-15.37c0-0.11,0.05-0.21,0.12-0.271c0.13-0.14,0.38-0.14,0.52,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.101-0.04,0.2-0.11,0.26C36.57-15.04,36.479-15,36.38-15z" fill="#231F20"/>
+                    <path d="M42.75-12.939c-0.1,0-0.19-0.041-0.26-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.109,0.04-0.199,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.09-0.04,0.19-0.11,0.26C42.95-12.98,42.85-12.939,42.75-12.939z" fill="#231F20"/>
+                    <path d="M47.06-19.689c-0.09,0-0.189-0.041-0.26-0.101c-0.07-0.08-0.109-0.17-0.109-0.271c0-0.1,0.039-0.199,0.109-0.27c0.141-0.141,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C47.26-19.73,47.16-19.689,47.06-19.689z" fill="#231F20"/>
+                    <path d="M47.25-13.689c-0.1,0-0.19-0.041-0.26-0.111c-0.07-0.06-0.11-0.159-0.11-0.26c0-0.109,0.04-0.199,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.07,0.11,0.16,0.11,0.27c0,0.101-0.04,0.2-0.12,0.26C47.45-13.73,47.35-13.689,47.25-13.689z" fill="#231F20"/>
+                    <path d="M29.06-20.061c-0.09,0-0.189-0.039-0.26-0.109s-0.109-0.16-0.109-0.27c0-0.101,0.039-0.191,0.109-0.261c0.141-0.14,0.391-0.14,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S29.16-20.061,29.06-20.061z" fill="#231F20"/>
+                    <path d="M31.13-14.811c-0.1,0-0.2-0.039-0.27-0.109c-0.07-0.07-0.11-0.17-0.11-0.27c0-0.101,0.04-0.191,0.11-0.261c0.14-0.14,0.39-0.14,0.529,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.03,0.189-0.11,0.27C31.32-14.85,31.229-14.811,31.13-14.811z" fill="#231F20"/>
+                    <path d="M26.44-16.689c-0.101,0-0.19-0.041-0.261-0.111c-0.069-0.06-0.109-0.159-0.109-0.26c0-0.1,0.029-0.199,0.1-0.27c0.15-0.141,0.4-0.141,0.54,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.051,0.2-0.12,0.26C26.64-16.73,26.54-16.689,26.44-16.689z" fill="#231F20"/>
+                    <path d="M39.56-17.061c-0.1,0-0.189-0.039-0.26-0.109s-0.109-0.17-0.109-0.27c0-0.101,0.039-0.191,0.109-0.261c0.141-0.14,0.391-0.14,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S39.67-17.061,39.56-17.061z" fill="#231F20"/>
+                    <path d="M43.31-22.87c-0.09,0-0.189-0.05-0.26-0.12s-0.109-0.16-0.109-0.26s0.039-0.189,0.109-0.27c0.141-0.141,0.391-0.141,0.53,0c0.07,0.08,0.11,0.17,0.11,0.27s-0.04,0.189-0.11,0.27C43.51-22.92,43.41-22.87,43.31-22.87z" fill="#231F20"/>
+                    <path d="M44.44-17.061c-0.101,0-0.19-0.039-0.261-0.109c-0.08-0.07-0.109-0.17-0.109-0.27c0-0.101,0.029-0.191,0.1-0.261c0.14-0.14,0.39-0.14,0.54,0c0.06,0.069,0.1,0.16,0.1,0.261c0,0.1-0.04,0.199-0.1,0.27C44.63-17.1,44.54-17.061,44.44-17.061z" fill="#231F20"/>
+                    <path d="M26.81-24.75c-0.09,0-0.189-0.04-0.26-0.11c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.11,0.039-0.2,0.109-0.271c0.141-0.14,0.391-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C27.01-24.79,26.91-24.75,26.81-24.75z" fill="#231F20"/>
+                    <path d="M49.69-20.25c-0.101,0-0.2-0.04-0.271-0.11c-0.06-0.06-0.11-0.159-0.11-0.26c0-0.11,0.051-0.21,0.12-0.28c0.12-0.119,0.38-0.13,0.53,0.01c0.06,0.07,0.11,0.16,0.11,0.271c0,0.101-0.051,0.19-0.12,0.26C49.89-20.29,49.79-20.25,49.69-20.25z" fill="#231F20"/>
+                    <path d="M36-24.189c-0.1,0-0.19-0.041-0.26-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.109,0.04-0.199,0.11-0.27c0.13-0.13,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.09-0.04,0.19-0.11,0.26C36.2-24.23,36.1-24.189,36-24.189z" fill="#231F20"/>
+                    <path d="M36.38-20.25c-0.1,0-0.2-0.04-0.27-0.11C36.05-20.42,36-20.52,36-20.62c0-0.11,0.05-0.21,0.12-0.271c0.13-0.14,0.38-0.14,0.52,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.101-0.04,0.2-0.11,0.26C36.57-20.29,36.479-20.25,36.38-20.25z" fill="#231F20"/>
+                    <path d="M3.19-23.62c-0.101,0-0.2-0.05-0.271-0.12C2.85-23.801,2.81-23.9,2.81-24s0.051-0.2,0.12-0.27c0.12-0.131,0.38-0.141,0.53,0.01C3.52-24.2,3.57-24.1,3.57-24s-0.04,0.199-0.11,0.27S3.29-23.62,3.19-23.62z" fill="#231F20"/>
+                    <path d="M5.63-24.561c-0.11,0-0.2-0.05-0.27-0.119c-0.07-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.11-0.261c0.119-0.13,0.39-0.149,0.529,0c0.07,0.069,0.12,0.16,0.12,0.261c0,0.1-0.05,0.199-0.12,0.27C5.82-24.6,5.729-24.561,5.63-24.561z" fill="#231F20"/>
+                    <path d="M3.75-70.5c-0.1,0-0.19-0.04-0.26-0.11c-0.07-0.069-0.11-0.159-0.11-0.26s0.04-0.2,0.11-0.271c0.14-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271s-0.04,0.19-0.11,0.26C3.95-70.54,3.85-70.5,3.75-70.5z" fill="#231F20"/>
+                    <path d="M10.5-66.189c-0.1,0-0.2-0.041-0.271-0.111c-0.06-0.06-0.1-0.159-0.1-0.26c0-0.1,0.04-0.199,0.11-0.27c0.13-0.13,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.2-0.12,0.26C10.7-66.23,10.6-66.189,10.5-66.189z" fill="#231F20"/>
+                    <path d="M4.5-66c-0.1,0-0.2-0.04-0.271-0.11c-0.06-0.069-0.1-0.159-0.1-0.26c0-0.11,0.04-0.2,0.11-0.271c0.12-0.129,0.39-0.14,0.529,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.101-0.04,0.19-0.11,0.26C4.7-66.04,4.6-66,4.5-66z" fill="#231F20"/>
+                    <path d="M22.88-68.62c-0.1,0-0.2-0.05-0.27-0.12C22.55-68.801,22.5-68.9,22.5-69s0.04-0.189,0.11-0.27c0.13-0.131,0.39-0.141,0.529,0c0.08,0.08,0.11,0.17,0.11,0.27s-0.04,0.199-0.11,0.27C23.07-68.67,22.979-68.62,22.88-68.62z" fill="#231F20"/>
+                    <path d="M31.5-71.25c-0.09,0-0.19-0.04-0.26-0.11c-0.07-0.069-0.11-0.17-0.11-0.271c0-0.1,0.04-0.189,0.11-0.26c0.149-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.26c0,0.101-0.04,0.201-0.11,0.271C31.7-71.29,31.6-71.25,31.5-71.25z" fill="#231F20"/>
+                    <path d="M47.25-67.689c-0.09,0-0.19-0.041-0.26-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.11-0.27c0.149-0.141,0.38-0.141,0.52,0c0.08,0.07,0.12,0.17,0.12,0.27c0,0.101-0.04,0.19-0.11,0.26C47.45-67.73,47.35-67.689,47.25-67.689z" fill="#231F20"/>
+                    <path d="M34.13-67.12c-0.1,0-0.2-0.05-0.27-0.12c-0.061-0.061-0.11-0.16-0.11-0.26s0.05-0.2,0.12-0.27c0.13-0.131,0.38-0.141,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C34.32-67.17,34.229-67.12,34.13-67.12z" fill="#231F20"/>
+                    <path d="M23.25-65.25c-0.1,0-0.2-0.04-0.271-0.11c-0.06-0.06-0.1-0.159-0.1-0.271c0-0.1,0.04-0.189,0.11-0.26c0.13-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.26c0,0.111-0.04,0.201-0.12,0.271C23.45-65.29,23.35-65.25,23.25-65.25z" fill="#231F20"/>
+                    <path d="M13.69-69.939c-0.101,0-0.2-0.041-0.271-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.12-0.27c0.12-0.13,0.38-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C13.89-69.98,13.79-69.939,13.69-69.939z" fill="#231F20"/>
+                    <path d="M16.32-67.131c-0.11,0-0.21-0.039-0.271-0.109c-0.07-0.061-0.109-0.16-0.109-0.26s0.039-0.2,0.109-0.27c0.12-0.131,0.391-0.141,0.53,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C16.51-67.17,16.41-67.131,16.32-67.131z" fill="#231F20"/>
+                    <path d="M41.63-65.061c-0.1,0-0.2-0.039-0.27-0.109c-0.07-0.08-0.11-0.17-0.11-0.27c0-0.091,0.04-0.191,0.11-0.261c0.149-0.149,0.399-0.14,0.54,0c0.06,0.069,0.1,0.16,0.1,0.261c0,0.1-0.04,0.199-0.11,0.27C41.83-65.11,41.729-65.061,41.63-65.061z" fill="#231F20"/>
+                    <path d="M7.88-68.811c-0.1,0-0.2-0.039-0.27-0.119C7.55-68.99,7.5-69.09,7.5-69.189c0-0.101,0.04-0.191,0.11-0.261c0.13-0.14,0.39-0.149,0.529,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C8.07-68.85,7.979-68.811,7.88-68.811z" fill="#231F20"/>
+                    <path d="M30-64.881c-0.1,0-0.19-0.029-0.26-0.109c-0.07-0.061-0.11-0.16-0.11-0.26s0.04-0.189,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.08,0.11,0.17,0.11,0.27s-0.04,0.189-0.11,0.27C30.2-64.91,30.1-64.881,30-64.881z" fill="#231F20"/>
+                    <path d="M11.07-63.561c-0.11,0-0.2-0.039-0.271-0.119c-0.07-0.061-0.109-0.16-0.109-0.26c0-0.101,0.039-0.191,0.109-0.261c0.13-0.14,0.391-0.149,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S11.16-63.561,11.07-63.561z" fill="#231F20"/>
+                    <path d="M34.88-63.37c-0.1,0-0.2-0.05-0.27-0.12c-0.061-0.061-0.11-0.16-0.11-0.26s0.05-0.2,0.12-0.27c0.13-0.131,0.38-0.131,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C35.07-63.42,34.979-63.37,34.88-63.37z" fill="#231F20"/>
+                    <path d="M17.06-71.62c-0.09,0-0.199-0.05-0.26-0.12c-0.07-0.061-0.109-0.16-0.109-0.26s0.039-0.189,0.109-0.27c0.13-0.131,0.391-0.141,0.53,0c0.07,0.08,0.11,0.17,0.11,0.27s-0.04,0.199-0.11,0.27C17.26-71.67,17.16-71.62,17.06-71.62z" fill="#231F20"/>
+                    <path d="M37.31-71.061c-0.1,0-0.189-0.039-0.26-0.109s-0.109-0.17-0.109-0.27c0-0.101,0.039-0.191,0.109-0.261c0.141-0.14,0.391-0.14,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.189-0.11,0.27C37.51-71.1,37.42-71.061,37.31-71.061z" fill="#231F20"/>
+                    <path d="M42.19-69c-0.101,0-0.2-0.04-0.271-0.11c-0.07-0.069-0.1-0.159-0.1-0.26c0-0.11,0.029-0.2,0.1-0.271c0.15-0.14,0.39-0.14,0.54,0c0.07,0.07,0.1,0.16,0.1,0.271c0,0.101-0.04,0.19-0.1,0.26C42.39-69.04,42.29-69,42.19-69z" fill="#231F20"/>
+                    <path d="M45.38-63.939c-0.1,0-0.2-0.041-0.27-0.111C45.04-64.12,45-64.21,45-64.311c0-0.1,0.04-0.199,0.11-0.27c0.149-0.141,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C45.57-63.98,45.479-63.939,45.38-63.939z" fill="#231F20"/>
+                    <path d="M13.31-47.811c-0.1,0-0.189-0.039-0.26-0.119c-0.07-0.061-0.109-0.16-0.109-0.26c0-0.101,0.039-0.191,0.109-0.261c0.13-0.14,0.391-0.149,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S13.41-47.811,13.31-47.811z" fill="#231F20"/>
+                    <path d="M1.5-48c-0.1,0-0.2-0.04-0.271-0.11c-0.06-0.069-0.1-0.17-0.1-0.26c0-0.101,0.04-0.2,0.11-0.271c0.13-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C1.7-48.04,1.6-48,1.5-48z" fill="#231F20"/>
+                    <path d="M5.82-42c-0.11,0-0.2-0.04-0.271-0.11c-0.07-0.069-0.109-0.17-0.109-0.26c0-0.101,0.039-0.2,0.109-0.271c0.13-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C6.01-42.04,5.91-42,5.82-42z" fill="#231F20"/>
+                    <path d="M3.75-35.62c-0.09,0-0.19-0.04-0.26-0.11C3.42-35.801,3.38-35.9,3.38-36s0.04-0.2,0.11-0.27c0.14-0.131,0.38-0.141,0.529,0C4.09-36.2,4.13-36.1,4.13-36s-0.04,0.199-0.11,0.27C3.95-35.66,3.85-35.62,3.75-35.62z" fill="#231F20"/>
+                    <path d="M10.5-31.311c-0.1,0-0.2-0.039-0.271-0.119c-0.06-0.061-0.1-0.16-0.1-0.26c0-0.101,0.04-0.201,0.11-0.271c0.12-0.12,0.38-0.14,0.529,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C10.7-31.35,10.6-31.311,10.5-31.311z" fill="#231F20"/>
+                    <path d="M4.5-31.12c-0.1,0-0.2-0.05-0.271-0.12c-0.06-0.061-0.1-0.16-0.1-0.26s0.04-0.189,0.11-0.27c0.13-0.131,0.39-0.141,0.529,0c0.07,0.08,0.11,0.17,0.11,0.27s-0.04,0.199-0.12,0.27C4.7-31.17,4.6-31.12,4.5-31.12z" fill="#231F20"/>
+                    <path d="M10.88-49.311c-0.1,0-0.2-0.039-0.27-0.119c-0.07-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.11-0.261c0.13-0.14,0.39-0.149,0.529,0c0.08,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C11.07-49.35,10.979-49.311,10.88-49.311z" fill="#231F20"/>
+                    <path d="M20.06-50.439c-0.1,0-0.189-0.041-0.26-0.111c-0.07-0.06-0.109-0.159-0.109-0.26c0-0.1,0.039-0.199,0.109-0.27c0.15-0.141,0.38-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C20.26-50.48,20.17-50.439,20.06-50.439z" fill="#231F20"/>
+                    <path d="M4.13-45.561c-0.1,0-0.2-0.039-0.27-0.119c-0.07-0.061-0.11-0.16-0.11-0.26c0-0.101,0.05-0.201,0.12-0.271c0.12-0.12,0.38-0.14,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.03,0.199-0.11,0.27C4.32-45.6,4.229-45.561,4.13-45.561z" fill="#231F20"/>
+                    <path d="M7.5-51.939c-0.1,0-0.2-0.041-0.271-0.111c-0.06-0.069-0.1-0.159-0.1-0.26c0-0.1,0.04-0.199,0.11-0.27c0.13-0.13,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C7.7-51.98,7.6-51.939,7.5-51.939z" fill="#231F20"/>
+                    <path d="M24.94-47.061c-0.101,0-0.2-0.039-0.271-0.119c-0.06-0.061-0.1-0.16-0.1-0.26c0-0.101,0.04-0.191,0.109-0.261c0.12-0.14,0.38-0.14,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.051,0.199-0.12,0.27C25.14-47.1,25.04-47.061,24.94-47.061z" fill="#231F20"/>
+                    <path d="M27.38-45.75c-0.11,0-0.2-0.04-0.27-0.12C27.04-45.93,27-46.02,27-46.12c0-0.11,0.05-0.21,0.12-0.28c0.109-0.119,0.38-0.13,0.52,0.01c0.07,0.07,0.11,0.16,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C27.57-45.79,27.479-45.75,27.38-45.75z" fill="#231F20"/>
+                    <path d="M7.88-38.811c-0.1,0-0.2-0.039-0.27-0.119c-0.07-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.11-0.271c0.13-0.13,0.39-0.14,0.529,0c0.07,0.079,0.11,0.17,0.11,0.271c0,0.1-0.04,0.199-0.11,0.27C8.07-38.85,7.979-38.811,7.88-38.811z" fill="#231F20"/>
+                    <path d="M22.88-33.75c-0.1,0-0.2-0.04-0.27-0.11c-0.061-0.06-0.11-0.159-0.11-0.271c0-0.1,0.04-0.189,0.11-0.26c0.13-0.129,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.26c0,0.111-0.04,0.201-0.11,0.271C23.07-33.79,22.979-33.75,22.88-33.75z" fill="#231F20"/>
+                    <path d="M31.5-36.381c-0.1,0-0.19-0.029-0.26-0.1c-0.07-0.07-0.11-0.17-0.11-0.27s0.04-0.189,0.11-0.26c0.149-0.15,0.39-0.141,0.529-0.01c0.07,0.08,0.11,0.17,0.11,0.27s-0.04,0.199-0.11,0.27C31.7-36.41,31.6-36.381,31.5-36.381z" fill="#231F20"/>
+                    <path d="M29.44-50.061c-0.101,0-0.2-0.039-0.271-0.119c-0.06-0.061-0.1-0.16-0.1-0.26c0-0.101,0.04-0.191,0.109-0.261c0.12-0.13,0.38-0.14,0.53,0c0.07,0.069,0.1,0.16,0.1,0.261c0,0.1-0.029,0.199-0.1,0.27S29.54-50.061,29.44-50.061z" fill="#231F20"/>
+                    <path d="M41.25-51c-0.1,0-0.19-0.04-0.26-0.11c-0.07-0.06-0.11-0.159-0.11-0.271c0-0.1,0.04-0.199,0.11-0.26c0.13-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.16,0.11,0.26c0,0.111-0.04,0.201-0.12,0.271C41.45-51.04,41.35-51,41.25-51z" fill="#231F20"/>
+                    <path d="M27.19-39c-0.101,0-0.2-0.04-0.271-0.12c-0.06-0.05-0.1-0.149-0.1-0.261c0-0.1,0.04-0.189,0.109-0.26c0.12-0.129,0.38-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.26c0,0.111-0.051,0.211-0.12,0.271C27.39-39.04,27.29-39,27.19-39z" fill="#231F20"/>
+                    <path d="M47.25-32.811c-0.1,0-0.19-0.039-0.26-0.109c-0.07-0.07-0.11-0.17-0.11-0.27c0-0.101,0.04-0.191,0.11-0.261c0.14-0.14,0.39-0.14,0.529,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C47.45-32.85,47.35-32.811,47.25-32.811z" fill="#231F20"/>
+                    <path d="M34.13-32.25c-0.1,0-0.2-0.04-0.27-0.11c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.11,0.05-0.21,0.12-0.271c0.13-0.129,0.38-0.14,0.52,0c0.07,0.061,0.11,0.16,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C34.32-32.29,34.229-32.25,34.13-32.25z" fill="#231F20"/>
+                    <path d="M23.25-30.37c-0.1,0-0.2-0.05-0.271-0.12c-0.06-0.061-0.1-0.16-0.1-0.26s0.04-0.2,0.11-0.27c0.12-0.131,0.39-0.141,0.529,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C23.45-30.41,23.35-30.37,23.25-30.37z" fill="#231F20"/>
+                    <path d="M13.69-35.061c-0.101,0-0.2-0.039-0.271-0.119c-0.06-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.12-0.261c0.12-0.13,0.38-0.149,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.051,0.199-0.12,0.27C13.89-35.1,13.79-35.061,13.69-35.061z" fill="#231F20"/>
+                    <path d="M16.32-32.25c-0.11,0-0.2-0.04-0.271-0.11c-0.07-0.069-0.109-0.17-0.109-0.26c0-0.101,0.039-0.2,0.109-0.271c0.13-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C16.51-32.29,16.41-32.25,16.32-32.25z" fill="#231F20"/>
+                    <path d="M39.13-29.811c-0.1,0-0.2-0.039-0.27-0.109c-0.07-0.07-0.11-0.17-0.11-0.27c0-0.101,0.04-0.191,0.11-0.261c0.14-0.14,0.39-0.14,0.529,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C39.32-29.85,39.229-29.811,39.13-29.811z" fill="#231F20"/>
+                    <path d="M49.31-39.37c-0.09,0-0.189-0.05-0.26-0.12c-0.07-0.061-0.109-0.16-0.109-0.26s0.039-0.2,0.119-0.27c0.131-0.131,0.381-0.141,0.521,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C49.51-39.42,49.41-39.37,49.31-39.37z" fill="#231F20"/>
+                    <path d="M30.56-41.439c-0.09,0-0.189-0.041-0.26-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.1,0.039-0.199,0.109-0.27c0.15-0.141,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C30.76-41.48,30.67-41.439,30.56-41.439z" fill="#231F20"/>
+                    <path d="M49.69-49.689c-0.101,0-0.2-0.041-0.271-0.111c-0.06-0.06-0.11-0.159-0.11-0.26c0-0.109,0.051-0.199,0.12-0.27c0.12-0.13,0.38-0.141,0.53,0c0.06,0.07,0.11,0.16,0.11,0.27c0,0.101-0.051,0.2-0.12,0.26C49.88-49.73,49.79-49.689,49.69-49.689z" fill="#231F20"/>
+                    <path d="M35.44-51.561c-0.101,0-0.19-0.039-0.271-0.109c-0.06-0.07-0.1-0.17-0.1-0.27c0-0.101,0.04-0.201,0.109-0.271c0.13-0.13,0.38-0.13,0.53,0.01c0.06,0.06,0.11,0.16,0.11,0.261c0,0.1-0.051,0.199-0.12,0.27C35.63-51.6,35.54-51.561,35.44-51.561z" fill="#231F20"/>
+                    <path d="M7.88-33.939c-0.1,0-0.2-0.041-0.27-0.111C7.54-34.12,7.5-34.21,7.5-34.311c0-0.1,0.04-0.199,0.11-0.27c0.13-0.13,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.03,0.19-0.11,0.26C8.07-33.98,7.979-33.939,7.88-33.939z" fill="#231F20"/>
+                    <path d="M24.94-51.561c-0.101,0-0.2-0.039-0.271-0.119c-0.07-0.061-0.1-0.16-0.1-0.26c0-0.101,0.029-0.191,0.1-0.261c0.13-0.14,0.39-0.14,0.54,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.189-0.11,0.27C25.14-51.6,25.04-51.561,24.94-51.561z" fill="#231F20"/>
+                    <path d="M15.56-51.561c-0.1,0-0.199-0.039-0.26-0.119c-0.07-0.061-0.109-0.16-0.109-0.26c0-0.101,0.039-0.191,0.109-0.261c0.13-0.14,0.391-0.149,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S15.67-51.561,15.56-51.561z" fill="#231F20"/>
+                    <path d="M30-30c-0.09,0-0.19-0.04-0.26-0.11c-0.07-0.06-0.11-0.159-0.11-0.271c0-0.1,0.04-0.189,0.11-0.26c0.14-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.26c0,0.111-0.04,0.201-0.12,0.271C30.2-30.04,30.1-30,30-30z" fill="#231F20"/>
+                    <path d="M11.07-28.689c-0.11,0-0.21-0.041-0.271-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.1,0.039-0.199,0.109-0.27c0.13-0.13,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C11.26-28.73,11.16-28.689,11.07-28.689z" fill="#231F20"/>
+                    <path d="M44.25-54.189c-0.09,0-0.19-0.041-0.26-0.111c-0.07-0.06-0.11-0.159-0.11-0.26c0-0.109,0.04-0.199,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.2-0.12,0.26C44.45-54.23,44.35-54.189,44.25-54.189z" fill="#231F20"/>
+                    <path d="M34.88-28.5c-0.1,0-0.2-0.04-0.27-0.11c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.11,0.04-0.2,0.11-0.271c0.14-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C35.07-28.54,34.979-28.5,34.88-28.5z" fill="#231F20"/>
+                    <path d="M45.13-47.311c-0.1,0-0.2-0.039-0.27-0.119c-0.061-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.11-0.261c0.149-0.149,0.39-0.14,0.529,0c0.08,0.069,0.12,0.16,0.12,0.261c0,0.1-0.05,0.199-0.12,0.27C45.32-47.35,45.229-47.311,45.13-47.311z" fill="#231F20"/>
+                    <path d="M15-42.37c-0.1,0-0.2-0.05-0.271-0.12c-0.06-0.061-0.1-0.16-0.1-0.26s0.04-0.189,0.11-0.27c0.13-0.131,0.39-0.141,0.529,0c0.07,0.08,0.11,0.17,0.11,0.27s-0.04,0.189-0.11,0.27C15.2-42.41,15.1-42.37,15-42.37z" fill="#231F20"/>
+                    <path d="M11.07-42c-0.11,0-0.21-0.04-0.271-0.11c-0.07-0.069-0.109-0.159-0.109-0.26s0.039-0.2,0.109-0.271c0.13-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.271s-0.04,0.19-0.11,0.26C11.26-42.04,11.16-42,11.07-42z" fill="#231F20"/>
+                    <path d="M21.19-39.75c-0.101,0-0.2-0.04-0.271-0.11c-0.06-0.06-0.11-0.159-0.11-0.271c0-0.1,0.04-0.189,0.12-0.26c0.12-0.129,0.38-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.26c0,0.111-0.051,0.211-0.12,0.271C21.38-39.79,21.29-39.75,21.19-39.75z" fill="#231F20"/>
+                    <path d="M22.13-43.131c-0.1,0-0.2-0.039-0.27-0.109c-0.07-0.061-0.11-0.16-0.11-0.26s0.05-0.2,0.12-0.27c0.12-0.131,0.38-0.141,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C22.32-43.16,22.229-43.131,22.13-43.131z" fill="#231F20"/>
+                    <path d="M18.94-45.561c-0.101,0-0.2-0.039-0.271-0.119c-0.07-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.12-0.261c0.12-0.14,0.38-0.149,0.53,0c0.06,0.069,0.1,0.16,0.1,0.261c0,0.1-0.04,0.199-0.1,0.27C19.13-45.6,19.04-45.561,18.94-45.561z" fill="#231F20"/>
+                    <path d="M17.06-36.75c-0.1,0-0.189-0.04-0.26-0.11c-0.07-0.069-0.109-0.159-0.109-0.271c0-0.09,0.039-0.189,0.109-0.26c0.13-0.14,0.391-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.26c0,0.111-0.04,0.201-0.11,0.271C17.26-36.79,17.16-36.75,17.06-36.75z" fill="#231F20"/>
+                    <path d="M46.31-42.37c-0.09,0-0.189-0.05-0.26-0.12c-0.07-0.061-0.109-0.16-0.109-0.26s0.039-0.2,0.119-0.27c0.131-0.131,0.381-0.141,0.521,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C46.51-42.42,46.41-42.37,46.31-42.37z" fill="#231F20"/>
+                    <path d="M32.81-46.87c-0.09,0-0.189-0.04-0.26-0.11s-0.109-0.17-0.109-0.27s0.039-0.2,0.109-0.27c0.141-0.141,0.391-0.141,0.53,0c0.07,0.069,0.11,0.17,0.11,0.27s-0.04,0.199-0.11,0.27S32.91-46.87,32.81-46.87z" fill="#231F20"/>
+                    <path d="M39-42c-0.09,0-0.19-0.04-0.26-0.11c-0.07-0.069-0.11-0.159-0.11-0.271c0-0.1,0.04-0.189,0.11-0.26c0.14-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.26c0,0.101-0.04,0.201-0.11,0.271C39.2-42.04,39.1-42,39-42z" fill="#231F20"/>
+                    <path d="M40.69-45.37c-0.101,0-0.19-0.04-0.271-0.11c-0.07-0.08-0.1-0.17-0.1-0.27s0.029-0.2,0.1-0.27c0.14-0.141,0.39-0.141,0.54,0c0.06,0.069,0.1,0.17,0.1,0.27s-0.04,0.199-0.109,0.27C40.88-45.41,40.79-45.37,40.69-45.37z" fill="#231F20"/>
+                    <path d="M37.31-36.189c-0.09,0-0.189-0.041-0.26-0.111c-0.07-0.06-0.109-0.159-0.109-0.26c0-0.109,0.039-0.199,0.109-0.27c0.141-0.13,0.391-0.141,0.53,0c0.07,0.07,0.11,0.16,0.11,0.27c0,0.101-0.04,0.2-0.11,0.26C37.51-36.23,37.41-36.189,37.31-36.189z" fill="#231F20"/>
+                    <path d="M42.19-34.12c-0.101,0-0.19-0.04-0.261-0.11c-0.08-0.08-0.109-0.17-0.109-0.27s0.04-0.2,0.109-0.27c0.13-0.131,0.38-0.131,0.53,0c0.06,0.069,0.1,0.17,0.1,0.27s-0.029,0.189-0.1,0.27C42.38-34.16,42.29-34.12,42.19-34.12z" fill="#231F20"/>
+                    <path d="M43.31-38.25c-0.09,0-0.189-0.04-0.26-0.11c-0.07-0.06-0.109-0.159-0.109-0.26c0-0.11,0.039-0.2,0.109-0.271c0.13-0.14,0.391-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.101-0.04,0.2-0.11,0.26C43.51-38.29,43.41-38.25,43.31-38.25z" fill="#231F20"/>
+                    <path d="M45.38-29.061c-0.1,0-0.2-0.039-0.27-0.109C45.05-29.24,45-29.34,45-29.439c0-0.101,0.05-0.201,0.12-0.271c0.13-0.13,0.38-0.13,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C45.57-29.1,45.479-29.061,45.38-29.061z" fill="#231F20"/>
+                    <path d="M50.25-29.25c-0.09,0-0.19-0.04-0.26-0.11c-0.07-0.06-0.11-0.159-0.11-0.26c0-0.11,0.04-0.21,0.11-0.271c0.14-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.101-0.04,0.2-0.12,0.26C50.45-29.29,50.35-29.25,50.25-29.25z" fill="#231F20"/>
+                    <path d="M54.94-27.37c-0.101,0-0.2-0.05-0.271-0.12c-0.06-0.061-0.11-0.16-0.11-0.26s0.04-0.189,0.12-0.27c0.12-0.131,0.391-0.131,0.53,0.01c0.07,0.07,0.11,0.16,0.11,0.26s-0.051,0.199-0.12,0.27C55.14-27.42,55.04-27.37,54.94-27.37z" fill="#231F20"/>
+                    <path d="M55.88-52.5c-0.1,0-0.2-0.04-0.27-0.11c-0.07-0.069-0.11-0.17-0.11-0.26c0-0.101,0.04-0.2,0.11-0.271c0.13-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.03,0.19-0.11,0.26C56.07-52.54,55.979-52.5,55.88-52.5z" fill="#231F20"/>
+                    <path d="M54.19-33.939c-0.101,0-0.2-0.041-0.271-0.111c-0.06-0.06-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.11-0.27c0.13-0.13,0.39-0.141,0.53,0c0.08,0.07,0.12,0.17,0.12,0.27c0,0.101-0.051,0.2-0.12,0.26C54.38-33.98,54.29-33.939,54.19-33.939z" fill="#231F20"/>
+                    <path d="M60.75-27c-0.1,0-0.2-0.04-0.271-0.11c-0.06-0.069-0.1-0.17-0.1-0.271c0-0.1,0.04-0.189,0.11-0.26c0.14-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.16,0.11,0.26c0,0.111-0.04,0.201-0.11,0.271C60.95-27.04,60.86-27,60.75-27z" fill="#231F20"/>
+                    <path d="M55.69-40.689c-0.101,0-0.2-0.041-0.271-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.12-0.27c0.12-0.13,0.38-0.141,0.521,0c0.08,0.07,0.12,0.17,0.12,0.27c0,0.101-0.04,0.19-0.11,0.26C55.88-40.73,55.79-40.689,55.69-40.689z" fill="#231F20"/>
+                    <path d="M61.69-45c-0.101,0-0.2-0.04-0.261-0.11c-0.08-0.069-0.12-0.17-0.12-0.26c0-0.101,0.04-0.2,0.11-0.271c0.13-0.14,0.39-0.14,0.54,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C61.88-45.04,61.79-45,61.69-45z" fill="#231F20"/>
+                    <path d="M66.38-28.311c-0.1,0-0.2-0.05-0.27-0.119C66.04-28.49,66-28.59,66-28.689c0-0.101,0.05-0.201,0.12-0.271c0.12-0.13,0.38-0.14,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C66.57-28.35,66.479-28.311,66.38-28.311z" fill="#231F20"/>
+                    <path d="M72.57-27.189c-0.11,0-0.21-0.041-0.271-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.109,0.039-0.199,0.109-0.27c0.13-0.13,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C72.76-27.23,72.67-27.189,72.57-27.189z" fill="#231F20"/>
+                    <path d="M68.07-42.939c-0.11,0-0.21-0.041-0.271-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.109,0.039-0.199,0.109-0.27c0.12-0.13,0.4-0.141,0.53,0.01c0.07,0.061,0.11,0.15,0.11,0.26c0,0.09-0.04,0.19-0.11,0.26C68.27-42.98,68.17-42.939,68.07-42.939z" fill="#231F20"/>
+                    <path d="M72.38-49.689c-0.1,0-0.2-0.041-0.27-0.111c-0.07-0.069-0.11-0.17-0.11-0.26c0-0.109,0.05-0.199,0.12-0.27c0.109-0.13,0.38-0.141,0.52,0c0.07,0.07,0.11,0.16,0.11,0.27c0,0.09-0.04,0.19-0.11,0.26C72.57-49.73,72.479-49.689,72.38-49.689z" fill="#231F20"/>
+                    <path d="M72.57-43.689c-0.11,0-0.21-0.041-0.271-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.109,0.039-0.209,0.119-0.27c0.11-0.13,0.381-0.141,0.521,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C72.76-43.73,72.67-43.689,72.57-43.689z" fill="#231F20"/>
+                    <path d="M72.57-32.811c-0.11,0-0.21-0.05-0.271-0.119c-0.07-0.061-0.109-0.16-0.109-0.26c0-0.101,0.039-0.201,0.119-0.271c0.11-0.12,0.381-0.14,0.521,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S72.67-32.811,72.57-32.811z" fill="#231F20"/>
+                    <path d="M54.38-50.061c-0.1,0-0.2-0.039-0.27-0.119c-0.07-0.07-0.11-0.16-0.11-0.26c0-0.101,0.05-0.201,0.12-0.271c0.13-0.13,0.38-0.14,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.189-0.11,0.27C54.57-50.1,54.479-50.061,54.38-50.061z" fill="#231F20"/>
+                    <path d="M53.25-59.25c-0.1,0-0.2-0.04-0.26-0.11c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.11,0.04-0.2,0.11-0.271c0.13-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C53.45-59.29,53.35-59.25,53.25-59.25z" fill="#231F20"/>
+                    <path d="M51.19-37.87c-0.101,0-0.19-0.04-0.261-0.11c-0.08-0.07-0.109-0.17-0.109-0.27s0.029-0.189,0.1-0.27c0.14-0.131,0.4-0.141,0.54,0.01c0.07,0.07,0.1,0.16,0.1,0.26s-0.029,0.199-0.1,0.27C51.38-37.91,51.29-37.87,51.19-37.87z" fill="#231F20"/>
+                    <path d="M59.13-41.811c-0.1,0-0.2-0.039-0.27-0.119c-0.061-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.201,0.12-0.271c0.12-0.13,0.38-0.14,0.52,0.01c0.07,0.069,0.12,0.16,0.12,0.261c0,0.1-0.05,0.199-0.12,0.27C59.32-41.85,59.229-41.811,59.13-41.811z" fill="#231F20"/>
+                    <path d="M51.75-46.689c-0.1,0-0.2-0.041-0.271-0.111c-0.06-0.06-0.1-0.159-0.1-0.26c0-0.1,0.04-0.199,0.11-0.27c0.12-0.13,0.38-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.2-0.12,0.26C51.94-46.73,51.85-46.689,51.75-46.689z" fill="#231F20"/>
+                    <path d="M56.63-64.12c-0.1,0-0.2-0.05-0.27-0.12c-0.061-0.061-0.11-0.16-0.11-0.26s0.04-0.2,0.12-0.27c0.12-0.131,0.39-0.141,0.53,0.01C56.96-64.7,57-64.6,57-64.5s-0.04,0.199-0.11,0.27C56.83-64.17,56.729-64.12,56.63-64.12z" fill="#231F20"/>
+                    <path d="M57.94-66.561c-0.101,0-0.2-0.039-0.271-0.109c-0.07-0.08-0.11-0.17-0.11-0.27c0-0.101,0.04-0.191,0.11-0.261c0.14-0.149,0.4-0.14,0.54,0c0.07,0.069,0.1,0.16,0.1,0.261c0,0.1-0.029,0.199-0.1,0.27S58.04-66.561,57.94-66.561z" fill="#231F20"/>
+                    <path d="M64.88-47.061c-0.11,0-0.2-0.05-0.27-0.119c-0.07-0.061-0.101-0.16-0.101-0.26c0-0.101,0.03-0.191,0.101-0.261c0.14-0.14,0.38-0.149,0.529-0.01c0.08,0.079,0.11,0.17,0.11,0.271c0,0.1-0.04,0.199-0.11,0.27C65.07-47.1,64.979-47.061,64.88-47.061z" fill="#231F20"/>
+                    <path d="M69.94-62.061c-0.101,0-0.2-0.05-0.271-0.119c-0.06-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.11-0.261c0.13-0.14,0.39-0.149,0.54,0c0.07,0.069,0.1,0.16,0.1,0.261c0,0.109-0.04,0.199-0.109,0.27C70.13-62.1,70.04-62.061,69.94-62.061z" fill="#231F20"/>
+                    <path d="M67.31-70.689c-0.09,0-0.199-0.041-0.26-0.111c-0.07-0.06-0.109-0.159-0.109-0.26c0-0.1,0.039-0.199,0.109-0.27c0.13-0.13,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.2-0.11,0.26C67.51-70.73,67.41-70.689,67.31-70.689z" fill="#231F20"/>
+                    <path d="M53.63-68.62c-0.1,0-0.2-0.04-0.27-0.11c-0.07-0.08-0.11-0.17-0.11-0.27s0.04-0.189,0.11-0.26c0.149-0.15,0.39-0.141,0.529-0.01C53.96-69.2,54-69.1,54-69s-0.03,0.189-0.11,0.26C53.82-68.66,53.729-68.62,53.63-68.62z" fill="#231F20"/>
+                    <path d="M64.69-66.381c-0.101,0-0.2-0.039-0.271-0.109c-0.07-0.061-0.11-0.16-0.11-0.26s0.04-0.189,0.11-0.27c0.14-0.131,0.39-0.141,0.53,0c0.08,0.08,0.109,0.17,0.109,0.27s-0.04,0.199-0.1,0.27C64.89-66.41,64.79-66.381,64.69-66.381z" fill="#231F20"/>
+                    <path d="M68.63-52.881c-0.1,0-0.2-0.039-0.27-0.109c-0.07-0.07-0.11-0.16-0.11-0.26s0.04-0.2,0.12-0.27c0.12-0.131,0.38-0.141,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C68.83-52.92,68.729-52.881,68.63-52.881z" fill="#231F20"/>
+                    <path d="M71.44-55.5c-0.101,0-0.2-0.04-0.271-0.11c-0.06-0.069-0.1-0.17-0.1-0.26c0-0.11,0.04-0.2,0.109-0.271c0.12-0.129,0.38-0.14,0.53,0c0.06,0.07,0.11,0.16,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C71.64-55.54,71.54-55.5,71.44-55.5z" fill="#231F20"/>
+                    <path d="M62.25-69.75c-0.1,0-0.2-0.04-0.271-0.11c-0.06-0.069-0.1-0.17-0.1-0.26c0-0.101,0.04-0.2,0.11-0.271c0.13-0.129,0.38-0.14,0.529,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C62.45-69.79,62.35-69.75,62.25-69.75z" fill="#231F20"/>
+                    <path d="M69.75-47.061c-0.1,0-0.2-0.039-0.271-0.119c-0.06-0.061-0.1-0.16-0.1-0.26c0-0.101,0.04-0.191,0.11-0.261c0.12-0.13,0.39-0.149,0.529,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.12,0.27C69.95-47.1,69.85-47.061,69.75-47.061z" fill="#231F20"/>
+                    <path d="M52.13-64.12c-0.1,0-0.2-0.05-0.27-0.12c-0.07-0.061-0.11-0.16-0.11-0.26s0.04-0.189,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0.01c0.07,0.07,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C52.32-64.17,52.229-64.12,52.13-64.12z" fill="#231F20"/>
+                    <path d="M52.13-54.75c-0.1,0-0.2-0.04-0.27-0.11c-0.07-0.06-0.11-0.159-0.11-0.26c0-0.11,0.04-0.2,0.12-0.271c0.13-0.14,0.38-0.14,0.52,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.101-0.04,0.2-0.11,0.26C52.32-54.79,52.229-54.75,52.13-54.75z" fill="#231F20"/>
+                    <path d="M66-30.75c-0.1,0-0.19-0.04-0.26-0.11c-0.07-0.069-0.11-0.17-0.11-0.26c0-0.11,0.04-0.2,0.11-0.271c0.13-0.14,0.39-0.14,0.529,0c0.07,0.061,0.11,0.16,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C66.2-30.79,66.1-30.75,66-30.75z" fill="#231F20"/>
+                    <path d="M63.75-38.62c-0.1,0-0.2-0.05-0.271-0.12c-0.06-0.061-0.1-0.16-0.1-0.26s0.04-0.189,0.11-0.26c0.13-0.141,0.39-0.15,0.529-0.01c0.07,0.08,0.11,0.17,0.11,0.27s-0.04,0.199-0.12,0.27C63.95-38.67,63.85-38.62,63.75-38.62z" fill="#231F20"/>
+                    <path d="M60.19-32.62c-0.101,0-0.2-0.05-0.271-0.12c-0.06-0.061-0.11-0.16-0.11-0.26s0.051-0.2,0.12-0.27c0.12-0.131,0.38-0.141,0.53,0.01c0.06,0.06,0.11,0.16,0.11,0.26s-0.051,0.199-0.12,0.27C60.38-32.66,60.29-32.62,60.19-32.62z" fill="#231F20"/>
+                    <path d="M68.82-36.939c-0.11,0-0.21-0.041-0.271-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.109,0.039-0.199,0.109-0.27c0.13-0.13,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C69.01-36.98,68.92-36.939,68.82-36.939z" fill="#231F20"/>
+                    <path d="M61.32-54.189c-0.11,0-0.21-0.041-0.271-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.1,0.039-0.199,0.109-0.27c0.141-0.141,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C61.51-54.23,61.42-54.189,61.32-54.189z" fill="#231F20"/>
+                    <path d="M61.69-50.25c-0.101,0-0.2-0.04-0.271-0.12c-0.06-0.05-0.11-0.149-0.11-0.25s0.04-0.2,0.12-0.271c0.12-0.129,0.38-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.271s-0.051,0.2-0.12,0.26C61.89-50.29,61.79-50.25,61.69-50.25z" fill="#231F20"/>
+                    <path d="M63.94-60.37c-0.101,0-0.2-0.05-0.271-0.11c-0.07-0.07-0.11-0.17-0.11-0.27s0.04-0.2,0.12-0.27c0.12-0.131,0.38-0.141,0.53,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.199-0.11,0.27C64.13-60.41,64.04-60.37,63.94-60.37z" fill="#231F20"/>
+                    <path d="M60.57-61.311c-0.11,0-0.21-0.039-0.271-0.119c-0.07-0.061-0.109-0.16-0.109-0.26c0-0.101,0.039-0.191,0.109-0.261c0.13-0.14,0.391-0.149,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S60.67-61.311,60.57-61.311z" fill="#231F20"/>
+                    <path d="M58.13-58.12c-0.1,0-0.2-0.05-0.27-0.12c-0.07-0.061-0.11-0.16-0.11-0.26s0.05-0.2,0.12-0.27c0.12-0.121,0.38-0.141,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.26s-0.04,0.189-0.11,0.26C58.32-58.17,58.229-58.12,58.13-58.12z" fill="#231F20"/>
+                    <path d="M66.94-56.25c-0.101,0-0.2-0.04-0.271-0.11c-0.06-0.069-0.1-0.17-0.1-0.26c0-0.11,0.04-0.21,0.109-0.271c0.12-0.129,0.38-0.149,0.521,0c0.069,0.07,0.12,0.16,0.12,0.271c0,0.09-0.04,0.19-0.11,0.26C67.13-56.29,67.04-56.25,66.94-56.25z" fill="#231F20"/>
+                    <path d="M56.81-72c-0.1,0-0.199-0.04-0.26-0.11c-0.07-0.069-0.109-0.17-0.109-0.271c0-0.1,0.039-0.189,0.109-0.26c0.13-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.26c0,0.101-0.04,0.201-0.11,0.271C57.01-72.04,56.92-72,56.81-72z" fill="#231F20"/>
+                    <path d="M46.13-25.5c-0.1,0-0.2-0.04-0.27-0.11c-0.07-0.069-0.11-0.159-0.11-0.26s0.04-0.2,0.12-0.271c0.12-0.129,0.38-0.14,0.52,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C46.31-25.54,46.22-25.5,46.13-25.5z" fill="#231F20"/>
+                    <path d="M41.63-26.25c-0.1,0-0.189-0.04-0.27-0.11c-0.07-0.069-0.11-0.17-0.11-0.271c0-0.09,0.04-0.189,0.11-0.26c0.149-0.149,0.409-0.14,0.54,0c0.06,0.07,0.1,0.17,0.1,0.26c0,0.101-0.04,0.201-0.11,0.271C41.83-26.29,41.729-26.25,41.63-26.25z" fill="#231F20"/>
+                    <path d="M10.13-60.37c-0.1,0-0.2-0.05-0.27-0.12c-0.07-0.07-0.11-0.16-0.11-0.26s0.04-0.189,0.11-0.27c0.13-0.131,0.39-0.141,0.529,0c0.07,0.08,0.12,0.17,0.12,0.27s-0.05,0.189-0.12,0.26C10.32-60.41,10.229-60.37,10.13-60.37z" fill="#231F20"/>
+                    <path d="M18.57-59.061c-0.11,0-0.2-0.039-0.271-0.119c-0.07-0.061-0.109-0.16-0.109-0.26c0-0.101,0.039-0.191,0.109-0.261c0.13-0.14,0.391-0.14,0.53,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S18.66-59.061,18.57-59.061z" fill="#231F20"/>
+                    <path d="M4.32-60.939c-0.11,0-0.21-0.041-0.271-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.1,0.039-0.199,0.109-0.27c0.13-0.13,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C4.51-60.98,4.41-60.939,4.32-60.939z" fill="#231F20"/>
+                    <path d="M15.94-55.311c-0.101,0-0.2-0.039-0.271-0.119c-0.07-0.061-0.11-0.16-0.11-0.26c0-0.101,0.051-0.201,0.12-0.271c0.12-0.12,0.38-0.14,0.53,0.01c0.06,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S16.04-55.311,15.94-55.311z" fill="#231F20"/>
+                    <path d="M1.69-56.25c-0.101,0-0.2-0.04-0.271-0.11c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.11,0.051-0.21,0.12-0.271c0.11-0.129,0.391-0.149,0.53,0.01c0.06,0.051,0.11,0.15,0.11,0.261c0,0.101-0.04,0.19-0.11,0.26C1.89-56.29,1.79-56.25,1.69-56.25z" fill="#231F20"/>
+                    <path d="M9.57-54.75c-0.11,0-0.2-0.04-0.271-0.11c-0.07-0.069-0.109-0.17-0.109-0.26c0-0.101,0.039-0.2,0.109-0.271c0.13-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.17,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C9.76-54.79,9.66-54.75,9.57-54.75z" fill="#231F20"/>
+                    <path d="M24.75-61.87c-0.1,0-0.19-0.05-0.26-0.11c-0.07-0.08-0.11-0.17-0.11-0.27s0.04-0.2,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.069,0.11,0.17,0.11,0.27s-0.04,0.189-0.11,0.26C24.95-61.92,24.85-61.87,24.75-61.87z" fill="#231F20"/>
+                    <path d="M30.56-54.37c-0.09,0-0.189-0.04-0.26-0.11c-0.07-0.08-0.109-0.17-0.109-0.27s0.039-0.2,0.109-0.27c0.15-0.141,0.391-0.131,0.53,0c0.07,0.069,0.11,0.17,0.11,0.27s-0.04,0.189-0.11,0.26S30.66-54.37,30.56-54.37z" fill="#231F20"/>
+                    <path d="M41.25-59.061c-0.1,0-0.19-0.039-0.26-0.109c-0.07-0.07-0.11-0.17-0.11-0.27c0-0.101,0.04-0.201,0.11-0.271c0.13-0.13,0.39-0.13,0.529,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.12,0.27C41.45-59.1,41.35-59.061,41.25-59.061z" fill="#231F20"/>
+                    <path d="M24.63-57.811c-0.1,0-0.2-0.039-0.27-0.119c-0.07-0.061-0.101-0.16-0.101-0.26c0-0.101,0.04-0.201,0.11-0.271c0.12-0.12,0.38-0.14,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C24.82-57.85,24.729-57.811,24.63-57.811z" fill="#231F20"/>
+                    <path d="M20.63-56.061c-0.1,0-0.2-0.039-0.27-0.109c-0.07-0.07-0.11-0.17-0.11-0.27c0-0.101,0.05-0.201,0.12-0.271c0.13-0.13,0.38-0.13,0.52,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C20.82-56.1,20.729-56.061,20.63-56.061z" fill="#231F20"/>
+                    <path d="M33.75-56.439c-0.1,0-0.19-0.041-0.26-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.09-0.04,0.19-0.11,0.26C33.95-56.48,33.85-56.439,33.75-56.439z" fill="#231F20"/>
+                    <path d="M37.5-62.25c-0.09,0-0.19-0.04-0.26-0.11c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.11,0.04-0.21,0.11-0.271c0.13-0.14,0.39-0.14,0.529,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.09-0.04,0.19-0.11,0.26C37.69-62.29,37.6-62.25,37.5-62.25z" fill="#231F20"/>
+                    <path d="M38.63-56.439c-0.1,0-0.2-0.041-0.27-0.111c-0.07-0.069-0.11-0.159-0.11-0.26c0-0.1,0.04-0.199,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C38.82-56.48,38.729-56.439,38.63-56.439z" fill="#231F20"/>
+                    <path d="M43.88-59.62c-0.1,0-0.2-0.04-0.27-0.11c-0.07-0.07-0.11-0.17-0.11-0.27s0.04-0.2,0.11-0.27c0.14-0.141,0.39-0.141,0.529,0c0.07,0.069,0.11,0.17,0.11,0.27s-0.04,0.189-0.11,0.26C44.07-59.66,43.979-59.62,43.88-59.62z" fill="#231F20"/>
+                    <path d="M30.56-59.62c-0.09,0-0.189-0.04-0.26-0.11S30.19-59.9,30.19-60s0.039-0.2,0.109-0.27c0.15-0.141,0.391-0.141,0.53,0C30.9-60.2,30.94-60.1,30.94-60s-0.04,0.199-0.11,0.27C30.76-59.67,30.66-59.62,30.56-59.62z" fill="#231F20"/>
+                    <path d="M15.19-28.12c-0.101,0-0.2-0.05-0.271-0.12s-0.11-0.16-0.11-0.26s0.04-0.189,0.12-0.27c0.12-0.131,0.38-0.141,0.53,0.01c0.07,0.07,0.11,0.16,0.11,0.26s-0.04,0.189-0.11,0.27C15.38-28.16,15.29-28.12,15.19-28.12z" fill="#231F20"/>
+                    <path d="M4.13-72.561c-0.1,0-0.2-0.039-0.27-0.119c-0.07-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.11-0.261c0.13-0.14,0.39-0.14,0.529,0c0.07,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C4.32-72.6,4.229-72.561,4.13-72.561z" fill="#231F20"/>
+                    <path d="M18.94-72.561c-0.101,0-0.2-0.039-0.271-0.119c-0.07-0.07-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.12-0.261c0.12-0.14,0.38-0.149,0.53,0c0.06,0.069,0.1,0.16,0.1,0.261c0,0.1-0.029,0.189-0.1,0.27C19.13-72.6,19.04-72.561,18.94-72.561z" fill="#231F20"/>
+                    <path d="M40.69-72.381c-0.101,0-0.2-0.029-0.271-0.109c-0.07-0.061-0.1-0.16-0.1-0.26s0.029-0.189,0.1-0.26c0.15-0.15,0.39-0.15,0.54-0.01c0.07,0.069,0.1,0.17,0.1,0.27s-0.04,0.199-0.109,0.27C40.89-72.41,40.79-72.381,40.69-72.381z" fill="#231F20"/>
+                    <path d="M56.81,0c-0.1,0-0.199-0.04-0.26-0.11c-0.07-0.06-0.109-0.159-0.109-0.26c0-0.11,0.039-0.2,0.109-0.271c0.12-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.101-0.04,0.2-0.11,0.26C57.01-0.04,56.91,0,56.81,0z" fill="#231F20"/>
+                </g>
+                <g>
+                    <path d="M0.57-27.189c-0.11,0-0.21-0.041-0.271-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.109,0.039-0.199,0.109-0.27c0.13-0.13,0.391-0.141,0.53,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C0.76-27.23,0.67-27.189,0.57-27.189z" fill="#231F20"/>
+                    <path d="M0.38-49.689c-0.1,0-0.2-0.041-0.27-0.111C0.04-49.87,0-49.971,0-50.061c0-0.109,0.05-0.199,0.12-0.27c0.109-0.13,0.38-0.141,0.52,0c0.07,0.07,0.11,0.16,0.11,0.27c0,0.09-0.04,0.19-0.11,0.26C0.57-49.73,0.479-49.689,0.38-49.689z" fill="#231F20"/>
+                    <path d="M0.57-43.689c-0.11,0-0.21-0.041-0.271-0.111c-0.07-0.069-0.109-0.159-0.109-0.26c0-0.109,0.039-0.209,0.119-0.27c0.11-0.13,0.381-0.141,0.521,0c0.07,0.07,0.11,0.17,0.11,0.27c0,0.101-0.04,0.19-0.11,0.26C0.76-43.73,0.67-43.689,0.57-43.689z" fill="#231F20"/>
+                    <path d="M0.57-32.811c-0.11,0-0.21-0.05-0.271-0.119c-0.07-0.061-0.109-0.16-0.109-0.26c0-0.101,0.039-0.201,0.119-0.271c0.11-0.12,0.381-0.14,0.521,0.01c0.07,0.06,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27S0.67-32.811,0.57-32.811z" fill="#231F20"/>
+                </g>
+                <g>
+                    <path d="M4.13-72.561c-0.1,0-0.2-0.039-0.27-0.119c-0.061-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.11-0.261c0.13-0.13,0.39-0.14,0.529,0c0.08,0.069,0.11,0.16,0.11,0.261c0,0.1-0.04,0.199-0.11,0.27C4.32-72.6,4.229-72.561,4.13-72.561z" fill="#231F20"/>
+                    <path d="M18.94-72.561c-0.101,0-0.2-0.039-0.271-0.119c-0.06-0.061-0.11-0.16-0.11-0.26c0-0.101,0.04-0.191,0.12-0.261c0.12-0.14,0.38-0.149,0.53,0c0.06,0.069,0.1,0.16,0.1,0.261c0,0.1-0.04,0.199-0.109,0.27C19.13-72.6,19.04-72.561,18.94-72.561z" fill="#231F20"/>
+                    <path d="M40.69-72.37c-0.101,0-0.2-0.05-0.271-0.12c-0.06-0.061-0.1-0.16-0.1-0.26s0.04-0.2,0.109-0.27c0.13-0.131,0.38-0.141,0.53,0.01c0.06,0.06,0.1,0.16,0.1,0.26s-0.04,0.199-0.109,0.27C40.89-72.42,40.79-72.37,40.69-72.37z" fill="#231F20"/>
+                    <path d="M56.81-72c-0.1,0-0.199-0.04-0.26-0.11c-0.07-0.06-0.109-0.159-0.109-0.26c0-0.11,0.039-0.2,0.109-0.271c0.12-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.271c0,0.101-0.04,0.2-0.11,0.26C57.01-72.04,56.91-72,56.81-72z" fill="#231F20"/>
+                </g>
+            </g>
+        </pattern>
+    </defs>
+</svg>

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -137,18 +137,6 @@ def run_tr55(model_input, landscape):
     """
     A thin Celery wrapper around our TR55 implementation.
     """
-    # TODO Remove this.
-    # hard coded values for test
-    landscape = {
-        'result': {
-            'cell_count': 147,
-            'distribution': {
-                'd:hi_residential': 33,
-                'c:commercial': 42,
-                'a:deciduous_forest': 72
-            }
-        }
-    }
     time.sleep(5)
 
     # TODO Get the real simpulation data.

--- a/src/mmw/js/src/core/patterns.js
+++ b/src/mmw/js/src/core/patterns.js
@@ -1,0 +1,49 @@
+"use strict";
+
+var colors = {
+    // Land Cover
+    'lir'        : '#329b9c',
+    'hir'        : '#39afa1',
+    'commercial' : '#40c2a8',
+    'forest'     : '#53e9b4',
+    'turf_grass' : '#4aeab3',
+    'pasture'    : '#51dec2',
+    'grassland'  : '#54d2d0',
+    'row_crop'   : '#52c6dd',
+    'wetland'    : '#4ebaea',
+
+    // Conservation Practice
+    'rain_garden'        : '#51dec2',
+    'veg_infil_basin'    : '#52c6dd',
+    'porous_paving'      : '#54d2d0',
+    'green_roof'         : '#4ebaea',
+    'no_till_agriculture': '#53e9b4',
+    'cluster_housing'    : '#4aeab3'
+};
+
+var getDrawOpts = function(pattern) {
+    if (!pattern || !colors[pattern]) {
+        // Unknown pattern, return generic grey
+        return {
+            clickable: false,
+            color: '#888',
+            opacity: 1,
+            weight: 3,
+            fillColor: '#888',
+            fillOpacity: 0.74
+        }
+    } else {
+        return {
+            clickable: false,
+            color: colors[pattern],
+            opacity: 1,
+            weight: 3,
+            fillColor: 'url(#fill-' + pattern + ')',
+            fillOpacity: 0.74
+        };
+    }
+};
+
+module.exports = {
+    getDrawOpts: getDrawOpts
+};

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -10,6 +10,7 @@ var $ = require('jquery'),
     drawUtils = require('../draw/utils'),
     headerTmpl = require('./templates/header.html'),
     filters = require('../filters'),
+    patterns = require('./patterns'),
     modalConfirmTmpl = require('./templates/confirmModal.html'),
     modalInputTmpl = require('./templates/inputModal.html'),
     modalShareTmpl = require('./templates/shareModal.html'),
@@ -219,7 +220,7 @@ var MapView = Marionette.ItemView.extend({
 
         var layers = modificationsColl.reduce(function(acc, model) {
                 try {
-                    var opts = drawUtils.randomDrawOpts();
+                    var opts = patterns.getDrawOpts(model.get('value'));
                     return acc.concat(new L.GeoJSON(model.get('shape'), opts));
                 } catch (ex) {
                     console.log('Error creating Leaflet layer (invalid GeoJSON object)');

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -63,36 +63,8 @@ function cancelDrawing(map) {
     map.fire('draw:drawstop');
 }
 
-// TODO: Remove
-function randomDrawOpts() {
-    var dashes = [
-        '5, 5',
-        '5, 10',
-        '10, 5',
-        '5, 1',
-        '1, 5',
-        '0.9',
-        '15, 10, 5',
-        '15, 10, 5, 10',
-        '15, 10, 5, 10, 15',
-        '5, 5, 1, 5'
-    ];
-
-    function choice() {
-        return arguments[Math.floor(Math.random() * arguments.length)];
-    }
-
-    return {
-        clickable: false,
-        color: '#' + choice('f', '0') + choice('f', '0') + choice('f', '0'),
-        fillColor: '#' + choice('f', '0') + choice('f', '0') + choice('f', '0'),
-        dashArray: choice.apply(null, dashes)
-    };
-}
-
 module.exports = {
     drawPolygon: drawPolygon,
     placeMarker: placeMarker,
-    cancelDrawing: cancelDrawing,
-    randomDrawOpts: randomDrawOpts
+    cancelDrawing: cancelDrawing
 };

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -5,7 +5,7 @@ var $ = require('jquery'),
 
 function drawPolygon(map, drawOpts) {
     var defer = $.Deferred(),
-        tool = new L.Draw.Polygon(map, drawOpts || {}),
+        tool = new L.Draw.Polygon(map, { shapeOptions: drawOpts || {}}),
         clearEvents = function() {
             map.off('draw:created');
             map.off('draw:drawstop');
@@ -33,7 +33,7 @@ function drawPolygon(map, drawOpts) {
 
 function placeMarker(map, drawOpts) {
     var defer = $.Deferred(),
-        tool = new L.Draw.Marker(map, drawOpts || {}),
+        tool = new L.Draw.Marker(map, { shapeOptions: drawOpts || {}}),
         clearEvents = function() {
             map.off('draw:created');
             map.off('draw:drawstop');

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -5,6 +5,7 @@ var _ = require('lodash'),
     Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
     drawUtils = require('../draw/utils'),
+    patterns = require('../core/patterns'),
     models = require('./models'),
     landCoverTmpl = require('./templates/controls/landCover.html'),
     conservationPracticeTmpl = require('./templates/controls/conservationPractice.html'),
@@ -47,7 +48,7 @@ var DrawControlView = ControlView.extend({
             controlName = this.getControlName(),
             controlValue = $el.data('value'),
             map = App.getLeafletMap();
-        drawUtils.drawPolygon(map).then(function(geojson) {
+        drawUtils.drawPolygon(map, patterns.getDrawOpts(controlValue)).then(function(geojson) {
             self.addModification(new models.ModificationModel({
                 name: controlName,
                 value: controlValue,

--- a/src/mmw/js/src/modeling/templates/controls/conservationPractice.html
+++ b/src/mmw/js/src/modeling/templates/controls/conservationPractice.html
@@ -1,3 +1,5 @@
+{% import './utils.html' as utils %}
+
 <div id="conservation-practice-tools" class="dropdown"> <!-- Conservation Practice Tools -->
     <button class="btn btn-sm btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
     <i class="fa fa-plus-circle"></i> Conservation Practice
@@ -5,32 +7,14 @@
     <div id="conserve-tools" class="dropdown-menu draw-tools menu-left" role="menu"> <!-- Dropdown -->
         <div class="pad-1"> <!-- Dropdown Content -->
             <ul class="row">
-                <li>
-                    <div class="thumb" data-value="Rain Garden"></div>
-                    <label class="dark">Rain garden</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="Veg Infil Basin"></div>
-                    <label class="dark">Veg Infil Basin</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="Porous Paving"></div>
-                    <label class="dark">Porous Paving</label>
-                </li>
+                {{ utils.thumb('Rain Garden', 'rain_garden') }}
+                {{ utils.thumb('Veg Infil Basin', 'veg_infil_basin') }}
+                {{ utils.thumb('Porous Paving', 'porous_paving') }}
             </ul>
             <ul class="row">
-                <li>
-                    <div class="thumb" data-value="Green Roof"></div>
-                    <label class="dark">Green Roof</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="No-Till Agriculture"></div>
-                    <label class="dark">No-Till Agriculture</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="Cluster Housing"></div>
-                    <label class="dark">Cluster Housing</label>
-                </li>
+                {{ utils.thumb('Green Roof', 'green_roof') }}
+                {{ utils.thumb('No-Till Agriculture', 'no_till_agriculture') }}
+                {{ utils.thumb('Cluster Housing', 'cluster_housing') }}
             </ul>
         </div> <!-- End Dropdown Content -->
 

--- a/src/mmw/js/src/modeling/templates/controls/landCover.html
+++ b/src/mmw/js/src/modeling/templates/controls/landCover.html
@@ -1,3 +1,5 @@
+{% import './utils.html' as utils %}
+
 <div id="land-cover-tools" class="dropdown"> <!-- Landcover Tools -->
     <button class="btn btn-sm btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
     <i class="fa fa-plus-circle"></i> Land Cover
@@ -5,46 +7,19 @@
     <div id="land-tools" class="dropdown-menu menu-left" role="menu"> <!-- Dropdown -->
         <div class="pad-1"> <!-- Dropdown Content -->
             <ul class="row">
-                <li>
-                    <div class="thumb" data-value="LIR"></div>
-                    <label class="dark">LIR</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="HIR"></div>
-                    <label class="dark">HIR</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="Commercial"></div>
-                    <label class="dark">Commercial</label>
-                </li>
+                {{ utils.thumb('LIR', 'lir') }}
+                {{ utils.thumb('HIR', 'hir') }}
+                {{ utils.thumb('Commercial', 'commercial') }}
             </ul>
             <ul class="row">
-                <li>
-                    <div class="thumb" data-value="Forest"></div>
-                    <label class="dark">Forest</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="Turf Grass"></div>
-                    <label class="dark">Turf Grass</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="Pasture"></div>
-                    <label class="dark">Pasture</label>
-                </li>
+                {{ utils.thumb('Forest', 'forest') }}
+                {{ utils.thumb('Turf Grass', 'turf_grass') }}
+                {{ utils.thumb('Pasture', 'pasture') }}
             </ul>
             <ul class="row">
-                <li>
-                    <div class="thumb" data-value="Grassland"></div>
-                    <label class="dark">Grassland</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="Row Crop"></div>
-                    <label class="dark">Row Crop</label>
-                </li>
-                <li>
-                    <div class="thumb" data-value="Wetland"></div>
-                    <label class="dark">Wetland</label>
-                </li>
+                {{ utils.thumb('Grassland', 'grassland') }}
+                {{ utils.thumb('Row Crop', 'row_crop') }}
+                {{ utils.thumb('Wetland', 'wetland') }}
             </ul>
         </div> <!-- End Dropdown Content -->
 

--- a/src/mmw/js/src/modeling/templates/controls/utils.html
+++ b/src/mmw/js/src/modeling/templates/controls/utils.html
@@ -1,0 +1,10 @@
+{% macro thumb(name, value, size=56) %}
+    <li>
+        <div class="thumb" data-value="{{ value }}">
+            <svg>
+                <rect height="{{ size }}" width="{{ size }}" fill="url(#fill-{{ value }})"></rect>
+            </svg>
+        </div>
+        <label class="dark">{{ name }}</label>
+    </li>
+{% endmacro %}

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -8,6 +8,7 @@ var _ = require('lodash'),
     assert = require('chai').assert,
     Marionette = require('../../shim/backbone.marionette'),
     sinon = require('sinon'),
+    patterns = require('../core/patterns'),
     models = require('./models'),
     views = require('./views');
 
@@ -124,6 +125,22 @@ describe('Modeling', function() {
                 assert.equal($('#sandbox #mod-landcover tr td:nth-child(2)').text(), '44.4 km2');
                 assert.equal($('#sandbox #mod-conservationpractice tr td:first-child').text(), 'Rain Garden');
                 assert.equal($('#sandbox #mod-conservationpractice tr td:nth-child(2)').text(), '106.4 km2');
+            });
+
+            it('ensures each modification has a pattern', function() {
+                $('.inline.controls .thumb').each(function() {
+                    var pattern = 'pattern#fill-' + $(this).data('value');
+                    assert.isDefined($(pattern));
+                });
+            });
+
+            it('ensures each modification has draw options', function() {
+                var unknownDrawOpts = patterns.getDrawOpts('');
+
+                $('.inline.controls .thumb').each(function() {
+                    var thisDrawOpts = patterns.getDrawOpts($(this).data('value'));
+                    assert.notEqual(thisDrawOpts, unknownDrawOpts);
+                });
             });
         });
 


### PR DESCRIPTION
Adds SVG patterns made by @ctaylo37 to the `/model` view. They look like this:

![image](https://cloud.githubusercontent.com/assets/1430060/8095092/68ce1678-0f99-11e5-971f-4ba5940326fc.png)

Land Cover Thumbnails:

![image](https://cloud.githubusercontent.com/assets/1430060/8095123/99237cd2-0f99-11e5-987f-859dadcb72d0.png)

Conservation Practice Thumbnails:

![image](https://cloud.githubusercontent.com/assets/1430060/8095139/abadedf6-0f99-11e5-9a12-3bc93b801c19.png)

**Testing Instructions**

 * Draw an area of interest, move on to `/model` view
 * Add a scenario, add various Land Cover and Conservation Practice modifications

**Alternate Scenarios**

 * Try saving modifications and revisit page to ensure they show up correctly

**Notes**

While I'm happy with most of the work done here, the one issue which I need help with is finding the best strategy for pattern loading. Currently it has been added to the end of `base.html`, which means we have an addition of 616 KB to every full page load. Perhaps this is acceptable because all further interaction is done via AJAX calls. Or perhaps we should somehow dynamically load this when people land on the `/model` view, which would make initial load faster, but the transition and loading of this page a little slower. We may even consider adding loading animations to the modification drop-downs until the patterns are loaded.

Another attempt might be to minify `patterns.html`. I've removed all extraneous spacing, but it is still well-indented to be human readable. We could probably save some bandwidth if we got rid of all newlines and whitespace.

Input, there and elsewhere, is welcome.

Connects #257 