### PR TITLE
Add CustomActionNode to create a VPC endpoint for Amazon S3

### DIFF
--- a/deployment/cfn/s3_vpc_endpoint.py
+++ b/deployment/cfn/s3_vpc_endpoint.py
@@ -1,0 +1,114 @@
+from boto.vpc import VPCConnection
+from boto.ec2.regioninfo import RegionInfo
+from boto.ec2.ec2object import TaggedEC2Object
+
+from majorkirby import CustomActionNode
+
+
+class RouteTables(list):
+    """Represents a list of route tables"""
+    def startElement(self, name, attrs, connection):
+        pass
+
+    def endElement(self, name, value, connection):
+        if name == 'item':
+            self.append(value)
+
+
+class VPCEndpoint(TaggedEC2Object):
+    """Represents a VPC endpoint"""
+    def __init__(self, connection=None):
+        super(VPCEndpoint, self).__init__(connection)
+        self.id = None
+        self.vpc_id = None
+        self.state = None
+        self.route_tables = RouteTables()
+        self.policy_document = None
+        self.service_name = None
+
+    def __repr__(self):
+        return 'VPCEndpoint:%s' % self.id
+
+    def startElement(self, name, attrs, connection):
+        retval = super(VPCEndpoint, self).startElement(name, attrs, connection)
+        if retval is not None:
+            return retval
+        if name == 'routeTableIdSet':
+            return self.route_tables
+        else:
+            return None
+
+    def endElement(self, name, value, connection):
+        if name == 'vpcEndpointId':
+            self.id = value
+        elif name == 'vpcId':
+            self.vpc_id = value
+        elif name == 'state':
+            self.state = value
+        elif name == 'policyDocument':
+            self.policy_document = value
+        elif name == 'serviceName':
+            self.service_name = value
+        else:
+            setattr(self, name, value)
+
+
+class CustomVPCConnection(VPCConnection):
+    """Represents a custom VPC connection"""
+    def __init__(self, region='us-east-1', api_version='2015-04-15', **kwargs):
+        region_info = RegionInfo(self, region,
+                                 'ec2.{}.amazonaws.com'.format(region))
+        super(CustomVPCConnection, self).__init__(api_version=api_version,
+                                                  region=region_info, **kwargs)
+
+    def get_vpc_endpoint(self, vpc_id, route_table_id):
+        """Gets a VPC endpoint by ID and associated route table ID"""
+        vpc_endpoints = self.get_list('DescribeVpcEndpoints', {},
+                                      [('item', VPCEndpoint)], verb='POST')
+
+        for vpc_endpoint in vpc_endpoints:
+            if (vpc_endpoint.vpc_id == vpc_id and
+                    vpc_endpoint.route_tables[0] == route_table_id):
+                return vpc_endpoint
+
+        return None
+
+    def create_vpc_endpoint(self, vpc_id, route_table_id, service_name):
+        """Creates a VPC endpoint in the VPC and ties it with a route table"""
+        params = {'VpcId': vpc_id, 'RouteTableId.1': route_table_id,
+                  'ServiceName': service_name}
+        return self.get_object('CreateVpcEndpoint', params, VPCEndpoint,
+                               verb='POST')
+
+
+class S3VPCEndpoint(CustomActionNode):
+    """Represents a VPC endpoint for Amazon S3"""
+    INPUTS = {
+        'Region': ['global:Region'],
+        'VpcId': ['global:VpcId', 'VPC:VpcId'],
+        'RouteTableId': ['global:RouteTableId', 'VPC:RouteTableId'],
+        'StackType': ['global:StackType'],
+    }
+
+    DEFAULTS = {
+        'Region': 'us-east-1',
+        'StackType': 'Staging',
+    }
+
+    ATTRIBUTES = {'StackType': 'StackType'}
+
+    def action(self):
+        region = self.get_input('Region')
+        vpc_id = self.get_input('VpcId')
+        route_table_id = self.get_input('RouteTableId')
+
+        conn = CustomVPCConnection(region=region,
+                                   profile_name=self.aws_profile)
+        vpc_endpoint = conn.get_vpc_endpoint(vpc_id, route_table_id)
+
+        if vpc_endpoint is None:
+            conn.create_vpc_endpoint(vpc_id, route_table_id,
+                                     self.get_service_name(region))
+
+    def get_service_name(self, region):
+        return 'com.amazonaws.{}.s3'.format(region)

