### PR TITLE
Stop geolocating automatically without user input

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -93,7 +93,7 @@ function addLocateMeButton(map, maxZoom, maxAge) {
         metric: false,
         drawCircle: false,
         showPopup: false,
-        follow: true,
+        follow: false,
         markerClass: L.marker,
         markerStyle: {
             opacity: 0.0,
@@ -181,7 +181,6 @@ var MapView = Marionette.ItemView.extend({
         // already been centered.
         if (navigator.geolocation) {
             var options = {
-                enableHighAccuracy: true,
                 maximumAge : maxAge,
                 timeout : timeout
             };


### PR DESCRIPTION
## Overview

The `follow` option, when set to true, automatically follows the user even if they move the map manually. See documentation here: https://github.com/domoritz/leaflet-locatecontrol#possible-options.  

In Firefox, this behavior doesn't occur at all. In Chrome, this behavior occurs automatically after ~30 seconds. In Safari, this behavior was not triggered until the user clicks the Locate Me button, but thereafter was instantaneous, so the user can't even search for other locations.

Also remove `enableHighAccuracy`, which is a more expensive and slow operation which gives us unnecessarily detailed resolution. Since the use case here is of very large areas, we are perfectly fine with low resolution, more approximate than accurate locations, which will be faster and not burden batteries on devices. A coarse location is generally preferred over a fine grained location https://developers.google.com/web/fundamentals/device-access/user-location/obtain-location?hl=en#prefer-a-coarse-location-over-a-fine-grained-location

## Testing Instructions

First, ensure that you are able to reproduce the problem. In the `develop` branch:

 * Open the app in Chrome / Safari, search for a location far away (such as New York) and draw an area of interest.
 * Once in the Analyze view, click the Locate Me button. This will update the map to your current location.
 * Click the back arrow to go back to the draw view. This will center the map on the selected area. Click forward to come back to the Analyze view.
 * Wait 30 - 60 seconds. Move the mouse around. The map should automatically update to your location.

If you are able to reproduce the problem, then checkout this branch and run the bundle:

```shell
$ ./scripts/bundle.sh
```

and perform the same steps. The map should not automatically update to your location.

Connects #479 