### PR TITLE
Feedback icons for geocoded search

### DIFF
--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -5,7 +5,6 @@ var Backbone = require('../../shim/backbone'),
 
 var GeocoderModel = Backbone.Model.extend({
     defaults: {
-        message: '',
         query: ''
     }
 });

--- a/src/mmw/js/src/geocode/templates/noResults.html
+++ b/src/mmw/js/src/geocode/templates/noResults.html
@@ -1,1 +1,0 @@
-<em>No results</em>

--- a/src/mmw/js/src/geocode/templates/search.html
+++ b/src/mmw/js/src/geocode/templates/search.html
@@ -1,3 +1,7 @@
 <input class="search-input" id="geocoder-search" type="text" placeholder="Search"/>
-<span class="message">{{ message }}</span>
+<i class="search-icon fa fa-search"></i>
 <div id="geocode-search-results-region"></div>
+<div class="message hidden">
+    <span></span>
+    <button class="dismiss"><i class="fa fa-times"></i></button>
+</div>

--- a/src/mmw/js/src/geocode/tests.js
+++ b/src/mmw/js/src/geocode/tests.js
@@ -13,6 +13,9 @@ var _ = require('lodash'),
     models = require('./models');
 
 describe('Geocoder', function() {
+    var MSG_EMPTY = 'No results found.',
+        MSG_ERROR = 'Oops! Something went wrong.';
+
     before(function() {
         if ($('#sandbox').length === 0) {
             $('<div>', {id: 'sandbox'}).appendTo('body');
@@ -34,12 +37,6 @@ describe('Geocoder', function() {
     });
 
     describe('SearchBoxView', function() {
-        it('renders no list items if there no suggestions', function(done) {
-            this.server.respondWith([200, { 'Content-Type': 'application/json' }, '[]']);
-
-            testNumberOfResults(0, done);
-        });
-
         it('renders one list item if there is one suggestion', function(done) {
             var testData = getTestSuggestions(1),
                 responseData = JSON.stringify({ suggestions: testData });
@@ -58,13 +55,24 @@ describe('Geocoder', function() {
             testNumberOfResults(testData.length, done);
         });
 
+        it('renders no list items and an error message if there are no suggestions', function(done) {
+            this.server.respondWith([200, { 'Content-Type': 'application/json' }, '[]']);
+            var view = createView();
+
+            view.handleSearch('a query').then(function() {
+                assert.equal($('#sandbox li').length, 0);
+                assert.include($('.message').text().trim(), MSG_EMPTY);
+                done();
+            }());
+        });
+
         it('renders an error message if there was a problem getting suggestions', function(done) {
             this.server.respondWith([500, { 'Content-Type': 'application/json' }, '[]']);
             var view = createView();
 
             view.handleSearch('a query').then(function() {
                 assert.equal($('#sandbox li').length, 0);
-                assert.include($('.message').text(), 'error');
+                assert.include($('.message').text().trim(), MSG_ERROR);
                 done();
             }());
         });
@@ -82,7 +90,7 @@ describe('Geocoder', function() {
 
                 view.selectFirst().done(function() {
                     assert.equal($('#sandbox li').length, 0);
-                    assert.include($('.message').text(), 'error');
+                    assert.include($('.message').text().trim(), MSG_ERROR);
                     done();
                 }());
             }());

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -38,8 +38,37 @@
     }
   }
 
-  .message{
+  .search-icon {
+    font-size: 0.8rem;
+    margin-left: -2.5rem;
+    color: $black-54;
+
+    &.empty {
+      color: $black-24;
+    }
+
+    &.error {
+      color: $ui-danger;
+    }
+  }
+
+  .message {
     position: absolute;
+    color: $paper-74;
+    background-color: $black-54;
+    border-radius: 2px;
+    box-shadow: 0 0 6px $black-74;
+    font-size: 0.7rem;
+    padding: 0.5rem 1rem;
+    margin-top: 6px;
+    width: 300px;
+
+    .dismiss {
+      float: right;
+      padding: 0;
+      border: none;
+      background-color: transparent;
+    }
   }
 }
 

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -40,8 +40,10 @@
 
   .search-icon {
     font-size: 0.8rem;
-    margin-left: -2.5rem;
     color: $black-54;
+    position: absolute;
+    top: 30px;
+    left: 293px;
 
     &.empty {
       color: $black-24;

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -14,6 +14,7 @@ $ui-primary: #273238; /*Dark Grey*/
 $ui-secondary: #394750; /*Medium Grey*/
 $ui-light: #eceff1; /*Light Grey*/
 $ui-grey: #d0d8dc; /* Output Tab Bar */
+$ui-danger: #e0412d; /*Errors*/
 $active: #51dec2; /*Bright*/
 $brand-primary: #389b9b; /*Teal*/
 $sky-blue: #bbe5f5; /*Sky*/


### PR DESCRIPTION
**Overview**

 * Add icon UI and configuration for various states of search, including
   default, working, empty (no results), and error.
 * Tease out `message` from model into view, since its purpose is only
   for presentation and not persistence / API access
 * Standardize and consolidate search box state manipulations to a small
   number of `setState____` methods
 * Switch from using `emptyView` and `noResultsTmpl` to just the
   `message` box as defined in `searchTmpl`, according to mockups
 * Style `message` box according to mockups, make dismiss button reset
   search box state and hide `message` box
 * Add `ui-danger` style for errors

**Screencaps**

Searching for location with results:

![search-main](https://cloud.githubusercontent.com/assets/1430060/8186433/45e99bb8-1418-11e5-85fb-03ea4d5007b5.gif)

Searching for a location without results:

![search-empty](https://cloud.githubusercontent.com/assets/1430060/8186440/519cdb28-1418-11e5-8fb2-e1f92203cd32.gif)

Error in search:

![search-error](https://cloud.githubusercontent.com/assets/1430060/8186451/5ddce874-1418-11e5-814e-fd365ab2ceb2.gif)


**Testing Instructions**

 * Search for a real location. Click the location. Try selecting a location by pressing Enter while searching.
 * Search for a fake location. Ensure you see the "No results found." message
 * Disconnect internet and search for a location. Ensure you see the "Oops! Something went wrong." message

**Acknowledgements**

Thanks to @ctaylo37 for figuring out the Firefox and Safari issue.

Connects #62 
