### PR TITLE
Prevent geolocation from repositioning late

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -11,7 +11,8 @@ var MapModel = Backbone.Model.extend({
         lng: 0,
         zoom: 0,
         areaOfInterest: null,           // GeoJSON
-        halfSize: false
+        halfSize: false,
+        geolocationEnabled: true
     },
 
     revertMaskLayer: function() {


### PR DESCRIPTION
To test: 
 * Change the maxAge constant to 0, so the geolocator will not use a cached version of your position. We want to force it to get a new position which takes some time.
 * Go to URL for saved model
 * It shouldn't change the map position to your geolocated position. (You can verify that the geolocator is getting a position, but just not updating the map by setting a breakpoint in the `geolocation_success` function)
 * Repeat, except this time go to the home page and quickly drag the map to change the position. The geolocator shouldn't change the position.
 * Go to the home page and wait a few seconds. It should change the position to your geolocated position.
 
Connects #460 
Connects #479 