### PR TITLE
Fix flash of white on bar chart when running model simulation

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -38,6 +38,9 @@ var Tr55TaskModel = coreModels.TaskModel.extend({
 
 var ResultModel = Backbone.Model.extend({
     defaults: {
+        name: '',
+        displayName: '',
+        result: null,
         polling: false
     }
 });

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -728,6 +728,10 @@ var BarChartView = Marionette.ItemView.extend({
     },
     className: 'chart-container',
 
+    ui: {
+        barChart: '.bar-chart'
+    },
+
     initialize: function() {
         this.listenTo(this.model, 'change', this.addChart);
     },
@@ -738,7 +742,7 @@ var BarChartView = Marionette.ItemView.extend({
 
     addChart: function() {
         var selector = '#' + this.id() + ' .bar-chart';
-        $(selector).empty();
+        this.clearView();
         var result = this.model.get('result');
         if (result) {
             var indVar = 'type',
@@ -763,6 +767,17 @@ var BarChartView = Marionette.ItemView.extend({
                     depDisplayNames: ['Infiltration', 'Runoff', 'Evapotranspiration']
                 };
             chart.makeBarChart(selector, data, indVar, depVars, options);
+        }
+    },
+
+    // Clear view if polling just ended.
+    clearView: function() {
+        var prevAttrs = this.model.previousAttributes(),
+            wasPolling = prevAttrs.polling,
+            isPolling = this.model.get('polling'),
+            pollingJustEnded = wasPolling && !isPolling;
+        if (pollingJustEnded) {
+            this.ui.barChart.empty();
         }
     }
 });


### PR DESCRIPTION
This fixes a problem where the bar chart flashes white when you run a
new simulation.

Fixed by clearing the bar chart view only when polling has ended,
instead of clearing it when polling changes.

Test by running a few model simulations. The bar chart update should
look smoother.