### PR TITLE
Disallow unauthenticated requests to project listing

### DIFF
--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -30,7 +30,7 @@ from apps.modeling.serializers import (ProjectSerializer,
 
 
 @decorators.api_view(['GET', 'POST'])
-@decorators.permission_classes((IsAuthenticatedOrReadOnly, ))
+@decorators.permission_classes((IsAuthenticated, ))
 def projects(request):
     """Get a list of all projects with embedded scenarios available for
        the logged in user.  POST to create a new project associated with the


### PR DESCRIPTION
The app can still support public project sharing via the readonly DRF
decorator on the `/project` endpoint, but `/projects` is only meaningful
to authenticated users.  This will prevent `500` errors for anonymous
access (via bots in the case we were seeing) and instead give a `403`.

Public projects are still accessible.

Connects #487 

To test:

* Browse to `/api/modeling/projects` when not logged in, you should receive a `403` and not a `500`.
* Access a public project, which should still be available to browse.