### PR TITLE
Don't fit bounds when toggling the model output

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -109,7 +109,7 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
 
         this.$el.animate({ height: '55%' }, 200, function() {
             self.trigger('animateIn');
-            App.map.set('halfSize', true);
+            App.map.setHalfSize(true);
         });
         if (this.lock !== undefined) {
             this.lock.resolve();
@@ -119,7 +119,7 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
     animateOut: function() {
         var self = this;
 
-        App.map.set('halfSize', false);
+        App.map.setFullSize(true);
         this.$el.animate({ height: '0%' }, 200, function() {
             self.trigger('animateOut');
         });

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -44,7 +44,16 @@ var MapModel = Backbone.Model.extend({
 
             this.set('areaOfInterest', aoi);
         }
-    }
+    },
+
+    setHalfSize: function(fit) {
+        this.set('size', { half: true, fit: !!fit });
+    },
+
+    setFullSize: function(fit) {
+        this.set('size', { half: false, fit: !!fit });
+    },
+
 });
 
 var TaskModel = Backbone.Model.extend({

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -163,7 +163,7 @@ describe('Core', function() {
                         model: model
                     });
 
-                model.set('halfSize', true);
+                model.setHalfSize();
                 assert.isTrue($('#map').hasClass('half'));
 
                 view._leafletMap.remove();
@@ -176,7 +176,7 @@ describe('Core', function() {
                         model: model
                     });
 
-                model.set('halfSize', false);
+                model.setFullSize();
                 assert.isFalse($('#map').hasClass('half'));
 
                 view._leafletMap.remove();

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -122,7 +122,7 @@ var MapView = Marionette.ItemView.extend({
     modelEvents: {
         'change': 'updateView',
         'change:areaOfInterest': 'updateAreaOfInterest',
-        'change:halfSize': 'toggleMapSize',
+        'change:size': 'toggleMapSize',
         'change:maskLayerApplied': 'toggleMask'
     },
 
@@ -305,7 +305,8 @@ var MapView = Marionette.ItemView.extend({
     },
 
     toggleMapSize: function() {
-        if (this.model.get('halfSize')) {
+        var size = this.model.get('size');
+        if (size.half) {
             $(this.ui.map).addClass('half');
         } else {
             $(this.ui.map).removeClass('half');
@@ -313,12 +314,19 @@ var MapView = Marionette.ItemView.extend({
 
         this._leafletMap.invalidateSize();
 
+        if (size.fit) {
+            this.fitToAoi();
+        }
+    },
+
+    fitToAoi: function() {
         var areaOfInterest = this.model.get('areaOfInterest');
         if (areaOfInterest) {
             var layer = new L.GeoJSON(areaOfInterest);
             this._leafletMap.fitBounds(layer.getBounds(), { reset: true });
         }
     }
+
 });
 
 // Apply a mask over the entire map excluding bounds/shape specified.

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -608,7 +608,7 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
         var self = this;
         this.$el.animate({ height: '55%', 'min-height': '300px' }, 200, function() {
             self.trigger('animateIn');
-            App.map.set('halfSize', true);
+            App.map.setHalfSize(false);
             $(self.ui.toggle.selector).blur()
                 .find('i')
                     .removeClass('fa-angle-up')
@@ -617,12 +617,13 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
         });
     },
 
-    animateOut: function() {
-        var self = this;
+    animateOut: function(fitToBounds) {
+        var self = this,
+            fit = _.isUndefined(fitToBounds) ? true : fitToBounds;
 
         // Change map to full size first so there isn't empty space when
         // results window animates out
-        App.map.set('halfSize', false);
+        App.map.setFullSize(fit);
 
         this.$el.animate({ height: '0%', 'min-height': '50px' }, 200, function() {
             self.trigger('animateOut');
@@ -637,7 +638,7 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
         if (this.$el.css('height') === '50px') {
             this.animateIn();
         } else {
-            this.animateOut();
+            this.animateOut(false);
         }
     }
 });


### PR DESCRIPTION
Restructure how views tell the map to go half size, so they can also
specify whether or not the bounds should be fit to the new size.  All
main region switching will still initially fit the AoI in the map, but
once the user begins toggling the model output pane, the bounds remain
consistent (and clipped if the map is shrinking).

The previously existing issue where the map fit going towards modelling doesn't fit the entire AoI is still present.  I suspect the fit is happening at a middle point in the animation or possible the map div reaches above and below a header.  The issue created for that is #518

Connects #401 