### PR TITLE
Only show Share menu item when saved

### DIFF
--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -8,7 +8,7 @@
         <i class="fa fa-caret-down"></i>
         </button>
         <ul class="dropdown-menu menu-right" role="menu">
-            {% if id and editable %}
+            {% if not is_new and editable %}
                 <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="share-project">Share</a></li>
                 <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="project-privacy">{% if is_private %}Make Public{% else %}Make Private{% endif %}</a></li>
                 <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="delete-project">Delete</a></li>
@@ -17,7 +17,7 @@
             {% if editable %}
                 <li role="presentation"><a role="menuitem" tabindex="-1" data-toggle="modal" id="rename-project">Rename</a></li>
             {% endif %}
-            {% if not id %}
+            {% if is_new %}
                 <li role="presentation"><a role="menuitem" tabindex="-1" id="save-project">Save</a></li>
             {% endif %}
             <li role="presentation"><a role="menuitem" tabindex="-1" id="print-project">Print</a></li>

--- a/src/mmw/js/src/modeling/templates/scenarioTabPanel.html
+++ b/src/mmw/js/src/modeling/templates/scenarioTabPanel.html
@@ -6,7 +6,7 @@
             <i class="fa fa-caret-down"></i>
             </button>
             <ul class="dropdown-menu menu-right" role="menu">
-                {% if editable %}
+                {% if editable and not is_new %}
                     <li role="presentation"><a role="menuitem" tabindex="-1" data-action="share">Share</a></li>
                 {% endif %}
                 <li role="presentation"><a role="menuitem" tabindex="-1" data-action="print">Print</a></li>

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -90,6 +90,14 @@ describe('Modeling', function() {
                 assert.equal($('#sandbox ul.nav.nav-tabs > li').length, 3);
             });
 
+            function checkMenuItemsMatch(expectedItems) {
+                var $menuItems = $('#sandbox ul.nav.nav-tabs li.active ul.dropdown-menu li'),
+                    menuItems = $menuItems.map(function() {
+                        return $(this).text();
+                    }).get();
+                assert.deepEqual(menuItems, expectedItems);
+            }
+
             it('renders tab dropdowns for editing if the user owns the project', function() {
                 App.user.set('id', 1);
                 var project = getTestProject();
@@ -99,8 +107,7 @@ describe('Modeling', function() {
                 var view = new views.ScenarioTabPanelsView({ collection: project.get('scenarios') });
 
                 $('#sandbox').html(view.render().el);
-                // Get dropdown items in the tab. (share, print, rename, duplicate, delete).
-                assert.equal($('#sandbox ul.nav.nav-tabs li.active ul.dropdown-menu li').length, 5);
+                checkMenuItemsMatch(['Print', 'Rename', 'Duplicate', 'Delete']);
             });
 
             it('renders appropriate tab dropdowns if the user does not own the project', function() {
@@ -112,8 +119,20 @@ describe('Modeling', function() {
                 var view = new views.ScenarioTabPanelsView({ collection: project.get('scenarios') });
 
                 $('#sandbox').html(view.render().el);
-                // Get dropdown items in the tab. (print).
-                assert.equal($('#sandbox ul.nav.nav-tabs li.active ul.dropdown-menu li').length, 1);
+                checkMenuItemsMatch(['Print']);
+            });
+
+            it('renders tab dropdown for sharing if the scenario is saved', function() {
+                App.user.set('id', 1);
+                var project = getTestProject();
+
+                // Simulate scenario that has been saved.
+                project.get('scenarios').invoke('set', 'id', 1);
+
+                var view = new views.ScenarioTabPanelsView({ collection: project.get('scenarios') });
+
+                $('#sandbox').html(view.render().el);
+                checkMenuItemsMatch(['Share', 'Print', 'Rename', 'Duplicate', 'Delete']);
             });
         });
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -103,7 +103,8 @@ var ProjectMenuView = Marionette.ItemView.extend({
 
     templateHelpers: function() {
         return {
-            editable: isEditable(this.model)
+            editable: isEditable(this.model),
+            is_new: this.model.isNew()
         };
     },
 
@@ -275,7 +276,8 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
     templateHelpers: function() {
         return {
             cid: this.model.cid,
-            editable: isEditable(this.model)
+            editable: isEditable(this.model),
+            is_new: this.model.isNew()
         };
     },
 


### PR DESCRIPTION
To test, when logged out, check that there is no 'Share' item in the Project and Scenario menus. When logged in, check that the 'Share' item appears in both menus.

The testem tests fail some of the time (see #530) but this also occurs on the develop branch.

Connects #516 