### PR TITLE
Refresh bar chart on animateIn

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -14,8 +14,7 @@ var $ = require('jquery'),
     tableRowTmpl = require('./templates/tableRow.html'),
     tabPanelTmpl = require('./templates/tabPanel.html'),
     tabContentTmpl = require('./templates/tabContent.html'),
-    barChartTmpl = require('../core/templates/barChart.html'),
-    TransitionRegion = require('../../shim/marionette.transition-region');
+    barChartTmpl = require('../core/templates/barChart.html');
 
 var AnalyzeWindow = Marionette.LayoutView.extend({
     id: 'analyze-output-wrapper',
@@ -24,7 +23,6 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
     regions: {
         headerRegion: '#analyze-header-region',
         detailsRegion: {
-            regionClass: TransitionRegion,
             el: '#analyze-details-region'
         }
     },

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -27,6 +27,12 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
         }
     },
 
+    initialize: function() {
+        this.listenTo(this, 'animateIn', function() {
+            $('#analyze-output-wrapper .bar-chart').trigger('bar-chart:refresh');
+        });
+    },
+
     onShow: function() {
         this.showHeaderRegion();
         this.showAnalyzingMessage();


### PR DESCRIPTION
The chart in the Analyze view is initially the correct size as a benevolent side effect of https://github.com/WikiWatershed/model-my-watershed/pull/456

However, the chart is still the wrong size when hitting back from the Modeling view. This PR fixes that problem.

Connects #103 
