### PR TITLE
Cache Model Run Results to Scenarios

### DIFF
--- a/src/mmw/apps/modeling/migrations/0009_scenario_results_to_json.py
+++ b/src/mmw/apps/modeling/migrations/0009_scenario_results_to_json.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def clear_results_with_u_prefix(apps, schema_editor):
+    Scenario = apps.get_model('modeling', 'Scenario')
+    for scenario in Scenario.objects.filter(results__contains="[{u'"):
+        scenario.results = "[]"
+        scenario.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0008_delete_district'),
+    ]
+
+    # https://docs.djangoproject.com/en/1.8/topics/migrations/#data-migrations
+    operations = [
+        migrations.RunPython(clear_results_with_u_prefix)
+    ]

--- a/src/mmw/apps/modeling/migrations/0010_scenario_inputmod_hash.py
+++ b/src/mmw/apps/modeling/migrations/0010_scenario_inputmod_hash.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0009_scenario_results_to_json'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='scenario',
+            name='inputmod_hash',
+            field=models.CharField(help_text='A hash of the values for inputs to compare to the existing model results, to determine if the persisted result apply to the current values', max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name='scenario',
+            name='modification_hash',
+            field=models.CharField(help_text='A hash of the values for modifications to compare to the existing model results, to determine if the persisted result apply to the current values', max_length=255, null=True),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -46,13 +46,19 @@ class Scenario(models.Model):
     inputs = models.TextField(
         null=True,
         help_text='Serialized JSON representation of scenario inputs')
+    inputmod_hash = models.CharField(
+        max_length=255,
+        null=True,
+        help_text='A hash of the values for inputs & modifications to ' +
+                  'compare to the existing model results, to determine if ' +
+                  'the persisted result apply to the current values')
     modifications = models.TextField(
         null=True,
         help_text='Serialized JSON representation of scenarios modifications ')
     modification_hash = models.CharField(
         max_length=255,
         null=True,
-        help_text='A hash of the values for modifications & inputs to ' +
+        help_text='A hash of the values for modifications to ' +
                   'compare to the existing model results, to determine if ' +
                   'the persisted result apply to the current values')
     census = models.TextField(

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -28,6 +28,7 @@ class ScenarioSerializer(serializers.ModelSerializer):
     inputs = JsonField()
     modifications = JsonField()
     census = JsonField(required=False, allow_null=True)
+    results = JsonField(required=False, allow_null=True)
 
 
 class ProjectSerializer(gis_serializers.GeoModelSerializer):

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -194,6 +194,7 @@ def run_tr55(census, model_input):
     model_output = simulate_modifications(census, fn=simulate_day)
 
     return {
+        'inputmod_hash': model_input['inputmod_hash'],
         'census': census,
         'runoff': model_output,
         'quality': format_quality(model_output)

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -23,6 +23,7 @@ class TaskRunnerTestCase(TestCase):
                     'value': 1.2
                 }
             ],
+            'inputmod_hash': '9780bd0887ab5008620efd25bd2eec3f',
             'modifications': [{
                 'name': 'conservation_practice',
                 'area': 15.683767964377065,

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -88,6 +88,7 @@ var TaskModel = Backbone.Model.extend({
             onStart: _.noop,
             pollSuccess: _.noop,
             pollFailure: _.noop,
+            pollEnd: _.noop,
             startFailure: _.noop
         });
 
@@ -111,7 +112,8 @@ var TaskModel = Backbone.Model.extend({
                         } else {
                             taskHelper.pollFailure();
                         }
-                    });
+                    })
+                    .always(taskHelper.pollEnd);
             })
             .fail(taskHelper.startFailure);
     },

