### PR TITLE
Add support for detecting AMI SHA via HTTP

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
@@ -6,6 +6,12 @@ server {
 
   access_log /var/log/nginx/mmw-app.access.log logstash_json;
 
+  {% if ['packer'] | is_in(group_names) -%}
+  location /version.txt {
+    alias /srv/version.txt;
+  }
+  {% endif %}
+
   location /static/ {
     {% if ['packer'] | is_in(group_names) -%}
     etag on;

--- a/deployment/ansible/roles/model-my-watershed.tiler/templates/nginx-mmw-tiler.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.tiler/templates/nginx-mmw-tiler.conf.j2
@@ -4,6 +4,12 @@ server {
 
   access_log /var/log/nginx/mmw-tiler.access.log logstash_json;
 
+  {% if ['packer'] | is_in(group_names) -%}
+  location /version.txt {
+    alias /srv/version.txt;
+  }
+  {% endif %}
+
   location / {
     {% if ['packer'] | is_in(group_names) -%}
     expires max;

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -105,7 +105,8 @@
                 "sleep 5",
                 "sudo apt-get update -qq",
                 "sudo apt-get install python-pip python-dev -y",
-                "sudo pip install ansible==1.9.0.1"
+                "sudo pip install ansible==1.9.0.1",
+                "sudo /bin/sh -c 'echo {{user `version`}} > /srv/version.txt'"
             ]
         },
         {


### PR DESCRIPTION
During the Packer provisioning steps, the version (usually a Git SHA) passed through is written to a file inside of the machine image. The application and tile server Nginx configuration files have been updated to map `/version.txt` to this file so that external requests can provide AMI version information.

Connects #484