### PR TITLE
Cache geoprocessing service results

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ $ ./scripts/manage.sh test
 Or just for a specific app:
 
 ```bash
-$ ./scripts/manage.sh test appname
+$ ./scripts/manage.sh test apps.app_name.tests
 ```
+
+More info [here](https://docs.djangoproject.com/en/1.8/topics/testing/).
 
 ##### JavaScript
 

--- a/src/mmw/apps/modeling/migrations/0007_scenario_census.py
+++ b/src/mmw/apps/modeling/migrations/0007_scenario_census.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0006_auto_20150630_1320'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='scenario',
+            name='census',
+            field=models.TextField(help_text='Serialized JSON representation of geoprocessing results', null=True),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -92,6 +92,9 @@ class Scenario(models.Model):
         help_text='A hash of the values for modifications & inputs to ' +
                   'compare to the existing model results, to determine if ' +
                   'the persisted result apply to the current values')
+    census = models.TextField(
+        null=True,
+        help_text='Serialized JSON representation of geoprocessing results')
     results = models.TextField(
         null=True,
         help_text='Serialized JSON representation of the model results')

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -27,6 +27,7 @@ class ScenarioSerializer(serializers.ModelSerializer):
 
     inputs = JsonField()
     modifications = JsonField()
+    census = JsonField(required=False, allow_null=True)
 
 
 class ProjectSerializer(gis_serializers.GeoModelSerializer):

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -118,7 +118,7 @@ def run_analyze(area_of_interest):
 
 
 @shared_task
-def make_gt_service_call_task(model_input):
+def prepare_census(model_input):
     """
     Call geotrellis and calculate the tile data for use in the TR55 model.
     """
@@ -145,8 +145,10 @@ def make_gt_service_call_task(model_input):
                     'a:deciduous_forest': {'cell_count': 1}
                 }
             }
-        ]
+        ],
+        'modification_hash': model_input['modification_hash']
     }
+
     return census
 
 
@@ -183,7 +185,6 @@ def run_tr55(census, model_input):
     # demonstration purposes.
     modifications = get_census_modifications(model_input)
     census['modifications'] = modifications
-    print(census)
 
     def simulate_day(cell, cell_count):
         soil_type, land_use = cell.lower().split(':')
@@ -193,6 +194,7 @@ def run_tr55(census, model_input):
     model_output = simulate_modifications(census, fn=simulate_day)
 
     return {
+        'census': census,
         'runoff': model_output,
         'quality': format_quality(model_output)
     }

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -15,25 +15,57 @@ from rest_framework.test import APIClient
 
 
 class TaskRunnerTestCase(TestCase):
-
-    @override_settings(CELERY_ALWAYS_EAGER=True)
-    def test_tr55_job_runs_in_chain(self):
-        model_input = {
+    def setUp(self):
+        self.model_input = {
             'inputs': [
                 {
                     'name': 'precipitation',
                     'value': 1.2
                 }
             ],
-            'modifications': []
+            'modifications': [{
+                'name': 'conservation_practice',
+                'area': 15.683767964377065,
+                'value': 'rain_garden',
+                'shape': {
+                    'geometry': {
+                        'type': 'Polygon',
+                        'coordinates': [[
+                            [-75.09326934814453, 40.10092245173233],
+                            [-75.13343811035156, 40.060731050581396],
+                            [-75.0637435913086, 40.065460682065535],
+                            [-75.0692367553711, 40.095670021782404],
+                            [-75.09326934814453, 40.10092245173233]
+                        ]]
+                    },
+                    'type': 'Feature',
+                    'properties': {}
+                },
+                'units': 'km<sup>2</sup>',
+                'type': ''
+            }],
+            'area_of_interest': {
+                'type': 'MultiPolygon',
+                'coordinates': [[
+                    [[-75.06271362304688, 40.15893480687665],
+                     [-75.2728271484375, 39.97185812402586],
+                     [-74.99130249023438, 40.10958807474143],
+                     [-75.06271362304688, 40.15893480687665]]
+                ]]
+            },
+            'modification_hash': '39f488abec2de49f17652631ae843946'
         }
 
         created = now()
-        job = Job.objects.create(created_at=created, result='', error='',
-                                 traceback='', user=None, status='started')
-        job.save()
+        self.job = Job.objects.create(created_at=created, result='', error='',
+                                      traceback='', user=None,
+                                      status='started')
+        self.job.save()
 
-        task_list = views._initiate_tr55_job_chain(model_input, job.id)
+    @override_settings(CELERY_ALWAYS_EAGER=True)
+    def test_tr55_job_runs_in_chain(self):
+        task_list = views._initiate_tr55_job_chain(self.model_input,
+                                                   self.job.id)
 
         found_job = Job.objects.get(uuid=task_list.id)
 
@@ -49,21 +81,84 @@ class TaskRunnerTestCase(TestCase):
     def test_tr55_job_error_in_chain(self):
         model_input = {
             'inputs': [],
-            'modifications': []
+            'modifications': [],
+            'modification_hash': 'j39fj9fg7yshb399h4nsdhf'
         }
 
-        created = now()
-        job = Job.objects.create(created_at=created, result='', error='',
-                                 traceback='', user=None, status='started')
-
-        job.save()
-
         with self.assertRaises(Exception) as context:
-            views._initiate_tr55_job_chain(model_input, job.id)
+            views._initiate_tr55_job_chain(model_input, self.job.id)
 
         self.assertEqual(str(context.exception),
                          'No precipitation value defined',
                          'Unexpected exception occurred')
+
+    def test_tr55_chain_skips_census_if_census_is_up_to_date(self):
+        # Census with current modification_hash
+        self.model_input['census'] = {
+            'cell_count': 100,
+            'distribution': {
+                'c:commercial': {
+                    'cell_count': 70
+                },
+                'a:deciduous_forest': {
+                    'cell_count': 30
+                }
+            },
+            'modification_hash': '39f488abec2de49f17652631ae843946',
+            'modifications': [{
+                'bmp': 'no_till',
+                'cell_count': 1,
+                'distribution': {
+                    'a:deciduous_forest': {'cell_count': 1},
+                }
+            }]
+        }
+
+        task_list = views._initiate_tr55_job_chain(self.model_input,
+                                                   self.job.id)
+
+        task_count = len(list(task_list._parents()))
+        self.assertEqual(task_count, 1,
+                         'Task list contains the wrong number of tasks')
+
+    @override_settings(CELERY_ALWAYS_EAGER=True)
+    def test_tr55_chain_generates_census_if_census_is_stale(self):
+        # Census with stale modification_hash
+        self.model_input['census'] = {
+            'cell_count': 100,
+            'distribution': {
+                'c:commercial': {
+                    'cell_count': 70
+                },
+                'a:deciduous_forest': {
+                    'cell_count': 30
+                }
+            },
+            'modification_hash': 'j3jk3jk3jn3knm3nmn39usd',
+            'modifications': [{
+                'bmp': 'no_till',
+                'cell_count': 1,
+                'distribution': {
+                    'a:deciduous_forest': {'cell_count': 1},
+                }
+            }]
+        }
+
+        task_list = views._initiate_tr55_job_chain(self.model_input,
+                                                   self.job.id)
+
+        task_count = len(list(task_list._parents()))
+        self.assertEqual(task_count, 2,
+                         'Task list contains the wrong number of tasks')
+
+    @override_settings(CELERY_ALWAYS_EAGER=True)
+    def test_tr55_chain_generates_census_if_census_does_not_exist(self):
+        task_list = views._initiate_tr55_job_chain(self.model_input,
+                                                   self.job.id)
+
+        task_count = len(list(task_list._parents()))
+        self.assertEqual(task_count, 2,
+                         'Task list contains the wrong number of tasks')
 
 
 class APIAccessTestCase(TestCase):

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -107,7 +107,7 @@ JS_DEPS=(jquery backbone backbone.marionette \
          leaflet leaflet-draw leaflet.locatecontrol \
          lodash underscore \
          d3 nunjucks turf-area turf-buffer turf-random \
-         zeroclipboard)
+         zeroclipboard blueimp-md5)
 BROWSERIFY_EXT=""
 BROWSERIFY_REQ=""
 for DEP in "${JS_DEPS[@]}"

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -2,6 +2,7 @@
 
 var Backbone = require('../../shim/backbone'),
     _ = require('underscore'),
