### PR TITLE
Remove X-Frame-Options to allow iframing from ITSI

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -237,7 +237,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
 )


### PR DESCRIPTION
X-Frame-Options prevents clickjacking, but disables iframe embeds from other domains. Since we require ITSI Portal to be able to ember the app in an iframe, we remove it.

**Testing Instructions**

 * Open the home page and look at response headers for the first request and ensure that `X-Frame-Options` header is not present
 * Try opening the page from within an iframe: http://codepen.io/anon/pen/waqLxY

Connects #415 