### PR TITLE
Fix SuggestionModel Unit Test

### DIFF
--- a/src/mmw/js/src/draw/tests.js
+++ b/src/mmw/js/src/draw/tests.js
@@ -75,7 +75,8 @@ describe('Draw', function() {
         });
 
         it('fails to add AOI when shape id cannot be retrieved by getShapeAndAnalyze', function(done) {
-            var successCount = 10,
+            // Set successCount high enough so that the polling will fail.
+            var successCount = 6,
                 deferred = setupGetShapeAndAnalyze(successCount),
                 success;
 
@@ -87,6 +88,8 @@ describe('Draw', function() {
                     success = false;
                 }).
                 always(function() {
+                    App.getLeafletMap().closePopup();
+                    App.getLeafletMap()._panAnim = false;
                     assert.equal(success, false);
                     done();
                 });


### PR DESCRIPTION
The SuggestionModel#setMapViewLocation test was failing when run alongside the Draw test "fails to add AOI when shape id cannot be retrieved by getShapeAndAnalyze", but worked in isolation. The Draw test opened a Leaflet popup which set map._panAnim to a truthy value, which led the SuggestionModel test to execute some code that tried to get a style on the window that doesn't exist. I tried to just close the popup, but that didn't work. I then manually set the _panAnim to null, and that fixed it. Setting an internal property doesn't seem like a good idea, but I'm not sure how else to fix this.

It seems like unit tests interfering with each other is a common problem. Maybe we can just clear the entire map state (or recreate it) after each test (or set of tests) is done.

To test:
Make sure that testem tests pass. Try reloading them a few times to make sure.

Connects #530 