### PR TITLE
Add application health check

### DIFF
--- a/src/mmw/apps/monitoring/urls.py
+++ b/src/mmw/apps/monitoring/urls.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.conf.urls import patterns, url
+from apps.monitoring.views import health_check
+
+urlpatterns = patterns(
+    '',
+    url(r'^$', health_check, name='health_check'),
+)

--- a/src/mmw/apps/monitoring/views.py
+++ b/src/mmw/apps/monitoring/views.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from rest_framework import status
+
+from django.http import JsonResponse
+from django.core.cache import caches
+from django.db import connections
+
+from mmw.middleware import bypass_middleware
+
+import uuid
+
+
+@bypass_middleware
+def health_check(request):
+    response = {}
+
+    for check in [_check_cache, _check_database]:
+        response.update(check())
+
+    if all(map(lambda x: x[0]['default']['ok'], response.values())):
+        return JsonResponse(response, status=status.HTTP_200_OK)
+    else:
+        return JsonResponse(response,
+                            status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+def _check_cache(cache='default'):
+    key = 'health-check-{}'.format(uuid.uuid4())
+
+    try:
+        caches[cache].set(key, uuid.uuid4())
+
+        # Loss of connectivity to Redis does not always throw an
+        # exception because DJANGO_REDIS_IGNORE_EXCEPTIONS is True.
+        if caches[cache].get(key) is None:
+            response = {cache: {'ok': False}}
+        else:
+            response = {cache: {'ok': True}}
+            caches[cache].delete(key)
+    except Exception as e:
+        response = {
+            cache: {
+                'ok': False,
+                'msg': str(e)
+            },
+        }
+
+    return {'caches': [response]}
+
+
+def _check_database(database='default'):
+    try:
+        connections[database].introspection.table_names()
+
+        response = {database: {'ok': True}}
+    except Exception as e:
+        response = {
+            database: {
+                'ok': False,
+                'msg': str(e)
+            },
+        }
+
+    return {'databases': [response]}

--- a/src/mmw/mmw/middleware.py
+++ b/src/mmw/mmw/middleware.py
@@ -1,0 +1,40 @@
+from django.conf import settings
+from django.core.handlers.base import BaseHandler
+from django.core import urlresolvers
+
+
+def bypass_middleware(view):
+    view.bypass_middleware = True
+
+    return view
+
+
+class BypassMiddleware(object):
+    """
+    Customized version of a gist detailing this technique by @bryanhelmig
+
+    See also: https://gist.github.com/bryanhelmig/9d09d1bd9a63504371d2
+    """
+    def process_request(self, request):
+        """Replicates a lot of code from BaseHandler#get_response."""
+        # Setup URL resolver
+        urlconf = settings.ROOT_URLCONF
+        urlresolvers.set_urlconf(urlconf)
+        resolver = urlresolvers.RegexURLResolver(r'^/', urlconf)
+        callback, callback_args, \
+            callback_kwargs = resolver.resolve(request.path_info)
+
+        if getattr(callback, 'bypass_middleware', False):
+            # bypass_middleware decorator was used; zero out all
+            # middleware and return the response.
+            handler = BaseHandler()
+
+            handler._request_middleware = []
+            handler._view_middleware = []
+            handler._template_response_middleware = []
+            handler._response_middleware = []
+            handler._exception_middleware = []
+
+            response = handler.get_response(request)
+
+            return response

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -233,6 +233,7 @@ TEMPLATE_DIRS = (
 MIDDLEWARE_CLASSES = (
     # Default Django middleware.
     'django.middleware.common.CommonMiddleware',
+    'mmw.middleware.BypassMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -277,18 +278,10 @@ DJANGO_APPS = (
 
 THIRD_PARTY_APPS = (
     'rest_framework',
-    'watchman',
     'registration',
 )
 
 # THIRD-PARTY CONFIGURATION
-
-# watchman
-# Disable Storage checking, to avoid creating files on S3 on every health check
-WATCHMAN_CHECKS = (
-    'watchman.checks.caches',
-    'watchman.checks.databases',
-)
 
 # rest_framework
 REST_FRAMEWORK = {

--- a/src/mmw/mmw/urls.py
+++ b/src/mmw/mmw/urls.py
@@ -7,7 +7,6 @@ from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
 import registration.backends.default.urls
-import watchman.urls
 import rest_framework.urls
 
 import apps.geocode.urls
@@ -16,16 +15,17 @@ import apps.home.urls
 import apps.home.views
 import apps.water_balance.urls
 import apps.user.urls
+import apps.monitoring.urls
 
 admin.autodiscover()
 
 urlpatterns = patterns(
     '',
     url(r'^', include(apps.home.urls)),
+    url(r'^health-check/', include(apps.monitoring.urls)),
     url(r'^api-auth/', include(rest_framework.urls,
                                namespace='rest_framework')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^health-check/', include(watchman.urls)),
     url(r'^accounts/', include(registration.backends.default.urls)),
     url(r'^api/geocode/', include(apps.geocode.urls)),
     url(r'^api/modeling/', include(apps.modeling.urls)),

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -1,7 +1,6 @@
 Django>=1.8,<1.8.99
 gunicorn==19.1.1
 django-statsd-mozilla==0.3.14
-django-watchman==0.5.0
 django-redis==3.8.3
 hiredis==0.1.6
 djangorestframework==3.1.1


### PR DESCRIPTION
Each probe initiates a connection attempt to the PostgreSQL database and Redis. Failure of either returns an HTTP 503, while success of both returns an HTTP 200. The health check is mounted at `/health-check`.

The inclusion of `BypassMiddleware` is needed because when the connection to PostgreSQL is severed, 
other middleware end up triggering exceptions before the `health_check` response can be returned. This hurts our ability to know if the health check failure is just PostgreSQL or PostgreSQL and Redis.

Connects #370

---

**Testing**

I'm worried that the `BypassMiddleware` will cause problems with other pages. Thus far, I haven't been able to find anything broken and all tests still pass. If there are other solutions to avoid processing middleware, feel free to suggest them.

- [x] Provision the `app` server
- [x] Login to the `services` virtual machine and stop the Redis or PostgreSQL service
- [x] Inspect the JSON payload provided by [http://localhost:8000/health-check](http://localhost:8000/health-check)
- [x] Ensure that nothing breaks because of the `BypassMiddleware` middleware