### PR TITLE
Consolidate UserSerializer

### DIFF
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -7,15 +7,10 @@ from django.http import Http404
 from django.contrib.auth.models import User
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template.context_processors import csrf
-from rest_framework import serializers, viewsets
+from rest_framework import viewsets
+
 from apps.modeling.models import Project
-
-
-# Serializers define the API representation.
-class UserSerializer(serializers.HyperlinkedModelSerializer):
-    class Meta:
-        model = User
-        fields = ('url', 'username', 'email', 'is_staff')
+from apps.user.serializers import UserSerializer
 
 
 # ViewSets define the view behavior.

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -2,19 +2,13 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from django.contrib.auth.models import User
 from rest_framework import serializers
 from rest_framework_gis import serializers as gis_serializers
 
 from apps.modeling.models import Project, Scenario
+from apps.user.serializers import UserSerializer
 
 import json
-
-
-class UserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = ('id', 'username', 'email')
 
 
 class ModificationsField(serializers.BaseSerializer):

--- a/src/mmw/apps/user/serializers.py
+++ b/src/mmw/apps/user/serializers.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.contrib.auth.models import User
+from rest_framework import serializers
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'email', 'is_staff')


### PR DESCRIPTION
This patch consolidates the two `UserSerializer` definitions into one
that is housed in the `user` app.

**To test**:
Try creating a new user and/or signing in to the application with a user that you have created.  Also, try saving a restoring a project.  All of those things should continue to be possible.

Fixes #254