### PR TITLE
Change /model to /project

### DIFF
--- a/src/mmw/apps/home/tests.py
+++ b/src/mmw/apps/home/tests.py
@@ -37,20 +37,20 @@ class RouteAccessTestCase(TestCase):
         self.c.login(username='test', password='test')
 
     def test_any_user_can_get_model_route_without_project_id(self):
-        response = self.c.get('/model/')
+        response = self.c.get('/project/')
 
         self.assertEqual(response.status_code, 200)
 
         self.c.logout()
 
-        response = self.c.get('/model/')
+        response = self.c.get('/project/')
 
         self.assertEqual(response.status_code, 200)
 
     def test_project_owner_can_get_model_route_with_project_id(self):
         project_id = self.create_private_project()
 
-        response = self.c.get('/model/' + project_id + '/')
+        response = self.c.get('/project/' + project_id + '/')
 
         self.assertEqual(response.status_code, 200)
 
@@ -60,7 +60,7 @@ class RouteAccessTestCase(TestCase):
         self.c.logout()
         self.c.login(username='foo', password='bar')
 
-        response = self.c.get('/model/' + project_id + '/')
+        response = self.c.get('/project/' + project_id + '/')
 
         self.assertEqual(response.status_code, 200)
 
@@ -70,7 +70,7 @@ class RouteAccessTestCase(TestCase):
         self.c.logout()
         self.c.login(username='foo', password='bar')
 
-        response = self.c.get('/model/' + project_id + '/')
+        response = self.c.get('/project/' + project_id + '/')
 
         self.assertEqual(response.status_code, 404)
 
@@ -79,7 +79,7 @@ class RouteAccessTestCase(TestCase):
 
         self.c.logout()
 
-        response = self.c.get('/model/' + project_id + '/')
+        response = self.c.get('/project/' + project_id + '/')
 
         self.assertEqual(response.status_code, 200)
 
@@ -88,7 +88,7 @@ class RouteAccessTestCase(TestCase):
 
         self.c.logout()
 
-        response = self.c.get('/model/' + project_id + '/')
+        response = self.c.get('/project/' + project_id + '/')
 
         self.assertEqual(response.status_code, 404)
 

--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -4,16 +4,16 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.conf.urls import patterns, url
-from apps.home.views import home_page, model, compare
+from apps.home.views import home_page, project, compare
 
 
 urlpatterns = patterns(
     '',
     url(r'^$', home_page, name='home_page'),
-    url(r'^model/$', model, name='model'),
-    url(r'^model/(?P<proj_id>[0-9]+)/$', model, name='model'),
-    url(r'^model/(?P<proj_id>[0-9]+)/scenario/(?P<scenario_id>[0-9]+)/$',
-        model, name='model'),
+    url(r'^project/$', project, name='project'),
+    url(r'^project/(?P<proj_id>[0-9]+)/$', project, name='project'),
+    url(r'^project/(?P<proj_id>[0-9]+)/scenario/(?P<scenario_id>[0-9]+)/$',
+        project, name='project'),
     url(r'^analyze$', home_page, name='analyze'),
     url(r'^compare$', compare, name='compare'),
     url(r'^error', home_page, name='error'),

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -17,7 +17,7 @@ def home_page(request):
     return render_to_response('home/home.html', csrf_token)
 
 
-def model(request, proj_id=None, scenario_id=None):
+def project(request, proj_id=None, scenario_id=None):
     """
     If proj_id was specified, check that the user owns
     the project or if the project is public.

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -69,7 +69,7 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
                 shape: this.model.get('area_of_interest'),
                 can_go_back: true,
                 next_label: 'Model',
-                url: 'model'
+                url: 'project'
             })
         }));
     },

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -7,14 +7,14 @@ var App = require('../app'),
     models = require('./models');
 
 var ModelingController = {
-    modelPrepare: function(projectId) {
+    projectPrepare: function(projectId) {
         if (!projectId && !App.map.get('areaOfInterest')) {
             router.navigate('', { trigger: true });
             return false;
         }
     },
 
-    model: function(projectId, scenarioParam) {
+    project: function(projectId, scenarioParam) {
         var project;
 
         if (projectId) {
@@ -80,7 +80,7 @@ var ModelingController = {
         }
     },
 
-    modelCleanUp: function() {
+    projectCleanUp: function() {
         App.getMapView().updateModifications(null);
         App.rootView.subHeaderRegion.empty();
         App.rootView.footerRegion.empty();

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -222,8 +222,8 @@ var ProjectModel = Backbone.Model.extend({
 
     getReferenceUrl: function() {
         // Return a url fragment that can access this project at its
-        // current state /model/<id>/scenario/<id>
-        var root = '/model/';
+        // current state /project/<id>/scenario/<id>
+        var root = '/project/';
 
         if (this.get('id')) {
             var modelPart = this.id,

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -318,7 +318,7 @@ describe('Modeling', function() {
             });
 
             describe('#getReferenceUrl', function() {
-                var base = '/model/';
+                var base = '/project/';
 
                 it('generates no url fragment for unsaved projects', function() {
                     var project = new models.ProjectModel({ id: null });

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -11,10 +11,10 @@ var router = require('./router').router,
 
 router.addRoute(/^/, DrawController, 'draw');
 router.addRoute(/^analyze/, AnalyzeController, 'analyze');
-router.addRoute(/^model/, ModelingController, 'model');
-router.addRoute('model/:projectId', ModelingController, 'model');
-router.addRoute('model/:projectId/', ModelingController, 'model');
-router.addRoute('model/:projectId/scenario/:scenarioId/', ModelingController, 'model');
+router.addRoute(/^project/, ModelingController, 'project');
+router.addRoute('project/:projectId', ModelingController, 'project');
+router.addRoute('project/:projectId/', ModelingController, 'project');
+router.addRoute('project/:projectId/scenario/:scenarioId/', ModelingController, 'project');
 router.addRoute(/^compare/, AppController, 'compare');
 router.addRoute('error(/)(:type)', ErrorController, 'error');
 router.addRoute('sign-up(/)', SignUpController, 'signUp');


### PR DESCRIPTION
* Change the /model route to /project, and update all
references and tests. This route name provides a more
direct mapping the to resource that is being loaded.

**To Test:**
- Navigate to the project page from the root page using the UI controls.
- Save the project.
- Revisit the project using the URL.
- Run the tests.

Connects to #365