### PR TITLE
Simplify Celery chain assembly and testing

### DIFF
--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -114,12 +114,11 @@ class TaskRunnerTestCase(TestCase):
             }]
         }
 
-        task_list = views._initiate_tr55_job_chain(self.model_input,
-                                                   self.job.id)
+        job_chain = views._construct_tr55_job_chain(self.model_input,
+                                                    self.job.id)
 
-        task_count = len(list(task_list._parents()))
-        self.assertEqual(task_count, 1,
-                         'Task list contains the wrong number of tasks')
+        self.assertFalse('tasks.prepare_census' in str(job_chain),
+                         'Census preparation should be skipped')
 
     @override_settings(CELERY_ALWAYS_EAGER=True)
     def test_tr55_chain_generates_census_if_census_is_stale(self):
@@ -144,21 +143,19 @@ class TaskRunnerTestCase(TestCase):
             }]
         }
 
-        task_list = views._initiate_tr55_job_chain(self.model_input,
-                                                   self.job.id)
+        job_chain = views._construct_tr55_job_chain(self.model_input,
+                                                    self.job.id)
 
-        task_count = len(list(task_list._parents()))
-        self.assertEqual(task_count, 2,
-                         'Task list contains the wrong number of tasks')
+        self.assertTrue('tasks.prepare_census' in str(job_chain),
+                        'Census preparation should not be skipped')
 
     @override_settings(CELERY_ALWAYS_EAGER=True)
     def test_tr55_chain_generates_census_if_census_does_not_exist(self):
-        task_list = views._initiate_tr55_job_chain(self.model_input,
-                                                   self.job.id)
+        job_chain = views._construct_tr55_job_chain(self.model_input,
+                                                    self.job.id)
 
-        task_count = len(list(task_list._parents()))
-        self.assertEqual(task_count, 2,
-                         'Task list contains the wrong number of tasks')
+        self.assertTrue('tasks.prepare_census' in str(job_chain),
+                        'Census preparation should not be skipped')
 
 
 class APIAccessTestCase(TestCase):


### PR DESCRIPTION
## Overview

By separating out the construction for the TR55 job chain, we make it more readable and more testable. The tests are now more robust because we are checking for presence of specific methods, rather than just the number of tasks, which may change in the future if other tasks are added.

## Testing Instructions

Run all Python tests. Ensure that TR55 models can still be run from the UI.

Connects #512 by slightly improving #553 