### PR TITLE
Turn off DRF GUI in production and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Tiler                  | 4000 | [http://localhost:4000](http://localhost:4000)
 
 In order to speed up things up, you may want to consider leveraging the `vagrant-cachier` plugin. If installed, it is automatically used by Vagrant.
 
+### Test Mode
+
+In order to run the app in test mode, which simulates the production static asset bundle, reprovision with `VAGRANT_ENV=TEST vagrant provision`.
+
 ### Testing
 
 Run all the tests:

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -39,6 +39,12 @@ EMAIL_BOTO_CHECK_QUOTA = False
 DEFAULT_FROM_EMAIL = 'noreply@mmw.azavea.com'
 # END EMAIL CONFIGURATION
 
+# Turn off DRF GUI
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    )
+}
 
 # Django Storages CONFIGURATION
 mac_metadata = instance_metadata['network']['interfaces']['macs']

--- a/src/mmw/mmw/settings/test.py
+++ b/src/mmw/mmw/settings/test.py
@@ -20,3 +20,10 @@ SELENIUM_TEST_COMMAND_OPTIONS = {'pattern': 'uitest*.py'}
 
 DJANGO_LIVE_TEST_SERVER_ADDRESS = os.environ.get(
     'DJANGO_LIVE_TEST_SERVER_ADDRESS', 'localhost:9001')
+
+# Turn off DRF GUI
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    )
+}


### PR DESCRIPTION
To test:
 * Go to localhost:8000/api/modeling/projects/. You should see the DRF GUI.
 * Switch to test mode by running `VAGRANT_ENV=TEST vagrant provision` (This will take ~10 min or so.)
 * Go to the same URL. This time you should just see some raw JSON.
 * The same setting used to turn off the GUI in test mode is in the production config, but there's no easy way to test production mode locally. 

Connects #471 