### PR TITLE
Add support for EC2 AMI pruning by service type

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -15,7 +15,7 @@ Next, install [Packer](https://packer.io/) using the steps detailed on Packer's 
 
 ## Create Identity and Access Management (IAM) roles
 
-TBD
+See [Create an IAM Instance Profile for Your Amazon EC2 Instances](http://docs.aws.amazon.com/codedeploy/latest/userguide/how-to-create-iam-instance-profile.html).
 
 ## Configure an AWS Profile using the AWS CLI
 
@@ -39,10 +39,18 @@ Stack launching is managed with `mmw_stack.py`. This command provides an interfa
 
 Before launching the Model My Watershed stack, AMIs for each service need to be generated:
 
-
 ```bash
 $ ./mmw_stack.py create-ami --aws-profile mmw-stg --mmw-profile staging \
                             --machine-type mmw-{app,monitoring,tiler,worker}
+```
+
+### Pruning AMIs
+
+After creating several AMIs, older ones become stale and are no longer needed. To prune them use:
+
+```bash
+$ ./mmw_stack.py prune-ami --aws-profile mmw-stg --mmw-profile staging \
+                           --keep 5 --machine-type mmw-{app,monitoring,tiler,worker}
 ```
 
 ### Launching Stacks

--- a/deployment/ec2/amis.py
+++ b/deployment/ec2/amis.py
@@ -1,0 +1,43 @@
+"""Helper functions to handle EC2 related operations with Boto"""
+
+import boto
+import logging
+
+
+LOGGER = logging.getLogger('mmw')
+LOGGER.addHandler(logging.StreamHandler())
+LOGGER.setLevel(logging.INFO)
+
+MACHINE_TYPE_MAPPING = {
+    'mmw-app': 'Application',
+    'mmw-monitoring': 'Monitoring',
+    'mmw-tiler': 'Tiler',
+    'mmw-worker': 'Worker',
+}
+
+
+def _prune_ami(ami):
+    """Actually deregister AMI and its associated snapshot"""
+    LOGGER.info('Identified that [%s] is eligible to be pruned..', ami.id)
+
+    ami.deregister(delete_snapshot=True)
+
+    LOGGER.info('Deregistered [%s] and snapshot [%s]..', ami.id,
+                ami.block_device_mapping['/dev/sda1'].snapshot_id)
+
+
+def prune(mmw_config, machine_type, keep, aws_profile):
+    """Filter owned AMIs by machine type, environment, and count"""
+    stack_type = mmw_config['StackType']
+
+    conn = boto.connect_ec2(profile_name=aws_profile)
+    images = conn.get_all_images(owners='self', filters={
+        'tag:Service': MACHINE_TYPE_MAPPING[machine_type],
+        'tag:Environment': stack_type
+    })
+
+    if len(images) > keep:
+        map(_prune_ami,
+            list(sorted(images, key=lambda i: i.creationDate))[0:len(images) - keep])  # NOQA
+    else:
+        LOGGER.info('No AMIs are eligible for pruning')

--- a/deployment/mmw_stack.py
+++ b/deployment/mmw_stack.py
@@ -5,6 +5,7 @@ import argparse
 import os
 
 from cfn.stacks import build_stacks, get_config
+from ec2.amis import prune
 from packer.driver import run_packer
 
 
@@ -17,6 +18,10 @@ def launch_stacks(mmw_config, aws_profile, **kwargs):
 
 def create_ami(mmw_config, aws_profile, machine_type, **kwargs):
     run_packer(mmw_config, machine_type, aws_profile=aws_profile)
+
+
+def prune_amis(mmw_config, aws_profile, machine_type, keep, **kwargs):
+    prune(mmw_config, machine_type, keep, aws_profile=aws_profile)
 
 
 def main():
@@ -53,11 +58,21 @@ def main():
     mmw_ami.add_argument('--machine-type', type=str,
                          choices=['mmw-app', 'mmw-tiler', 'mmw-worker',
                                   'mmw-monitoring'],
-                         default=None,
-                         help='One of "mmw-app", "mmw-tiler", "mmw-worker",'
-                         '"mmw-monitoring"')
-
+                         default=None, help='Machine type to create AMI')
     mmw_ami.set_defaults(func=create_ami)
+
+    mmw_prune_ami = subparsers.add_parser('prune-ami',
+                                          help='Prune stale Model My '
+                                               'Watershed AMIs',
+                                          parents=[common_parser])
+    mmw_prune_ami.add_argument('--machine-type', type=str, required=True,
+                               choices=['mmw-app', 'mmw-tiler', 'mmw-worker',
+                                        'mmw-monitoring'],
+                               help='AMI type to prune')
+    mmw_prune_ami.add_argument('--keep', type=int, default=10,
+                               help='Number of AMIs to keep')
+
+    mmw_prune_ami.set_defaults(func=prune_amis)
 
     args = parser.parse_args()
     mmw_config = get_config(args.mmw_config_path, args.mmw_profile)


### PR DESCRIPTION
A CLI subcommand has been added to deregister AMIs and remove root volume snapshots. See `README` additions for more details.

Connects #440. Also, tagging @kdeloach and @lliss.