### PR TITLE
Simplify checking of URL when making AJAX call.

### DIFF
--- a/src/mmw/js/src/core/csrf.js
+++ b/src/mmw/js/src/core/csrf.js
@@ -26,19 +26,12 @@ function getCookie(name) {
     return cookieValue;
 }
 
-// Source: http://stackoverflow.com/questions/6238351/fastest-way-to-detect-external-urls
-var isExternal = (function(){
-    var domainRe = /https?:\/\/((?:[\w\d]+\.)+[\w\d]{2,})/i;
+// Internal requests are relative.
+function isExternal(url) {
+    var domainRegExp = /^http/i;
 
-    return function(url) {
-        function domain(url) {
-          var result = domainRe.exec(url) !== null ? domainRe.exec(url)[1] : null;
-          return result;
-        }
-
-        return domain(location.href) !== domain(url);
-    };
-})();
+    return domainRegExp.exec(url) !== null;
+}
 
 exports.jqueryAjaxSetupOptions = {
     beforeSend: function(xhr, settings) {

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -424,7 +424,7 @@ describe('Core', function() {
             }
         });
 
-        it('doesn\'t attach CSRF tokens to external requests', function() {
+        it('doesn\'t attach CSRF tokens to external requests over HTTP', function() {
             var requestMethods = [
                 'GET',
                 'HEAD',
@@ -440,6 +440,34 @@ describe('Core', function() {
                 $.ajax({
                     method: method,
                     url: 'http://www.example.com',
+                    success: function(data) {
+                        sinon.spy(null, data);
+                    }
+                });
+            });
+
+            for(var i=0; i<this.requests.length; i++) {
+                assert.notProperty(this.requests[i].requestHeaders, 'X-Requested-With');
+                assert.notProperty(this.requests[i].requestHeaders, 'X-CSRFToken');
+            }
+        });
+
+        it('doesn\'t attach CSRF tokens to external requests over HTTPS', function() {
+            var requestMethods = [
+                'GET',
+                'HEAD',
+                'OPTIONS',
+                'TRACE',
+                'POST',
+                'PUT',
+                'DELETE',
+                'PATCH'
+            ];
+
+            _.each(requestMethods, function(method) {
+                $.ajax({
+                    method: method,
+                    url: 'https://www.secure-example.com',
                     success: function(data) {
                         sinon.spy(null, data);
                     }


### PR DESCRIPTION
* All in internal AJAX requests should be relative, so check if there
is the requested URL starts with a HTTP. If it does, it shouldn't
have the CSRF header set.
* Fixes an issue that prevented API calls on staging because the CSRF
header was not being set on the requests.

Connects to  #422