### PR TITLE
Hide dropdown button on inactive scenario tabs

### DIFF
--- a/src/mmw/js/src/modeling/templates/scenarioTabPanel.html
+++ b/src/mmw/js/src/modeling/templates/scenarioTabPanel.html
@@ -1,21 +1,23 @@
 <a href="#{{ cid }}" data-scenario-cid="{{ cid }}" aria-controls="home" role="tab" data-toggle="tab" class="tab-name"><span>{{ name }}</span></a>
-<div class="scenario-btn-dropdown">
-    <div class="dropdown">
-        <button class="btn btn-sm btn-icon dark dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
-        <i class="fa fa-caret-down"></i>
-        </button>
-        <ul class="dropdown-menu menu-right" role="menu">
-            {% if editable %}
-                <li role="presentation"><a role="menuitem" tabindex="-1" data-action="share">Share</a></li>
-            {% endif %}
-            <li role="presentation"><a role="menuitem" tabindex="-1" data-action="print">Print</a></li>
-            {% if not is_current_conditions %}
+{% if active %}
+    <div class="scenario-btn-dropdown">
+        <div class="dropdown">
+            <button class="btn btn-sm btn-icon dark dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
+            <i class="fa fa-caret-down"></i>
+            </button>
+            <ul class="dropdown-menu menu-right" role="menu">
                 {% if editable %}
-                <li role="presentation"><a role="menuitem" tabindex="-1" data-action="rename">Rename</a></li>
-                <li role="presentation"><a role="menuitem" tabindex="-1" data-action="duplicate">Duplicate</a></li>
-                <li role="presentation"><a role="menuitem" tabindex="-1" data-action="delete">Delete</a></li>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" data-action="share">Share</a></li>
                 {% endif %}
-            {% endif %}
-        </ul>
+                <li role="presentation"><a role="menuitem" tabindex="-1" data-action="print">Print</a></li>
+                {% if not is_current_conditions %}
+                    {% if editable %}
+                    <li role="presentation"><a role="menuitem" tabindex="-1" data-action="rename">Rename</a></li>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" data-action="duplicate">Duplicate</a></li>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" data-action="delete">Delete</a></li>
+                    {% endif %}
+                {% endif %}
+            </ul>
+        </div>
     </div>
-</div>
+{% endif %}


### PR DESCRIPTION
I could think of three approaches to solve the problem of sharing the incorrect scenario URL:

 1. **Make the Share modal prompt the correct URL**. ~~The reason we currently use `window.location.href` is to avoid hardcoding a Scenario URL in the code, since it may change over time (see #365, #377). It would become one more place that needs to be updated if the URL structure changes, and thus add fragility and brittleness to the codebase.~~ There is a method `getReferenceUrl` on the `Project` model which can get us this value, and in fact is updated with URL changes https://github.com/WikiWatershed/model-my-watershed/pull/513/files#diff-9abeff034ba5a68b4814ee90721888ebR223. However, we would also have to do the same treatment for every item in that dropdown list, which right now only includes `Print`, but could have more options in the future.
 2. **Make clicking the dropdown icon activate the tab**. This is what the original card asked for, but unfortunately the dropdown button and the containing tab header are two different views, and stringing them together will create unnecessary coupling. Furthermore, we use Bootstrap's implementations for tabs and dropdown lists which aren't very easy to hook in to or override the behavior of.
 3. **Hide the dropdown button on inactive tabs**. This is straightforward to implement and is also in line with conventions of Google Sheets. However, it now makes sharing inactive scenarios slightly more difficult, since users have to click twice instead of once, first to make that scenario active and then click the dropdown. There is also a slight visual vacuum when the icons is hidden, although perhaps I feel that way because I'm so used to seeing it before. But it is still better than removing that space, which would disturb visual positioning of unrelated tabs.

I went with 3 in this case:

![image](https://cloud.githubusercontent.com/assets/1430060/8410810/8d796842-1e4e-11e5-9754-05be8ff28e6e.png)

but if others feel strongly about going with 1 or 2 I can comply.

Connects #378 