### PR TITLE
Fix geocodeing issue.

### DIFF
--- a/src/mmw/apps/geocode/views.py
+++ b/src/mmw/apps/geocode/views.py
@@ -18,11 +18,12 @@ geocoder = Geocoder(sources=settings.OMGEO_SETTINGS)
 @decorators.permission_classes((AllowAny, ))
 def geocode(request, format=None):
     query = request.REQUEST.get('search', None)
+    key = request.REQUEST.get('key', None)
     if (not query):
         response = Response(data={'error': 'Search parameter is required.'},
                             status=400)
         return response
-    pq = PlaceQuery(query=query, country='US')
+    pq = PlaceQuery(query=query, country='US', key=key)
     result = geocoder.geocode(pq)
     candidates = result['candidates']
     candidates = [_omgeo_candidate_to_dict(c) for c in candidates]


### PR DESCRIPTION
It turns out that way back in PR #69 we forgot to add the key to our geocoder
endpoint. Python-Omgeo works by accepting query text and a key in the PlaceQuery
object. The `key` is passed on to the ESRI geocoder as magicKey. We had simply
omitted this and our results were thus not the result of doing a geocode on the
key but only on the query text. This resulted in ambiguous results.

Connects #485 