### PR TITLE
Serve /favicon.ico from Nginx

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
@@ -12,6 +12,10 @@ server {
   }
   {% endif %}
 
+  location /favicon.ico {
+    alias {{ app_static_root }}favicon.png;
+  }
+
   location /static/ {
     {% if ['packer'] | is_in(group_names) -%}
     etag on;


### PR DESCRIPTION
This is just to prevent Django from having to do unnecessary work when clients blindly request `/favicon.ico` despite our HTML meta tags.

Connects #498

---

**Testing**

- [x] Provision and hit `/favicon.ico`