### PR TITLE
Add Flower UI for Celery; use API endpoint for ELB health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The `app` virtual machine contains an instance of the Django application, `servi
 `worker` contains:
 
 - Celery
+- Flower
 
 ### Getting Started
 
@@ -95,6 +96,7 @@ pgweb                  | 5433 | [http://localhost:5433](http://localhost:5433)
 Redis                  | 6379 | `redis-cli -h localhost 6379`
 Testem                 | 7357 | [http://localhost:7357](http://localhost:7357)
 Tiler                  | 4000 | [http://localhost:4000](http://localhost:4000)
+Flower                 | 5555 | [http://localhost:5555](http://localhost:5555)
 
 ### Caching
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,6 +99,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       worker.vm.synced_folder "src/mmw", "/opt/app/"
     end
 
+    # Flower
+    worker.vm.network "forwarded_port", {
+      guest: 80,
+      host: 5555
+    }.merge(VAGRANT_NETWORK_OPTIONS)
+
     worker.vm.provider "virtualbox" do |v|
       v.memory = 1024
     end

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/defaults/main.yml
@@ -18,3 +18,7 @@ celery_logs: "/var/log/celery/%n.log"
 celery_number_of_workers: 2
 celery_processes_per_worker: 1
 celery_log_level: "INFO"
+
+flower_log: "/var/log/celery/flower.log"
+flower_log_rotate_count: 5
+flower_log_rotate_interval: daily

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/handlers/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: Restart Celery
   service: name=celeryd state=restarted
+
+- name: Restart Flower
+  service: name=flower state=restarted

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/meta/main.yml
@@ -5,3 +5,4 @@ dependencies:
   - { role: "azavea.pip" }
   - { role: "model-my-watershed.monitoring", collectd_prefix: "collectd.worker.", when: "['test'] | is_not_in(group_names)" }
   - { role: "model-my-watershed.celery" }
+  - { role: "model-my-watershed.nginx" }

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/flower.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/flower.yml
@@ -1,0 +1,33 @@
+---
+- name: Configure Flower service definition
+  template: src=upstart-flower.conf.j2
+            dest=/etc/init/flower.conf
+  notify:
+    - Restart Flower
+
+- name: Configure Nginx site
+  template: src=nginx-flower.conf.j2
+            dest=/etc/nginx/sites-available/flower.conf
+  notify:
+    - Restart Nginx
+
+- name: Enable Nginx site
+  file: src=/etc/nginx/sites-available/flower.conf
+        dest=/etc/nginx/sites-enabled/flower
+        state=link
+  notify:
+    - Restart Nginx
+
+- name: Touch Flower log file if it does not exist
+  command: touch {{ flower_log }}
+           creates={{ flower_log }}
+
+- name: Set Flower log file permissions
+  file: path={{ flower_log }}
+        owner=celery
+        group=celery
+        mode=0664
+
+- name: Configure Flower log rotation
+  template: src=logrotate-flower.j2
+            dest=/etc/logrotate.d/flower

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/main.yml
@@ -4,3 +4,4 @@
 - { include: dependencies.yml }
 - { include: celery-user.yml }
 - { include: celery-service.yml }
+- { include: flower.yml }

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/templates/logrotate-flower.j2
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/templates/logrotate-flower.j2
@@ -1,0 +1,10 @@
+{{ flower_log }} {
+  rotate {{ flower_log_rotate_count }}
+  {{ flower_log_rotate_interval }}
+  compress
+  missingok
+  postrotate
+    restart flower
+  endscript
+  notifempty
+}

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/templates/nginx-flower.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/templates/nginx-flower.conf.j2
@@ -1,0 +1,37 @@
+server {
+  listen *:80;
+  server_name _;
+
+  access_log /var/log/nginx/flower.access.log logstash_json;
+
+  {% if ['packer'] | is_in(group_names) -%}
+  location /version.txt {
+    alias /srv/version.txt;
+  }
+  {% endif %}
+
+  location /health-check/ {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    proxy_pass http://127.0.0.1:5555/api/workers;
+
+    break;
+  }
+
+  location / {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    proxy_pass http://127.0.0.1:5555;
+  }
+}
+

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/templates/upstart-flower.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/templates/upstart-flower.conf.j2
@@ -1,0 +1,20 @@
+description	"flower"
+
+{% if ['development', 'test'] | some_are_in(group_names) -%}
+start on (vagrant-mounted)
+{% else %}
+start on (local-filesystems and net-device-up IFACE!=lo)
+{% endif %}
+stop on shutdown
+
+respawn
+setuid celery
+chdir {{ app_home }}
+
+script
+exec envdir /etc/mmw.d/env /usr/local/bin/celery flower \
+    --app=mmw.celery:app \
+    --address=127.0.0.1 \
+    --logging={{ celery_log_level }} \
+    --port=5555 >> {{ flower_log }} 2>&1
+end script

--- a/deployment/ansible/roles/model-my-watershed.celery/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 celery_version: 3.1.18
 djcelery_version: 3.1.16
+flower_version: 0.8.2

--- a/deployment/ansible/roles/model-my-watershed.celery/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery/tasks/main.yml
@@ -4,3 +4,4 @@
   with_items:
     - { name: "celery[redis]", version: "{{ celery_version }}" }
     - { name: "django-celery", version: "{{ djcelery_version }}" }
+    - { name: "flower", version: "{{ flower_version }}" }

--- a/deployment/packer/driver.py
+++ b/deployment/packer/driver.py
@@ -54,7 +54,8 @@ def get_git_sha():
                    'describe',
                    '--tags',
                    '--always',
-                   '--dirty']
+                   '--dirty',
+                   '--abbrev=40']
 
     return subprocess.check_output(git_command).rstrip()
 


### PR DESCRIPTION
Installs and sets up Flower to provide a UI for the Celery workers. In addition to the UI, Flower also provides API endpoints. These API endpoints are exposed via Nginx, and pinged by a load balancer to determine worker health. The following DNS records are also created:

- `blue-workers.mmw.azavea.com`
- `green-workers.mmw.azavea.com`

Their only purpose is to provide a way for humans to look at Flower remotely. Access is scoped to the `IPAccess` configuration setting.

Connects #21 and #372

---

**Testing**

- [x] Ensure Flower UI comes up on `worker`
- [x] Run some jobs to see if they populate the Flower UI

**Testing (Optional)**

- [x] Create a new worker AMI based off of this branch
- [x] Spin up a new worker stack to see if all of the new AWS resources have been created
- [x] Ensure Flower UI is only visible via `IPAccess`