### PR TITLE
Remove udev rules; just restart Celery always

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -114,6 +114,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.groups = ANSIBLE_GROUPS.merge(ANSIBLE_ENV_GROUPS)
       ansible.raw_arguments = ["--timeout=60"]
     end
+
+    worker.vm.provision "shell", inline: "service celeryd restart > /dev/null", run: "always"
   end
 
   config.vm.define "app" do |app|

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
@@ -11,10 +11,5 @@
   notify:
     - Restart Celery
 
-- name: Configure udev rules to wait for Vagrant mount
-  template: src=50-vagrant-mount.rules.j2
-            dest=/etc/udev/rules.d/50-vagrant-mount.rules
-  when: "['development', 'test'] | some_are_in(group_names)"
-
 - name: Enable Celery service
   service: name=celeryd enabled=yes state=started

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/templates/50-vagrant-mount.rules.j2
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/templates/50-vagrant-mount.rules.j2
@@ -1,2 +1,0 @@
-SUBSYSTEM=="bdi",ACTION=="add",RUN+="/usr/bin/screen -m -d bash -c 'sleep 5; /usr/sbin/service celeryd start'"
-SUBSYSTEM=="bdi",ACTION=="remove",RUN+="/usr/bin/screen -m -d bash -c 'sleep 5; /usr/sbin/service celeryd stop'"


### PR DESCRIPTION
Shell provisioning steps are supposed to happen late in the provisioning process. Here, a shell provisioner is added that always runs. Its job is to attempt to restart Celery in case it didn't start because the Vagrant synced folder wasn't mounted yet.

---

**Testing**

- [x] Destroy `worker` VM so that `udev` rules are removed
- [x] Recreate the `worker` VM
- [x] Attempt to `reload` it several times to see if there are any issues in the Vagrant pre-provisioning process