### PR TITLE
Rebrand mini-app from "simple" to "micro"

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -3,7 +3,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% block metatitle %}
     <title>Model My Watershed</title>
+    {% endblock metatitle %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="{% static 'favicon.png' %}" sizes="16x16">

--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -2,11 +2,15 @@
 
 {% load staticfiles %}
 
+{% block metatitle %}
+    <title>Model My Watershed - Micro Site Storm Model</title>
+{% endblock metatitle %}
+
 {% block header %}
     <header class="water-balance">
 
         <nav id="app-header" class="navbar-watershed">
-            <div class="brand"><a href="#">Model My Watershed</a></div>
+            <div class="brand"><a href="/">Model My Watershed</a><a href="#">&nbsp;&dash;&nbsp;Micro Site Storm Model</a></div>
             <div class="navigation">
                 <ul class="main">
                     <li class="header-link">
@@ -16,7 +20,7 @@
                             </a>
                             <div id="info" class="dropdown-menu menu-right" role="menu" aria-labelledby="select-area">
                                 <h2>Water Balance Model</h2>
-                                <p>Welcome to the Model My Watershed simple water-balance simulator. See how changes in the amount of rainfall, the surfaces on which the rain falls and the texture of the soil change where the water goes. To begin, decide how much rain will fall by using the slide bar on the upper right.  Then select the land-cover type where the rain will fall. Finally, pick a soil type. The coarsest soils (sandy soils) are on the left and the finest soils (clay loam) are on the right.  As the simulation runs, follow where the water flows.  Also, look at the column in the center that shows how much water goes in each direction.</p>
+                                <p>Welcome to the Model My Watershed - Micro Site Storm Model simulator. See how changes in the amount of rainfall, the surfaces on which the rain falls and the texture of the soil change where the water goes. To begin, decide how much rain will fall by using the slide bar on the upper right.  Then select the land-cover type where the rain will fall. Finally, pick a soil type. The coarsest soils (sandy soils) are on the left and the finest soils (clay loam) are on the right.  As the simulation runs, follow where the water flows.  Also, look at the column in the center that shows how much water goes in each direction.</p>
                             </div>
                         </div>
                     </li>

--- a/src/mmw/mmw/urls.py
+++ b/src/mmw/mmw/urls.py
@@ -34,6 +34,6 @@ urlpatterns = patterns(
     url(r'^accounts/', include(registration.backends.default.urls)),
     url(r'^api/geocode/', include(apps.geocode.urls)),
     url(r'^api/modeling/', include(apps.modeling.urls)),
-    url(r'^simple/', include(apps.water_balance.urls)),
+    url(r'^micro/', include(apps.water_balance.urls)),
     url(r'^user/', include(apps.user.urls))
 )


### PR DESCRIPTION
 * Add `metatitle` block to `base.html` so page title can be set by
   child template
 * Change mini-app URL from `/simple` to `/micro`
 * Add "Model My Watershed Micro Site Storm Model" branding to title,
   header, and information dropdown in the mini-app.

**Testing Instructions**

 * Go to [`/micro`](http://localhost:8000/micro) and ensure you see the correct branding everywhere

Connects #423 