### PR TITLE
Human-readable labels in modifications dropdown.

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -62,6 +62,12 @@ var DrawControlView = ControlView.extend({
 var LandCoverView = DrawControlView.extend({
     template: landCoverTmpl,
 
+    templateHelpers: function() {
+        return {
+            label: models.getHumanReadableLabel
+        };
+    },
+
     getControlName: function() {
         return 'landcover';
     }
@@ -69,6 +75,12 @@ var LandCoverView = DrawControlView.extend({
 
 var ConservationPracticeView = DrawControlView.extend({
     template: conservationPracticeTmpl,
+
+    templateHelpers: function() {
+        return {
+            label: models.getHumanReadableLabel
+        };
+    },
 
     getControlName: function() {
         return 'conservation_practice';

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -156,6 +156,8 @@ var ModificationModel = coreModels.GeoModel.extend({
     )
 });
 
+ModificationModel.prototype.label = getHumanReadableLabel;
+
 var ModificationsCollection = Backbone.Collection.extend({
     model: ModificationModel
 });
@@ -341,6 +343,32 @@ function getControlsForModelPackage(modelPackageName) {
     throw 'Model package not supported ' + modelPackageName;
 }
 
+function getHumanReadableLabel(value) {
+    var mapping = {
+        'commercial': 'Commercial',
+        'forest': 'Forest',
+        'grassland': 'Grassland',
+        'hir': 'HIR',
+        'lir': 'LIR',
+        'pasture': 'Pasture',
+        'row_crop': 'Row Crop',
+        'turf_grass': 'Turf Grass',
+        'wetland': 'Wetland',
+        'cluster_housing': 'Cluster Housing',
+        'green_roof': 'Green Roof',
+        'no_till_agriculture': 'No-Till Agriculture',
+        'porous_paving': 'Porous Paving',
+        'rain_garden': 'Rain Garden',
+        'veg_infil_basin': 'Veg Infil Basin'
+    };
+
+    if (mapping[value]) {
+        return mapping[value];
+    } else {
+        throw 'Unknown Land Cover or Conservation Practice: ' + value;
+    }
+}
+
 module.exports = {
     getControlsForModelPackage: getControlsForModelPackage,
     ResultModel: ResultModel,
@@ -353,5 +381,6 @@ module.exports = {
     ModificationModel: ModificationModel,
     ModificationsCollection: ModificationsCollection,
     ScenarioModel: ScenarioModel,
-    ScenariosCollection: ScenariosCollection
+    ScenariosCollection: ScenariosCollection,
+    getHumanReadableLabel: getHumanReadableLabel
 };

--- a/src/mmw/js/src/modeling/templates/controls/conservationPractice.html
+++ b/src/mmw/js/src/modeling/templates/controls/conservationPractice.html
@@ -7,14 +7,14 @@
     <div id="conserve-tools" class="dropdown-menu draw-tools menu-left" role="menu"> <!-- Dropdown -->
         <div class="pad-1"> <!-- Dropdown Content -->
             <ul class="row">
-                {{ utils.thumb('Rain Garden', 'rain_garden') }}
-                {{ utils.thumb('Veg Infil Basin', 'veg_infil_basin') }}
-                {{ utils.thumb('Porous Paving', 'porous_paving') }}
+                {{ utils.thumb(label, 'rain_garden') }}
+                {{ utils.thumb(label, 'veg_infil_basin') }}
+                {{ utils.thumb(label, 'porous_paving') }}
             </ul>
             <ul class="row">
-                {{ utils.thumb('Green Roof', 'green_roof') }}
-                {{ utils.thumb('No-Till Agriculture', 'no_till_agriculture') }}
-                {{ utils.thumb('Cluster Housing', 'cluster_housing') }}
+                {{ utils.thumb(label, 'green_roof') }}
+                {{ utils.thumb(label, 'no_till_agriculture') }}
+                {{ utils.thumb(label, 'cluster_housing') }}
             </ul>
         </div> <!-- End Dropdown Content -->
 

--- a/src/mmw/js/src/modeling/templates/controls/landCover.html
+++ b/src/mmw/js/src/modeling/templates/controls/landCover.html
@@ -7,19 +7,19 @@
     <div id="land-tools" class="dropdown-menu menu-left" role="menu"> <!-- Dropdown -->
         <div class="pad-1"> <!-- Dropdown Content -->
             <ul class="row">
-                {{ utils.thumb('LIR', 'lir') }}
-                {{ utils.thumb('HIR', 'hir') }}
-                {{ utils.thumb('Commercial', 'commercial') }}
+                {{ utils.thumb(label, 'lir') }}
+                {{ utils.thumb(label, 'hir') }}
+                {{ utils.thumb(label, 'commercial') }}
             </ul>
             <ul class="row">
-                {{ utils.thumb('Forest', 'forest') }}
-                {{ utils.thumb('Turf Grass', 'turf_grass') }}
-                {{ utils.thumb('Pasture', 'pasture') }}
+                {{ utils.thumb(label, 'forest') }}
+                {{ utils.thumb(label, 'turf_grass') }}
+                {{ utils.thumb(label, 'pasture') }}
             </ul>
             <ul class="row">
-                {{ utils.thumb('Grassland', 'grassland') }}
-                {{ utils.thumb('Row Crop', 'row_crop') }}
-                {{ utils.thumb('Wetland', 'wetland') }}
+                {{ utils.thumb(label, 'grassland') }}
+                {{ utils.thumb(label, 'row_crop') }}
+                {{ utils.thumb(label, 'wetland') }}
             </ul>
         </div> <!-- End Dropdown Content -->
 

--- a/src/mmw/js/src/modeling/templates/controls/utils.html
+++ b/src/mmw/js/src/modeling/templates/controls/utils.html
@@ -1,10 +1,10 @@
-{% macro thumb(name, value, size=56) %}
+{% macro thumb(label, value, size=56) %}
     <li>
         <div class="thumb" data-value="{{ value }}">
             <svg>
                 <rect height="{{ size }}" width="{{ size }}" fill="url(#fill-{{ value }})"></rect>
             </svg>
         </div>
-        <label class="dark">{{ name }}</label>
+        <label class="dark">{{ label(value) }}</label>
     </li>
 {% endmacro %}

--- a/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
+++ b/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
@@ -27,7 +27,7 @@
                 <table id="mod-{{ controlName|lower|replace(' ', '') }}" class="table modifications custom-hover">
                 {% for model in models %}
                     <tr>
-                        <td>{{ model.get('value') }}</td>
+                        <td>{{ model.label(model.get('value')) }}</td>
                         <td class="strong text-right">{{ model.get('area')|round(1)|toLocaleString }} {{ model.get('units') }}</td>
                         <td class="text-right"><button class="btn btn-sm btn-icon dark" type="button" data-delete="{{ model.cid }}">
                         <i class="fa fa-trash"></i>

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -519,7 +519,7 @@ var greaterThanOneAcrePolygon = { "type": "FeatureCollection", "features": [ { "
 
 var modificationsSample1 = {
     "name":"Land Cover",
-    "value":"LIR",
+    "value":"lir",
     "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-76.00479125976562,40.19251207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]]}},
     "area":10977.041602204828,
     "units":"acres"
@@ -527,7 +527,7 @@ var modificationsSample1 = {
 
 var modificationsSample2  = {
     "name":"Conservation Practice",
-    "value":"Rain Garden",
+    "value":"rain_garden",
     "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-75.53237915039062,40.18307014852534],[-75.66009521484375,40.107487419012415],[-75.50491333007812,40.10118506258701],[-75.43350219726561,40.13899044275822],[-75.42800903320312,40.1673306817866],[-75.53237915039062,40.18307014852534]]]}},
     "area":26292.18855342856,
     "units":"acres"


### PR DESCRIPTION
A helper function has been created to map non-human-readable names to human-readable ones.

**To Test**
   * Choose an area of interest
   * Create a new scenario and draw some land use and/or conservation polygons
   * Click on the "modifications" button
   * You should now see human-readable labels
   * If you save and restore, you should still see human-readable labels

Connects WikiWatershed/model-my-watershed#369