### PR TITLE
Don't show modified bar if Current Conds

### DIFF
--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -7,10 +7,15 @@ var $ = require('jquery'),
 
 var ResultView = Marionette.ItemView.extend({
     template: barChartTmpl,
+
     className: 'chart-container runoff-chart-container',
 
     modelEvents: {
         'change': 'addChart'
+    },
+
+    initialize: function(options) {
+        this.scenario = options.scenario;
     },
 
     onAttach: function() {
@@ -33,15 +38,24 @@ var ResultView = Marionette.ItemView.extend({
         if (result) {
             var indVar = 'type',
                 depVars = ['inf', 'runoff', 'et'],
-                data = [
-                    getBarData('Original', 'unmodified'),
-                    getBarData('Modified', 'modified')
-                ],
+                data,
                 options = {
                     barColors: ['#329b9c', '#4aeab3', '#4ebaea'],
                     depAxisLabel: 'Level',
                     depDisplayNames: ['Infiltration', 'Runoff', 'Evaporation']
                 };
+
+            if (this.scenario.get('is_current_conditions')) {
+                data = [
+                    getBarData('', 'unmodified'),
+                ];
+                this.$el.addClass('current-conditions');
+            } else {
+                data = [
+                    getBarData('Original', 'unmodified'),
+                    getBarData('Modified', 'modified')
+                ];
+            }
             chart.makeBarChart(selector, data, indVar, depVars, options);
         }
     }

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -594,7 +594,8 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
             scenario = scenarios.getActiveScenario();
         if (scenario) {
             this.detailsRegion.show(new ResultsDetailsView({
-                collection: scenario.get('results')
+                collection: scenario.get('results'),
+                scenario: scenario
             }));
         }
     },
@@ -647,6 +648,10 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
     collection: models.ResultCollection,
     template: resultsDetailsTmpl,
 
+    initialize: function(options) {
+        this.scenario = options.scenario;
+    },
+
     regions: {
         panelsRegion: '.tab-panels-region',
         contentRegion: '.tab-contents-region'
@@ -658,7 +663,8 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         }));
 
         this.contentRegion.show(new ResultsTabContentsView({
-            collection: this.collection
+            collection: this.collection,
+            scenario: this.scenario
         }));
     },
 
@@ -725,6 +731,10 @@ var ResultsTabContentView = Marionette.LayoutView.extend({
         return this.model.get('name');
     },
 
+    initialize: function(options) {
+        this.scenario = options.scenario;
+    },
+
     onShow: function() {
         var modelPackage = App.currProject.get('model_package'),
             resultName = this.model.get('name');
@@ -733,7 +743,8 @@ var ResultsTabContentView = Marionette.LayoutView.extend({
                 switch(resultName) {
                     case 'runoff':
                         this.resultRegion.show(new tr55RunoffViews.ResultView({
-                            model: this.model
+                            model: this.model,
+                            scenario: this.scenario
                         }));
                         break;
                     case 'quality':
@@ -757,6 +768,12 @@ var ResultsTabContentsView = Marionette.CollectionView.extend({
     tagName: 'div',
     className: 'tab-content',
     childView: ResultsTabContentView,
+    childViewOptions: function() {
+        return {scenario: this.scenario};
+    },
+    initialize: function(options) {
+        this.scenario = options.scenario;
+    },
     onRender: function() {
         this.$el.find('.tab-pane:first').addClass('active');
     }

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -33,6 +33,11 @@
       height: 100%;
       width: 50%
     }
+
+    .runoff-chart-container.current-conditions{
+      height: 100%;
+      width: 29%
+    }
   }
 
   .tab-content{


### PR DESCRIPTION
To test:
Open the modeling view and check that in the Runoff tab for Current Conditions there is only one bar with no label on the x axis. For other scenarios, there should be Original and Modified bars as before.

@mmcfarland I removed the 'Original' label for Current Conditions, since there is only one bar, but I could add it back if you want.

Connects #469 