--- a/src/mmw/js/src/modeling/mocks.js
+++ b/src/mmw/js/src/modeling/mocks.js
@@ -1,0 +1,343 @@
+"use strict";
+
+var scenarios = {
+    sample: {
+        "active": true,
+        "census": {
+            "cell_count": 100,
+            "distribution": {
+                "a:deciduous_forest": {
+                    "cell_count": 30
+                },
+                "c:commercial": {
+                    "cell_count": 70
+                }
+            },
+            "modification_hash": "87c42548da30fe1615eb6e6f5a3b0371",
+            "modifications": [
+                {
+                    "cell_count": 8,
+                    "distribution": {
+                        "c:commercial": {
+                            "cell_count": 8
+                        }
+                    },
+                    "reclassification": "a:chaparral"
+                }
+            ]
+        },
+        "created_at": "2015-07-14T21:45:07.446363Z",
+        "id": 120,
+        "inputs": [
+            {
+                "area": "0",
+                "name": "precipitation",
+                "shape": null,
+                "type": "",
+                "units": "m<sup>2</sup>",
+                "value": 4.6
+            }
+        ],
+        "inputmod_hash": "d000ef136a6c566032ed84c487508ab287c42548da30fe1615eb6e6f5a3b0371",
+        "is_current_conditions": false,
+        "job_id": null,
+        "modification_hash": "87c42548da30fe1615eb6e6f5a3b0371",
+        "modifications": [
+            {
+                "area": 648.1614728140878,
+                "name": "landcover",
+                "shape": {
+                    "geometry": {
+                        "coordinates": [
+                            [
+                                [
+                                    -75.1647502183914,
+                                    39.95236473500341
+                                ],
+                                [
+                                    -75.16454637050629,
+                                    39.95232772476147
+                                ],
+                                [
+                                    -75.16461610794067,
+                                    39.952011080761736
+                                ],
+                                [
+                                    -75.1648199558258,
+                                    39.952031642104906
+                                ],
+                                [
+                                    -75.1647502183914,
+                                    39.95236473500341
+                                ]
+                            ]
+                        ],
+                        "type": "Polygon"
+                    },
+                    "properties": {},
+                    "type": "Feature"
+                },
+                "type": "",
+                "units": "m<sup>2</sup>",
+                "value": "grassland"
+            },
+            {
+                "area": 279.12201442036167,
+                "name": "landcover",
+                "shape": {
+                    "geometry": {
+                        "coordinates": [
+                            [
+                                [
+                                    -75.16457855701447,
+                                    39.953195404053794
+                                ],
+                                [
+                                    -75.1643317937851,
+                                    39.953166618661406
+                                ],
+                                [
+                                    -75.16432106494904,
+                                    39.95328176015835
+                                ],
+                                [
+                                    -75.16454637050629,
+                                    39.953322882074595
+                                ],
+                                [
+                                    -75.16457855701447,
+                                    39.953195404053794
+                                ]
+                            ]
+                        ],
+                        "type": "Polygon"
+                    },
+                    "properties": {},
+                    "type": "Feature"
+                },
+                "type": "",
+                "units": "m<sup>2</sup>",
+                "value": "commercial"
+            }
+        ],
+        "modified_at": "2015-07-14T21:45:38.497360Z",
+        "name": "New Scenario",
+        "project": 63,
+        "results": [
+            {
+                "displayName": "Runoff",
+                "name": "runoff",
+                "polling": false,
+                "inputmod_hash": "d000ef136a6c566032ed84c487508ab287c42548da30fe1615eb6e6f5a3b0371",
+                "result": {
+                    "modified": {
+                        "bod": 168.53055291800564,
+                        "cell_count": 100,
+                        "distribution": {
+                            "a:deciduous_forest": {
+                                "bod": 0,
+                                "cell_count": 30,
+                                "et": 0.14489999999999997,
+                                "inf": 4.4551,
+                                "runoff": 0,
+                                "tn": 0,
+                                "tp": 0,
+                                "tss": 0
+                            },
+                            "c:commercial": {
+                                "bod": 168.53055291800564,
+                                "cell_count": 70,
+                                "distribution": {
+                                    "a:chaparral": {
+                                        "bod": 0.01101971503083698,
+                                        "cell_count": 8,
+                                        "et": 0.207,
+                                        "inf": 4.352681141178938,
+                                        "runoff": 0.04031885882106137,
+                                        "tn": 3.4323702555066e-05,
+                                        "tp": 1.0839063964757685e-06,
+                                        "tss": 0.007045391577092494
+                                    },
+                                    "c:commercial": {
+                                        "bod": 168.5195332029748,
+                                        "cell_count": 62,
+                                        "et": 0.012419999999999999,
+                                        "inf": 0.6738166467659927,
+                                        "runoff": 3.913763353234007,
+                                        "tn": 1.2367159291508636,
+                                        "tp": 0.19570010307442237,
+                                        "tss": 34.36983060244543
+                                    }
+                                },
+                                "et": 0.034657714285714285,
+                                "inf": 1.0942583032703295,
+                                "runoff": 3.4710839824439557,
+                                "tn": 1.2367502528534187,
+                                "tp": 0.19570118698081884,
+                                "tss": 34.37687599402253
+                            }
+                        },
+                        "et": 0.0677304,
+                        "inf": 2.1025108122892306,
+                        "modification_hash": "87c42548da30fe1615eb6e6f5a3b0371",
+                        "runoff": 2.429758787710769,
+                        "tn": 1.2367502528534187,
+                        "tp": 0.19570118698081884,
+                        "tss": 34.37687599402253
+                    },
+                    "unmodified": {
+                        "bod": 190.26398910013282,
+                        "cell_count": 100,
+                        "distribution": {
+                            "a:deciduous_forest": {
+                                "bod": 0,
+                                "cell_count": 30,
+                                "et": 0.14489999999999997,
+                                "inf": 4.4551,
+                                "runoff": 0,
+                                "tn": 0,
+                                "tp": 0,
+                                "tss": 0
+                            },
+                            "c:commercial": {
+                                "bod": 190.26398910013282,
+                                "cell_count": 70,
+                                "et": 0.012419999999999999,
+                                "inf": 0.6738166467659927,
+                                "runoff": 3.9137633532340064,
+                                "tn": 1.3962921780735555,
+                                "tp": 0.2209517292775736,
+                                "tss": 38.804647454373864
+                            }
+                        },
+                        "et": 0.052163999999999995,
+                        "inf": 1.8082016527361946,
+                        "modification_hash": "87c42548da30fe1615eb6e6f5a3b0371",
+                        "runoff": 2.7396343472638045,
+                        "tn": 1.3962921780735555,
+                        "tp": 0.2209517292775736,
+                        "tss": 38.804647454373864
+                    }
+                }
+            },
+            {
+                "displayName": "Water Quality",
+                "name": "quality",
+                "polling": false,
+                "inputmod_hash": "d000ef136a6c566032ed84c487508ab287c42548da30fe1615eb6e6f5a3b0371",
+                "result": [
+                    {
+                        "load": 168.53055291800564,
+                        "measure": "Biochemical Oxygen Demand"
+                    },
+                    {
+                        "load": 34.37687599402253,
+                        "measure": "Total Suspended Solids"
+                    },
+                    {
+                        "load": 1.2367502528534187,
+                        "measure": "Total Nitrogen"
+                    },
+                    {
+                        "load": 0.19570118698081884,
+                        "measure": "Total Phosphorus"
+                    }
+                ]
+            }
+        ],
+        "taskModel": {
+            "error": "",
+            "finished": "2015-07-14T21:46:02.069Z",
+            "job": "8aef636e-2079-4f87-98dc-471d090141ad",
+            "job_uuid": "8aef636e-2079-4f87-98dc-471d090141ad",
+            "pollInterval": 500,
+            "result": "{\"runoff\": {\"unmodified\": {\"modification_hash\": \"87c42548da30fe1615eb6e6f5a3b0371\", \"cell_count\": 100, \"distribution\": {\"c:commercial\": {\"cell_count\": 70, \"tp\": 0.2209517292775736, \"tn\": 1.3962921780735555, \"runoff\": 3.9137633532340064, \"et\": 0.012419999999999999, \"inf\": 0.6738166467659927, \"bod\": 190.26398910013282, \"tss\": 38.804647454373864}, \"a:deciduous_forest\": {\"cell_count\": 30, \"tp\": 0.0, \"tn\": 0.0, \"runoff\": 0.0, \"et\": 0.14489999999999997, \"inf\": 4.4551, \"bod\": 0.0, \"tss\": 0.0}}, \"tp\": 0.2209517292775736, \"tn\": 1.3962921780735555, \"runoff\": 2.7396343472638045, \"et\": 0.052163999999999995, \"inf\": 1.8082016527361946, \"bod\": 190.26398910013282, \"tss\": 38.804647454373864}, \"modified\": {\"modification_hash\": \"87c42548da30fe1615eb6e6f5a3b0371\", \"cell_count\": 100, \"distribution\": {\"c:commercial\": {\"cell_count\": 70, \"distribution\": {\"a:chaparral\": {\"cell_count\": 8, \"tp\": 1.0839063964757685e-06, \"tn\": 3.4323702555066e-05, \"runoff\": 0.04031885882106137, \"et\": 0.207, \"inf\": 4.352681141178938, \"bod\": 0.01101971503083698, \"tss\": 0.007045391577092494}, \"c:commercial\": {\"cell_count\": 62, \"tp\": 0.19570010307442237, \"tn\": 1.2367159291508636, \"runoff\": 3.913763353234007, \"et\": 0.012419999999999999, \"inf\": 0.6738166467659927, \"bod\": 168.5195332029748, \"tss\": 34.36983060244543}}, \"tp\": 0.19570118698081884, \"tn\": 1.2367502528534187, \"runoff\": 3.4710839824439557, \"et\": 0.034657714285714285, \"inf\": 1.0942583032703295, \"bod\": 168.53055291800564, \"tss\": 34.37687599402253}, \"a:deciduous_forest\": {\"cell_count\": 30, \"tp\": 0.0, \"tn\": 0.0, \"runoff\": 0.0, \"et\": 0.14489999999999997, \"inf\": 4.4551, \"bod\": 0.0, \"tss\": 0.0}}, \"tp\": 0.19570118698081884, \"tn\": 1.2367502528534187, \"runoff\": 2.429758787710769, \"et\": 0.0677304, \"inf\": 2.1025108122892306, \"bod\": 168.53055291800564, \"tss\": 34.37687599402253}}, \"census\": {\"cell_count\": 100, \"distribution\": {\"c:commercial\": {\"cell_count\": 70}, \"a:deciduous_forest\": {\"cell_count\": 30}}, \"modification_hash\": \"87c42548da30fe1615eb6e6f5a3b0371\", \"modifications\": [{\"cell_count\": 8, \"distribution\": {\"c:commercial\": {\"cell_count\": 8}}, \"reclassification\": \"a:chaparral\"}]}, \"quality\": [{\"load\": 168.53055291800564, \"measure\": \"Biochemical Oxygen Demand\"}, {\"load\": 34.37687599402253, \"measure\": \"Total Suspended Solids\"}, {\"load\": 1.2367502528534187, \"measure\": \"Total Nitrogen\"}, {\"load\": 0.19570118698081884, \"measure\": \"Total Phosphorus\"}]}",
+            "started": "2015-07-14T21:46:01.997Z",
+            "status": "complete",
+            "taskName": "tr55",
+            "taskType": "modeling",
+            "timeout": 5000
+        },
+        "user_id": 1
+    }
+};
+
+var polygons = {
+    greaterThanOneAcre: {
+        "features": [
+            {
+                "geometry": {
+                    "coordinates": [
+                        [
+                            [
+                                -75.17273247241974,
+                                39.950349703806005
+                            ],
+                            [
+                                -75.1707261800766,
+                                39.95009473644421
+                            ],
+                            [
+                                -75.17104804515839,
+                                39.94857313726802
+                            ],
+                            [
+                                -75.17302215099335,
+                                39.94882399784062
+                            ],
+                            [
+                                -75.17273247241974,
+                                39.950349703806005
+                            ]
+                        ]
+                    ],
+                    "type": "Polygon"
+                },
+                "properties": {},
+                "type": "Feature"
+            }
+        ],
+        "type": "FeatureCollection"
+    }
+};
+
+var modifications = {
+    sample1: {
+        "name":"Land Cover",
+        "value":"lir",
+        "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-76.00479125976562,40.19251207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]]}},
+        "area":10977.041602204828,
+        "units":"acres"
+    },
+
+    sample1OutOfOrder: {
+        "area":10977.041602204828,
+        "name":"Land Cover",
+        "units":"acres",
+        "shape":{"type":"Feature","geometry":{"coordinates":[[[-76.00479125976562,40.19251207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]], "type":"Polygon"},"properties":{}},
+        "value":"lir"
+    },
+
+    sample2: {
+        "name":"Conservation Practice",
+        "value":"rain_garden",
+        "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-75.53237915039062,40.18307014852534],[-75.66009521484375,40.107487419012415],[-75.50491333007812,40.10118506258701],[-75.43350219726561,40.13899044275822],[-75.42800903320312,40.1673306817866],[-75.53237915039062,40.18307014852534]]]}},
+        "area":26292.18855342856,
+        "units":"acres"
+    },
+
+    // Identical to sample1 except has a slightly smaller area
+    sample3: {
+        "name":"Land Cover",
+        "value":"lir",
+        "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-76.00479125976562,40.19252207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]]}},
+        "area":10777.041602204828,
+        "units":"acres"
+    }
+};
+
+module.exports = {
+    scenarios: scenarios,
+    polygons: polygons,
+    modifications: modifications
+};

--- a/src/mmw/js/src/modeling/mocks.js
+++ b/src/mmw/js/src/modeling/mocks.js
@@ -1,5 +1,11 @@
 "use strict";
 
+var polling = {
+    getTR55Started: '{"status":"started", "job":"8aef636e-2079-4f87-98dc-471d090141ad"}',
+    getJobSuccess: '{"started": "2015-07-14T21:46:01.997Z","finished": "2015-07-14T21:46:02.069Z", "job_uuid": "8aef636e-2079-4f87-98dc-471d090141ad", "status": "complete", "result": "{\\"runoff\\": {\\"unmodified\\": {\\"modification_hash\\": \\"87c42548da30fe1615eb6e6f5a3b0371\\", \\"cell_count\\": 100, \\"distribution\\": {\\"c:commercial\\": {\\"cell_count\\": 70, \\"tp\\": 0.2209517292775736, \\"tn\\": 1.3962921780735555, \\"runoff\\": 3.9137633532340064, \\"et\\": 0.012419999999999999, \\"inf\\": 0.6738166467659927, \\"bod\\": 190.26398910013282, \\"tss\\": 38.804647454373864}, \\"a:deciduous_forest\\": {\\"cell_count\\": 30, \\"tp\\": 0.0, \\"tn\\": 0.0, \\"runoff\\": 0.0, \\"et\\": 0.14489999999999997, \\"inf\\": 4.4551, \\"bod\\": 0.0, \\"tss\\": 0.0}}, \\"tp\\": 0.2209517292775736, \\"tn\\": 1.3962921780735555, \\"runoff\\": 2.7396343472638045, \\"et\\": 0.052163999999999995, \\"inf\\": 1.8082016527361946, \\"bod\\": 190.26398910013282, \\"tss\\": 38.804647454373864}, \\"modified\\": {\\"modification_hash\\": \\"87c42548da30fe1615eb6e6f5a3b0371\\", \\"cell_count\\": 100, \\"distribution\\": {\\"c:commercial\\": {\\"cell_count\\": 70, \\"distribution\\": {\\"a:chaparral\\": {\\"cell_count\\": 8, \\"tp\\": 1.0839063964757685e-06, \\"tn\\": 3.4323702555066e-05, \\"runoff\\": 0.04031885882106137, \\"et\\": 0.207, \\"inf\\": 4.352681141178938, \\"bod\\": 0.01101971503083698, \\"tss\\": 0.007045391577092494}, \\"c:commercial\\": {\\"cell_count\\": 62, \\"tp\\": 0.19570010307442237, \\"tn\\": 1.2367159291508636, \\"runoff\\": 3.913763353234007, \\"et\\": 0.012419999999999999, \\"inf\\": 0.6738166467659927, \\"bod\\": 168.5195332029748, \\"tss\\": 34.36983060244543}}, \\"tp\\": 0.19570118698081884, \\"tn\\": 1.2367502528534187, \\"runoff\\": 3.4710839824439557, \\"et\\": 0.034657714285714285, \\"inf\\": 1.0942583032703295, \\"bod\\": 168.53055291800564, \\"tss\\": 34.37687599402253}, \\"a:deciduous_forest\\": {\\"cell_count\\": 30, \\"tp\\": 0.0, \\"tn\\": 0.0, \\"runoff\\": 0.0, \\"et\\": 0.14489999999999997, \\"inf\\": 4.4551, \\"bod\\": 0.0, \\"tss\\": 0.0}}, \\"tp\\": 0.19570118698081884, \\"tn\\": 1.2367502528534187, \\"runoff\\": 2.429758787710769, \\"et\\": 0.0677304, \\"inf\\": 2.1025108122892306, \\"bod\\": 168.53055291800564, \\"tss\\": 34.37687599402253}}, \\"census\\": {\\"cell_count\\": 100, \\"distribution\\": {\\"c:commercial\\": {\\"cell_count\\": 70}, \\"a:deciduous_forest\\": {\\"cell_count\\": 30}}, \\"modification_hash\\": \\"87c42548da30fe1615eb6e6f5a3b0371\\", \\"modifications\\": [{\\"cell_count\\": 8, \\"distribution\\": {\\"c:commercial\\": {\\"cell_count\\": 8}}, \\"reclassification\\": \\"a:chaparral\\"}]}, \\"quality\\": [{\\"load\\": 168.53055291800564, \\"measure\\": \\"Biochemical Oxygen Demand\\"}, {\\"load\\": 34.37687599402253, \\"measure\\": \\"Total Suspended Solids\\"}, {\\"load\\": 1.2367502528534187, \\"measure\\": \\"Total Nitrogen\\"}, {\\"load\\": 0.19570118698081884, \\"measure\\": \\"Total Phosphorus\\"}]}", "error": ""}',
+    getJobFailure: '{"started": "2015-07-14T21:46:01.997Z","finished": "2015-07-14T21:46:02.069Z", "job_uuid": "8aef636e-2079-4f87-98dc-471d090141ad", "status": "failed", "result": "", "error": "Some error occurred"}'
+};
+
 var scenarios = {
     sample: {
         "active": true,
@@ -337,6 +343,7 @@ var modifications = {
 };
 
 module.exports = {
+    polling: polling,
     scenarios: scenarios,
     polygons: polygons,
     modifications: modifications

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -40,6 +40,7 @@ var ResultModel = Backbone.Model.extend({
     defaults: {
         name: '',
         displayName: '',
+        inputmod_hash: null,
         result: null,
         polling: false
     }
@@ -250,6 +251,7 @@ var ScenarioModel = Backbone.Model.extend({
         is_current_conditions: false,
         user_id: 0, // User that created the project
         inputs: null, // ModificationsCollection
+        inputmod_hash: null, // MD5 string
         modifications: null, // ModificationsCollection
         modification_hash: null, // MD5 string
         active: false,
@@ -360,7 +362,10 @@ var ScenarioModel = Backbone.Model.extend({
                     results.forEach(function(resultModel) {
                         var resultName = resultModel.get('name');
                         if (serverResults[resultName]) {
-                            resultModel.set('result', serverResults[resultName]);
+                            resultModel.set({
+                                'result': serverResults[resultName],
+                                'inputmod_hash': serverResults.inputmod_hash
+                            });
                         } else {
                             console.log('Response is missing ' + resultName + '.');
                         }
@@ -378,6 +383,7 @@ var ScenarioModel = Backbone.Model.extend({
                         modifications: self.get('modifications').toJSON(),
                         area_of_interest: App.currProject.get('area_of_interest'),
                         census: self.get('census'),
+                        inputmod_hash: self.get('inputmod_hash'),
                         modification_hash: self.get('modification_hash')
                     })
                 },

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -7,6 +7,8 @@ var _ = require('lodash'),
     Backbone = require('backbone'),
     assert = require('chai').assert,
     sinon = require('sinon'),
+    mocks = require('./mocks'),
+    utils = require('../core/utils'),
     models = require('./models'),
     views = require('./views'),
     App = require('../app.js'),
@@ -146,8 +148,8 @@ describe('Modeling', function() {
                     model: this.model,
                     collection: models.getControlsForModelPackage('tr-55')
                 });
-                this.modsModel1 = new models.ModificationModel(modificationsSample1);
-                this.modsModel2 = new models.ModificationModel(modificationsSample2);
+                this.modsModel1 = new models.ModificationModel(mocks.modifications.sample1);
+                this.modsModel2 = new models.ModificationModel(mocks.modifications.sample2);
                 $('#sandbox').html(this.view.render().el);
             });
 
@@ -364,7 +366,7 @@ describe('Modeling', function() {
             });
         });
 
-        describe('ModificatioModel', function() {
+        describe('ModificationModel', function() {
             it('inherits defaults from coreModels.GeoModel', function() {
                 var model = new models.ModificationModel({});
 
@@ -373,24 +375,72 @@ describe('Modeling', function() {
             });
         });
 
+        describe('ModificationCollection', function() {
+            it('sorts modifications correctly', function() {
+                var collection = new models.ModificationsCollection();
+
+                collection.add(mocks.modifications.sample1);
+                collection.add(mocks.modifications.sample2);
+                collection.add(mocks.modifications.sample3);
+
+                var collectionOrder = collection.pluck('area'),
+                    knownOrder = [
+                        (new models.ModificationModel(mocks.modifications.sample2)).get('area'),
+                        (new models.ModificationModel(mocks.modifications.sample1)).get('area'),
+                        (new models.ModificationModel(mocks.modifications.sample3)).get('area')
+                    ];
+
+                assert.deepEqual(collectionOrder, knownOrder,
+                    'Collection was not sorted correctly'
+                );
+            });
+        });
+
         describe('ScenarioModel', function() {
             // TODO: Add tests for existing methods.
 
+            describe('#getCollectionHash', function() {
+                it('generates the same hash when given two collections in different order', function() {
+                    var modificationsOne = new models.ModificationsCollection(),
+                        modificationsTwo = new models.ModificationsCollection();
+
+                    modificationsOne.add(new models.ModificationModel(mocks.modifications.sample1));
+                    modificationsOne.add(new models.ModificationModel(mocks.modifications.sample2));
+
+                    modificationsTwo.add(new models.ModificationModel(mocks.modifications.sample2));
+                    modificationsTwo.add(new models.ModificationModel(mocks.modifications.sample1OutOfOrder));
+
+                    var hashOne = utils.getCollectionHash(modificationsOne),
+                        hashTwo = utils.getCollectionHash(modificationsTwo);
+
+                    assert.equal(hashOne, hashTwo);
+                });
+            });
+
             describe('#updateModificationHash', function() {
+                it('initializes modification and inputmod hashes', function() {
+                    var model = getTestScenarioModel(),
+                        modification_hash = utils.getCollectionHash(model.get('modifications')),
+                        inputmod_hash = utils.getCollectionHash(model.get('inputs')) + modification_hash;
+
+                    assert.equal(model.get('modification_hash'), modification_hash);
+                    assert.equal(model.get('inputmod_hash'), inputmod_hash);
+                });
+
                 it('generates and sets modification_hash based on the scenario\'s modifications', function() {
                     var model = new models.ScenarioModel({
-                            modifications: [modificationsSample1]
+                            modifications: [mocks.modifications.sample1]
                         });
 
                     model.updateModificationHash();
-                    assert.equal(model.get('modification_hash'), 'b0eb4af3250d9c1320d659805afaf049');
+                    assert.equal(model.get('modification_hash'), '40c4fdd89b06a0e9b7e1c3c5c2bd1f17');
 
-                    var mod = new models.ModificationModel(modificationsSample2);
+                    var mod = new models.ModificationModel(mocks.modifications.sample2);
                     model.get('modifications').add(mod);
-                    assert.equal(model.get('modification_hash'), '07fb74f0e09eb1c31f3db8c78219758f');
+                    assert.equal(model.get('modification_hash'), 'dcda6a697d33a3bc95c95cc401e774bb');
 
                     model.get('modifications').remove(mod);
-                    assert.equal(model.get('modification_hash'), 'b0eb4af3250d9c1320d659805afaf049');
+                    assert.equal(model.get('modification_hash'), '40c4fdd89b06a0e9b7e1c3c5c2bd1f17');
                 });
 
                 it('is called when the modifications for a scenario changes', function() {
@@ -569,23 +619,9 @@ describe('Modeling', function() {
 
 // var lessThanOneAcrePolygon = { "type": "Feature", "properties": {}, "geometry": { "type": "Polygon", "coordinates": [ [ [ -75.17049014568327, 39.95056149048882 ], [ -75.17032116651535, 39.950538872524845 ], [ -75.17038553953171, 39.9502037145458 ], [ -75.17057061195372, 39.95022633262059 ], [ -75.17049014568327, 39.95056149048882 ] ] ] } };
 
-var greaterThanOneAcrePolygon = { "type": "FeatureCollection", "features": [ { "type": "Feature", "properties": {}, "geometry": { "type": "Polygon", "coordinates": [ [ [ -75.17273247241974, 39.950349703806005 ], [ -75.1707261800766, 39.95009473644421 ], [ -75.17104804515839, 39.94857313726802 ], [ -75.17302215099335, 39.94882399784062 ], [ -75.17273247241974, 39.950349703806005 ] ] ] } } ] };
-
-var modificationsSample1 = {
-    "name":"Land Cover",
-    "value":"lir",
-    "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-76.00479125976562,40.19251207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]]}},
-    "area":10977.041602204828,
-    "units":"acres"
-};
-
-var modificationsSample2  = {
-    "name":"Conservation Practice",
-    "value":"rain_garden",
-    "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-75.53237915039062,40.18307014852534],[-75.66009521484375,40.107487419012415],[-75.50491333007812,40.10118506258701],[-75.43350219726561,40.13899044275822],[-75.42800903320312,40.1673306817866],[-75.53237915039062,40.18307014852534]]]}},
-    "area":26292.18855342856,
-    "units":"acres"
-};
+function getTestScenarioModel() {
+    return new models.ScenarioModel(mocks.scenarios.sample);
+}
 
 function getTestScenarioCollection() {
     var collection = new models.ScenariosCollection([
@@ -598,7 +634,7 @@ function getTestScenarioCollection() {
                 modifications: [
                     {
                         name: 'Mod 1',
-                        shape: _.cloneDeep(greaterThanOneAcrePolygon)
+                        shape: _.cloneDeep(mocks.polygons.greaterThanOneAcre)
                     }
                 ],
                 active: true

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -611,7 +611,7 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
                 .find('i')
                     .removeClass('fa-angle-up')
                     .addClass('fa-angle-down');
-            self.detailsRegion.currentView.triggerBarChartRefresh();
+            triggerBarChartRefresh();
         });
     },
 
@@ -665,10 +665,6 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
             collection: this.collection,
             scenario: this.scenario
         }));
-    },
-
-    triggerBarChartRefresh: function() {
-        this.panelsRegion.currentView.triggerBarChartRefresh();
     }
 });
 
@@ -703,9 +699,7 @@ var ResultsTabPanelsView = Marionette.CollectionView.extend({
         this.$el.find('li:first').addClass('active');
     },
 
-    triggerBarChartRefresh: function() {
-        $('#model-output-wrapper .bar-chart').trigger('bar-chart:refresh');
-    }
+    triggerBarChartRefresh: triggerBarChartRefresh
 });
 
 // Creates the appropriate view to visualize a result based
@@ -775,11 +769,16 @@ var ResultsTabContentsView = Marionette.CollectionView.extend({
     },
     onRender: function() {
         this.$el.find('.tab-pane:first').addClass('active');
+        triggerBarChartRefresh();
     }
 });
 
 function isEditable(scenario) {
     return App.user.userMatch(scenario.get('user_id'));
+}
+
+function triggerBarChartRefresh() {
+    $('#model-output-wrapper .bar-chart').trigger('bar-chart:refresh');
 }
 
 module.exports = {


### PR DESCRIPTION
## Overview

Enables reading saved results from scenario when requesting existing project or scenario from server, thus reducing requirement for repeated model runs.

Previously, loading a saved project incurred extraneous model run requests, one per scenario:

![image](https://cloud.githubusercontent.com/assets/1430060/8629701/ae95236e-272b-11e5-8f6a-71fb847647d1.png)

Now we do not re-run the model if there are no changes:

![image](https://cloud.githubusercontent.com/assets/1430060/8629709/c06ffb54-272b-11e5-83fe-0f32b40ed090.png)

However, if for whatever reason a scenario does not have a saved result, then the model is run on project load, and the results subsequently saved:

![image](https://cloud.githubusercontent.com/assets/1430060/8629733/05008d1a-272c-11e5-8928-a73d1c8db98d.png)

The scenario is **always** saved after a model run, even if a model run failed. In this case, the results would be set to `[]`, but other changes, such as inputs and modifications, will be saved to the database. This allows the user to re-open the project at a later date, at which time the model will be re-run with the saved inputs and modifications from last time.

~~Also, by saving only after a model run, we minimize duplicate save requests for the same scenario, instead grouping all changes into one `PUT`.~~

Since model runs can potentially take a long time, we also save the scenario inputs and modifications before starting the model run. This takes care of the edge case when a user closes the browser window before the model run completes, and loses their work. Whenever there are changes to `inputs` or `modifications`, we update the corresponding `inputmod_hash` and `modification_hash` fields. When starting model runs, we pass in these hashes, and they are included in the model output, which is then saved to the `modeling_scenario.results` field. When loading an existing project, we check to see if the `results` field is empty, and if it isn't, if the `inputmod_hash` matches that on the scenario, indicating a _stale_ result. If the `results` are empty or stale, we run the model, else we do nothing since everything is up to date.

## Data Changes

We had so far not marked `modeling_scenario.results` as a `JsonField`. Thus the existing data was incompatible, since it had the DRF `u` prefixed strings that was fixed for the modifications field in #320. Thus, we have a [data migration](https://docs.djangoproject.com/en/1.8/topics/migrations/#data-migrations) that sets the `results` field to `[]` for each row that had the `u` prefix. Thus, when such a scenario is loaded the next time, its results will be recalculated and saved in the correct format for the future.

We also add the `modeling_scenario.inputmod_hash` field in a second migration.

## Testing Instructions

 1. Run bundle and migrations `./scripts/bundle.sh && ./scripts/manage.sh migrate`
 2. Log in as a user and create a new project.
 3. Reload this existing project. Ensure that model calculations are not run for freshly loaded / unchanged project.
 4. Make arbitrary changes to the scenario: add modifications, change the slider, jump around between tabs. Ensure that after you stop and refresh the page, the previous state is recreated faithfully.
 5. Load an old project (if you have any on your system) which would have had its `results` emptied as part of the migration. Ensure that model calculations are run and saved. Reload the same project and ensure that model calculations are not re-run.
 6. Log out, and create a new project. Ensure that while model calculations are run, the scenario is not saved. Make arbitrary changes and then log in to save the project. Reload the project and ensure that model calculations were not run.
 7. Log out, and open a public project. Make changes, adjust the slider, ensure that the scenario is not saved after model calculations are run by reloading the page and finding it restored to its original state.
 8. Ensure that the model output graphs are rendered correctly when loading existing projects, and after model calculations are run.

Connects #548 