### PR TITLE
Add NTP role to monitoring server playbook

### DIFF
--- a/deployment/ansible/monitoring-servers.yml
+++ b/deployment/ansible/monitoring-servers.yml
@@ -7,6 +7,7 @@
       apt: update_cache=yes cache_valid_time=3600
 
   roles:
+    - { role: "azavea.ntp" }
     - { role: "model-my-watershed.graphite", when: "['test'] | is_not_in(group_names)" }
     - { role: "model-my-watershed.logstash", when: "['test'] | is_not_in(group_names)" }
     - { role: "azavea.kibana", when: "['test'] | is_not_in(group_names)" }


### PR DESCRIPTION
After #208, base roles were moved into `model-my-watershed.base`, but the monitoring server playbook does not list the base role as a dependency. Of the roles in `model-my-watershed.base`, `azavea.ntp` is the only one we want on the monitoring server.