### PR TITLE
Use Leaflet.Draw fork that supports touch

### DIFF
--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -1534,8 +1534,8 @@
     },
     "leaflet-draw": {
       "version": "0.2.3",
-      "from": "leaflet-draw@0.2.3",
-      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-0.2.3.tgz"
+      "from": "git://github.com/michaelguild13/Leaflet.draw.git#e2fe3a4",
+      "resolved": "git://github.com/michaelguild13/Leaflet.draw.git#e2fe3a4c176979235845e8fbb1c5017414035765"
     },
     "leaflet.locatecontrol": {
       "version": "0.43.0",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -30,7 +30,7 @@
     "jshint": "2.8.0",
     "jstify": "0.9.0",
     "leaflet": "0.7.3",
-    "leaflet-draw": "0.2.3",
+    "leaflet-draw": "git://github.com/michaelguild13/Leaflet.draw#e2fe3a4",
     "leaflet.locatecontrol": "0.43.0",
     "livereloadify": "2.0.0",
     "lodash": "3.6.0",


### PR DESCRIPTION
## Introduction

We are switching to [Michael Guild's fork](https://github.com/michaelguild13/Leaflet.draw) of [Leaflet.Draw](https://github.com/Leaflet/Leaflet.draw/) to get support for touch screens. There are a number of considerations that must be taken into account.

### Original Issue

The original issue on Leaflet.Draw is here: https://github.com/Leaflet/Leaflet.draw/issues/2. The conversation on that thread started with a few contributors who came up with various solutions which worked in some cases and didn't in others, until Guild came along and essentially took ownership of the effort, and has been working on it on-and-off for more than a year now. As the conversation moves along, the comments get more and more supportive and appreciative, and the bugs become rarer and more edge-case-y. There is also some discussion about [Tom Blackmore's fork](https://github.com/tablackmore/Leaflet.draw/tree/touch), and [Jacob Toye](https://github.com/jacobtoye) (who seems to be a core developer of Leaflet.Draw) initially seemed to favor his approach. However, Guild's fork has been more active, has been used and tested by more people, and is up to date with the current Leaflet.Draw codebase.

### Pull Request

Guild has an open pull request to the main repo here: https://github.com/Leaflet/Leaflet.draw/pull/285. Initial conversation is about syntax, but eventually people start testing it and liking it, and Toye chimes in with his approval and a promise to carve out time for Leaflet.Draw in the future. The main issues people have with the PR are:

 * It has too many commits, should be squashed to make more readable
 * It has other experiments, particularly related to styling, that are unrelated to the core touch functionality, that people want to be separated out
 * There is some discussion of errors in Internet Explorer, not sure if they relate to click or touch functionality
 * He seems to have done more work in private somewhere, which hasn't been added to his GitHub yet

But overall consensus is positive, with the hopes that his work will be merged into the main Leaflet.Draw repo at some point in the near future. The main blocker for that effort is simply time on the part of both Guild and Toye, who had not been able to pay much attention to this, until recently when activity has started again.

## Concerns

 1. So far we have been using Leaflet.Draw 0.2.3, but all of Guild's work is up-to-date with `master`, thus we are not just getting the touch support, but all sorts of changes to Leaflet.Draw.
 2. Guild's repo is very much a development repo, not a release one. There aren't any tests, or tags, or releases. The [current head](https://github.com/michaelguild13/Leaflet.draw/tree/e2fe3a4c176979235845e8fbb1c5017414035765) seems to work well enough, and that's what I've pinned in `package.json`. All our existing tests are passing, and prelimnary testing in Chrome and Mobile Safari on iOS has been flawless. But we need to test more.

## Testing

To test this, check out the PR branch and run 

```bash
$ ./scripts/npm.sh install
$ ./scripts/bundle.sh --vendor
```

Then check with various browsers and devices that the map is usable:

 * Test drawing a polygon Area of Interest
 * Test delineating a watershed
 * Test zooming and panning with the polygon drawn
 * Test drawing modifications

Tested on:

 * [x] Chrome 43.0.2357.130 (64-bit) on Mac OS X 10.10
 * [x] Mobile Safari on iPad Mini 2 running iOS 8.3 — Modifications needed to be tapped twice, the first time simulated a hover and the second a click.
 * [x] :warning: Mobile Safari on iPad 2 running iOS 8.1 — Had some odd behavior when entering `/analyze` view. Modifications needed to be tapped twice, the first time simulated a hover and the second a click.
 * [x] Mobile Safari on iPhone 6 running iOS 8.3
 * [x] Chrome 43.0.2357.61 on iPhone 6 running iOS 8.3
 * [x] Firefox 38.0.5 on Mac OS X 10.10
 * [x] :warning: Safari 8.0.6 on Mac OS X 10.10 — Had some odd behavior when entering `/analyze` view.
 * [x] Chrome 43.0.2357.93 on Moto E running Android 5.1 Lollipop
 * [x] Firefox on Nexus 5 on Android 4.4 KitKat
 * [x] Chrome on Nexus 7 running Android 5.0 Lollipop
 * [x] Chrome on Linux
 * [x] Firefox on Linux
 * [x] Chrome 43.0.2357.130 m on Windows 7 Enterprise SP1
 * [x] Firefox 38.0.5 on Windows 7 Enterprise SP1
 * [x] :warning: Internet Explorer 11.0.9600.17843 on Windows 7 Enterprise SP1 — Precipitation Slider does not show up. SVG patterns do not show up. See #504 
 * [x] :x: Internet Explorer 11.0.9600 on Surface Pro 3 running Windows 8.1 Pro — The site **does not render at all** because IE on Surface does not support the touch events in Guild's repo and throws an error.
 * [x] :x: Chrome 43 on Surface Pro 3 running Windows 8.1 Pro — Touch interaction works (when you touch the screen with a finger), but **click interaction (with trackpad and stylus) fails to close the polygon, instead keeps adding new overlapping points.**
 * [x] :x: Firefox 38 on Surface Pro 3 running Windows 8.1 Pro — Click interaction works (when you use trackpad or stylus), but touch interaction fails to register a `mouseclick` event. **Each touch acts as a hover / `mousemove` event instead of a click.**
 * [ ] IE Mobile on Windows Phone

:warning: = Minor problems, possibly unrelated to touch functionality
:x: = Major problems related to touch functionality

I will leave this PR open until I've tested at least on the above platforms.

Connects #476