### PR TITLE
Prevent double saving projects on initialization.

### DIFF
--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -50,6 +50,7 @@ var ModelingController = {
                 scenarios: new models.ScenariosCollection()
             });
 
+            // TODO evalutate if we can remove this global by reworking this code.
             App.currProject = project;
 
             project.get('scenarios').add([
@@ -61,7 +62,12 @@ var ModelingController = {
                     name: 'New Scenario',
                     active: true
                 })
-            ]);
+                // Silent is set to true because we don't actually want to save the
+                // project without some user interaction. This initialization
+                // should set the stage but we should wait for something else to
+                // happen to save. Ideally we will move this into the project
+                // creation when we get rid of the global.
+            ], { silent: true });
 
             project.on('change:id', function() {
                 router.navigate(project.getReferenceUrl());


### PR DESCRIPTION
We were not able to restore saved projects because our initialization of the
project caused it to save not once but twice (when actually we did not want it
to save at all). This was caused by adding two scenarios to the new project.
Adding scenarios triggers an initial save. This is expected functionality however
adding two simultaneously caused two saves on the yet unsaved project which
caused two POST events rather than a POST and PUT. The scenarios were then
taking the last returned result and in most cases were getting the wrong project
id, which resulted in an error.

This prevents an initial save by adding the scenarios to the collection with the
silent option. Further, we introduce a flag on the project which is used to see
if a save has been attempted on the project and prevents saving if it has been
but an id has not yet been returned.

Connects #443 