### PR TITLE
Don't clear charts when polling starts

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -374,7 +374,6 @@ var ScenarioModel = Backbone.Model.extend({
                 },
 
                 onStart: function() {
-                    results.setNullResults();
                     results.setPolling(true);
                 },
 


### PR DESCRIPTION
To test: 
 * In modeling view, change precip level. 
 * The current chart should not clear before the new one appears.
