### PR TITLE
Add a tile service health check

### DIFF
--- a/deployment/cfn/tiler.py
+++ b/deployment/cfn/tiler.py
@@ -269,7 +269,7 @@ class Tiler(StackNode):
                 )
             ],
             HealthCheck=elb.HealthCheck(
-                Target='HTTP:80/',
+                Target='HTTP:80/health-check/',
                 HealthyThreshold='3',
                 UnhealthyThreshold='2',
                 Interval='30',

--- a/src/tiler/healthCheck.js
+++ b/src/tiler/healthCheck.js
@@ -1,0 +1,127 @@
+var Step = require('windshaft/node_modules/step');
+var Pg = require('windshaft/node_modules/cartodb-psql/node_modules/pg');
+var Redis = require('windshaft/node_modules/redis-mpool/node_modules/redis');
+
+/**
+ * Attempts to connect to a PostgreSQL database, providing the
+ * callback with the error object.
+ *
+ * The error object is the second callback argument because
+ * error objects in the first argument cause Step to short
+ * circuit. In the case of a health check, we want all
+ * errors.
+ *
+ * @param {string} host
+ * @param {string} port
+ * @param {string} user
+ * @param {string} password
+ * @param {string} database
+ * @param {function} callback
+ */
+function checkPostgres(host, port, user, password, database, callback) {
+  var conString = ['postgres://', user, ':', password, '@', host, '/', database].join('');
+  var client = new Pg.Client(conString);
+
+  client.connect(function(err) {
+    client.end();
+    callback(null, err);
+  });
+}
+
+/**
+ * Attempts to connect to a Redis data store, providing the
+ * callback with the error object.
+ *
+ * The error object is the second callback argument because
+ * error objects in the first argument cause Step to short
+ * circuit. In the case of a health check, we want all
+ * errors.
+ *
+ * @param {string} host
+ * @param {string} port
+ * @param {function} callback
+ */
+function checkRedis(host, port, callback) {
+  var client = Redis.createClient(port, host);
+
+  client.on('connect', function(err) {
+    client.quit();
+    callback(null, err);
+  });
+
+  client.on('error', function(err) {
+    client.quit();
+    callback(null, err);
+  });
+}
+
+function buildPayload(err) {
+  var payload = {};
+
+  if (err) {
+    payload = {'ok': !err, 'msg': err.toString()};
+  } else {
+    payload = {'ok': !err};
+  }
+
+  return payload;
+}
+
+/**
+ * Makes use of the PostgreSQL and Redis checks above to return
+ * a JSON object representing the health of both data stores:
+ *
+ * {
+ *   "databases": [
+ *     {
+ *       "default": {
+ *         "ok": true
+ *       }
+ *    }
+ *   ],
+ *   "caches": [
+ *     {
+ *       "default": {
+ *         "ok": true
+ *       }
+ *     }
+ *   ]
+ * }
+ *
+ * @param {object} config - The configuration object passed to Windshaft.Server()
+ */
+module.exports = function createHealthCheckHandler(config) {
+  var pgConf = config.grainstore.datasource,
+
+    pgHost = pgConf.host,
+    pgPort = pgConf.port,
+    pgUser = pgConf.user,
+    pgPassword = pgConf.password,
+    pgDatabase = pgConf.dbname,
+
+    redisHost = config.redis.host,
+    redisPort = config.redis.port;
+
+  return function(req, res) {
+    var status = {};
+
+    Step(
+      function executeChecks() {
+        checkPostgres(pgHost, pgPort, pgUser, pgPassword, pgDatabase, this.parallel());
+        checkRedis(redisHost, redisPort, this.parallel());
+      },
+      function sendResponse(err, databaseError, cacheError) {
+        var response = {},
+            statusCode = 503;
+
+        response.databases = [{'default': buildPayload(databaseError)}];
+        response.caches = [{'default': buildPayload(cacheError)}];
+
+        if (databaseError && cacheError) {
+          statusCode = 200;
+        }
+
+        res.send(response, statusCode);
+    });
+  };
+};

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -1,4 +1,5 @@
 var Windshaft = require('windshaft'),
+    healthCheck = require('./healthCheck'),
     fs = require('fs'),
     styles = fs.readFileSync('styles.mss', { encoding: 'utf8' });
 
@@ -22,6 +23,7 @@ var config = {
     base_url_notable: '/:tableId',
     grainstore: {
         datasource: {
+            dbname: dbName,
             user: dbUser,
             host: dbHost,
             port: dbPort,
@@ -69,5 +71,6 @@ var config = {
 
 // Initialize tile server on port 4000
 var ws = new Windshaft.Server(config);
+ws.get('/health-check', healthCheck(config));
 ws.listen(4000);
 console.log('Starting MMW Windshaft tiler on http://localhost:4000' + config.base_url + '/:z/:x/:y.*');


### PR DESCRIPTION
Each probe initiates a connection attempt to the PostgreSQL database and Redis. Failure of either returns an HTTP 503, while success of both returns an HTTP 200. The health check is mounted at `/health-check`.

Connects #371

---

**Testing**

- [x] Provision the `tiler`
- [x] Login to the `services` virtual machine and stop the Redis or PostgreSQL service
- [x] Inspect the JSON payload provided by [http://localhost:4000/health-check](http://localhost:4000/health-check)