### PR TITLE
Handle cases when `response` or `responseJSON` is undefined

### DIFF
--- a/src/mmw/js/src/user/tests.js
+++ b/src/mmw/js/src/user/tests.js
@@ -81,6 +81,22 @@ describe('User', function() {
             assert.equal(validationError, 'Invalid username or password', 'Could not find failed login message.');
         });
 
+        it ('creates an error when failing to communicate with server', function() {
+            this.server.respondWith([500, {}, '']);
+            var loginView = new views.LoginModalView({
+                el: '#sandbox',
+                model: new models.LoginFormModel({}),
+                app: App
+            }).render();
+
+            loginView.$el.find('#username').val('bad');
+            loginView.$el.find('#password').val('apple');
+            loginView.$el.find('#primary-button').click();
+            var validationError = loginView.$el.find('ul li').first().text();
+
+            assert.equal(validationError, 'Server communication error', 'Could not find failed server message.');
+        });
+
         it('logs the user in when there is a valid response', function() {
             var username = 'bob';
             this.server.respondWith([200, { 'Content-Type': 'application/json' }, '{"result": "success", "username": "bob" }']);

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -80,7 +80,7 @@ var ModalBaseView = Marionette.ItemView.extend({
     // Default failure handler, will display any `errors` received from server.
     handleServerFailure: function(response) {
         var server_errors = ["Server communication error"];
-        if (response.responseJSON.errors) {
+        if (response && response.responseJSON && response.responseJSON.errors) {
             server_errors = response.responseJSON.errors;
         }
         this.model.set({


### PR DESCRIPTION
Also add a test to exercise that bit of code. In the test we simulate an error 500, but what is more relevant is the empty response string.

Connects #374 