### PR TITLE
Add AoI outline to mask layer.

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -327,7 +327,10 @@ function applyMask(featureGroup, shapeLayer) {
         outerRing = getLatLngs(worldBounds),
         innerRings = getLatLngs(shapeLayer),
         polygonOptions = {
-            stroke: false,
+            stroke: true,
+            color: '#fff',
+            weight: 3.5,
+            opacity: 1,
             fill: true,
             fillColor: '#000',
             fillOpacity: 0.5,


### PR DESCRIPTION
* Add a white border to the area of interest mask layer for
aesthetic purposes.

**To test:**
- Draw or select an area of interest.

![selection_048](https://cloud.githubusercontent.com/assets/1042475/8414763/426b603e-1e68-11e5-91e1-3ac3ead1835b.png)

Connects to #342 