--- a/deployment/cfn/stacks.py
+++ b/deployment/cfn/stacks.py
@@ -1,6 +1,7 @@
 from majorkirby import GlobalConfigNode
 
 from vpc import VPC
+from s3_vpc_endpoint import S3VPCEndpoint
 from private_hosted_zone import PrivateHostedZone
 
 import ConfigParser
@@ -29,13 +30,18 @@ def build_graph(mmw_config, aws_profile, **kwargs):
     """
     global_config = GlobalConfigNode(**mmw_config)
     vpc = VPC(globalconfig=global_config, aws_profile=aws_profile)
+    s3_vpc_endpoint = S3VPCEndpoint(globalconfig=global_config, VPC=vpc,
+                                    aws_profile=aws_profile)
     private_hosted_zone = PrivateHostedZone(globalconfig=global_config,
-                                            VPC=vpc, aws_profile=aws_profile)
+                                            VPC=vpc,
+                                            aws_profile=aws_profile)
 
-    return vpc, private_hosted_zone
+    return s3_vpc_endpoint, private_hosted_zone
 
 
 def build_stacks(mmw_config, aws_profile, **kwargs):
     """Trigger actual building of graphs"""
-    vpc_graph, private_hosted_zone_graph = build_graph(mmw_config, aws_profile)
+    s3_vpc_endpoint_graph, private_hosted_zone_graph = build_graph(
+        mmw_config, aws_profile)
+    s3_vpc_endpoint_graph.go()
     private_hosted_zone_graph.go()

--- a/deployment/cfn/vpc.py
+++ b/deployment/cfn/vpc.py
@@ -107,9 +107,7 @@ class VPC(StackNode):
             'BastionHostAMI', Type='String', Description='Bastion host AMI'
         ), 'BastionHostAMI')
 
-        self.create_vpc()
-
-        # TODO: Setup VPC endpoint to bypass NAT when talking to S3
+        public_route_table = self.create_vpc()
 
         self.add_output(Output('AvailabilityZones',
                                Value=','.join(self.default_azs)))
@@ -117,6 +115,7 @@ class VPC(StackNode):
                                Value=Join(',', map(Ref, self.default_private_subnets))))  # NOQA
         self.add_output(Output('PublicSubnets',
                                Value=Join(',', map(Ref, self.default_public_subnets))))  # NOQA
+        self.add_output(Output('RouteTableId', Value=Ref(public_route_table)))
 
     def get_recent_nat_ami(self):
         try:
@@ -139,6 +138,8 @@ class VPC(StackNode):
         public_route_table = self.create_routing_resources()
         self.create_subnets(public_route_table)
         self.create_bastion()
+
+        return public_route_table
 
     def create_routing_resources(self):
         gateway = self.create_resource(


### PR DESCRIPTION
By default, instances in the private subnet have to route traffic through a NAT instance in a public subnet to communicate with Amazon S3. Setting up a VPC endpoint allows the traffic to flow directly to Amazon S3 from private subnets via a special route:

  https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/

This is being done in a `CustomActionNode` because CloudFormation does not have support for creating VPC endpoints. Also, many of the additional Python classes are necessary because Boto does not have
direct support for describing and creating VPC endpoints.

Connects #287. Also, tagging @kdeloach and @lliss.

---

To test, go through the process of launching a stack and check the VPC > Endpoints page. There should be an entry associated with the `MMWVPC` and the default route table for `com.amazonaws.us-east-1.s3`.