### PR TITLE
Redirect STDERR for Celery service restart

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,7 +115,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.raw_arguments = ["--timeout=60"]
     end
 
-    worker.vm.provision "shell", inline: "service celeryd restart > /dev/null", run: "always"
+    worker.vm.provision "shell", inline: "service celeryd restart >> /dev/null 2>&1", run: "always"
   end
 
   config.vm.define "app" do |app|


### PR DESCRIPTION
On `worker` provisioning attempts that trigger a restart of the Celery service, the shell provisioner step that follows triggers an error message indicating that the Celery service PID file already exists. This change suppresses that error message since it doesn't appear to impact the service's availability.