### PR TITLE
Make modals more intuitive and keyboard-friendly

### DIFF
--- a/src/mmw/js/src/core/templates/confirmModal.html
+++ b/src/mmw/js/src/core/templates/confirmModal.html
@@ -5,7 +5,7 @@
         </div>
         <div class="modal-footer">
             <button type="button" class="btn btn-md btn-default" data-dismiss="modal">{{ cancelLabel }}</button>
-            <button type="button" class="btn btn-md btn-default confirm" data-dismiss="modal">{{ confirmLabel }}</button>
+            <button type="button" class="btn btn-md btn-active confirm" data-dismiss="modal">{{ confirmLabel }}</button>
         </div>
     </div>
 </div>

--- a/src/mmw/js/src/core/templates/inputModal.html
+++ b/src/mmw/js/src/core/templates/inputModal.html
@@ -14,7 +14,7 @@
         </div>
         <div class="modal-footer">
             <button type="button" class="btn btn-md btn-default" data-dismiss="modal">Cancel</button>
-            <button type="button" class="btn btn-md btn-default save">Save</button>
+            <button type="button" class="btn btn-md btn-active save">Save</button>
         </div>
     </div>
 </div>

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -399,6 +399,8 @@ var ModificationPopupView = Marionette.ItemView.extend({
 });
 
 var BaseModal = Marionette.ItemView.extend({
+    className: BASIC_MODAL_CLASS,
+
     attributes: {
         'tabindex': '-1'
     },
@@ -437,7 +439,7 @@ var BaseModal = Marionette.ItemView.extend({
 });
 
 var ConfirmModal = BaseModal.extend({
-    className: BASIC_MODAL_CLASS,
+    template: modalConfirmTmpl,
 
     ui: {
         confirmation: '.confirm'
@@ -447,8 +449,6 @@ var ConfirmModal = BaseModal.extend({
         'click @ui.confirmation': 'primaryAction'
     }, BaseModal.prototype.events),
 
-    template: modalConfirmTmpl,
-
     primaryAction: function() {
         this.triggerMethod('confirmation');
         this.hide();
@@ -456,8 +456,6 @@ var ConfirmModal = BaseModal.extend({
 });
 
 var InputModal = BaseModal.extend({
-    className: BASIC_MODAL_CLASS,
-
     template: modalInputTmpl,
 
     ui: {
@@ -486,8 +484,6 @@ var InputModal = BaseModal.extend({
 });
 
 var ShareModal = BaseModal.extend({
-    className: BASIC_MODAL_CLASS,
-
     template: modalShareTmpl,
 
     ui: {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -16,6 +16,7 @@ var $ = require('jquery'),
     modificationPopupTmpl = require('./templates/modificationPopup.html'),
     areaOfInterestTmpl = require('../core/templates/areaOfInterestHeader.html'),
 
+    ENTER_KEYCODE = 13,
     BASIC_MODAL_CLASS = 'modal modal-basic fade';
 
 require('leaflet.locatecontrol');
@@ -398,15 +399,36 @@ var ModificationPopupView = Marionette.ItemView.extend({
 });
 
 var BaseModal = Marionette.ItemView.extend({
-    initialize: function() {
-        var self = this;
-        this.$el.on('hide.bs.modal', function() {
-            self.destroy();
-        });
+    attributes: {
+        'tabindex': '-1'
+    },
+
+    events: {
+        'shown.bs.modal': 'onModalShown',
+        'keyup': 'onKeyUp',
+        'hidden.bs.modal': 'onModalHidden'
     },
 
     onRender: function() {
         this.$el.modal('show');
+    },
+
+    onModalShown: function() {
+        // Not implemented.
+    },
+
+    onKeyUp: function(e) {
+        if (e.keyCode === ENTER_KEYCODE) {
+            this.primaryAction();
+        }
+    },
+
+    primaryAction: function() {
+        // Not implemented.
+    },
+
+    onModalHidden: function() {
+        this.destroy();
     },
 
     hide: function() {
@@ -421,14 +443,15 @@ var ConfirmModal = BaseModal.extend({
         confirmation: '.confirm'
     },
 
-    events: {
-        'click @ui.confirmation': 'triggerConfirmation'
-    },
+    events: _.defaults({
+        'click @ui.confirmation': 'primaryAction'
+    }, BaseModal.prototype.events),
 
     template: modalConfirmTmpl,
 
-    triggerConfirmation: function() {
+    primaryAction: function() {
         this.triggerMethod('confirmation');
+        this.hide();
     }
 });
 
@@ -443,11 +466,15 @@ var InputModal = BaseModal.extend({
         error: '.error'
     },
 
-    events: {
-        'click @ui.save': 'updateFromInput'
+    events: _.defaults({
+        'click @ui.save': 'primaryAction'
+    }, BaseModal.prototype.events),
+
+    onModalShown: function() {
+        this.ui.input.focus().select();
     },
 
-    updateFromInput: function() {
+    primaryAction: function() {
         var val = this.ui.input.val().trim();
         if (val) {
             this.triggerMethod('update', val);
@@ -469,13 +496,11 @@ var ShareModal = BaseModal.extend({
         'input': 'input'
     },
 
-    events: {
+    events: _.defaults({
         'click @ui.signin': 'signIn'
-    },
+    }, BaseModal.prototype.events),
 
-    // Override to initialize ZeroClipboard
     initialize: function() {
-        BaseModal.prototype.initialize.call(this);
         this.zc = new ZeroClipboard();
     },
 
@@ -487,6 +512,10 @@ var ShareModal = BaseModal.extend({
         });
 
         this.$el.modal('show');
+    },
+
+    onModalShown: function() {
+        this.ui.input.focus().select();
     },
 
     signIn: function() {


### PR DESCRIPTION
Pre-select text in Share and Input modals so one may begin typing new values immediately, and trigger the primary action upon pressing <kbd>Enter</kbd>.

This does not work for the Confirm modal because there is not text input to receive `keyup` events. Since confirmation should require a higher degree of user attention, perhaps it is fitting that they must use the mouse to select the option they want. However, if this behavior is deemed inconsistent, there are hacks we can use to force the modal div to receive keyboard input.

**Testing Instructions**

 * Try renaming a project to test the input modal.
 * Try deleting a project to test the confirm modal.
 * Try sharing a project to test the share modal.
 * Try closing the modals by pressing <kbd>Esc</kbd>

Connects #343 