+    md5 = require('blueimp-md5').md5,
     App = require('../app'),
     coreModels = require('../core/models');
 
@@ -250,6 +251,7 @@ var ScenarioModel = Backbone.Model.extend({
         user_id: 0, // User that created the project
         inputs: null, // ModificationsCollection
         modifications: null, // ModificationsCollection
+        modification_hash: null, // MD5 string
         active: false,
         job_id: null,
         results: null // ResultCollection
@@ -275,6 +277,7 @@ var ScenarioModel = Backbone.Model.extend({
 
         this.on('change:project change:name', this.attemptSave, this);
         this.get('inputs').on('add', this.attemptSave, this);
+        this.get('modifications').on('add remove change', this.updateModificationHash, this);
         this.get('modifications').on('add remove', this.attemptSave, this);
 
         var debouncedGetResults = _.debounce(_.bind(this.getResults, this), 500);
@@ -392,6 +395,12 @@ var ScenarioModel = Backbone.Model.extend({
             };
 
         taskModel.start(taskHelper);
+    },
+
+    updateModificationHash: function() {
+        var hash = md5(JSON.stringify(this.get('modifications')));
+
+        this.set('modification_hash', hash);
     }
 });
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -254,7 +254,8 @@ var ScenarioModel = Backbone.Model.extend({
         modification_hash: null, // MD5 string
         active: false,
         job_id: null,
-        results: null // ResultCollection
+        results: null, // ResultCollection
+        census: null // JSON blob
     },
 
     initialize: function(attrs) {
@@ -275,7 +276,7 @@ var ScenarioModel = Backbone.Model.extend({
         this.set('inputs', new ModificationsCollection(attrs.inputs));
         this.set('modifications', new ModificationsCollection(attrs.modifications));
 
-        this.on('change:project change:name', this.attemptSave, this);
+        this.on('change:project change:name change:census', this.attemptSave, this);
         this.get('inputs').on('add', this.attemptSave, this);
         this.get('modifications').on('add remove change', this.updateModificationHash, this);
         this.get('modifications').on('add remove', this.attemptSave, this);
@@ -358,7 +359,10 @@ var ScenarioModel = Backbone.Model.extend({
                             console.log('Response is missing ' + resultName + '.');
                         }
                     });
+
+                    self.set('census', serverResults.census);
                 }
+
                 results.setPolling(false);
             },
             taskHelper = {
@@ -366,7 +370,9 @@ var ScenarioModel = Backbone.Model.extend({
                     model_input: JSON.stringify({
                         inputs: self.get('inputs').toJSON(),
                         modifications: self.get('modifications').toJSON(),
-                        area_of_interest: App.currProject.get('area_of_interest')
+                        area_of_interest: App.currProject.get('area_of_interest'),
+                        census: self.get('census'),
+                        modification_hash: self.get('modification_hash')
                     })
                 },
 

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -375,6 +375,46 @@ describe('Modeling', function() {
 
         describe('ScenarioModel', function() {
             // TODO: Add tests for existing methods.
+
+            describe('#updateModificationHash', function() {
+                it('generates and sets modification_hash based on the scenario\'s modifications', function() {
+                    var model = new models.ScenarioModel({
+                            modifications: [modificationsSample1]
+                        });
+
+                    model.updateModificationHash();
+                    assert.equal(model.get('modification_hash'), 'b0eb4af3250d9c1320d659805afaf049');
+
+                    var mod = new models.ModificationModel(modificationsSample2);
+                    model.get('modifications').add(mod);
+                    assert.equal(model.get('modification_hash'), '07fb74f0e09eb1c31f3db8c78219758f');
+
+                    model.get('modifications').remove(mod);
+                    assert.equal(model.get('modification_hash'), 'b0eb4af3250d9c1320d659805afaf049');
+                });
+
+                it('is called when the modifications for a scenario changes', function() {
+                    var spy = sinon.spy(models.ScenarioModel.prototype, 'updateModificationHash'),
+                        model = new models.ScenarioModel({});
+
+                    model.get('modifications').add(new models.ModificationModel(modificationsSample1));
+                    assert.isTrue(spy.calledOnce);
+
+                    models.ScenarioModel.prototype.updateModificationHash.restore();
+                });
+
+                it('is called before model#attemptSave when the modifications change', function() {
+                    var modSpy = sinon.spy(models.ScenarioModel.prototype, 'updateModificationHash'),
+                        saveSpy = sinon.spy(models.ScenarioModel.prototype, 'attemptSave'),
+                        model = new models.ScenarioModel({});
+
+                    model.addModification(new models.ModificationModel(modificationsSample1));
+                    assert.isTrue(modSpy.calledBefore(saveSpy));
+
+                    models.ScenarioModel.prototype.updateModificationHash.restore();
+                    models.ScenarioModel.prototype.attemptSave.restore();
+                });
+            });
         });
 
         describe('ScenarioCollection', function() {

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "backbone": {
       "version": "1.1.2",
-      "from": "backbone@1.1.2",
+      "from": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz"
     },
     "backbone.marionette": {
@@ -36,7 +36,7 @@
     },
     "bootstrap-select": {
       "version": "1.6.4",
-      "from": "bootstrap-select@git://github.com/azavea/bootstrap-select",
+      "from": "../../tmp/npm-25399-f33e3414/1431608850408-0.06566630373708904/f1755efa102a41e43fc367ba36ce905b8f2b90e1",
       "resolved": "git://github.com/azavea/bootstrap-select#f1755efa102a41e43fc367ba36ce905b8f2b90e1"
     },
     "browserify": {
@@ -46,7 +46,7 @@
       "dependencies": {
         "JSONStream": {
           "version": "0.10.0",
-          "from": "JSONStream@>=0.10.0 <0.11.0",
+          "from": "JSONStream@~0.10.0",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "dependencies": {
             "jsonparse": {
@@ -55,25 +55,25 @@
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
             },
             "through": {
-              "version": "2.3.7",
-              "from": "through@>=2.2.7 <3.0.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+              "version": "2.3.6",
+              "from": "through@>=2.2.7 <3",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "assert": {
           "version": "1.3.0",
-          "from": "assert@>=1.3.0 <1.4.0",
+          "from": "assert@~1.3.0",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
           "version": "4.0.1",
-          "from": "browser-pack@>=4.0.0 <5.0.0",
+          "from": "browser-pack@^4.0.0",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "JSONStream@>=0.8.4 <0.9.0",
+              "from": "JSONStream@~0.8.4",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
@@ -82,25 +82,25 @@
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
-                  "version": "2.3.7",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "combine-source-map@>=0.3.0 <0.4.0",
+              "from": "combine-source-map@~0.3.0",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.1",
-                  "from": "inline-source-map@>=0.3.0 <0.4.0",
+                  "from": "inline-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.3.0",
-                      "from": "source-map@>=0.3.0 <0.4.0",
+                      "from": "source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "dependencies": {
                         "amdefine": {
@@ -114,12 +114,12 @@
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "convert-source-map@>=0.3.0 <0.4.0",
+                  "from": "convert-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.31 <0.2.0",
+                  "from": "source-map@~0.1.31",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -133,17 +133,17 @@
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
+              "from": "through2@~0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "readable-stream@~1.0.17",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -152,31 +152,31 @@
             },
             "umd": {
               "version": "3.0.0",
-              "from": "umd@>=3.0.0 <4.0.0",
+              "from": "umd@^3.0.0",
               "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
             }
           }
         },
         "browser-resolve": {
           "version": "1.8.2",
-          "from": "browser-resolve@>=1.7.1 <2.0.0",
+          "from": "browser-resolve@^1.7.1",
           "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "browserify-zlib@>=0.1.2 <0.2.0",
+          "from": "browserify-zlib@~0.1.2",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
               "version": "0.2.6",
-              "from": "pako@>=0.2.0 <0.3.0",
+              "from": "pako@~0.2.0",
               "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
             }
           }
         },
         "buffer": {
           "version": "3.1.2",
-          "from": "buffer@>=3.0.0 <4.0.0",
+          "from": "buffer@^3.0.0",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
           "dependencies": {
             "base64-js": {
@@ -186,19 +186,19 @@
             },
             "ieee754": {
               "version": "1.1.4",
-              "from": "ieee754@>=1.1.4 <2.0.0",
+              "from": "ieee754@^1.1.4",
               "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
             },
             "is-array": {
               "version": "1.0.1",
-              "from": "is-array@>=1.0.1 <2.0.0",
+              "from": "is-array@^1.0.1",
               "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "builtins@>=0.0.3 <0.1.0",
+          "from": "builtins@~0.0.3",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
@@ -207,42 +207,42 @@
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
-          "version": "1.4.8",
-          "from": "concat-stream@>=1.4.1 <1.5.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+          "version": "1.4.7",
+          "from": "concat-stream@~1.4.1",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "typedarray@~0.0.5",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "from": "console-browserify@^1.1.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
+              "from": "date-now@^0.1.4",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "constants-browserify@>=0.0.1 <0.1.0",
+          "from": "constants-browserify@~0.0.1",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
           "version": "3.9.13",
-          "from": "crypto-browserify@>=3.0.0 <4.0.0",
+          "from": "crypto-browserify@^3.0.0",
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
           "dependencies": {
             "browserify-aes": {
               "version": "1.0.0",
-              "from": "browserify-aes@>=1.0.0 <2.0.0",
+              "from": "browserify-aes@^1.0.0",
               "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
             },
             "browserify-sign": {
@@ -252,51 +252,51 @@
               "dependencies": {
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "from": "bn.js@^1.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "browserify-rsa": {
                   "version": "1.1.1",
-                  "from": "browserify-rsa@>=1.1.0 <2.0.0",
+                  "from": "browserify-rsa@^1.1.0",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                 },
                 "elliptic": {
                   "version": "1.0.1",
-                  "from": "elliptic@>=1.0.0 <2.0.0",
+                  "from": "elliptic@^1.0.0",
                   "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "from": "brorand@^1.0.1",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
                       "version": "1.0.2",
-                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "from": "hash.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                     }
                   }
                 },
                 "parse-asn1": {
                   "version": "2.0.0",
-                  "from": "parse-asn1@>=2.0.0 <3.0.0",
+                  "from": "parse-asn1@^2.0.0",
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
                       "version": "1.0.3",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "from": "asn1.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "minimalistic-assert@^1.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
                     },
                     "asn1.js-rfc3280": {
                       "version": "1.0.0",
-                      "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
+                      "from": "asn1.js-rfc3280@^1.0.0",
                       "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
                     },
                     "pemstrip": {
@@ -310,27 +310,27 @@
             },
             "create-ecdh": {
               "version": "2.0.0",
-              "from": "create-ecdh@>=2.0.0 <3.0.0",
+              "from": "create-ecdh@^2.0.0",
               "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "from": "bn.js@^1.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "elliptic": {
                   "version": "1.0.1",
-                  "from": "elliptic@>=1.0.0 <2.0.0",
+                  "from": "elliptic@^1.0.0",
                   "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "from": "brorand@^1.0.1",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
                       "version": "1.0.2",
-                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "from": "hash.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                     }
                   }
@@ -339,44 +339,44 @@
             },
             "create-hash": {
               "version": "1.1.1",
-              "from": "create-hash@>=1.1.0 <2.0.0",
+              "from": "create-hash@^1.1.0",
               "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "dependencies": {
                 "ripemd160": {
                   "version": "1.0.0",
-                  "from": "ripemd160@>=1.0.0 <2.0.0",
+                  "from": "ripemd160@^1.0.0",
                   "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
                 },
                 "sha.js": {
-                  "version": "2.4.0",
-                  "from": "sha.js@>=2.3.6 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.0.tgz"
+                  "version": "2.3.6",
+                  "from": "sha.js@^2.3.6",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                 }
               }
             },
             "create-hmac": {
               "version": "1.1.3",
-              "from": "create-hmac@>=1.1.0 <2.0.0",
+              "from": "create-hmac@^1.1.0",
               "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
               "version": "3.0.1",
-              "from": "diffie-hellman@>=3.0.1 <4.0.0",
+              "from": "diffie-hellman@^3.0.1",
               "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "from": "bn.js@^1.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "miller-rabin": {
                   "version": "1.1.5",
-                  "from": "miller-rabin@>=1.1.2 <2.0.0",
+                  "from": "miller-rabin@^1.1.2",
                   "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "from": "brorand@^1.0.1",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     }
                   }
@@ -385,37 +385,37 @@
             },
             "pbkdf2-compat": {
               "version": "3.0.2",
-              "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
+              "from": "pbkdf2-compat@^3.0.1",
               "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
             },
             "public-encrypt": {
               "version": "2.0.0",
-              "from": "public-encrypt@>=2.0.0 <3.0.0",
+              "from": "public-encrypt@^2.0.0",
               "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "from": "bn.js@^1.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "browserify-rsa": {
                   "version": "2.0.0",
-                  "from": "browserify-rsa@>=2.0.0 <3.0.0",
+                  "from": "browserify-rsa@^2.0.0",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                 },
                 "parse-asn1": {
                   "version": "3.0.0",
-                  "from": "parse-asn1@>=3.0.0 <4.0.0",
+                  "from": "parse-asn1@^3.0.0",
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
                       "version": "1.0.3",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "from": "asn1.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "minimalistic-assert@^1.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
@@ -426,29 +426,29 @@
             },
             "randombytes": {
               "version": "2.0.1",
-              "from": "randombytes@>=2.0.0 <3.0.0",
+              "from": "randombytes@^2.0.0",
               "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             }
           }
         },
         "deep-equal": {
           "version": "1.0.0",
-          "from": "deep-equal@>=1.0.0 <2.0.0",
+          "from": "deep-equal@^1.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@>=0.0.0 <0.1.0",
+          "from": "defined@~0.0.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
           "version": "1.3.5",
-          "from": "deps-sort@>=1.3.5 <2.0.0",
+          "from": "deps-sort@^1.3.5",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "JSONStream@>=0.8.4 <0.9.0",
+              "from": "JSONStream@~0.8.4",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
@@ -457,30 +457,30 @@
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
-                  "version": "2.3.7",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
+              "from": "minimist@~0.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
+              "from": "through2@~0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "readable-stream@~1.0.17",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -491,49 +491,49 @@
         },
         "domain-browser": {
           "version": "1.1.4",
-          "from": "domain-browser@>=1.1.0 <1.2.0",
+          "from": "domain-browser@~1.1.0",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
         },
         "duplexer2": {
           "version": "0.0.2",
-          "from": "duplexer2@>=0.0.2 <0.1.0",
+          "from": "duplexer2@~0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "events": {
           "version": "1.0.2",
-          "from": "events@>=1.0.0 <1.1.0",
+          "from": "events@~1.0.0",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
           "version": "4.5.3",
-          "from": "glob@>=4.0.5 <5.0.0",
+          "from": "glob@^4.0.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "inflight@^1.0.4",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.4",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "minimatch@^2.0.1",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "brace-expansion@^1.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "balanced-match@^0.2.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -547,12 +547,12 @@
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@^1.3.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -561,39 +561,39 @@
         },
         "has": {
           "version": "1.0.0",
-          "from": "has@>=1.0.0 <2.0.0",
+          "from": "has@^1.0.0",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "http-browserify@>=1.4.0 <2.0.0",
+          "from": "http-browserify@^1.4.0",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@>=0.2.0 <0.3.0",
+              "from": "Base64@~0.2.0",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https-browserify@>=0.0.0 <0.1.0",
+          "from": "https-browserify@~0.0.0",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.1 <2.1.0",
+          "from": "inherits@~2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
           "version": "6.2.1",
-          "from": "insert-module-globals@>=6.2.0 <7.0.0",
+          "from": "insert-module-globals@^6.2.0",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "from": "JSONStream@~0.7.1",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
@@ -605,17 +605,17 @@
             },
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "combine-source-map@>=0.3.0 <0.4.0",
+              "from": "combine-source-map@~0.3.0",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.1",
-                  "from": "inline-source-map@>=0.3.0 <0.4.0",
+                  "from": "inline-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.3.0",
-                      "from": "source-map@>=0.3.0 <0.4.0",
+                      "from": "source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "dependencies": {
                         "amdefine": {
@@ -629,12 +629,12 @@
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "convert-source-map@>=0.3.0 <0.4.0",
+                  "from": "convert-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.31 <0.2.0",
+                  "from": "source-map@~0.1.31",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -648,12 +648,12 @@
             },
             "lexical-scope": {
               "version": "1.1.0",
-              "from": "lexical-scope@>=1.1.0 <1.2.0",
+              "from": "lexical-scope@~1.1.0",
               "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
               "dependencies": {
                 "astw": {
                   "version": "1.1.0",
-                  "from": "astw@>=1.1.0 <1.2.0",
+                  "from": "astw@~1.1.0",
                   "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                   "dependencies": {
                     "esprima-fb": {
@@ -667,13 +667,13 @@
             },
             "process": {
               "version": "0.6.0",
-              "from": "process@>=0.6.0 <0.7.0",
+              "from": "process@~0.6.0",
               "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
             },
             "through": {
-              "version": "2.3.7",
-              "from": "through@>=2.3.4 <2.4.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+              "version": "2.3.6",
+              "from": "through@~2.3.4",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
@@ -684,17 +684,17 @@
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
-          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+          "from": "labeled-stream-splicer@^1.0.0",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
               "version": "1.3.1",
-              "from": "stream-splicer@>=1.1.0 <2.0.0",
+              "from": "stream-splicer@^1.1.0",
               "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "dependencies": {
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "readable-wrap@>=1.0.0 <2.0.0",
+                  "from": "readable-wrap@^1.0.0",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 },
                 "indexof": {
@@ -707,13 +707,13 @@
           }
         },
         "module-deps": {
-          "version": "3.7.6",
-          "from": "module-deps@>=3.7.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.6.tgz",
+          "version": "3.7.5",
+          "from": "module-deps@^3.7.0",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.5.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "from": "JSONStream@~0.7.1",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
@@ -722,82 +722,82 @@
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
-                  "version": "2.3.7",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "detective": {
               "version": "4.0.0",
-              "from": "detective@>=4.0.0 <5.0.0",
+              "from": "detective@^4.0.0",
               "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.9.0",
-                  "from": "acorn@>=0.9.0 <0.10.0",
+                  "from": "acorn@~0.9.0",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 },
                 "escodegen": {
                   "version": "1.6.1",
-                  "from": "escodegen@>=1.4.1 <2.0.0",
+                  "from": "escodegen@^1.4.1",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "dependencies": {
                     "estraverse": {
                       "version": "1.9.3",
-                      "from": "estraverse@>=1.9.1 <2.0.0",
+                      "from": "estraverse@^1.9.1",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                     },
                     "esutils": {
                       "version": "1.1.6",
-                      "from": "esutils@>=1.1.6 <2.0.0",
+                      "from": "esutils@^1.1.6",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                     },
                     "esprima": {
                       "version": "1.2.5",
-                      "from": "esprima@>=1.2.2 <2.0.0",
+                      "from": "esprima@^1.2.2",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
-                      "from": "optionator@>=0.5.0 <0.6.0",
+                      "from": "optionator@^0.5.0",
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
                         "prelude-ls": {
                           "version": "1.1.1",
-                          "from": "prelude-ls@>=1.1.1 <1.2.0",
+                          "from": "prelude-ls@~1.1.1",
                           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                         },
                         "deep-is": {
                           "version": "0.1.3",
-                          "from": "deep-is@>=0.1.2 <0.2.0",
+                          "from": "deep-is@~0.1.2",
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "from": "wordwrap@~0.0.2",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         },
                         "type-check": {
                           "version": "0.3.1",
-                          "from": "type-check@>=0.3.1 <0.4.0",
+                          "from": "type-check@~0.3.1",
                           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                         },
                         "levn": {
                           "version": "0.2.5",
-                          "from": "levn@>=0.2.5 <0.3.0",
+                          "from": "levn@~0.2.5",
                           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                         },
                         "fast-levenshtein": {
                           "version": "1.0.6",
-                          "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                          "from": "fast-levenshtein@~1.0.0",
                           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                         }
                       }
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.40 <0.2.0",
+                      "from": "source-map@~0.1.40",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
@@ -813,34 +813,34 @@
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
+              "from": "minimist@~0.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "stream-combiner2@>=1.0.0 <1.1.0",
+              "from": "stream-combiner2@~1.0.0",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@>=0.5.1 <0.6.0",
+                  "from": "through2@~0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "from": "readable-stream@~1.0.17",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "3.0.0",
-                      "from": "xtend@>=3.0.0 <3.1.0",
+                      "from": "xtend@~3.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                     }
                   }
@@ -854,36 +854,36 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "from": "minimist@~0.0.7",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.4.2",
-              "from": "through2@>=0.4.1 <0.5.0",
+              "from": "through2@~0.4.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "readable-stream@~1.0.17",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "2.1.2",
-                  "from": "xtend@>=2.1.1 <2.2.0",
+                  "from": "xtend@~2.1.1",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "dependencies": {
                     "object-keys": {
                       "version": "0.4.0",
-                      "from": "object-keys@>=0.4.0 <0.5.0",
+                      "from": "object-keys@~0.4.0",
                       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                     }
                   }
@@ -892,63 +892,63 @@
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "xtend@^4.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "os-browserify@>=0.1.1 <0.2.0",
+          "from": "os-browserify@~0.1.1",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "1.0.1",
-          "from": "parents@>=1.0.1 <2.0.0",
+          "from": "parents@^1.0.1",
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.11.15",
-              "from": "path-platform@>=0.11.15 <0.12.0",
+              "from": "path-platform@~0.11.15",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "path-browserify@>=0.0.0 <0.1.0",
+          "from": "path-browserify@~0.0.0",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.10.1",
-          "from": "process@>=0.10.0 <0.11.0",
+          "from": "process@^0.10.0",
           "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "punycode@>=1.2.3 <1.3.0",
+          "from": "punycode@~1.2.3",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "from": "querystring-es3@~0.2.0",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.13 <2.0.0",
+          "from": "readable-stream@^1.1.13",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "core-util-is@~1.0.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "1.1.6",
-          "from": "resolve@>=1.1.4 <2.0.0",
+          "from": "resolve@^1.1.4",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shallow-copy": {
@@ -958,70 +958,70 @@
         },
         "shasum": {
           "version": "1.0.1",
-          "from": "shasum@>=1.0.0 <2.0.0",
+          "from": "shasum@^1.0.0",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+              "from": "json-stable-stringify@~0.0.0",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "jsonify@~0.0.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
             },
             "sha.js": {
               "version": "2.3.6",
-              "from": "sha.js@>=2.3.0 <2.4.0",
+              "from": "sha.js@~2.3.0",
               "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
             }
           }
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "shell-quote@>=0.0.1 <0.1.0",
+          "from": "shell-quote@~0.0.1",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "from": "stream-browserify@^1.0.0",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "string_decoder@~0.10.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "subarg@>=1.0.0 <2.0.0",
+          "from": "subarg@^1.0.0",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "1.1.1",
-              "from": "minimist@>=1.1.0 <2.0.0",
+              "from": "minimist@^1.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
             }
           }
         },
         "syntax-error": {
           "version": "1.1.2",
-          "from": "syntax-error@>=1.1.1 <2.0.0",
+          "from": "syntax-error@^1.1.1",
           "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.9.0",
-              "from": "acorn@>=0.9.0 <0.10.0",
+              "from": "acorn@~0.9.0",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "through2@>=1.0.0 <2.0.0",
+          "from": "through2@^1.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "xtend": {
@@ -1033,17 +1033,17 @@
         },
         "timers-browserify": {
           "version": "1.4.0",
-          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "from": "timers-browserify@^1.0.1",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "tty-browserify@>=0.0.0 <0.1.0",
+          "from": "tty-browserify@~0.0.0",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
           "version": "0.10.3",
-          "from": "url@>=0.10.1 <0.11.0",
+          "from": "url@~0.10.1",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
@@ -1060,12 +1060,12 @@
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.1 <0.11.0",
+          "from": "util@~0.10.1",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "vm-browserify@>=0.0.1 <0.1.0",
+          "from": "vm-browserify@~0.0.1",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
@@ -1077,7 +1077,7 @@
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "xtend@>=3.0.0 <4.0.0",
+          "from": "xtend@^3.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
@@ -1123,32 +1123,38 @@
     },
     "jshint": {
       "version": "2.8.0",
-      "from": "jshint@2.8.0",
+      "from": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.6",
-          "from": "cli@0.6.x",
+          "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~ 3.2.1",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2"
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.4",
-                      "from": "lru-cache@2"
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0"
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
@@ -1158,42 +1164,50 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@1.1.x",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@^0.1.4"
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@0.1.x"
+          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.3",
-          "from": "htmlparser2@3.8.x",
+          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@2.3"
+              "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "domutils@1.5",
+              "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "dom-serializer@0",
+                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "domelementtype@~1.1.1"
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     },
                     "entities": {
                       "version": "1.1.1",
-                      "from": "entities@~1.1.1"
+                      "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
                 }
@@ -1201,51 +1215,62 @@
             },
             "domelementtype": {
               "version": "1.3.0",
-              "from": "domelementtype@1"
+              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@1.1",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0"
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1"
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x"
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1"
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@1.0"
+              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.8",
-          "from": "minimatch@2.0.x",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@^1.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@^0.2.0"
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1"
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -1253,15 +1278,17 @@
         },
         "shelljs": {
           "version": "0.3.0",
-          "from": "shelljs@0.3.x"
+          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.2",
-          "from": "strip-json-comments@1.0.x"
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "lodash": {
           "version": "3.7.0",
-          "from": "lodash@3.7.x",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
         }
       }
@@ -1534,12 +1561,12 @@
     },
     "leaflet-draw": {
       "version": "0.2.3",
-      "from": "git://github.com/michaelguild13/Leaflet.draw.git#e2fe3a4",
-      "resolved": "git://github.com/michaelguild13/Leaflet.draw.git#e2fe3a4c176979235845e8fbb1c5017414035765"
+      "from": "leaflet-draw@0.2.3",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-0.2.3.tgz"
     },
     "leaflet.locatecontrol": {
       "version": "0.43.0",
-      "from": "leaflet.locatecontrol@",
+      "from": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz",
       "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz"
     },
     "livereloadify": {
@@ -3299,7 +3326,7 @@
     },
     "retina.js": {
       "version": "1.3.0",
-      "from": "retina.js@git://github.com/imulus/retinajs#1.3.0",
+      "from": "../../tmp/npm-25399-f33e3414/1431608855853-0.4285626483615488/a70e73639817473bad7bbb33f866b8e060e5f5a7",
       "resolved": "git://github.com/imulus/retinajs#a70e73639817473bad7bbb33f866b8e060e5f5a7"
     },
     "sinon": {
@@ -3930,17 +3957,17 @@
     },
     "turf-area": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/turf-area/-/turf-area-1.1.1.tgz",
+      "from": "turf-area@*",
       "resolved": "https://registry.npmjs.org/turf-area/-/turf-area-1.1.1.tgz",
       "dependencies": {
         "geojson-area": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.2.0.tgz",
+          "from": "geojson-area@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.2.0.tgz",
           "dependencies": {
             "wgs84": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+              "from": "wgs84@0.0.0",
               "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz"
             }
           }
@@ -3949,7 +3976,7 @@
     },
     "turf-buffer": {
       "version": "1.0.4",
-      "from": "https://registry.npmjs.org/turf-buffer/-/turf-buffer-1.0.4.tgz",
+      "from": "turf-buffer@*",
       "resolved": "https://registry.npmjs.org/turf-buffer/-/turf-buffer-1.0.4.tgz",
       "dependencies": {
         "geojson-normalize": {
@@ -3976,24 +4003,24 @@
         },
         "turf-featurecollection": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/turf-featurecollection/-/turf-featurecollection-1.0.1.tgz",
+          "from": "turf-featurecollection@1.0.1",
           "resolved": "https://registry.npmjs.org/turf-featurecollection/-/turf-featurecollection-1.0.1.tgz"
         },
         "turf-polygon": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz",
+          "from": "turf-polygon@1.0.3",
           "resolved": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz"
         }
       }
     },
     "turf-random": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/turf-random/-/turf-random-1.0.2.tgz",
+      "from": "turf-random@*",
       "resolved": "https://registry.npmjs.org/turf-random/-/turf-random-1.0.2.tgz",
       "dependencies": {
         "geojson-random": {
           "version": "0.2.2",
-          "from": "https://registry.npmjs.org/geojson-random/-/geojson-random-0.2.2.tgz",
+          "from": "geojson-random@>=0.2.2 <0.3.0",
           "resolved": "https://registry.npmjs.org/geojson-random/-/geojson-random-0.2.2.tgz"
         }
       }
@@ -4009,66 +4036,66 @@
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
       "dependencies": {
         "chokidar": {
-          "version": "1.0.0",
-          "from": "chokidar@>=1.0.0-rc4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0.tgz",
+          "version": "1.0.0-rc5",
+          "from": "chokidar@^1.0.0-rc4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc5.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.2.1",
-              "from": "anymatch@>=1.1.0 <2.0.0",
+              "from": "anymatch@^1.1.0",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.2.1.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.1.5",
-                  "from": "micromatch@>=2.1.0 <3.0.0",
+                  "from": "micromatch@^2.1.0",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.5.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@>=1.0.1 <2.0.0",
+                      "from": "arr-diff@^1.0.1",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
-                          "version": "0.2.3",
-                          "from": "array-slice@>=0.2.2 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                          "version": "0.2.2",
+                          "from": "array-slice@^0.2.2",
+                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
                         }
                       }
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@>=1.8.0 <2.0.0",
+                      "from": "braces@^1.8.0",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "from": "expand-range@^1.8.1",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
-                              "version": "2.2.2",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "version": "2.2.0",
+                              "from": "fill-range@^2.1.0",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.0.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "is-number@>=1.1.2 <2.0.0",
+                                  "from": "is-number@^1.1.0",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
-                                  "version": "1.0.0",
-                                  "from": "isobject@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
+                                  "version": "0.2.0",
+                                  "from": "isobject@^0.2.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "randomatic@>=1.1.0 <2.0.0",
+                                  "from": "randomatic@^1.1.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "version": "1.5.0",
+                                  "from": "repeat-string@^1.5.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.0.tgz"
                                 }
                               }
                             }
@@ -4076,19 +4103,19 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "preserve@^0.2.0",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.0",
-                          "from": "repeat-element@>=1.1.0 <2.0.0",
+                          "from": "repeat-element@^1.1.0",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz"
                         }
                       }
                     },
                     "debug": {
                       "version": "2.1.3",
-                      "from": "debug@>=2.1.3 <3.0.0",
+                      "from": "debug@^2.1.3",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
                       "dependencies": {
                         "ms": {
@@ -4100,225 +4127,225 @@
                     },
                     "expand-brackets": {
                       "version": "0.1.1",
-                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "from": "expand-brackets@^0.1.1",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "filename-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "kind-of@>=1.1.0 <2.0.0",
+                      "from": "kind-of@^1.1.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "0.2.1",
-                      "from": "object.omit@>=0.2.1 <0.3.0",
+                      "from": "object.omit@^0.2.1",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@>=0.1.1 <0.2.0",
+                          "from": "for-own@^0.1.1",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "from": "for-in@^0.1.4",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "0.2.0",
-                          "from": "isobject@>=0.2.0 <0.3.0",
+                          "from": "isobject@^0.2.0",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.0",
-                      "from": "parse-glob@>=3.0.0 <4.0.0",
+                      "from": "parse-glob@^3.0.0",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.0.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "glob-base@>=0.2.0 <0.3.0",
+                          "from": "glob-base@^0.2.0",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.0",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "from": "is-dotfile@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "is-extglob@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.3.0",
-                      "from": "regex-cache@>=0.3.0 <0.4.0",
+                      "from": "regex-cache@^0.3.0",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.3.0.tgz",
                       "dependencies": {
                         "benchmarked": {
                           "version": "0.1.4",
-                          "from": "benchmarked@>=0.1.3 <0.2.0",
+                          "from": "benchmarked@^0.1.3",
                           "resolved": "https://registry.npmjs.org/benchmarked/-/benchmarked-0.1.4.tgz",
                           "dependencies": {
                             "ansi": {
                               "version": "0.3.0",
-                              "from": "ansi@>=0.3.0 <0.4.0",
+                              "from": "ansi@^0.3.0",
                               "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                             },
                             "benchmark": {
                               "version": "1.0.0",
-                              "from": "benchmark@>=1.0.0 <2.0.0",
+                              "from": "benchmark@^1.0.0",
                               "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                             },
                             "chalk": {
                               "version": "1.0.0",
-                              "from": "chalk@>=1.0.0 <2.0.0",
+                              "from": "chalk@^1.0.0",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.0.1",
-                                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                                  "from": "ansi-styles@^2.0.1",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.3",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "escape-string-regexp@^1.0.2",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "1.0.3",
-                                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                                  "from": "has-ansi@^1.0.3",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "1.1.1",
-                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "from": "ansi-regex@^1.1.0",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                                     },
                                     "get-stdin": {
                                       "version": "4.0.1",
-                                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                                      "from": "get-stdin@^4.0.1",
                                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "2.0.1",
-                                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                                  "from": "strip-ansi@^2.0.1",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "1.1.1",
-                                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                                      "from": "ansi-regex@^1.0.0",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "1.3.1",
-                                  "from": "supports-color@>=1.3.0 <2.0.0",
+                                  "from": "supports-color@^1.3.0",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                                 }
                               }
                             },
                             "extend-shallow": {
                               "version": "1.1.2",
-                              "from": "extend-shallow@>=1.1.2 <2.0.0",
+                              "from": "extend-shallow@^1.1.2",
                               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
                             },
                             "file-reader": {
                               "version": "1.0.0",
-                              "from": "file-reader@>=1.0.0 <2.0.0",
+                              "from": "file-reader@^1.0.0",
                               "resolved": "https://registry.npmjs.org/file-reader/-/file-reader-1.0.0.tgz",
                               "dependencies": {
                                 "extend-shallow": {
                                   "version": "0.2.0",
-                                  "from": "extend-shallow@>=0.2.0 <0.3.0",
+                                  "from": "extend-shallow@^0.2.0",
                                   "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz",
                                   "dependencies": {
                                     "array-slice": {
-                                      "version": "0.2.3",
-                                      "from": "array-slice@>=0.2.2 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                                      "version": "0.2.2",
+                                      "from": "array-slice@^0.2.2",
+                                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
                                     }
                                   }
                                 },
                                 "map-files": {
                                   "version": "0.3.0",
-                                  "from": "map-files@>=0.3.0 <0.4.0",
+                                  "from": "map-files@^0.3.0",
                                   "resolved": "https://registry.npmjs.org/map-files/-/map-files-0.3.0.tgz",
                                   "dependencies": {
                                     "globby": {
                                       "version": "0.1.1",
-                                      "from": "globby@>=0.1.1 <0.2.0",
+                                      "from": "globby@^0.1.1",
                                       "resolved": "https://registry.npmjs.org/globby/-/globby-0.1.1.tgz",
                                       "dependencies": {
                                         "array-differ": {
                                           "version": "0.1.0",
-                                          "from": "array-differ@>=0.1.0 <0.2.0",
+                                          "from": "array-differ@^0.1.0",
                                           "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
                                         },
                                         "array-union": {
                                           "version": "0.1.0",
-                                          "from": "array-union@>=0.1.0 <0.2.0",
+                                          "from": "array-union@^0.1.0",
                                           "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
                                           "dependencies": {
                                             "array-uniq": {
                                               "version": "0.1.1",
-                                              "from": "array-uniq@>=0.1.0 <0.2.0",
+                                              "from": "array-uniq@^0.1.0",
                                               "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
                                             }
                                           }
                                         },
                                         "async": {
                                           "version": "0.9.0",
-                                          "from": "async@>=0.9.0 <0.10.0",
+                                          "from": "async@^0.9.0",
                                           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                                         },
                                         "glob": {
                                           "version": "4.5.3",
-                                          "from": "glob@>=4.0.2 <5.0.0",
+                                          "from": "glob@^4.0.2",
                                           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                                           "dependencies": {
                                             "inflight": {
                                               "version": "1.0.4",
-                                              "from": "inflight@>=1.0.4 <2.0.0",
+                                              "from": "inflight@^1.0.4",
                                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                                               "dependencies": {
                                                 "wrappy": {
                                                   "version": "1.0.1",
-                                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                                  "from": "wrappy@1",
                                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                                 }
                                               }
                                             },
                                             "inherits": {
                                               "version": "2.0.1",
-                                              "from": "inherits@>=2.0.0 <3.0.0",
+                                              "from": "inherits@2",
                                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                             },
                                             "minimatch": {
                                               "version": "2.0.4",
-                                              "from": "minimatch@>=2.0.1 <3.0.0",
+                                              "from": "minimatch@^2.0.1",
                                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
                                               "dependencies": {
                                                 "brace-expansion": {
                                                   "version": "1.1.0",
-                                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                                  "from": "brace-expansion@^1.0.0",
                                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                                                   "dependencies": {
                                                     "balanced-match": {
                                                       "version": "0.2.0",
-                                                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                                                      "from": "balanced-match@^0.2.0",
                                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                                                     },
                                                     "concat-map": {
@@ -4332,12 +4359,12 @@
                                             },
                                             "once": {
                                               "version": "1.3.1",
-                                              "from": "once@>=1.3.0 <2.0.0",
+                                              "from": "once@^1.3.0",
                                               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                                               "dependencies": {
                                                 "wrappy": {
                                                   "version": "1.0.1",
-                                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                                  "from": "wrappy@1",
                                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                                 }
                                               }
@@ -4348,12 +4375,12 @@
                                     },
                                     "relative": {
                                       "version": "0.1.6",
-                                      "from": "relative@>=0.1.6 <0.2.0",
+                                      "from": "relative@^0.1.6",
                                       "resolved": "https://registry.npmjs.org/relative/-/relative-0.1.6.tgz",
                                       "dependencies": {
                                         "normalize-path": {
                                           "version": "0.1.1",
-                                          "from": "normalize-path@>=0.1.1 <0.2.0",
+                                          "from": "normalize-path@^0.1.1",
                                           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-0.1.1.tgz"
                                         }
                                       }
@@ -4362,29 +4389,34 @@
                                 },
                                 "read-yaml": {
                                   "version": "1.0.0",
-                                  "from": "read-yaml@>=1.0.0 <2.0.0",
+                                  "from": "read-yaml@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.0.0.tgz",
                                   "dependencies": {
                                     "js-yaml": {
                                       "version": "3.2.7",
-                                      "from": "js-yaml@>=3.2.3 <4.0.0",
+                                      "from": "js-yaml@^3.2.3",
                                       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                                       "dependencies": {
                                         "argparse": {
                                           "version": "1.0.2",
-                                          "from": "argparse@>=1.0.0 <1.1.0",
+                                          "from": "argparse@~ 1.0.0",
                                           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                                           "dependencies": {
+                                            "lodash": {
+                                              "version": "3.6.0",
+                                              "from": "lodash@>= 3.2.0 < 4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                                            },
                                             "sprintf-js": {
                                               "version": "1.0.2",
-                                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                                              "from": "sprintf-js@~1.0.2",
                                               "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                                             }
                                           }
                                         },
                                         "esprima": {
                                           "version": "2.0.0",
-                                          "from": "esprima@>=2.0.0 <2.1.0",
+                                          "from": "esprima@~ 2.0.0",
                                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
                                         }
                                       }
@@ -4395,92 +4427,92 @@
                             },
                             "for-own": {
                               "version": "0.1.3",
-                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "from": "for-own@^0.1.3",
                               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                               "dependencies": {
                                 "for-in": {
                                   "version": "0.1.4",
-                                  "from": "for-in@>=0.1.4 <0.2.0",
+                                  "from": "for-in@^0.1.4",
                                   "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                                 }
                               }
                             },
                             "has-values": {
                               "version": "0.1.3",
-                              "from": "has-values@>=0.1.2 <0.2.0",
+                              "from": "has-values@^0.1.2",
                               "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
                             }
                           }
                         },
                         "chalk": {
                           "version": "0.5.1",
-                          "from": "chalk@>=0.5.1 <0.6.0",
+                          "from": "chalk@^0.5.1",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "1.1.0",
-                              "from": "ansi-styles@>=1.1.0 <2.0.0",
+                              "from": "ansi-styles@^1.1.0",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.3",
-                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                              "from": "escape-string-regexp@^1.0.0",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                             },
                             "has-ansi": {
                               "version": "0.1.0",
-                              "from": "has-ansi@>=0.1.0 <0.2.0",
+                              "from": "has-ansi@^0.1.0",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "0.2.1",
-                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "from": "ansi-regex@^0.2.1",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "0.3.0",
-                              "from": "strip-ansi@>=0.3.0 <0.4.0",
+                              "from": "strip-ansi@^0.3.0",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "0.2.1",
-                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "from": "ansi-regex@^0.2.1",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "0.2.0",
-                              "from": "supports-color@>=0.2.0 <0.3.0",
+                              "from": "supports-color@^0.2.0",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                             }
                           }
                         },
                         "micromatch": {
                           "version": "1.6.2",
-                          "from": "micromatch@>=1.2.2 <2.0.0",
+                          "from": "micromatch@^1.2.2",
                           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-1.6.2.tgz",
                           "dependencies": {
                             "extglob": {
                               "version": "0.2.0",
-                              "from": "extglob@>=0.2.0 <0.3.0",
+                              "from": "extglob@^0.2.0",
                               "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.2.0.tgz"
                             },
                             "parse-glob": {
                               "version": "2.1.1",
-                              "from": "parse-glob@>=2.1.1 <3.0.0",
+                              "from": "parse-glob@^2.1.1",
                               "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.1.1.tgz",
                               "dependencies": {
                                 "glob-base": {
                                   "version": "0.1.1",
-                                  "from": "glob-base@>=0.1.0 <0.2.0",
+                                  "from": "glob-base@^0.1.0",
                                   "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.1.1.tgz"
                                 },
                                 "glob-path-regex": {
                                   "version": "1.0.0",
-                                  "from": "glob-path-regex@>=1.0.0 <2.0.0",
+                                  "from": "glob-path-regex@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz"
                                 }
                               }
@@ -4489,17 +4521,17 @@
                         },
                         "to-key": {
                           "version": "1.0.0",
-                          "from": "to-key@>=1.0.0 <2.0.0",
+                          "from": "to-key@^1.0.0",
                           "resolved": "https://registry.npmjs.org/to-key/-/to-key-1.0.0.tgz",
                           "dependencies": {
                             "arr-map": {
                               "version": "1.0.0",
-                              "from": "arr-map@>=1.0.0 <2.0.0",
+                              "from": "arr-map@^1.0.0",
                               "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-1.0.0.tgz"
                             },
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "from": "for-in@^0.1.4",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
@@ -4512,71 +4544,71 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
+              "from": "arrify@^1.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
+              "from": "async-each@^0.1.5",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "glob-parent@>=1.0.0 <2.0.0",
+              "from": "glob-parent@^1.0.0",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.0",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "from": "is-binary-path@^1.0.0",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.0",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "from": "binary-extensions@^1.0.0",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "is-glob@>=1.1.3 <2.0.0",
+              "from": "is-glob@^1.1.3",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             },
             "readdirp": {
               "version": "1.3.0",
-              "from": "readdirp@>=1.3.0 <2.0.0",
+              "from": "readdirp@^1.3.0",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "from": "graceful-fs@~2.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.12 <0.3.0",
+                  "from": "minimatch@~0.2.12",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "from": "readable-stream@~1.0.26-2",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -4586,12 +4618,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -4602,37 +4634,37 @@
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@>=0.0.0 <0.1.0",
+          "from": "defined@~0.0.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "outpipe": {
-          "version": "1.1.1",
-          "from": "outpipe@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+          "version": "1.1.0",
+          "from": "outpipe@^1.1.0",
+          "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.0.tgz",
           "dependencies": {
             "shell-quote": {
               "version": "1.4.3",
-              "from": "shell-quote@>=1.4.2 <2.0.0",
+              "from": "shell-quote@^1.4.2",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "jsonify@~0.0.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "array-filter": {
                   "version": "0.0.1",
-                  "from": "array-filter@>=0.0.0 <0.1.0",
+                  "from": "array-filter@~0.0.0",
                   "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                 },
                 "array-reduce": {
                   "version": "0.0.0",
-                  "from": "array-reduce@>=0.0.0 <0.1.0",
+                  "from": "array-reduce@~0.0.0",
                   "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
                 },
                 "array-map": {
                   "version": "0.0.0",
-                  "from": "array-map@>=0.0.0 <0.1.0",
+                  "from": "array-map@~0.0.0",
                   "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                 }
               }
@@ -4641,7 +4673,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@~0.6.3",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -4651,7 +4683,7 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -4661,12 +4693,12 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -4675,7 +4707,7 @@
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "xtend@>=4.0.0 <5.0.0",
+          "from": "xtend@^4.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -29,6 +29,11 @@
         }
       }
     },
+    "blueimp-md5": {
+      "version": "1.1.0",
+      "from": "blueimp-md5@*",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-1.1.0.tgz"
+    },
     "bootstrap": {
       "version": "3.3.4",
       "from": "bootstrap@3.3.4",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "backbone": "1.1.2",
     "backbone.marionette": "2.4.1",
+    "blueimp-md5": "1.1.0",
     "bootstrap": "3.3.4",
     "bootstrap-select": "git://github.com/azavea/bootstrap-select",
     "browserify": "9.0.3",


### PR DESCRIPTION
When the modifications for a scenario don't change, but the inputs do, we now use the cached results from the geoprocessing endpoint that generates the landcover census.

See commit messages for details.

**To Test:**
- Run `./scripts/manage migrate`, as well as `./scripts/npm install`.
- Regenerate the vendor bundle.
- Create a new project. The initial model run should take about 2 seconds.
- Change the precipitation level. The model run should finish in less than a second.
- Add a modification. This model run should take about 2 seconds.
- Change the precipitation level. The model run should finish in less than a second.
- Run the tests. Tests were added on both the front-end and back-end.

Connects to #512 