### PR TITLE
Update the URL with active scenario

### DIFF
--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -12,6 +12,8 @@ urlpatterns = patterns(
     url(r'^$', home_page, name='home_page'),
     url(r'^model/$', model, name='model'),
     url(r'^model/(?P<proj_id>[0-9]+)/$', model, name='model'),
+    url(r'^model/(?P<proj_id>[0-9]+)/scenario/(?P<scenario_id>[0-9]+)/$',
+        model, name='model'),
     url(r'^analyze$', home_page, name='analyze'),
     url(r'^compare$', compare, name='compare'),
     url(r'^error', home_page, name='error'),

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -31,7 +31,7 @@ def home_page(request):
     return render_to_response('home/home.html', csrf_token)
 
 
-def model(request, proj_id=None):
+def model(request, proj_id=None, scenario_id=None):
     """
     If proj_id was specified, check that the user owns
     the project or if the project is public.

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -302,6 +302,34 @@ describe('Modeling', function() {
                             });
                 });
             });
+
+            describe('#getReferenceUrl', function() {
+                var base = '/model/';
+
+                it('generates no url fragment for unsaved projects', function() {
+                    var project = new models.ProjectModel({ id: null });
+                    assert.equal(project.getReferenceUrl(), base);
+                });
+
+                it('generates a project id fragment when a project is saved and no active scenario is set', function() {
+                    var project = new models.ProjectModel({ id: 42 });
+
+                    assert.equal(project.getReferenceUrl(), base + project.id);
+                });
+
+                it('generates a project & scenario id fragment when a project is saved and an active scenario is set', function() {
+                    var project = new models.ProjectModel({ id: 42 }),
+                        scenario = new models.ScenarioModel({ id: 23 }),
+                        coll = new models.ScenariosCollection([ scenario ]);
+
+                    project.set('scenarios', coll);
+
+                    coll.setActiveScenario(scenario);
+
+                    assert.equal(project.getReferenceUrl(), base + project.id +
+                                 '/scenario/' + scenario.id);
+                });
+            });
         });
 
         describe('ModificatioModel', function() {

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -354,7 +354,7 @@ describe('Modeling', function() {
 
                     assert.isFalse(collection.at(2).get('active'));
 
-                    collection.setActiveScenario(collection.at(2).cid);
+                    collection.setActiveScenario(collection.at(2));
 
                     assert.isTrue(collection.at(2).get('active'));
                 });
@@ -363,7 +363,7 @@ describe('Modeling', function() {
                     var collection = getTestScenarioCollection();
 
                     collection.first().set('active', true);
-                    collection.setActiveScenario(collection.at(2).cid);
+                    collection.setActiveScenario(collection.at(2));
 
                     assert.isFalse(collection.at(0).get('active'));
                     assert.isFalse(collection.at(1).get('active'));

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -241,7 +241,7 @@ var ScenariosView = Marionette.LayoutView.extend({
         var $el = $(e.currentTarget),
             cid = $el.data('scenario-cid');
 
-        this.collection.setActiveScenario(cid);
+        this.collection.setActiveScenarioByCid(cid);
     }
 });
 
@@ -376,7 +376,7 @@ var ScenarioTabPanelsView = Marionette.CollectionView.extend({
                 }),
                 newCid = this.collection.models[modelIndex - 1].cid;
 
-            this.collection.setActiveScenario(newCid);
+            this.collection.setActiveScenarioByCid(newCid);
        }
     }
 });
@@ -421,7 +421,7 @@ var ScenarioDropDownMenuView = Marionette.CompositeView.extend({
         var $el = $(e.currentTarget),
             cid = $el.data('scenario-cid');
 
-        this.collection.setActiveScenario(cid);
+        this.collection.setActiveScenarioByCid(cid);
     }
 });
 

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -14,6 +14,7 @@ router.addRoute(/^analyze/, AnalyzeController, 'analyze');
 router.addRoute(/^model/, ModelingController, 'model');
 router.addRoute('model/:projectId', ModelingController, 'model');
 router.addRoute('model/:projectId/', ModelingController, 'model');
+router.addRoute('model/:projectId/scenario/:scenarioId/', ModelingController, 'model');
 router.addRoute(/^compare/, AppController, 'compare');
 router.addRoute('error(/)(:type)', ErrorController, 'error');
 router.addRoute('sign-up(/)', SignUpController, 'signUp');


### PR DESCRIPTION
Allow the URL to be set with the active scenario and restore that
scenario to active status allows easier sharing of public links.

Testing:
* Non-saved projects should not generate unique url structures
* Saved projects should update the URL with the scenario ID when it's activated
* Full scenario URLs should select the correct tab on reload
* Bad scenario Ids redirect to the first scenario
* Adding a new scenario will update the URL with the correct ID when the ID is received from the save operation.

Connects #280 