### PR TITLE
Add HUC boundary layers

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -3,6 +3,31 @@
 set -e
 set -x
 
+usage="$(basename "$0") [-h] [-d] \n
+--Sets up a postgresql database for MMW \n
+\n
+where: \n
+    -h  show this help text\n
+    -d  load/reload base data\n
+"
+
+load_data=false
+
+while getopts ":hd" opt; do
+    case $opt in
+        h)
+            echo -e $usage
+            exit
+            ;;
+        d)
+            load_data=true
+            ;;
+        \?)
+            echo "invalid option: -$OPTARG"
+            exit
+            ;;
+    esac
+done
 # Export settings required to run psql non-interactively
 export PGHOST=$(cat /etc/mmw.d/env/MMW_DB_HOST)
 export PGDATABASE=$(cat /etc/mmw.d/env/MMW_DB_NAME)
@@ -14,3 +39,13 @@ psql -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 
 # Run migrations
 envdir /etc/mmw.d/env /opt/app/manage.py migrate
+
+if [ "$load_data" = "true" ] ; then
+	# Fetch boundary layer sql files
+	FILE_HOST="https://s3.amazonaws.com/data.mmw.azavea.com"
+	FILES=("boundary_huc12.sql.gz" "boundary_huc10.sql.gz" "boundary_huc08.sql.gz")
+
+	for f in "${FILES[@]}"; do
+	    curl -s $FILE_HOST/$f | gunzip -q | psql --single-transaction
+	done
+fi

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -24,6 +24,6 @@ urlpatterns = patterns(
     url(r'start/analyze/$', views.start_analyze, name='start_analyze'),
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),
-    url(r'boundary-layers/((?P<table_id>[0-9]+)/(?P<obj_id>[0-9]+)/|)$',
+    url(r'boundary-layers/((?P<table_id>\w+)/(?P<obj_id>[0-9]+)/|)$',
         views.boundary_layers, name='boundary_layers'),
 )

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -263,11 +263,31 @@ TILER_HOST = environ.get('MMW_TILER_HOST', 'localhost')
 
 
 # N. B. This must be kept in sync with src/tiler/server.js.  In the
-# dictionary below, the keys are the table ids.
-BOUNDARY_LAYERS = {
-    '0': {'display': 'Congressional Districts',
-          'table_name': 'modeling_district'}
-}
+# dictionary below, the keys are the table ids.  If `json_field` is provided
+# that column will be used for feature lookups, but default to 'geom' if not.
+BOUNDARY_LAYERS = [
+    {
+        'code': 'district',
+        'display': 'Congressional Districts',
+        'table_name': 'modeling_district'
+    },
+    {
+        'code': 'huc8',
+        'display': 'USGS Subbasin unit (HUC-8)',
+        'table_name': 'boundary_huc08'
+    },
+    {
+        'code': 'huc10',
+        'display': 'USGS Watershed unit (HUC-10)',
+        'table_name': 'boundary_huc10'
+    },
+    {
+        'code': 'huc12',
+        'display': 'USGS Subwatershed unit (HUC-12)',
+        'table_name': 'boundary_huc12',
+        'json_field': 'geom_detailed'
+    }
+]
 
 STREAM_LAYERS = [
     {

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -69,8 +69,3 @@
   "pages/compare",
   "pages/water-balance",
   "pages/analyze";
-
-#wrapper {
-  overflow:auto;
-  height:93px;
-}

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -12,12 +12,17 @@ var dbUser = process.env.MMW_DB_USER,
     redisPort = process.env.MMW_CACHE_PORT;
 
 // N. B. These must be kept in sync with src/mmw/mmw/settings/base.py
-// and there must be a style in styles.mss for every table.  The table
-// keys (e.g. 0 for 'modeling_district') should be given
-// sequentially).
-var interactivity = {'modeling_district': 'state_short,id'},
+var interactivity = {
+        'modeling_district': 'state_short,id',
+        'boundary_huc08': 'name,id',
+        'boundary_huc10': 'name,id',
+        'boundary_huc12': 'name,id'
+    },
     tables = {
-        0: 'modeling_district',
+        district: 'modeling_district',
+        huc8: 'boundary_huc08',
+        huc10: 'boundary_huc10',
+        huc12: 'boundary_huc12',
         'stream-low': 'deldem4net100r',
         'stream-medium': 'deldem4net50r',
         'stream-high': 'deldem4net20r'

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -1,4 +1,7 @@
-#modeling_district {
+#modeling_district,
+#boundary_huc08,
+#boundary_huc10,
+#boundary_huc12 {
   polygon-fill: #FF0000;
   polygon-opacity: 0.0;
   line-color: #000;


### PR DESCRIPTION
* Add references to 3 HUC Watershed Boundary Datasets
* Allow for specifying the order in which layers show up in the selector
* Use descriptive table aliases for helpful debugging

This PR doesn't include the data necessary to make this work, but I have gz sql files to create the tables and data for them, ~~for the reviewer (@caseypt, @lliss both have `huc08.tar.gz` it in your `/tmp` dir).  You should just be able to pipe the file to the psql~~

~~Keeping this as a WIP until we figure out how to distribute the data appropriately and also do some additional data work, notably to simply some features to reduce the load that exists on the tiler otherwise.~~

Connects #418 