### PR TITLE
Add support for toggling DNS and removing stacks based on color

### DIFF
--- a/deployment/cfn/application.py
+++ b/deployment/cfn/application.py
@@ -226,6 +226,7 @@ class Application(StackNode):
 
         app_server_security_group = self.add_resource(ec2.SecurityGroup(
             app_server_security_group_name,
+            DependsOn='sgAppServerLoadBalancer',
             GroupDescription='Enables access to application servers',
             VpcId=Ref(self.vpc_id),
             SecurityGroupIngress=[

--- a/deployment/cfn/public_hosted_zone.py
+++ b/deployment/cfn/public_hosted_zone.py
@@ -1,0 +1,47 @@
+from boto import route53 as r53
+
+from majorkirby import CustomActionNode
+
+
+class PublicHostedZone(CustomActionNode):
+    """Represents a Route53 public hosted zone"""
+    INPUTS = {
+        'Region': ['global:Region'],
+        'PublicHostedZoneName': ['global:PublicHostedZoneName'],
+        'AppServerLoadBalancerEndpoint':
+        ['global:AppServerLoadBalancerEndpoint',
+         'Application:AppServerLoadBalancerEndpoint'],
+        'AppServerLoadBalancerHostedZoneNameID':
+        ['global:AppServerLoadBalancerHostedZoneNameID',
+         'Application:AppServerLoadBalancerHostedZoneNameID'],
+        'StackType': ['global:StackType'],
+        'StackColor': ['global:StackColor'],
+    }
+
+    DEFAULTS = {
+        'Region': 'us-east-1',
+        'StackType': 'Staging',
+        'StackColor': 'Green',
+    }
+
+    ATTRIBUTES = {'StackType': 'StackType'}
+
+    def action(self):
+        region = self.get_input('Region')
+        hosted_zone_name = self.get_input('PublicHostedZoneName')
+        app_lb_endpoint = self.get_input('AppServerLoadBalancerEndpoint')
+        app_lb_hosted_zone_id = self.get_input('AppServerLoadBalancerHostedZoneNameID')  # NOQA
+
+        route53_conn = r53.connect_to_region(region,
+                                             profile_name=self.aws_profile)
+        public_hosted_zone = route53_conn.get_zone(hosted_zone_name)
+
+        record_sets = r53.record.ResourceRecordSets(route53_conn,
+                                                    public_hosted_zone.id)
+        record_sets.add_change('UPSERT', hosted_zone_name, 'A',
+                               alias_hosted_zone_id=app_lb_hosted_zone_id,
+                               alias_dns_name=app_lb_endpoint,
+                               alias_evaluate_target_health=True,
+                               identifier='Primary',
+                               failover='PRIMARY')
+        record_sets.commit()

--- a/deployment/cfn/tiler.py
+++ b/deployment/cfn/tiler.py
@@ -214,6 +214,7 @@ class Tiler(StackNode):
 
         tile_server_security_group = self.add_resource(ec2.SecurityGroup(
             tile_server_security_group_name,
+            DependsOn='sgTileServerLoadBalancer',
             GroupDescription='Enables access to tile servers',
             VpcId=Ref(self.vpc_id),
             SecurityGroupIngress=[

--- a/deployment/mmw_stack.py
+++ b/deployment/mmw_stack.py
@@ -4,7 +4,7 @@
 import argparse
 import os
 
-from cfn.stacks import build_stacks, get_config
+from cfn.stacks import build_stacks, destroy_stacks, get_config
 from ec2.amis import prune
 from packer.driver import run_packer
 
@@ -14,6 +14,10 @@ current_file_dir = os.path.dirname(os.path.realpath(__file__))
 
 def launch_stacks(mmw_config, aws_profile, **kwargs):
     build_stacks(mmw_config, aws_profile, **kwargs)
+
+
+def remove_stacks(mmw_config, aws_profile, **kwargs):
+    destroy_stacks(mmw_config, aws_profile, **kwargs)
 
 
 def create_ami(mmw_config, aws_profile, machine_type, **kwargs):
@@ -49,8 +53,19 @@ def main():
                             choices=['green', 'blue'],
                             default=None,
                             help='One of "green", "blue"')
-
+    mmw_stacks.add_argument('--activate-dns', action='store_true',
+                            default=False,
+                            help='Activate DNS for current stack color')
     mmw_stacks.set_defaults(func=launch_stacks)
+
+    mmw_remove_stacks = subparsers.add_parser('remove-stacks',
+                                              help='Remove MMW Stack',
+                                              parents=[common_parser])
+    mmw_remove_stacks.add_argument('--stack-color', type=str,
+                                   choices=['green', 'blue'],
+                                   required=True,
+                                   help='One of "green", "blue"')
+    mmw_remove_stacks.set_defaults(func=remove_stacks)
 
     mmw_ami = subparsers.add_parser('create-ami', help='Create AMI for Model '
                                                        'My Watershed Stack',
@@ -71,7 +86,6 @@ def main():
                                help='AMI type to prune')
     mmw_prune_ami.add_argument('--keep', type=int, default=10,
                                help='Number of AMIs to keep')
-
     mmw_prune_ami.set_defaults(func=prune_amis)
 
     args = parser.parse_args()

--- a/scripts/aws/staging-deployment.sh
+++ b/scripts/aws/staging-deployment.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+if env | grep -q "MMW_DEPLOY_DEBUG"; then
+  set -x
+fi
+
+CURRENT_STACK_COLOR=$(aws cloudformation describe-stacks \
+  --profile "${MMW_AWS_PROFILE}" \
+  --output text \
+  | egrep "TAGS\s+StackColor" \
+  | egrep "Blue|Green" \
+  | cut -f3 \
+  | uniq \
+  | tr "[:upper:]" "[:lower:]")
+
+STACK_COLOR_COUNT=$(echo "${CURRENT_STACK_COLOR}" \
+  | wc -l \
+  | xargs)
+
+# Determine which color stack to launch
+if [ "${STACK_COLOR_COUNT}" -gt 1 ]; then
+  echo "Both stack colors already exist."
+  exit 1
+elif [ "${CURRENT_STACK_COLOR}" = "blue" ]; then
+  NEW_STACK_COLOR="green"
+elif [ "${CURRENT_STACK_COLOR}" = "green" ]; then
+  NEW_STACK_COLOR="blue"
+fi
+
+pushd deployment
+
+# Attempt to launch a new stack & cutover DNS
+python mmw_stack.py launch-stacks \
+  --aws-profile "${MMW_AWS_PROFILE}" \
+  --mmw-profile "${MMW_PROFILE}" \
+  --mmw-config-path "${MMW_CONFIG_PATH}" \
+  --stack-color "${NEW_STACK_COLOR}" \
+  --activate-dns
+
+# Remove old stack
+python mmw_stack.py remove-stacks \
+  --aws-profile "${MMW_AWS_PROFILE}" \
+  --mmw-profile "${MMW_PROFILE}" \
+  --mmw-config-path "${MMW_CONFIG_PATH}" \
+  --stack-color "${CURRENT_STACK_COLOR}" \


### PR DESCRIPTION
Adds a command line option to the `launch-stacks` subcommand that does an `UPSERT` of the primary A record of `PublicHostedZoneName` using the stack's load balancer endpoint.

If the `--activate-dns` flag is not provided, no DNS records are altered.

Also, adds `remove-stacks` subcommand to remove all of the stacks associated with a given color. The only stacks associated with colors are:

- Application
- Tiler
- Worker

These changes also include a helper script that wraps all of the above for CI, and a fix for a race condition during application and tiler stack load balancer deletions.

Connects #464