### PR TITLE
Disable "modifications" dropdown.

### DIFF
--- a/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
+++ b/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
@@ -2,9 +2,15 @@
 
 <div id="modification-btn-wrapper"> <!-- Modifications Dropdown -->
     <div class="dropdown"> <!-- Dropdown Button -->
-        <button class="btn btn-sm btn-default inverted" type="button" data-toggle="dropdown" aria-expanded="true">
-        <span id="modification-number"><strong>{{ shapes|length }}</strong></span> Modifications
-        </button>
+        {% if not is_current_conditions %}
+            {% if shapes|length == 0 %}
+                <button class="btn btn-sm btn-default inverted" type="button" disabled="true">
+            {% else %}
+                <button class="btn btn-sm btn-default inverted" type="button" data-toggle="dropdown" aria-expanded="true">
+            {% endif %}
+                    <span id="modification-number"><strong>{{ shapes|length }}</strong></span> Modifications
+                </button>
+        {% endif %}
         <div id="modifications" class="dropdown-menu menu-right" role="menu"> <!-- DropdownContent -->
         {% for controlName, models in groupedShapes %}
             <div class="pad-1 brd-bottom">


### PR DESCRIPTION
Disable the "modifications" dropdown when there are no modifications.  Also, the button has been removed entirely when the scenario is not editable.

**To test**
   1. Create or go to a scenario with no modifications.
   2. Notice the disabled dropdown button.
   3. Add some modifications.
   4. Now the button should behave exactly as it did before.
   5. Remove the modifications.
   6. The button is disabled again.

Connects #473

![screenshot from 2015-07-01 17 25 10](https://cloud.githubusercontent.com/assets/11281373/8465364/aa4b9240-2017-11e5-8c0e-8bc9c03dd99f.png)
 ![screenshot from 2015-07-01 17 26 08](https://cloud.githubusercontent.com/assets/11281373/8465383/cfcab014-2017-11e5-9ee5-1fe9f1a7d155.png)
![screenshot from 2015-07-01 17 26 26](https://cloud.githubusercontent.com/assets/11281373/8465424/2106c45e-2018-11e5-8873-69798f6ddd2e.png)
