### PR TITLE
Add four new modificaton types.

### DIFF
--- a/src/mmw/apps/core/templates/patterns.html
+++ b/src/mmw/apps/core/templates/patterns.html
@@ -1977,6 +1977,538 @@
                 </g>
             </g>
         </pattern>
+        <!-- Chaparral-->
+        <pattern height="72" id="fill-chaparral" overflow="visible" patternUnits="userSpaceOnUse" viewBox="79.59 -151.59 72 72" width="72">
+            <g>
+                <polygon fill="#9b9b9c" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                <g>
+                    <polygon fill="none" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-156.105" y2="-78.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-84.105" y2="-6.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- Desert-->
+        <pattern height="72" id="fill-desert" overflow="visible" patternUnits="userSpaceOnUse" viewBox="79.59 -151.59 72 72" width="72">
+            <g>
+                <polygon fill="#9b9b9c" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                <g>
+                    <polygon fill="none" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-156.105" y2="-78.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-84.105" y2="-6.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- Short Grass Prairie-->
+        <pattern height="72" id="fill-sg_prairie" overflow="visible" patternUnits="userSpaceOnUse" viewBox="79.59 -151.59 72 72" width="72">
+            <g>
+                <polygon fill="#9b9b9c" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                <g>
+                    <polygon fill="none" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-156.105" y2="-78.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-84.105" y2="-6.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
+        <!-- Tall Grass Prairie-->
+        <pattern height="72" id="fill-tg_prairie" overflow="visible" patternUnits="userSpaceOnUse" viewBox="79.59 -151.59 72 72" width="72">
+            <g>
+                <polygon fill="#9b9b9c" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                <g>
+                    <polygon fill="none" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-162.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-168.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-174.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-180.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-186.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-192.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-198.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-204.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-210.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-216.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-222.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-228.105" y2="-144.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-228.105" y2="-150.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="162.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="168.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="174.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="180.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="186.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="192.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="198.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="204.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="210.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="216.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="222.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-156.105" y2="-78.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="90.106" y1="-90.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="96.106" y1="-96.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="102.106" y1="-102.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="108.106" y1="-108.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="114.106" y1="-114.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="120.106" y1="-120.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="126.106" y1="-126.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="132.106" y1="-132.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="138.106" y1="-138.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="144.106" y1="-144.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="150.106" y1="-150.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-156.105" y2="-72.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-156.105" y2="-78.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-156.105" y2="-84.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-156.105" y2="-90.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-156.105" y2="-96.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-156.105" y2="-102.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-156.105" y2="-108.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-156.105" y2="-114.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-156.105" y2="-120.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-156.105" y2="-126.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-156.105" y2="-132.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-156.105" y2="-138.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-156.105" y2="-144.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="228.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="150.106" x2="228.106" y1="-84.105" y2="-6.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="156.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="78.106" x2="156.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="84.106" x2="156.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="90.106" x2="156.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="96.106" x2="156.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="102.106" x2="156.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="108.106" x2="156.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="114.106" x2="156.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="120.106" x2="156.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="126.106" x2="156.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="132.106" x2="156.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="138.106" x2="156.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="144.106" x2="156.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                    <g>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="0.106" x2="84.106" y1="-84.105" y2="-0.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="6.106" x2="84.106" y1="-84.105" y2="-6.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="12.106" x2="84.106" y1="-84.105" y2="-12.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="18.106" x2="84.106" y1="-84.105" y2="-18.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="24.106" x2="84.106" y1="-84.105" y2="-24.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="30.106" x2="84.106" y1="-84.105" y2="-30.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="36.106" x2="84.106" y1="-84.105" y2="-36.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="42.106" x2="84.106" y1="-84.105" y2="-42.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="48.106" x2="84.106" y1="-84.105" y2="-48.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="54.106" x2="84.106" y1="-84.105" y2="-54.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="60.106" x2="84.106" y1="-84.105" y2="-60.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="66.106" x2="84.106" y1="-84.105" y2="-66.105"/>
+                        <line fill="none" stroke="#231F20" stroke-linejoin="round" stroke-width="0.3" x1="72.106" x2="84.106" y1="-84.105" y2="-72.105"/>
+                    </g>
+                </g>
+            </g>
+        </pattern>
         <!-- CONSERVATION PRACTICES -->
         <!-- No Till farming -->
         <pattern height="74.8" id="fill-no_till_agriculture" overflow="visible" patternUnits="userSpaceOnUse" viewBox="72.15 -74.8 72 74.8" width="72">

--- a/src/mmw/js/src/core/patterns.js
+++ b/src/mmw/js/src/core/patterns.js
@@ -11,6 +11,10 @@ var colors = {
     'grassland'  : '#54d2d0',
     'row_crop'   : '#52c6dd',
     'wetland'    : '#4ebaea',
+    'chaparral'  : '#16161d',
+    'desert'     : '#16161d',
+    'sg_prairie' : '#16161d',
+    'tg_prairie' : '#16161d',
 
     // Conservation Practice
     'rain_garden'        : '#51dec2',

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -511,15 +511,20 @@ function getControlsForModelPackage(modelPackageName, options) {
 
 function getHumanReadableLabel(value) {
     var mapping = {
+        'chaparral': 'Chaparral',
         'commercial': 'Commercial',
+        'desert': 'Desert',
         'forest': 'Forest',
         'grassland': 'Grassland',
         'hir': 'HIR',
         'lir': 'LIR',
         'pasture': 'Pasture',
         'row_crop': 'Row Crop',
+        'sg_prairie': 'Short Grass Prairie',
+        'tg_prairie': 'Tall Grass Prairie',
         'turf_grass': 'Turf Grass',
         'wetland': 'Wetland',
+
         'cluster_housing': 'Cluster Housing',
         'green_roof': 'Green Roof',
         'no_till_agriculture': 'No-Till Agriculture',

--- a/src/mmw/js/src/modeling/templates/controls/landCover.html
+++ b/src/mmw/js/src/modeling/templates/controls/landCover.html
@@ -10,16 +10,19 @@
                 {{ utils.thumb(label, 'lir') }}
                 {{ utils.thumb(label, 'hir') }}
                 {{ utils.thumb(label, 'commercial') }}
+                {{ utils.thumb(label, 'forest') }}
             </ul>
             <ul class="row">
-                {{ utils.thumb(label, 'forest') }}
                 {{ utils.thumb(label, 'turf_grass') }}
                 {{ utils.thumb(label, 'pasture') }}
-            </ul>
-            <ul class="row">
                 {{ utils.thumb(label, 'grassland') }}
                 {{ utils.thumb(label, 'row_crop') }}
-                {{ utils.thumb(label, 'wetland') }}
+            </ul>
+            <ul class="row">
+                {{ utils.thumb(label, 'chaparral') }}
+                {{ utils.thumb(label, 'tg_prairie') }}
+                {{ utils.thumb(label, 'sg_prairie') }}
+                {{ utils.thumb(label, 'desert') }}
             </ul>
         </div> <!-- End Dropdown Content -->
 


### PR DESCRIPTION
Added modification tools for four more land use type: "chaparral", "desert", "tall grass prairie", and "short grass prairie".

~~There is still one land use type that is present in the micro app but not in the modification tools: "wetland".~~
I said that backwards: "wetland" is in the tools but not in the micro-app.

**To test**
   * Go to a scenario
   * Click on "Land Cover" to bring up a selection of draw tools
   * You should notice four new draw tools
   * If you draw polygons with the new tools, those polygons should be saved and restored as expected

Connects WikiWatershed/model-my-watershed#424
