### PR TITLE
Fix geocoding

### DIFF
--- a/src/mmw/js/src/core/csrf.js
+++ b/src/mmw/js/src/core/csrf.js
@@ -26,12 +26,24 @@ function getCookie(name) {
     return cookieValue;
 }
 
+// Source: http://stackoverflow.com/questions/6238351/fastest-way-to-detect-external-urls
+var isExternal = (function(){
+    var domainRe = /https?:\/\/((?:[\w\d]+\.)+[\w\d]{2,})/i;
+
+    return function(url) {
+        function domain(url) {
+          var result = domainRe.exec(url) !== null ? domainRe.exec(url)[1] : null;
+          return result;
+        }
+
+        return domain(location.href) !== domain(url);
+    };
+})();
 
 exports.jqueryAjaxSetupOptions = {
-    crossDomain: false,
     beforeSend: function(xhr, settings) {
         var csrftoken = getCookie('csrftoken');
-        if (!csrfSafeMethod(settings.type)) {
+        if (!csrfSafeMethod(settings.type) && !isExternal(settings.url)) {
             xhr.setRequestHeader("X-CSRFToken", csrftoken);
         }
     }

--- a/src/mmw/js/src/core/setup.js
+++ b/src/mmw/js/src/core/setup.js
@@ -1,3 +1,4 @@
+"use strict";
 
 // Setup shims and require third party dependencies in the correct order.
 // For example, jQuery needs to exist before requiring boostrap.


### PR DESCRIPTION
Allow cross-domain AJAX. Only use CSFR internally.
* Remove option to deny cross domain AJAX requests.
* Check if requested URL is external before attaching
CSRF header.
* Add tests for CSRF module.

**To test**:
- Navigate to the home page.
- Try using the address search input.
- Try loading and saving a project.
- Run the tests.

Connects to #336