### PR TITLE
Invert tiler health conditional

### DIFF
--- a/src/tiler/healthCheck.js
+++ b/src/tiler/healthCheck.js
@@ -117,7 +117,7 @@ module.exports = function createHealthCheckHandler(config) {
         response.databases = [{'default': buildPayload(databaseError)}];
         response.caches = [{'default': buildPayload(cacheError)}];
 
-        if (databaseError && cacheError) {
+        if (!databaseError && !cacheError) {
           statusCode = 200;
         }
 


### PR DESCRIPTION
If there is no database error, nor cache error, then return 200 as the HTTP status code.