### PR TITLE
Post-Sign Up Login

### DIFF
--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -27,17 +27,24 @@ def login(request):
         user = authenticate(username=request.REQUEST.get('username'),
                             password=request.REQUEST.get('password'))
 
-        if user is not None and user.is_active:
-            auth_login(request, user)
-            response_data['result'] = 'success'
-            response_data['username'] = user.username
-            response_data['guest'] = False
-            response_data['id'] = user.id
+        if user is not None:
+            if user.is_active:
+                auth_login(request, user)
+                response_data['result'] = 'success'
+                response_data['username'] = user.username
+                response_data['guest'] = False
+                response_data['id'] = user.id
+            else:
+                response_data['errors'] = ['Please activate your account']
+                response_data['guest'] = True
+                response_data['id'] = 0
+                status_code = status.HTTP_400_BAD_REQUEST
         else:
             response_data['errors'] = ['Invalid username or password']
             response_data['guest'] = True
             response_data['id'] = 0
             status_code = status.HTTP_400_BAD_REQUEST
+
     elif request.method == 'GET':
         user = request.user
 

--- a/src/mmw/js/src/user/controllers.js
+++ b/src/mmw/js/src/user/controllers.js
@@ -7,6 +7,7 @@ var App = require('../app'),
 var SignUpController = {
     signUp: function() {
         new views.SignUpModalView({
+            app: App,
             model: new models.SignUpFormModel({})
         }).render();
     },

--- a/src/mmw/js/src/user/templates/signUpModal.html
+++ b/src/mmw/js/src/user/templates/signUpModal.html
@@ -14,7 +14,7 @@
 
 {% block footer %}
     {% if success %}
-        <button type="button" class="btn btn-lg btn-block btn-active" data-dismiss="modal">Continue As Guest</button>
+        <button type="button" class="btn btn-lg btn-block btn-active" id="dismiss-button" data-dismiss="modal">Login</button>
     {% else %}
         <button type="button" class="btn btn-lg btn-block btn-active" id="primary-button">Sign Up</button>
     {% endif %}

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -198,6 +198,10 @@ var SignUpModalView = ModalBaseView.extend({
             password2: $(this.ui.password2.selector).val(),
             agreed: $(this.ui.agreed.selector).prop('checked')
         }, { silent: true });
+    },
+
+    dismissAction: function() {
+        this.app.showLoginModal();
     }
 });
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -302,7 +302,6 @@ REST_FRAMEWORK = {
 
 # registration
 ACCOUNT_ACTIVATION_DAYS = 7  # One-week activation window.
-REGISTRATION_AUTO_LOGIN = True  # Automatically log the user in.
 
 # Add custom authentication classes
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
Adjusts Sign Up behavior so that users are not logged in automatically upon activation, and are directed to the Login form instead. If they try to log in before activation, they are informed that they need to activate their accounts.

**Testing Instructions**

 * Stop the app and run it manually so you see the console output:

```shell
vagrant ssh app -c 'sudo stop mmw-app'
./scripts/manage.sh runserver
```

 * Make sure you are not logged in. Click the Login button. Click Sign Up
 * Fill in the form and sign up as a new user.
 * Ensure that after signing up you see a dialog which instructs you to activate the account using link in email, and that you see a Login button.
 * Click the Login button. Attempt to log in as the new user.
 * Ensure that you see a message instructing you to activate your account first.
 * Follow the activation link in your "email" (from the console output)
 * Try logging in again after activation

**Notes**

This code assumes that any account which is not currently active has received a confirmation code. If an existing account is made inactive by a superuser, then they will receive the same message (to activate their account), whereas in this case they should see an "Invalid username or password" message. I'm not sure if such user deactivation is an expected use case for this app.

There is also no mechanism to resend the confirmation code. I've added #361 for that.

Connects #262 
Connects #259 