### PR TITLE
Add modal to resend activation

### DIFF
--- a/src/mmw/apps/user/urls.py
+++ b/src/mmw/apps/user/urls.py
@@ -8,6 +8,7 @@ from django.conf.urls import patterns, url
 from apps.user.views import (login,
                              sign_up,
                              forgot,
+                             resend,
                              logout,
                              itsi_login,
                              itsi_auth,
@@ -21,5 +22,6 @@ urlpatterns = patterns(
     url(r'^itsi/sign_up', itsi_sign_up, name='itsi_sign_up'),
     url(r'^login$', login, name='login'),
     url(r'^sign_up$', sign_up, name='sign_up'),
+    url(r'^resend$', resend, name='resend'),
     url(r'^forgot$', forgot, name='forgot')
 )

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -5,7 +5,10 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect, render_to_response
 from django.contrib.auth.forms import PasswordResetForm
+from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.sites.shortcuts import get_current_site
 
+from registration.models import RegistrationProfile
 from registration.forms import RegistrationFormUniqueEmail
 from registration.backends.default.views import RegistrationView
 
@@ -200,6 +203,34 @@ def sign_up(request):
         response_data = {"errors": errors}
         return Response(data=response_data,
                         status=status.HTTP_400_BAD_REQUEST)
+
+
+@decorators.api_view(['POST'])
+@decorators.permission_classes((AllowAny, ))
+def resend(request):
+    # Resend activation email if the key hasn't expired.
+    form = PasswordResetForm(request.POST)
+    if form.is_valid():
+        email = form.cleaned_data['email']
+        try:
+            registration_profile = RegistrationProfile.objects.get(
+                user__email=email)
+            if registration_profile.activation_key_expired():
+                response_data = {'errors': ["Activation key expired"]}
+                status_code = status.HTTP_400_BAD_REQUEST
+            else:
+                registration_profile.send_activation_email(
+                    get_current_site(request))
+                response_data = {'result': 'success'}
+                status_code = status.HTTP_200_OK
+        except ObjectDoesNotExist:
+            response_data = {'errors': ["Email cannot be found"]}
+            status_code = status.HTTP_400_BAD_REQUEST
+    else:
+        response_data = {'errors': ["Email is invalid"]}
+        status_code = status.HTTP_400_BAD_REQUEST
+
+    return Response(data=response_data, status=status_code)
 
 
 @decorators.api_view(['POST'])

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -183,6 +183,35 @@ var ForgotFormModel = ModalBaseModel.extend({
     }
 });
 
+var ResendFormModel = ModalBaseModel.extend({
+    defaults: {
+        email: null
+    },
+
+    url: '/user/resend',
+
+    validate: function(attrs) {
+        var errors = [];
+
+        if (!attrs.email) {
+            errors.push('Please enter an email address');
+        }
+
+        if (errors.length) {
+            this.set({
+                'client_errors': errors,
+                'server_errors': null
+            });
+            return errors;
+        } else {
+            this.set({
+                'client_errors': null,
+                'server_errors': null
+            });
+        }
+    }
+});
+
 var ItsiSignUpFormModel = ModalBaseModel.extend({
     defaults: {
         username: null,
@@ -231,6 +260,7 @@ module.exports = {
     UserModel: UserModel,
     LoginFormModel: LoginFormModel,
     SignUpFormModel: SignUpFormModel,
+    ResendFormModel: ResendFormModel,
     ForgotFormModel: ForgotFormModel,
     ItsiSignUpFormModel: ItsiSignUpFormModel
 };

--- a/src/mmw/js/src/user/templates/loginModal.html
+++ b/src/mmw/js/src/user/templates/loginModal.html
@@ -4,6 +4,9 @@
     <div class="forgot">
         <button type="button" class="btn btn-sm btn-default">Forgot?</button>
     </div>
+    <div class="resend">
+        <button type="button" class="btn btn-sm btn-default">Send Activation Email</button>
+    </div>
     <div class="sign-up">
         <button type="button" class="btn btn-sm btn-default" data-dismiss="modal">Sign Up</button>
     </div>

--- a/src/mmw/js/src/user/templates/resendModal.html
+++ b/src/mmw/js/src/user/templates/resendModal.html
@@ -1,0 +1,17 @@
+{% extends './baseModal.html' %}
+
+{% block form %}
+    {% if success %}
+        Please check your email to activate your account.
+    {% else %}
+        {{ field(email, 'email', 'Email', 'email') }}
+    {% endif %}
+{% endblock %}
+
+{% block footer %}
+    {% if success %}
+        <button id="login" type="button" class="btn btn-lg btn-block btn-active">Login</button>
+    {% else %}
+        <button type="button" class="btn btn-lg btn-block btn-active" id="primary-button">Send Activation Email</button>
+    {% endif %}
+{% endblock %}

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -127,6 +127,12 @@
   right: 2rem;
 }
 
+.resend {
+  position: absolute;
+  top: 1rem;
+  left: 6.25rem;
+}
+
 .forgot {
   position: absolute;
   top: 1rem;


### PR DESCRIPTION
To test:
 * Create a new account, but don't activate.
 * Click Send Activation Email (located between 'Forgot?' and 'Sign Up' on the Login modal)
 * Enter the email for the account just created. It should send an email (on the console in development mode).
 * Try triggering various error messages. Make sure the enter button works in addition to clicking the button.
   * Try entering a non-email address string.
   * Try entering a valid email address that is not associated with a user.
   * Try entering an email address for a user who has already activated their account.

This was pretty easy thanks to the refactoring done by @rajadain 

Connects #361 