### PR TITLE
Enable StatsD metrics from Django

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -57,6 +57,13 @@ DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 # END FILE STORAGE CONFIGURATION
 
 
+# STATSD CONFIGURATION
+STATSD_CLIENT = 'django_statsd.clients.normal'
+STATSD_PREFIX = 'django'
+STATSD_HOST = environ.get('MMW_STATSD_HOST', 'localhost')
+# END STATSD CONFIGURATION
+
+
 # CACHE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
 CACHES = {

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -1,6 +1,6 @@
 Django>=1.8,<1.8.99
 gunicorn==19.1.1
-django-statsd-mozilla==0.3.14
+django-statsd-mozilla==0.3.15
 django-redis==3.8.3
 hiredis==0.1.6
 djangorestframework==3.1.1


### PR DESCRIPTION
Use `django-statsd-mozilla` to sends timings via middleware. Also allows you to import a StatsD client within any module to emit custom metrics. See `boto_ses_mailer.py` for an example.

I could see this being useful for subcomponents of the background jobs. Celery will automatically emit job level metrics to Statsite.

Connects #543

---

**Testing**

- [ ] Provision the `app` server
- [ ] Interact with the application
- [ ] Check the Graphite UI to see if there are metrics under the `statsite` namespace [http://localhost:8080](http://localhost:8080)

![graphite_browser](https://cloud.githubusercontent.com/assets/43639/8487361/9d659824-20d9-11e5-9d5c-cb9fd61d7ff1.png)