### PR TITLE
Remove scenario modification tools for non-owners

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -105,7 +105,7 @@ var PrecipitationView = ControlView.extend({
     },
 
     getDisplayValue: function(value) {
-        return value === 0 ? '' : value.toFixed(1) + '"';
+        return value.toFixed(1) + '"';
     },
 
     onSliderDragged: function(e) {

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -9,6 +9,14 @@ var Backbone = require('../../shim/backbone'),
 var ModelPackageControlModel = Backbone.Model.extend({
     defaults: {
         name: ''
+    },
+
+    // Return true if this is an input control and false if it is a
+    // modification control.
+    isInputControl: function() {
+        return _.contains([
+            'precipitation'
+        ], this.get('name'));
     }
 });
 

--- a/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
+++ b/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
@@ -20,9 +20,11 @@
                     <tr>
                         <td>{{ model.label(model.get('value')) }}</td>
                         <td class="strong text-right">{{ model.get('area')|round(1)|toLocaleString }} {{ model.get('units') }}</td>
+                        {% if editable %}
                         <td class="text-right"><button class="btn btn-sm btn-icon dark" type="button" data-delete="{{ model.cid }}">
                         <i class="fa fa-trash"></i>
                         </button></td>
+                        {% endif %}
                     </tr>
                 {% endfor %}
                 </table>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -105,7 +105,7 @@ var ProjectMenuView = Marionette.ItemView.extend({
 
     templateHelpers: function() {
         return {
-            editable: App.user.userMatch(this.model.get('user_id'))
+            editable: isEditable(this.model)
         };
     },
 
@@ -216,10 +216,11 @@ var ScenariosView = Marionette.LayoutView.extend({
     template: scenariosBarTmpl,
 
     templateHelpers: function() {
+        // Check the first scenario in the collection as a proxy for the
+        // entire collection.
+        var scenario = this.collection.first();
         return {
-            // Check the first scenario in the collection as a proxy for the
-            // entire collection.
-            editable: App.user.userMatch(this.collection.first().get('user_id'))
+            editable: isEditable(scenario)
         };
     },
 
@@ -276,7 +277,7 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
     templateHelpers: function() {
         return {
             cid: this.model.cid,
-            editable: App.user.userMatch(this.model.get('user_id'))
+            editable: isEditable(this.model)
         };
     },
 
@@ -445,14 +446,14 @@ var ScenarioDropDownMenuView = Marionette.CompositeView.extend({
 var ToolbarTabContentView = Marionette.CompositeView.extend({
     model: models.ScenarioModel,
     template: scenarioToolbarTabContentTmpl,
-    collection: models.ModificationsCollection,
+    collection: models.ModelPackageControlsCollection,
     childViewContainer: '.controls',
 
     tagName: 'div',
     className: 'tab-pane',
 
-    childViewOptions: function(model) {
-        var modificationModel = this.getModificationForInputControl(model),
+    childViewOptions: function(inputControlModel) {
+        var modificationModel = this.getModificationForInputControl(inputControlModel),
             addModification = _.bind(this.model.addModification, this.model),
             addOrReplaceModification = _.bind(this.model.addOrReplaceModification, this.model);
         return {
@@ -497,8 +498,15 @@ var ToolbarTabContentView = Marionette.CompositeView.extend({
             });
         return {
             shapes: shapes,
-            groupedShapes: groupedShapes
+            groupedShapes: groupedShapes,
+            editable: isEditable(this.model)
         };
+    },
+
+    // Only display modification controls if scenario is editable.
+    // Input controls should always be shown.
+    filter: function(inputControlModel) {
+        return isEditable(this.model) || inputControlModel.isInputControl();
     },
 
     onRender: function() {
@@ -521,14 +529,15 @@ var ToolbarTabContentView = Marionette.CompositeView.extend({
         modificationsColl.remove(modification);
     },
 
-    getChildView: function(model) {
-        var controlName = model.get('name');
+    getChildView: function(inputControlModel) {
+        var controlName = inputControlModel.get('name');
         return controls.getControlView(controlName);
     },
 
-    getModificationForInputControl: function(model) {
+    // Return first modification for an input control.
+    getModificationForInputControl: function(inputControlModel) {
         var modificationsColl = this.model.get('modifications'),
-            controlName = model.get('name');
+            controlName = inputControlModel.get('name');
         return modificationsColl.findWhere({ name: controlName });
     }
 });
@@ -769,6 +778,10 @@ var ResultsTabContentsView = Marionette.CollectionView.extend({
         this.$el.find('.tab-pane:first').addClass('active');
     }
 });
+
+function isEditable(scenario) {
+    return App.user.userMatch(scenario.get('user_id'));
+}
 
 module.exports = {
     ModelingResultsWindow: ModelingResultsWindow,


### PR DESCRIPTION
Hides modifications tools for non-owners and renames a few arguments
to make things easier to understand.

How to test:
1. You should be able to see all modification controls on all owned projects.
2. You should only be able to see the precipitation slider on non-owned projects (or if you are logged out).
3. Changing the precip slider on non-owned projects should update the results panel, but should *not* save anything.

Connects #357
Connects #397