### PR TITLE
Better TR-55 Errors

### DIFF
--- a/src/mmw/apps/core/tasks.py
+++ b/src/mmw/apps/core/tasks.py
@@ -44,6 +44,9 @@ def save_job_error(self, uuid, job_id):
     A handler task attached to the Celery chain. Any exception thrown along the
     chain will trigger this task, which logs the failure to the Job row so that
     the poling client will know that the run failed.
+
+    To see failing task in Flower, follow instructions here:
+    https://github.com/WikiWatershed/model-my-watershed/pull/551#issuecomment-119333146
     """
     result = self.app.AsyncResult(uuid)
     error_message = 'Task {0} run from job {1} raised exception: {2}\n{3}'

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -177,9 +177,7 @@ def run_tr55(census, model_input):
     precip = _get_precip_value(model_input)
 
     if precip is None:
-        return {
-            'error': 'No precipitation value defined'
-        }
+        raise Exception('No precipitation value defined')
 
     # TODO: These next two lines are just for
     # demonstration purposes.

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -45,6 +45,26 @@ class TaskRunnerTestCase(TestCase):
                          'complete',
                          'Job found but incomplete.')
 
+    @override_settings(CELERY_ALWAYS_EAGER=True)
+    def test_tr55_job_error_in_chain(self):
+        model_input = {
+            'inputs': [],
+            'modifications': []
+        }
+
+        created = now()
+        job = Job.objects.create(created_at=created, result='', error='',
+                                 traceback='', user=None, status='started')
+
+        job.save()
+
+        with self.assertRaises(Exception) as context:
+            views._initiate_tr55_job_chain(model_input, job.id)
+
+        self.assertEqual(str(context.exception),
+                         'No precipitation value defined',
+                         'Unexpected exception occurred')
+
 
 class APIAccessTestCase(TestCase):
 


### PR DESCRIPTION
## Overview

Updates TR-55 task error handling so that, for a failing case when no inputs are specified, instead of getting something like this:

```json
{
  "status": "complete",
  "started": "2015-07-06T15:34:07.151Z",
  "finished": "2015-07-06T15:34:07.214Z",
  "result": "{\"error\": \"No precipitation value defined\"}",
  "error": "",
  "job_uuid": "bf4ae97c-9cd6-406f-945d-17162f4de236"
}
```

we get something like this:

```json
{
  "status": "failed",
  "started": "2015-07-06T16:04:15.733Z",
  "finished": "2015-07-06T16:04:16.136Z",
  "result": "",
  "error": "No precipitation value defined",
  "job_uuid": "c06823c2-8498-4d78-8475-c5fc45b5a2f5"
}
```

Notice the differences in `status`, `result`, and `error` fields.

## Reasoning

In [`modeling/views.py:212-216`](https://github.com/WikiWatershed/model-my-watershed/blob/develop/src/mmw/apps/modeling/views.py#L212-216) we see the following lines:

```python
def _initiate_tr55_job_chain(model_input, job_id):
    return chain(tasks.make_gt_service_call_task.s(model_input),
                 tasks.run_tr55.s(model_input),
                 save_job_result.s(job_id, model_input)) \
        .apply_async(link_error=save_job_error.s(job_id))
```

The `apply_async` associates an error handler to the task chain. Before, when we simply `return`ed the error, it would be added to the `result` field by [`save_job_result`](https://github.com/WikiWatershed/model-my-watershed/blob/develop/src/mmw/apps/core/tasks.py#L68-78). Now, since we raise an exception, it is handled instead by [`save_job_error`](https://github.com/WikiWatershed/model-my-watershed/blob/develop/src/mmw/apps/core/tasks.py#L42-64), and returns the proper JSON in addition to recording the exception in the back end.

## Testing Instructions

 * Clone this branch and restart Celery: `vagrant ssh worker -c 'sudo service restart celeryd'`
 * Run all tests `./scripts/test.sh`

We now need to simulate the API with an incorrect request, for which we need the CSRF token, since Django will refuse all POST requests without one. The easiest way to get it is from Chrome itself.

 * Open Chrome and navigate to [`http://localhost:8000/`](http://localhost:8000/)
 * Open Developer Tools and the Network tab. Filter to XHR.
 * In the app, draw a shape and proceed to the model stage
 * In the Network tab, you should see POST requests to `tr55/`. Right click one of them and select `Copy as cURL`
 * Paste that into a text editor. It will look something like this:  
```
curl 'http://localhost:8000/api/modeling/start/tr55/' -H 'Cookie: djdttop=233; djdt=hide; csrftoken=6GrWWplWpktARXH5UXze5RcxvgAlxE6G' -H 'Origin: http://localhost:8000' -H 'Accept-Encoding: gzip, deflate' -H 'Accept-Language: en-US,en;q=0.8' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' -H 'Accept: application/json, text/javascript, */*; q=0.01' -H 'Referer: http://localhost:8000/project' -H 'X-CSRFToken: 6GrWWplWpktARXH5UXze5RcxvgAlxE6G' -H 'X-Requested-With: XMLHttpRequest' -H 'Connection: keep-alive' --data 'model_input=%7B%22inputs%22%3A%5B%7B%22name%22%3A%22precipitation%22%2C%22value%22%3A1%2C%22type%22%3A%22%22%2C%22shape%22%3Anull%2C%22area%22%3A%220%22%2C%22units%22%3A%22m%3Csup%3E2%3C%2Fsup%3E%22%7D%5D%2C%22modifications%22%3A%5B%5D%2C%22area_of_interest%22%3A%7B%22type%22%3A%22MultiPolygon%22%2C%22coordinates%22%3A%5B%5B%5B%5B-75.23162841796875%2C40.057052221322%5D%2C%5B-75.48294067382812%2C39.78426800449771%5D%2C%5B-75.36346435546874%2C39.589815579543284%5D%2C%5B-75.16708374023438%2C39.940277770390324%5D%2C%5B-75.04898071289062%2C39.86653357724533%5D%2C%5B-75.0970458984375%2C40.1148394302364%5D%2C%5B-75.29067993164062%2C40.111688665595956%5D%2C%5B-75.23162841796875%2C40.057052221322%5D%5D%5D%5D%7D%7D' --compressed
```
 * Empty the `inputs` value, by replacing `%22inputs%22%3A%5B%7B%22name%22%3A%22precipitation%22%2C%22value%22%3A1%2C%22type%22%3A%22%22%2C%22shape%22%3Anull%2C%22area%22%3A%220%22%2C%22units%22%3A%22m%3Csup%3E2%3C%2Fsup%3E%22%7D%5D` (URL encoded form of `"inputs":[{"name":"precipitation","value":1,"type":"","shape":null,"area":"0","units":"m<sup>2</sup>"}]`) with `%22inputs%22%3A%5B%5D` (URL encoded form of `"inputs":[]`)
 * Run the curl command. You will get a job id like so:  
```json
{"status":"started","job":"28f00d6e-2bf5-4756-86d4-a813989534fe"}
```
 * Do a GET against that job id like so:  
```
curl 'http://localhost:8000/api/modeling/jobs/28f00d6e-2bf5-4756-86d4-a813989534fe/'
```
 * You should see JSON output like so:
```json
{"status":"failed","started":"2015-07-06T18:20:30.517Z","finished":"2015-07-06T18:20:30.936Z","result":"","error":"No precipitation value defined","job_uuid":"28f00d6e-2bf5-4756-86d4-a813989534fe"}
```

Instead of using cURL, one can also use a REST GUI such as [Postman REST Client](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en). Ensure that the headers `X-CSRFToken` and `X-Requested-With` are set in the POST request:  
  ![image](https://cloud.githubusercontent.com/assets/1430060/8529775/ee69eb26-23ea-11e5-837a-3e5eaacd8ea1.png)


## Notes

As part of this PR, I also add a unit test for empty inputs. In this test we assert that an exception is raised and that it's message is as expected when precipitation is not a specified input. We cannot test the JSON output of the worker like we do for the success case in `test_tr55_job_runs_in_chain`, because we set the `CELERY_ALWAYS_EAGER` flag to True. This flag allows us to run these tests without having an actual celery worker up, but unfortunately converts all `apply_async` calls to `apply`, thus short-circuiting the error handling performed in `core/tasks.py:save_job_error`.

If we want to test the JSON result, we will have to turn off the flag `CELERY_ALWAYS_EAGER` and setup a mock worker for testing. There are solutions such as https://github.com/RentMethod/celerytest which might help. But that would be more along the lines of integration testing rather than unit testing which is what we're doing here. See discussion on http://stackoverflow.com/a/17155922/2053314 for details.

Connects #535 