### PR TITLE
Always serve fonts over HTTPS.

### DIFF
--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -5,7 +5,7 @@
  * Google Font Library
  * Only used if not called in head
  */
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,500,700,900,300,400italic);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,500,700,900,300,400italic);
 
 /**
  * Vendor style importing


### PR DESCRIPTION
If we are on an HTTPS connection (as we will be in production) we want our fonts
to be served over HTTPS as well. Since there is no harm in it, always serve
fonts over an HTTPS connection.

Connects #402 