### PR TITLE
Add google layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,10 @@ This flag is for troubleshooting purposes only.
       --list       List browserify dependencies
       --vendor     Generate vendor bundle and copy assets
       -h, --help   Display this help text
+
+#### Adding JS dependencies
+
+To add a new JS depenency, update the `JS_DEPS` array in `bundle.sh`, and `package.json` accordingly.
+Because our dependencies are shrinkwrapped, follow the [instructions](https://docs.npmjs.com/cli/shrinkwrap#building-shrinkwrapped-packages) for adding a dependency to a shrinkwrapped package.
+Rebuild the vendor bundle using `./scripts/bundle.sh --vendor`.
+`npm` commands can be run using `./scripts/npm.sh`.

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -26,6 +26,6 @@ postgis_package_version: "2.1.*.pgdg14.04+1"
 
 elasticsearch_cluster_name: "logstash"
 
-nodejs_npm_version: 2.1.14
+nodejs_npm_version: 2.1.17
 
 java_version: "7u79-*"

--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -32,11 +32,14 @@
     {% endblock modals %}
 
     {% block javascript %}
-    <script type="text/javascript">
-        window.clientSettings = {{ client_settings | safe }};
-    </script>
-    <script type="text/javascript" src="{% static 'js/vendor.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/main.js' %}"></script>
+        <script type="text/javascript"
+                src="https://maps.googleapis.com/maps/api/js?key={{ client_settings.google_maps_api_key }}">
+        </script>
+        <script type="text/javascript">
+            window.clientSettings = {{ client_settings | safe }};
+        </script>
+        <script type="text/javascript" src="{% static 'js/vendor.js' %}"></script>
+        <script type="text/javascript" src="{% static 'js/main.js' %}"></script>
     {% endblock javascript %}
 
     {% include 'patterns.html' %}

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -34,7 +34,8 @@ def get_client_settings():
     client_settings = {
         'client_settings': json.dumps({
             'base_layers': settings.BASE_LAYERS,
-            'stream_layers': get_stream_layers()
+            'stream_layers': get_stream_layers(),
+            'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY
         })
     }
     return client_settings

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -104,7 +104,7 @@ CONCAT_VENDOR_CSS_COMMAND="cat \
 
 JS_DEPS=(jquery backbone backbone.marionette \
          bootstrap bootstrap-select \
-         leaflet leaflet-draw leaflet.locatecontrol \
+         leaflet leaflet-draw leaflet.locatecontrol leaflet-plugins \
          lodash underscore \
          d3 nunjucks turf-area turf-buffer turf-random \
          zeroclipboard blueimp-md5)

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -20,6 +20,7 @@ var $ = require('jquery'),
     BASIC_MODAL_CLASS = 'modal modal-basic fade';
 
 require('leaflet.locatecontrol');
+require('leaflet-plugins/layer/tile/Google');
 
 /**
  * A basic view for showing a static message.
@@ -151,10 +152,14 @@ var MapView = Marionette.ItemView.extend({
         addLocateMeButton(map, maxZoom, maxAge);
 
         var baseLayers = _.mapObject(settings.getSettings().base_layers, function(layerData) {
-            return new L.TileLayer(layerData.url, {
-                attribution: layerData.attribution || '',
-                maxZoom: layerData.maxZoom || 18
-            });
+            if (layerData.googleType) {
+                return new L.Google(layerData.googleType);
+            } else {
+                return new L.TileLayer(layerData.url, {
+                    attribution: layerData.attribution || '',
+                    maxZoom: layerData.maxZoom || 18
+                });
+            }
         }),
             defaultLayerName = _.findKey(settings.getSettings().base_layers, function(layerData) {
                 return layerData.default;

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -380,7 +380,7 @@ ITSI = {
 }
 
 BASE_LAYERS = {
-    'Default': {
+    'Mapbox Roads': {
         'url': 'https://{s}.tiles.mapbox.com/v3/ctaylor.lg2deoc9/{z}/{x}/{y}.png',
         'attribution': 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">Mapbox</a>',
         'maxZoom': 18,
@@ -389,5 +389,8 @@ BASE_LAYERS = {
     'ESRI World Imagery': {
         'url': 'https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
         'attribution': 'Map data from <a href="http://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9">ESRI</a>',
+    },
+    'Google Hybrid': {
+        'googleType': 'HYBRID' # can be one of SATELLITE, ROADMAP, HYBRID, TERRAIN
     },
 }

--- a/src/mmw/mmw/settings/development.py
+++ b/src/mmw/mmw/settings/development.py
@@ -71,3 +71,6 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 
 # END TOOLBAR CONFIGURATION
+
+# API key for testing/development
+GOOGLE_MAPS_API_KEY = 'AIzaSyB0D5gjoIHpmy-xdP2cr_0I-E7K6s_L0k4'

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -72,3 +72,7 @@ PRIVATE_AWS_STORAGE_URL_PROTOCOL = 'https:'
 # They are pulled from the instance metadata by Boto
 
 # END Django Storages CONFIGURATION
+
+# API key for testing/development
+# TODO replace with production key. Chip is going to ask Stroud for it.
+GOOGLE_MAPS_API_KEY = 'AIzaSyB0D5gjoIHpmy-xdP2cr_0I-E7K6s_L0k4'

--- a/src/mmw/mmw/settings/test.py
+++ b/src/mmw/mmw/settings/test.py
@@ -27,3 +27,6 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
     )
 }
+
+# API key for testing/development
+GOOGLE_MAPS_API_KEY = 'AIzaSyB0D5gjoIHpmy-xdP2cr_0I-E7K6s_L0k4'

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -9,109 +9,109 @@
     },
     "backbone.marionette": {
       "version": "2.4.1",
-      "from": "backbone.marionette@2.4.1",
+      "from": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.1.tgz",
       "dependencies": {
         "backbone.babysitter": {
-          "version": "0.1.6",
-          "from": "backbone.babysitter@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.6.tgz"
+          "version": "0.1.8",
+          "from": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz"
         },
         "backbone.wreqr": {
-          "version": "1.3.1",
-          "from": "backbone.wreqr@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.1.tgz"
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@>=1.4.4 <=1.6.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
     "blueimp-md5": {
       "version": "1.1.0",
-      "from": "blueimp-md5@*",
+      "from": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-1.1.0.tgz"
     },
     "bootstrap": {
       "version": "3.3.4",
-      "from": "bootstrap@3.3.4",
+      "from": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz"
     },
     "bootstrap-select": {
       "version": "1.6.4",
-      "from": "../../tmp/npm-25399-f33e3414/1431608850408-0.06566630373708904/f1755efa102a41e43fc367ba36ce905b8f2b90e1",
+      "from": "../../tmp/npm-31030-7f32f0c4/1436971651298-0.12548802117817104/f1755efa102a41e43fc367ba36ce905b8f2b90e1",
       "resolved": "git://github.com/azavea/bootstrap-select#f1755efa102a41e43fc367ba36ce905b8f2b90e1"
     },
     "browserify": {
       "version": "9.0.3",
-      "from": "browserify@9.0.3",
+      "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.10.0",
-          "from": "JSONStream@~0.10.0",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
-              "from": "jsonparse@0.0.5",
+              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
             },
             "through": {
-              "version": "2.3.6",
-              "from": "through@>=2.2.7 <3",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+              "version": "2.3.8",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "assert": {
           "version": "1.3.0",
-          "from": "assert@~1.3.0",
+          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
-          "version": "4.0.1",
-          "from": "browser-pack@^4.0.0",
-          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
+          "version": "4.0.4",
+          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.8.4",
-              "from": "JSONStream@~0.8.4",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "combine-source-map@~0.3.0",
+              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.1",
-                  "from": "inline-source-map@~0.3.0",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.3.0",
-                      "from": "source-map@~0.3.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "dependencies": {
                         "amdefine": {
-                          "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                         }
                       }
                     }
@@ -119,36 +119,41 @@
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "convert-source-map@~0.3.0",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@~0.1.31",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 }
               }
             },
+            "defined": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+            },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@~0.5.1",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.17",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -156,187 +161,177 @@
               }
             },
             "umd": {
-              "version": "3.0.0",
-              "from": "umd@^3.0.0",
-              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
             }
           }
         },
         "browser-resolve": {
-          "version": "1.8.2",
-          "from": "browser-resolve@^1.7.1",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
+          "version": "1.9.0",
+          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "browserify-zlib@~0.1.2",
+          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
-              "version": "0.2.6",
-              "from": "pako@~0.2.0",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
+              "version": "0.2.7",
+              "from": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
             }
           }
         },
         "buffer": {
-          "version": "3.1.2",
-          "from": "buffer@^3.0.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
+          "version": "3.3.1",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "base64-js@0.0.8",
+              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
-              "version": "1.1.4",
-              "from": "ieee754@^1.1.4",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+              "version": "1.1.6",
+              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
             },
             "is-array": {
               "version": "1.0.1",
-              "from": "is-array@^1.0.1",
+              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "builtins@~0.0.3",
+          "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
           "version": "0.0.1",
-          "from": "commondir@0.0.1",
+          "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
-          "version": "1.4.7",
-          "from": "concat-stream@~1.4.1",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+          "version": "1.4.10",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@~0.0.5",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@^1.1.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@^0.1.4",
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "constants-browserify@~0.0.1",
+          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
-          "version": "3.9.13",
-          "from": "crypto-browserify@^3.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+          "version": "3.9.14",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
           "dependencies": {
             "browserify-aes": {
-              "version": "1.0.0",
-              "from": "browserify-aes@^1.0.0",
-              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz"
             },
             "browserify-sign": {
-              "version": "2.8.0",
-              "from": "browserify-sign@2.8.0",
-              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+              "version": "3.0.2",
+              "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "1.1.1",
-                  "from": "browserify-rsa@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "elliptic": {
-                  "version": "1.0.1",
-                  "from": "elliptic@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@^1.0.1",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
-                      "version": "1.0.2",
-                      "from": "hash.js@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                     }
                   }
                 },
                 "parse-asn1": {
-                  "version": "2.0.0",
-                  "from": "parse-asn1@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.3",
-                      "from": "asn1.js@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "version": "2.1.2",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@^1.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
-                    },
-                    "asn1.js-rfc3280": {
-                      "version": "1.0.0",
-                      "from": "asn1.js-rfc3280@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
-                    },
-                    "pemstrip": {
-                      "version": "0.0.1",
-                      "from": "pemstrip@0.0.1",
-                      "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "create-ecdh": {
-              "version": "2.0.0",
-              "from": "create-ecdh@^2.0.0",
-              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "elliptic": {
-                  "version": "1.0.1",
-                  "from": "elliptic@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@^1.0.1",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
-                      "version": "1.0.2",
-                      "from": "hash.js@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                     }
                   }
                 }
@@ -344,83 +339,83 @@
             },
             "create-hash": {
               "version": "1.1.1",
-              "from": "create-hash@^1.1.0",
+              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "dependencies": {
                 "ripemd160": {
-                  "version": "1.0.0",
-                  "from": "ripemd160@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
                 },
                 "sha.js": {
-                  "version": "2.3.6",
-                  "from": "sha.js@^2.3.6",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+                  "version": "2.4.2",
+                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz"
                 }
               }
             },
             "create-hmac": {
               "version": "1.1.3",
-              "from": "create-hmac@^1.1.0",
+              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
-              "version": "3.0.1",
-              "from": "diffie-hellman@^3.0.1",
-              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+              "version": "3.0.2",
+              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "miller-rabin": {
-                  "version": "1.1.5",
-                  "from": "miller-rabin@^1.1.2",
-                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@^1.0.1",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     }
                   }
                 }
               }
             },
-            "pbkdf2-compat": {
-              "version": "3.0.2",
-              "from": "pbkdf2-compat@^3.0.1",
-              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
+            "pbkdf2": {
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
             },
             "public-encrypt": {
-              "version": "2.0.0",
-              "from": "public-encrypt@^2.0.0",
-              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "2.0.0",
-                  "from": "browserify-rsa@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "parse-asn1": {
-                  "version": "3.0.0",
-                  "from": "parse-asn1@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.3",
-                      "from": "asn1.js@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "version": "2.1.2",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@^1.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
@@ -431,64 +426,40 @@
             },
             "randombytes": {
               "version": "2.0.1",
-              "from": "randombytes@^2.0.0",
+              "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             }
           }
         },
         "deep-equal": {
           "version": "1.0.0",
-          "from": "deep-equal@^1.0.0",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@~0.0.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
-          "version": "1.3.5",
-          "from": "deps-sort@^1.3.5",
-          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+          "version": "1.3.9",
+          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.8.4",
-              "from": "JSONStream@~0.8.4",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-                }
-              }
-            },
-            "minimist": {
-              "version": "0.2.0",
-              "from": "minimist@~0.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-            },
-            "through2": {
-              "version": "0.5.1",
-              "from": "through2@~0.5.1",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.17",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             }
@@ -496,54 +467,54 @@
         },
         "domain-browser": {
           "version": "1.1.4",
-          "from": "domain-browser@~1.1.0",
+          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
         },
         "duplexer2": {
           "version": "0.0.2",
-          "from": "duplexer2@~0.0.2",
+          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "events": {
           "version": "1.0.2",
-          "from": "events@~1.0.0",
+          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
           "version": "4.5.3",
-          "from": "glob@^4.0.2",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@^1.0.4",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.4",
-              "from": "minimatch@^2.0.1",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "version": "2.0.8",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -551,13 +522,13 @@
               }
             },
             "once": {
-              "version": "1.3.1",
-              "from": "once@^1.3.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -566,145 +537,141 @@
         },
         "has": {
           "version": "1.0.0",
-          "from": "has@^1.0.0",
+          "from": "https://registry.npmjs.org/has/-/has-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "http-browserify@^1.4.0",
+          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@~0.2.0",
+              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https-browserify@~0.0.0",
+          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@~2.0.1",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
-          "version": "6.2.1",
-          "from": "insert-module-globals@^6.2.0",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
+          "version": "6.5.2",
+          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.7.4",
-              "from": "JSONStream@~0.7.1",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "combine-source-map": {
-              "version": "0.3.0",
-              "from": "combine-source-map@~0.3.0",
-              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
               "dependencies": {
-                "inline-source-map": {
-                  "version": "0.3.1",
-                  "from": "inline-source-map@~0.3.0",
-                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-                  "dependencies": {
-                    "source-map": {
-                      "version": "0.3.0",
-                      "from": "source-map@~0.3.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
                 "convert-source-map": {
-                  "version": "0.3.5",
-                  "from": "convert-source-map@~0.3.0",
-                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+                },
+                "inline-source-map": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                },
+                "lodash.memoize": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
                 },
                 "source-map": {
-                  "version": "0.1.43",
-                  "from": "source-map@~0.1.31",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "version": "0.4.3",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 }
               }
             },
             "lexical-scope": {
-              "version": "1.1.0",
-              "from": "lexical-scope@~1.1.0",
-              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
               "dependencies": {
                 "astw": {
-                  "version": "1.1.0",
-                  "from": "astw@~1.1.0",
-                  "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                   "dependencies": {
-                    "esprima-fb": {
-                      "version": "3001.1.0-dev-harmony-fb",
-                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                    "acorn": {
+                      "version": "1.2.2",
+                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     }
                   }
                 }
               }
             },
             "process": {
-              "version": "0.6.0",
-              "from": "process@~0.6.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
+              "version": "0.11.1",
+              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
             },
-            "through": {
-              "version": "2.3.6",
-              "from": "through@~2.3.4",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            "xtend": {
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
-          "from": "labeled-stream-splicer@^1.0.0",
+          "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
-              "version": "1.3.1",
-              "from": "stream-splicer@^1.1.0",
-              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
               "dependencies": {
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "readable-wrap@^1.0.0",
+                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
@@ -712,103 +679,108 @@
           }
         },
         "module-deps": {
-          "version": "3.7.5",
-          "from": "module-deps@^3.7.0",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.5.tgz",
+          "version": "3.8.1",
+          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.7.4",
-              "from": "JSONStream@~0.7.1",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
+            "defined": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+            },
             "detective": {
-              "version": "4.0.0",
-              "from": "detective@^4.0.0",
-              "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+              "version": "4.1.1",
+              "from": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "0.9.0",
-                  "from": "acorn@~0.9.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                  "version": "1.2.2",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                 },
                 "escodegen": {
                   "version": "1.6.1",
-                  "from": "escodegen@^1.4.1",
+                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "dependencies": {
                     "estraverse": {
                       "version": "1.9.3",
-                      "from": "estraverse@^1.9.1",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                     },
                     "esutils": {
                       "version": "1.1.6",
-                      "from": "esutils@^1.1.6",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                     },
                     "esprima": {
                       "version": "1.2.5",
-                      "from": "esprima@^1.2.2",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
-                      "from": "optionator@^0.5.0",
+                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
                         "prelude-ls": {
-                          "version": "1.1.1",
-                          "from": "prelude-ls@~1.1.1",
-                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                         },
                         "deep-is": {
                           "version": "0.1.3",
-                          "from": "deep-is@~0.1.2",
+                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
                         "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "wordwrap@~0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "version": "0.0.3",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         },
                         "type-check": {
                           "version": "0.3.1",
-                          "from": "type-check@~0.3.1",
+                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                         },
                         "levn": {
                           "version": "0.2.5",
-                          "from": "levn@~0.2.5",
+                          "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                         },
                         "fast-levenshtein": {
                           "version": "1.0.6",
-                          "from": "fast-levenshtein@~1.0.0",
+                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                         }
                       }
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@~0.1.40",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
-                          "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                         }
                       }
                     }
@@ -816,295 +788,254 @@
                 }
               }
             },
-            "minimist": {
-              "version": "0.2.0",
-              "from": "minimist@~0.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-            },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "stream-combiner2@~1.0.0",
+              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@~0.5.1",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.17",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "3.0.0",
-                      "from": "xtend@~3.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                     }
                   }
                 }
               }
             },
-            "subarg": {
-              "version": "0.0.1",
-              "from": "subarg@0.0.1",
-              "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "from": "minimist@~0.0.7",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                }
-              }
-            },
-            "through2": {
-              "version": "0.4.2",
-              "from": "through2@~0.4.1",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.17",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "2.1.2",
-                  "from": "xtend@~2.1.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-                  "dependencies": {
-                    "object-keys": {
-                      "version": "0.4.0",
-                      "from": "object-keys@~0.4.0",
-                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@^4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "os-browserify@~0.1.1",
+          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "1.0.1",
-          "from": "parents@^1.0.1",
+          "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.11.15",
-              "from": "path-platform@~0.11.15",
+              "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "path-browserify@~0.0.0",
+          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.10.1",
-          "from": "process@^0.10.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
           "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "punycode@~1.2.3",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "querystring-es3@~0.2.0",
+          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@^1.1.13",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@~1.0.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "1.1.6",
-          "from": "resolve@^1.1.4",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
-          "from": "shallow-copy@0.0.1",
+          "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
           "version": "1.0.1",
-          "from": "shasum@^1.0.0",
+          "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "json-stable-stringify@~0.0.0",
+              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@~0.0.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
             },
             "sha.js": {
               "version": "2.3.6",
-              "from": "sha.js@~2.3.0",
+              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
             }
           }
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "shell-quote@~0.0.1",
+          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "stream-browserify@^1.0.0",
+          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@~0.10.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "subarg@^1.0.0",
+          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "1.1.1",
-              "from": "minimist@^1.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
             }
           }
         },
         "syntax-error": {
-          "version": "1.1.2",
-          "from": "syntax-error@^1.1.1",
-          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+          "version": "1.1.4",
+          "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
           "dependencies": {
             "acorn": {
-              "version": "0.9.0",
-              "from": "acorn@~0.9.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "through2@^1.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "timers-browserify": {
-          "version": "1.4.0",
-          "from": "timers-browserify@^1.0.1",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
+          "version": "1.4.1",
+          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
+          "dependencies": {
+            "process": {
+              "version": "0.11.1",
+              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+            }
+          }
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "tty-browserify@~0.0.0",
+          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
           "version": "0.10.3",
-          "from": "url@~0.10.1",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             },
             "querystring": {
               "version": "0.2.0",
-              "from": "querystring@0.2.0",
+              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@~0.10.1",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "vm-browserify@~0.0.1",
+          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "indexof@0.0.1",
+              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "xtend@^3.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
     },
     "chai": {
       "version": "1.10.0",
-      "from": "chai@1.10.0",
+      "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
       "dependencies": {
         "assertion-error": {
           "version": "1.0.0",
-          "from": "assertion-error@1.0.0",
+          "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
         },
         "deep-eql": {
           "version": "0.1.3",
-          "from": "deep-eql@0.1.3",
+          "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
-              "from": "type-detect@0.1.1",
+              "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
             }
           }
@@ -1113,17 +1044,17 @@
     },
     "d3": {
       "version": "3.5.5",
-      "from": "d3@3.5.5",
+      "from": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz"
     },
     "font-awesome": {
       "version": "4.3.0",
-      "from": "font-awesome@4.3.0",
+      "from": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz"
     },
     "jquery": {
       "version": "2.1.3",
-      "from": "jquery@2.1.3",
+      "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz"
     },
     "jshint": {
@@ -1152,9 +1083,9 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
@@ -1300,137 +1231,137 @@
     },
     "jstify": {
       "version": "0.9.0",
-      "from": "jstify@0.9.0",
+      "from": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
       "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
       "dependencies": {
         "html-minifier": {
           "version": "0.6.9",
-          "from": "html-minifier@>=0.6.8 <0.7.0",
+          "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
           "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
           "dependencies": {
             "change-case": {
               "version": "2.1.6",
-              "from": "change-case@>=2.1.0 <2.2.0",
+              "from": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
               "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
               "dependencies": {
                 "camel-case": {
-                  "version": "1.1.1",
-                  "from": "camel-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz"
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz"
                 },
                 "constant-case": {
-                  "version": "1.1.0",
-                  "from": "constant-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.1.tgz"
                 },
                 "dot-case": {
                   "version": "1.1.1",
-                  "from": "dot-case@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
                 },
                 "is-lower-case": {
                   "version": "1.1.1",
-                  "from": "is-lower-case@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
                 },
                 "is-upper-case": {
                   "version": "1.1.1",
-                  "from": "is-upper-case@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
                 },
                 "lower-case": {
                   "version": "1.1.2",
-                  "from": "lower-case@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
                 },
                 "param-case": {
                   "version": "1.1.1",
-                  "from": "param-case@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
                 },
                 "pascal-case": {
-                  "version": "1.1.0",
-                  "from": "pascal-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz"
                 },
                 "path-case": {
                   "version": "1.1.1",
-                  "from": "path-case@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
                 },
                 "sentence-case": {
                   "version": "1.1.2",
-                  "from": "sentence-case@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
                 },
                 "snake-case": {
                   "version": "1.1.1",
-                  "from": "snake-case@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
                 },
                 "swap-case": {
-                  "version": "1.1.0",
-                  "from": "swap-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.1.tgz"
                 },
                 "title-case": {
-                  "version": "1.1.0",
-                  "from": "title-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.1.tgz"
                 },
                 "upper-case": {
                   "version": "1.1.2",
-                  "from": "upper-case@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
                 },
                 "upper-case-first": {
                   "version": "1.1.1",
-                  "from": "upper-case-first@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz"
                 }
               }
             },
             "clean-css": {
               "version": "2.2.23",
-              "from": "clean-css@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
               "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.2.0",
-                  "from": "commander@>=2.2.0 <2.3.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
                 }
               }
             },
             "cli": {
               "version": "0.6.6",
-              "from": "cli@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.1 <3.3.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                          "version": "2.6.5",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                         },
                         "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     }
@@ -1438,122 +1369,122 @@
                 },
                 "exit": {
                   "version": "0.1.2",
-                  "from": "exit@0.1.2",
+                  "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
                 }
               }
             },
             "uglify-js": {
-              "version": "2.4.19",
-              "from": "uglify-js@>=2.4.0 <2.5.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.19.tgz",
+              "version": "2.4.23",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.34",
-                  "from": "source-map@0.1.34",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                    }
-                  }
-                },
-                "yargs": {
-                  "version": "3.5.4",
-                  "from": "yargs@>=3.5.4 <3.6.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.0.2",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                    },
-                    "decamelize": {
-                      "version": "1.0.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "from": "window-size@0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
                 }
               }
             },
             "relateurl": {
               "version": "0.2.6",
-              "from": "relateurl@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz",
               "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
             }
           }
         },
         "through2": {
-          "version": "0.6.3",
-          "from": "through2@>=0.6.3 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "lodash.escape": {
           "version": "3.0.0",
-          "from": "lodash.escape@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
           "dependencies": {
             "lodash._basetostring": {
-              "version": "3.0.0",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
             }
           }
         }
@@ -1561,13 +1492,18 @@
     },
     "leaflet": {
       "version": "0.7.3",
-      "from": "leaflet@0.7.3",
+      "from": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
     },
     "leaflet-draw": {
       "version": "0.2.3",
-      "from": "leaflet-draw@0.2.3",
-      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-0.2.3.tgz"
+      "from": "../../tmp/npm-31030-7f32f0c4/1436971651262-0.632644888246432/e2fe3a4c176979235845e8fbb1c5017414035765",
+      "resolved": "git://github.com/michaelguild13/Leaflet.draw#e2fe3a4c176979235845e8fbb1c5017414035765"
+    },
+    "leaflet-plugins": {
+      "version": "1.3.8",
+      "from": "git://github.com/azavea/leaflet-plugins#feature/browserify",
+      "resolved": "git://github.com/azavea/leaflet-plugins#1fb49a72c8f53cf95786064b1569dc91bfebae6c"
     },
     "leaflet.locatecontrol": {
       "version": "0.43.0",
@@ -1663,9 +1599,9 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
@@ -1709,9 +1645,9 @@
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "dependencies": {
                     "abbrev": {
-                      "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+                      "version": "1.0.7",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 }
@@ -1728,7 +1664,7 @@
     },
     "lodash": {
       "version": "3.6.0",
-      "from": "lodash@3.6.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
     },
     "minifyify": {
@@ -1737,9 +1673,9 @@
       "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
       "dependencies": {
         "concat-stream": {
-          "version": "1.4.8",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+          "version": "1.5.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
@@ -1752,9 +1688,9 @@
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
-              "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
@@ -1766,10 +1702,20 @@
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
+                "process-nextick-args": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
             }
@@ -1786,9 +1732,9 @@
           "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
           "dependencies": {
             "lodash._createwrapper": {
-              "version": "3.0.6",
-              "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.6.tgz",
+              "version": "3.0.7",
+              "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
@@ -1796,9 +1742,9 @@
                   "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
                 },
                 "lodash._basecreate": {
-                  "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.2.tgz"
+                  "version": "3.0.3",
+                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
                 }
               }
             },
@@ -1815,9 +1761,9 @@
           }
         },
         "lodash.defaults": {
-          "version": "3.1.1",
-          "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.1.tgz",
+          "version": "3.1.2",
+          "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
           "dependencies": {
             "lodash.assign": {
               "version": "3.2.0",
@@ -1854,24 +1800,24 @@
                   }
                 },
                 "lodash.keys": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+                  "version": "3.1.2",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "3.9.0",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                      "version": "3.9.1",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     },
                     "lodash.isarray": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
                 }
@@ -1900,19 +1846,19 @@
               "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
               "dependencies": {
                 "lodash.keys": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+                  "version": "3.1.2",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "3.9.0",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                      "version": "3.9.1",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     }
                   }
                 }
@@ -1924,9 +1870,9 @@
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             },
             "lodash.isarray": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
             }
           }
         },
@@ -1943,21 +1889,21 @@
           }
         },
         "source-map": {
-          "version": "0.4.2",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+          "version": "0.4.3",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
             }
           }
         },
         "through": {
-          "version": "2.3.7",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+          "version": "2.3.8",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "tmp": {
           "version": "0.0.25",
@@ -2035,9 +1981,9 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                 }
               }
             },
@@ -2079,100 +2025,100 @@
     },
     "mocha": {
       "version": "2.0.1",
-      "from": "mocha@2.0.1",
+      "from": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "from": "commander@2.3.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "debug": {
           "version": "2.0.0",
-          "from": "debug@2.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "diff": {
           "version": "1.0.8",
-          "from": "diff@1.0.8",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "from": "escape-string-regexp@1.0.2",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.3",
-          "from": "glob@3.2.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "growl": {
           "version": "1.8.1",
-          "from": "growl@1.8.1",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
         },
         "jade": {
           "version": "0.26.3",
-          "from": "jade@0.26.3",
+          "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "dependencies": {
             "commander": {
               "version": "0.6.1",
-              "from": "commander@0.6.1",
+              "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
@@ -2190,14 +2136,14 @@
           "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
         },
         "chalk": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
@@ -2205,33 +2151,33 @@
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
@@ -2273,9 +2219,9 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
@@ -2294,9 +2240,9 @@
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         },
         "glob": {
-          "version": "5.0.6",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.6.tgz",
+          "version": "5.0.13",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.13.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.13.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
@@ -2359,9 +2305,9 @@
           }
         },
         "meow": {
-          "version": "3.1.0",
-          "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+          "version": "3.3.0",
+          "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "1.0.0",
@@ -2386,9 +2332,9 @@
               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
               "dependencies": {
                 "repeating": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
@@ -2412,9 +2358,9 @@
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
             },
             "object-assign": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
             }
           }
         },
@@ -2441,14 +2387,14 @@
           "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "dependencies": {
             "config-chain": {
-              "version": "1.1.8",
-              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+              "version": "1.1.9",
+              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
               "dependencies": {
                 "proto-list": {
-                  "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                  "version": "1.2.4",
+                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 }
               }
             },
@@ -2458,19 +2404,19 @@
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "nopt": {
-              "version": "3.0.2",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
@@ -2487,14 +2433,26 @@
               }
             },
             "osenv": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
             },
             "semver": {
-              "version": "4.3.4",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "uid-number": {
               "version": "0.0.5",
@@ -2504,14 +2462,14 @@
           }
         },
         "pangyp": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.0.tgz",
+          "version": "2.2.1",
+          "from": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.1.tgz",
           "dependencies": {
             "fstream": {
-              "version": "1.0.6",
-              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
+              "version": "1.0.7",
+              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
@@ -2557,9 +2515,9 @@
               }
             },
             "graceful-fs": {
-              "version": "3.0.7",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+              "version": "3.0.8",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "minimatch": {
               "version": "2.0.8",
@@ -2586,14 +2544,14 @@
               }
             },
             "nopt": {
-              "version": "3.0.2",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
@@ -2661,9 +2619,21 @@
               }
             },
             "osenv": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
             },
             "request": {
               "version": "2.51.0",
@@ -2725,14 +2695,14 @@
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "mime-types": {
-                      "version": "2.0.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                      "version": "2.0.14",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.10.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                          "version": "1.12.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     }
@@ -2759,14 +2729,14 @@
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                  "version": "0.4.1",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
@@ -2852,9 +2822,9 @@
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "semver": {
-              "version": "4.2.2",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "tar": {
               "version": "1.0.3",
@@ -2881,9 +2851,9 @@
           }
         },
         "request": {
-          "version": "2.55.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+          "version": "2.58.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
@@ -2920,9 +2890,14 @@
               }
             },
             "caseless": {
-              "version": "0.9.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+              "version": "0.10.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
+            },
+            "extend": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
@@ -2930,14 +2905,26 @@
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "version": "1.0.0-rc1",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.9.2",
-                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.3.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.2",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.2.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.14.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.14.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.14.0.tgz"
+                    }
+                  }
                 }
               }
             },
@@ -2947,14 +2934,14 @@
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.0.12",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+              "version": "2.0.14",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.10.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                  "version": "1.12.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                 }
               }
             },
@@ -2964,24 +2951,24 @@
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
-              "version": "2.4.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
             },
             "tunnel-agent": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
             },
             "http-signature": {
-              "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "version": "0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
@@ -3001,9 +2988,9 @@
               }
             },
             "oauth-sign": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+              "version": "0.8.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
@@ -3011,14 +2998,14 @@
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.13.0",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                  "version": "2.14.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                 },
                 "boom": {
-                  "version": "2.7.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+                  "version": "2.8.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
@@ -3043,14 +3030,14 @@
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
-              "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
@@ -3060,14 +3047,14 @@
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
-              "version": "1.7.0",
-              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+              "version": "1.8.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
-                  "version": "2.9.25",
-                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+                  "version": "2.9.33",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.33.tgz",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.33.tgz"
                 },
                 "commander": {
                   "version": "2.8.1",
@@ -3125,14 +3112,14 @@
           "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
           "dependencies": {
             "lodash": {
-              "version": "3.9.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.1.tgz"
+              "version": "3.10.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
             },
             "yargs": {
-              "version": "3.9.1",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.9.1.tgz",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.9.1.tgz",
+              "version": "3.15.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.1.0",
@@ -3150,14 +3137,14 @@
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                       "dependencies": {
                         "align-text": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                              "version": "2.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                             },
                             "longest": {
                               "version": "1.0.1",
@@ -3174,19 +3161,19 @@
                       }
                     },
                     "right-align": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.1.tgz",
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                              "version": "2.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                             },
                             "longest": {
                               "version": "1.0.1",
@@ -3215,9 +3202,9 @@
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
                 }
               }
             }
@@ -3268,9 +3255,9 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
@@ -3323,56 +3310,56 @@
       "resolved": "https://registry.npmjs.org/nunjucksify/-/nunjucksify-0.2.2.tgz",
       "dependencies": {
         "through": {
-          "version": "2.3.7",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+          "version": "2.3.8",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         }
       }
     },
     "retina.js": {
       "version": "1.3.0",
-      "from": "../../tmp/npm-25399-f33e3414/1431608855853-0.4285626483615488/a70e73639817473bad7bbb33f866b8e060e5f5a7",
+      "from": "../../tmp/npm-31030-7f32f0c4/1436971651112-0.5243154705967754/a70e73639817473bad7bbb33f866b8e060e5f5a7",
       "resolved": "git://github.com/imulus/retinajs#a70e73639817473bad7bbb33f866b8e060e5f5a7"
     },
     "sinon": {
       "version": "1.14.1",
-      "from": "sinon@1.14.1",
+      "from": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
-          "from": "formatio@1.1.1",
+          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "dependencies": {
             "samsam": {
               "version": "1.1.2",
-              "from": "samsam@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.3 <1.0.0",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "lolex": {
           "version": "1.1.0",
-          "from": "lolex@1.1.0",
+          "from": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
         }
       }
     },
     "testem": {
       "version": "0.5.15",
-      "from": "testem@0.5.15",
+      "from": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
       "resolved": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
       "dependencies": {
         "express": {
@@ -3451,64 +3438,64 @@
         },
         "mustache": {
           "version": "0.4.0",
-          "from": "mustache@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz"
         },
         "socket.io": {
           "version": "0.9.17",
-          "from": "socket.io@>=0.9.13 <0.10.0",
+          "from": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
-              "from": "socket.io-client@0.9.16",
+              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.5",
-                  "from": "uglify-js@1.2.5",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "ws@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "commander@>=2.1.0 <2.2.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "nan@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
+                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     }
                   }
                 },
                 "xmlhttprequest": {
                   "version": "1.4.2",
-                  "from": "xmlhttprequest@1.4.2",
+                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
-                  "from": "active-x-obfuscator@0.0.1",
+                  "from": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
-                      "from": "zeparser@0.0.5",
+                      "from": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
@@ -3517,59 +3504,59 @@
             },
             "policyfile": {
               "version": "0.0.4",
-              "from": "policyfile@0.0.4",
+              "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
             },
             "base64id": {
               "version": "0.1.0",
-              "from": "base64id@0.1.0",
+              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
-              "from": "redis@0.7.3",
+              "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
               "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
         "winston": {
           "version": "0.7.3",
-          "from": "winston@>=0.7.1 <0.8.0",
+          "from": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "dependencies": {
             "cycle": {
               "version": "1.0.3",
-              "from": "cycle@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "pkginfo": {
               "version": "0.3.0",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "request": {
               "version": "2.16.6",
-              "from": "request@>=2.16.0 <2.17.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "dependencies": {
                 "form-data": {
                   "version": "0.0.10",
-                  "from": "form-data@>=0.0.3 <0.1.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
@@ -3578,175 +3565,175 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.7 <1.3.0",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "hawk": {
                   "version": "0.10.2",
-                  "from": "hawk@>=0.10.2 <0.11.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.7.6",
-                      "from": "hoek@>=0.7.0 <0.8.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
                     },
                     "boom": {
                       "version": "0.3.8",
-                      "from": "boom@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
                     },
                     "cryptiles": {
                       "version": "0.1.3",
-                      "from": "cryptiles@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
                     },
                     "sntp": {
                       "version": "0.1.4",
-                      "from": "sntp@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.2.0",
-                  "from": "cookie-jar@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
                 },
                 "aws-sign": {
                   "version": "0.2.0",
-                  "from": "aws-sign@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.2.0",
-                  "from": "oauth-sign@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.2.0",
-                  "from": "forever-agent@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.2.0",
-                  "from": "tunnel-agent@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "3.0.0",
-                  "from": "json-stringify-safe@>=3.0.0 <3.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
                 },
                 "qs": {
                   "version": "0.5.6",
-                  "from": "qs@>=0.5.4 <0.6.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
                 }
               }
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
         },
         "charm": {
           "version": "0.0.8",
-          "from": "charm@>=0.0.5 <0.1.0",
+          "from": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "js-yaml@>=2.1.0 <2.2.0",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "tap": {
           "version": "0.4.13",
-          "from": "tap@>=0.4.4 <0.5.0",
+          "from": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
           "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
           "dependencies": {
             "buffer-equal": {
               "version": "0.0.1",
-              "from": "buffer-equal@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
             },
             "deep-equal": {
               "version": "0.0.0",
-              "from": "deep-equal@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
             },
             "difflet": {
               "version": "0.2.6",
-              "from": "difflet@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
               "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
               "dependencies": {
                 "traverse": {
                   "version": "0.6.6",
-                  "from": "traverse@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
                   "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
                 },
                 "charm": {
                   "version": "0.1.2",
-                  "from": "charm@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
@@ -3754,56 +3741,56 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@*",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "mkdirp": {
-              "version": "0.5.0",
-              "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nopt": {
               "version": "2.2.1",
-              "from": "nopt@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.5",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "runforcover": {
               "version": "0.0.2",
-              "from": "runforcover@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
               "dependencies": {
                 "bunker": {
                   "version": "0.1.2",
-                  "from": "bunker@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                   "dependencies": {
                     "burrito": {
                       "version": "0.2.12",
-                      "from": "burrito@>=0.2.5 <0.3.0",
+                      "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                       "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.5.2",
-                          "from": "traverse@>=0.5.1 <0.6.0",
+                          "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                         },
                         "uglify-js": {
                           "version": "1.1.1",
-                          "from": "uglify-js@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                         }
                       }
@@ -3814,106 +3801,106 @@
             },
             "slide": {
               "version": "1.1.6",
-              "from": "slide@*",
+              "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
             },
             "yamlish": {
-              "version": "0.0.6",
-              "from": "yamlish@*",
-              "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
+              "version": "0.0.7",
+              "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz"
             }
           }
         },
         "commander": {
-          "version": "2.7.1",
-          "from": "commander@*",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+          "version": "2.8.1",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
+              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "backbone": {
           "version": "1.0.0",
-          "from": "backbone@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz"
         },
         "styled_string": {
           "version": "0.0.1",
-          "from": "styled_string@*",
+          "from": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "fileset": {
-          "version": "0.1.5",
-          "from": "fileset@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+          "version": "0.1.8",
+          "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.4.0",
-              "from": "minimatch@>=0.0.0 <1.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             }
@@ -3921,38 +3908,38 @@
         },
         "growl": {
           "version": "1.7.0",
-          "from": "growl@>=1.7.0 <1.8.0",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
         },
         "consolidate": {
           "version": "0.8.0",
-          "from": "consolidate@>=0.8.0 <0.9.0",
+          "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz",
           "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz"
         },
         "did_it_work": {
           "version": "0.0.6",
-          "from": "did_it_work@>=0.0.5 <0.1.0",
+          "from": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz"
         },
         "fireworm": {
           "version": "0.4.4",
-          "from": "fireworm@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.9 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             }
@@ -3962,17 +3949,17 @@
     },
     "turf-area": {
       "version": "1.1.1",
-      "from": "turf-area@*",
+      "from": "https://registry.npmjs.org/turf-area/-/turf-area-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/turf-area/-/turf-area-1.1.1.tgz",
       "dependencies": {
         "geojson-area": {
           "version": "0.2.0",
-          "from": "geojson-area@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.2.0.tgz",
           "dependencies": {
             "wgs84": {
               "version": "0.0.0",
-              "from": "wgs84@0.0.0",
+              "from": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz"
             }
           }
@@ -3981,7 +3968,7 @@
     },
     "turf-buffer": {
       "version": "1.0.4",
-      "from": "turf-buffer@*",
+      "from": "https://registry.npmjs.org/turf-buffer/-/turf-buffer-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/turf-buffer/-/turf-buffer-1.0.4.tgz",
       "dependencies": {
         "geojson-normalize": {
@@ -4008,99 +3995,99 @@
         },
         "turf-featurecollection": {
           "version": "1.0.1",
-          "from": "turf-featurecollection@1.0.1",
+          "from": "https://registry.npmjs.org/turf-featurecollection/-/turf-featurecollection-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/turf-featurecollection/-/turf-featurecollection-1.0.1.tgz"
         },
         "turf-polygon": {
           "version": "1.0.3",
-          "from": "turf-polygon@1.0.3",
+          "from": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz"
         }
       }
     },
     "turf-random": {
       "version": "1.0.2",
-      "from": "turf-random@*",
+      "from": "https://registry.npmjs.org/turf-random/-/turf-random-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/turf-random/-/turf-random-1.0.2.tgz",
       "dependencies": {
         "geojson-random": {
           "version": "0.2.2",
-          "from": "geojson-random@>=0.2.2 <0.3.0",
+          "from": "https://registry.npmjs.org/geojson-random/-/geojson-random-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/geojson-random/-/geojson-random-0.2.2.tgz"
         }
       }
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "underscore@1.8.3",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "watchify": {
       "version": "3.1.0",
-      "from": "watchify@3.1.0",
+      "from": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
       "dependencies": {
         "chokidar": {
-          "version": "1.0.0-rc5",
-          "from": "chokidar@^1.0.0-rc4",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc5.tgz",
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
           "dependencies": {
             "anymatch": {
-              "version": "1.2.1",
-              "from": "anymatch@^1.1.0",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.2.1.tgz",
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
-                  "version": "2.1.5",
-                  "from": "micromatch@^2.1.0",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.5.tgz",
+                  "version": "2.1.6",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@^1.0.1",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
-                          "version": "0.2.2",
-                          "from": "array-slice@^0.2.2",
-                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
+                          "version": "0.2.3",
+                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@^1.8.0",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@^1.8.1",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
-                              "version": "2.2.0",
-                              "from": "fill-range@^2.1.0",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.0.tgz",
+                              "version": "2.2.2",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "is-number@^1.1.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
-                                  "version": "0.2.0",
-                                  "from": "isobject@^0.2.0",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.1.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "randomatic@^1.1.0",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.0",
-                                  "from": "repeat-string@^1.5.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.0.tgz"
+                                  "version": "1.5.2",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
                             }
@@ -4108,438 +4095,103 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@^0.2.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
-                          "version": "1.1.0",
-                          "from": "repeat-element@^1.1.0",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz"
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "debug": {
-                      "version": "2.1.3",
-                      "from": "debug@^2.1.3",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                      "version": "2.2.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
-                          "version": "0.7.0",
-                          "from": "ms@0.7.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                          "version": "0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.1",
-                      "from": "expand-brackets@^0.1.1",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@^2.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "kind-of@^1.1.0",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "0.2.1",
-                      "from": "object.omit@^0.2.1",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@^0.1.1",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@^0.1.4",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "0.2.0",
-                          "from": "isobject@^0.2.0",
+                          "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                         }
                       }
                     },
                     "parse-glob": {
-                      "version": "3.0.0",
-                      "from": "parse-glob@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.0.tgz",
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "glob-base@^0.2.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
-                          "version": "1.0.0",
-                          "from": "is-dotfile@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@^1.0.0",
+                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
-                      "version": "0.3.0",
-                      "from": "regex-cache@^0.3.0",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.3.0.tgz",
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
-                        "benchmarked": {
-                          "version": "0.1.4",
-                          "from": "benchmarked@^0.1.3",
-                          "resolved": "https://registry.npmjs.org/benchmarked/-/benchmarked-0.1.4.tgz",
-                          "dependencies": {
-                            "ansi": {
-                              "version": "0.3.0",
-                              "from": "ansi@^0.3.0",
-                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-                            },
-                            "benchmark": {
-                              "version": "1.0.0",
-                              "from": "benchmark@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
-                            },
-                            "chalk": {
-                              "version": "1.0.0",
-                              "from": "chalk@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.0.1",
-                                  "from": "ansi-styles@^2.0.1",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.3",
-                                  "from": "escape-string-regexp@^1.0.2",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "1.0.3",
-                                  "from": "has-ansi@^1.0.3",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "1.1.1",
-                                      "from": "ansi-regex@^1.1.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                                    },
-                                    "get-stdin": {
-                                      "version": "4.0.1",
-                                      "from": "get-stdin@^4.0.1",
-                                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "2.0.1",
-                                  "from": "strip-ansi@^2.0.1",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "1.1.1",
-                                      "from": "ansi-regex@^1.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "1.3.1",
-                                  "from": "supports-color@^1.3.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
-                                }
-                              }
-                            },
-                            "extend-shallow": {
-                              "version": "1.1.2",
-                              "from": "extend-shallow@^1.1.2",
-                              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
-                            },
-                            "file-reader": {
-                              "version": "1.0.0",
-                              "from": "file-reader@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/file-reader/-/file-reader-1.0.0.tgz",
-                              "dependencies": {
-                                "extend-shallow": {
-                                  "version": "0.2.0",
-                                  "from": "extend-shallow@^0.2.0",
-                                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz",
-                                  "dependencies": {
-                                    "array-slice": {
-                                      "version": "0.2.2",
-                                      "from": "array-slice@^0.2.2",
-                                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
-                                    }
-                                  }
-                                },
-                                "map-files": {
-                                  "version": "0.3.0",
-                                  "from": "map-files@^0.3.0",
-                                  "resolved": "https://registry.npmjs.org/map-files/-/map-files-0.3.0.tgz",
-                                  "dependencies": {
-                                    "globby": {
-                                      "version": "0.1.1",
-                                      "from": "globby@^0.1.1",
-                                      "resolved": "https://registry.npmjs.org/globby/-/globby-0.1.1.tgz",
-                                      "dependencies": {
-                                        "array-differ": {
-                                          "version": "0.1.0",
-                                          "from": "array-differ@^0.1.0",
-                                          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
-                                        },
-                                        "array-union": {
-                                          "version": "0.1.0",
-                                          "from": "array-union@^0.1.0",
-                                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
-                                          "dependencies": {
-                                            "array-uniq": {
-                                              "version": "0.1.1",
-                                              "from": "array-uniq@^0.1.0",
-                                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
-                                            }
-                                          }
-                                        },
-                                        "async": {
-                                          "version": "0.9.0",
-                                          "from": "async@^0.9.0",
-                                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                                        },
-                                        "glob": {
-                                          "version": "4.5.3",
-                                          "from": "glob@^4.0.2",
-                                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                                          "dependencies": {
-                                            "inflight": {
-                                              "version": "1.0.4",
-                                              "from": "inflight@^1.0.4",
-                                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                                              "dependencies": {
-                                                "wrappy": {
-                                                  "version": "1.0.1",
-                                                  "from": "wrappy@1",
-                                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                                }
-                                              }
-                                            },
-                                            "inherits": {
-                                              "version": "2.0.1",
-                                              "from": "inherits@2",
-                                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                            },
-                                            "minimatch": {
-                                              "version": "2.0.4",
-                                              "from": "minimatch@^2.0.1",
-                                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                                              "dependencies": {
-                                                "brace-expansion": {
-                                                  "version": "1.1.0",
-                                                  "from": "brace-expansion@^1.0.0",
-                                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                                                  "dependencies": {
-                                                    "balanced-match": {
-                                                      "version": "0.2.0",
-                                                      "from": "balanced-match@^0.2.0",
-                                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                                                    },
-                                                    "concat-map": {
-                                                      "version": "0.0.1",
-                                                      "from": "concat-map@0.0.1",
-                                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                                    }
-                                                  }
-                                                }
-                                              }
-                                            },
-                                            "once": {
-                                              "version": "1.3.1",
-                                              "from": "once@^1.3.0",
-                                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                                              "dependencies": {
-                                                "wrappy": {
-                                                  "version": "1.0.1",
-                                                  "from": "wrappy@1",
-                                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "relative": {
-                                      "version": "0.1.6",
-                                      "from": "relative@^0.1.6",
-                                      "resolved": "https://registry.npmjs.org/relative/-/relative-0.1.6.tgz",
-                                      "dependencies": {
-                                        "normalize-path": {
-                                          "version": "0.1.1",
-                                          "from": "normalize-path@^0.1.1",
-                                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-0.1.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "read-yaml": {
-                                  "version": "1.0.0",
-                                  "from": "read-yaml@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.0.0.tgz",
-                                  "dependencies": {
-                                    "js-yaml": {
-                                      "version": "3.2.7",
-                                      "from": "js-yaml@^3.2.3",
-                                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-                                      "dependencies": {
-                                        "argparse": {
-                                          "version": "1.0.2",
-                                          "from": "argparse@~ 1.0.0",
-                                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
-                                          "dependencies": {
-                                            "lodash": {
-                                              "version": "3.6.0",
-                                              "from": "lodash@>= 3.2.0 < 4.0.0",
-                                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
-                                            },
-                                            "sprintf-js": {
-                                              "version": "1.0.2",
-                                              "from": "sprintf-js@~1.0.2",
-                                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
-                                            }
-                                          }
-                                        },
-                                        "esprima": {
-                                          "version": "2.0.0",
-                                          "from": "esprima@~ 2.0.0",
-                                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "for-own": {
-                              "version": "0.1.3",
-                              "from": "for-own@^0.1.3",
-                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                              "dependencies": {
-                                "for-in": {
-                                  "version": "0.1.4",
-                                  "from": "for-in@^0.1.4",
-                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
-                                }
-                              }
-                            },
-                            "has-values": {
-                              "version": "0.1.3",
-                              "from": "has-values@^0.1.2",
-                              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
-                            }
-                          }
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
-                        "chalk": {
-                          "version": "0.5.1",
-                          "from": "chalk@^0.5.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "1.1.0",
-                              "from": "ansi-styles@^1.1.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.3",
-                              "from": "escape-string-regexp@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "0.1.0",
-                              "from": "has-ansi@^0.1.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "0.2.1",
-                                  "from": "ansi-regex@^0.2.1",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "0.3.0",
-                              "from": "strip-ansi@^0.3.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "0.2.1",
-                                  "from": "ansi-regex@^0.2.1",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "0.2.0",
-                              "from": "supports-color@^0.2.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-                            }
-                          }
-                        },
-                        "micromatch": {
-                          "version": "1.6.2",
-                          "from": "micromatch@^1.2.2",
-                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-1.6.2.tgz",
-                          "dependencies": {
-                            "extglob": {
-                              "version": "0.2.0",
-                              "from": "extglob@^0.2.0",
-                              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.2.0.tgz"
-                            },
-                            "parse-glob": {
-                              "version": "2.1.1",
-                              "from": "parse-glob@^2.1.1",
-                              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.1.1.tgz",
-                              "dependencies": {
-                                "glob-base": {
-                                  "version": "0.1.1",
-                                  "from": "glob-base@^0.1.0",
-                                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.1.1.tgz"
-                                },
-                                "glob-path-regex": {
-                                  "version": "1.0.0",
-                                  "from": "glob-path-regex@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "to-key": {
-                          "version": "1.0.0",
-                          "from": "to-key@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/to-key/-/to-key-1.0.0.tgz",
-                          "dependencies": {
-                            "arr-map": {
-                              "version": "1.0.0",
-                              "from": "arr-map@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-1.0.0.tgz"
-                            },
-                            "for-in": {
-                              "version": "0.1.4",
-                              "from": "for-in@^0.1.4",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
-                            }
-                          }
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
                     }
@@ -4549,86 +4201,91 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "arrify@^1.0.0",
+              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@^0.1.5",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "glob-parent@^1.0.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
-              "version": "1.0.0",
-              "from": "is-binary-path@^1.0.0",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
-                  "version": "1.3.0",
-                  "from": "binary-extensions@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "is-glob@^1.1.3",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "1.3.0",
-              "from": "readdirp@^1.3.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@~2.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@~0.2.12",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26-2",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -4639,37 +4296,37 @@
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@~0.0.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "outpipe": {
-          "version": "1.1.0",
-          "from": "outpipe@^1.1.0",
-          "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.0.tgz",
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
           "dependencies": {
             "shell-quote": {
               "version": "1.4.3",
-              "from": "shell-quote@^1.4.2",
+              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@~0.0.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "array-filter": {
                   "version": "0.0.1",
-                  "from": "array-filter@~0.0.0",
+                  "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                 },
                 "array-reduce": {
                   "version": "0.0.0",
-                  "from": "array-reduce@~0.0.0",
+                  "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
                 },
                 "array-map": {
                   "version": "0.0.0",
-                  "from": "array-map@~0.0.0",
+                  "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                 }
               }
@@ -4677,33 +4334,33 @@
           }
         },
         "through2": {
-          "version": "0.6.3",
-          "from": "through2@~0.6.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -4712,7 +4369,7 @@
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "xtend@^4.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -33,6 +33,7 @@
     "leaflet": "0.7.3",
     "leaflet-draw": "git://github.com/michaelguild13/Leaflet.draw#e2fe3a4",
     "leaflet.locatecontrol": "0.43.0",
+    "leaflet-plugins": "git://github.com/azavea/leaflet-plugins#feature/browserify",
     "livereloadify": "2.0.0",
     "lodash": "3.6.0",
     "minifyify": "7.0.0",


### PR DESCRIPTION
Because there is a new JS dep, you will first need to run `npm install` and `./scripts/bundle.sh --vendor`. To test, select the Google layer in the layer selector.

I branched off of my feature/layer-selector branch which is still under review. All the commits from that PR are included here, so just look at the ones starting at 'Add Google layer...' Once I merge that PR, I'll be able to rebase off of develop, and get rid of all these extraneous commits. Is there some way I can fix it now?

Connects #539