### PR TITLE
Allow application and worker AMIs to be created in parallel

### DIFF
--- a/deployment/ec2/amis.py
+++ b/deployment/ec2/amis.py
@@ -26,18 +26,26 @@ def _prune_ami(ami):
                 ami.block_device_mapping['/dev/sda1'].snapshot_id)
 
 
-def prune(mmw_config, machine_type, keep, aws_profile):
-    """Filter owned AMIs by machine type, environment, and count"""
+def prune(mmw_config, machine_types, keep, aws_profile):
+    """Filter owned AMIs by machine type, environment, and count
+
+    Args:
+      mmw_config (dict): Dict of configuration settings
+      machine_types (list): list of machine types to prune
+      keep (int): number of images of this machine type to keep
+      aws_profile (str): aws profile name to use for authentication
+    """
     stack_type = mmw_config['StackType']
 
     conn = boto.connect_ec2(profile_name=aws_profile)
-    images = conn.get_all_images(owners='self', filters={
-        'tag:Service': MACHINE_TYPE_MAPPING[machine_type],
-        'tag:Environment': stack_type
-    })
+    for machine_type in machine_types:
+        images = conn.get_all_images(owners='self', filters={
+            'tag:Service': MACHINE_TYPE_MAPPING[machine_type],
+            'tag:Environment': stack_type
+        })
 
-    if len(images) > keep:
-        map(_prune_ami,
-            list(sorted(images, key=lambda i: i.creationDate))[0:len(images) - keep])  # NOQA
-    else:
-        LOGGER.info('No AMIs are eligible for pruning')
+        if len(images) > keep:
+            map(_prune_ami,
+                list(sorted(images, key=lambda i: i.creationDate))[0:len(images) - keep])  # NOQA
+        else:
+            LOGGER.info('No [%s] AMIs are eligible for pruning', machine_type)

--- a/deployment/mmw_stack.py
+++ b/deployment/mmw_stack.py
@@ -71,6 +71,7 @@ def main():
                                                        'My Watershed Stack',
                                     parents=[common_parser])
     mmw_ami.add_argument('--machine-type', type=str,
+                         nargs=argparse.ONE_OR_MORE,
                          choices=['mmw-app', 'mmw-tiler', 'mmw-worker',
                                   'mmw-monitoring'],
                          default=None, help='Machine type to create AMI')
@@ -81,6 +82,7 @@ def main():
                                                'Watershed AMIs',
                                           parents=[common_parser])
     mmw_prune_ami.add_argument('--machine-type', type=str, required=True,
+                               nargs=argparse.ONE_OR_MORE,
                                choices=['mmw-app', 'mmw-tiler', 'mmw-worker',
                                         'mmw-monitoring'],
                                help='AMI type to prune')

--- a/deployment/packer/driver.py
+++ b/deployment/packer/driver.py
@@ -70,12 +70,12 @@ def get_git_branch():
     return subprocess.check_output(git_command).rstrip()
 
 
-def run_packer(mmw_config, machine_type, aws_profile):
+def run_packer(mmw_config, machine_types, aws_profile):
     """Function to run packer
 
     Args:
       mmw_config (dict): Dict of configuration settings
-      machine_type (str): type of machine to build
+      machine_types (list): list of machine types to build
       aws_profile (str): aws profile name to use for authentication
     """
 
@@ -105,7 +105,7 @@ def run_packer(mmw_config, machine_type, aws_profile):
         os.path.dirname(os.path.realpath(__file__)),
         'template.js')
 
-    LOGGER.info('Creating %s AMI in %s region', machine_type, region)
+    LOGGER.info('Creating %s AMI in %s region', machine_types, region)
 
     packer_command = ['packer', 'build',
                       '-var', 'version={}'.format(env.get('GIT_COMMIT',
@@ -118,8 +118,8 @@ def run_packer(mmw_config, machine_type, aws_profile):
                       '-var', 'postgresql_password={}'.format(mmw_config['RDSPassword']),  # NOQA
                       '-var', 'itsi_secret_key={}'.format(mmw_config['ITSISecretKey'])]  # NOQA
 
-    if machine_type is not None:
-        packer_command.extend(['-only', machine_type])
+    if machine_types is not None:
+        packer_command.extend(['-only', ','.join(machine_types)])
     else:
         packer_command.extend(['-except', 'mmw-monitoring'])
 


### PR DESCRIPTION
Small tweak to the command line validation for the `create-ami` subcommand that allows an application and worker AMI to be built at the same time.

This may finally close out https://github.com/WikiWatershed/model-my-watershed/issues/464.

---

**Testing**

- [ ] See if you can create two AMIs simultaneously with:

```bash
$ cd deployment
$ python mmw_stack.py create-ami \
     --aws-profile mmw-stg \
     --mmw-profile staging \
     --machine-type mmw-app mmw-worker