### PR TITLE
Add stream slider

### DIFF
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import json
+from urlparse import urljoin
 
 from django.http import Http404
 from django.shortcuts import render_to_response, get_object_or_404
@@ -13,10 +14,27 @@ from django.conf import settings
 from apps.modeling.models import Project
 
 
+def get_stream_layers():
+    tiler_prefix = '//'
+    tiler_host = settings.TILER_HOST
+    tiler_postfix = '/{z}/{x}/{y}'
+    tiler_base = '%s%s' % (tiler_prefix, tiler_host)
+
+    stream_layers = []
+    for layer in settings.STREAM_LAYERS:
+        stream_layers.append({
+            'display': layer['display'],
+            'endpoint': urljoin(tiler_base, layer['code'] + tiler_postfix)
+        })
+
+    return stream_layers
+
+
 def get_client_settings():
     client_settings = {
         'client_settings': json.dumps({
-            'base_layers': settings.BASE_LAYERS
+            'base_layers': settings.BASE_LAYERS,
+            'stream_layers': get_stream_layers()
         })
     }
     return client_settings

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var defaultSettings = {
-    base_layers: {}
+    base_layers: {},
+    stream_layers: {}
 };
 
 function setSettings(key, value) {

--- a/src/mmw/js/src/draw/templates/streamSlider.html
+++ b/src/mmw/js/src/draw/templates/streamSlider.html
@@ -1,0 +1,7 @@
+<div class="btn-md btn-primary btn-stream-slider">
+    <label>
+        Streams
+        <input id="stream-slider" type="range" min="0" max="3" step="1" value="0">
+        <span id="stream-value"></span>
+    </label>
+</div>

--- a/src/mmw/js/src/draw/templates/toolbar.html
+++ b/src/mmw/js/src/draw/templates/toolbar.html
@@ -2,3 +2,4 @@
 <div id="draw-area-region"></div>
 <div id="place-marker-region"></div>
 <div id="reset-draw-region"></div>
+<div id="stream-slider-region"></div>

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -268,6 +268,25 @@ BOUNDARY_LAYERS = {
     '0': {'display': 'Congressional Districts',
           'table_name': 'modeling_district'}
 }
+
+STREAM_LAYERS = [
+    {
+        'code': 'stream-low',
+        'display': 'Low-Res',
+        'table_name': 'deldem4net100r',
+    },
+    {
+        'code': 'stream-medium',
+        'display': 'Medium-Res',
+        'table_name': 'deldem4net50r',
+    },
+    {
+        'code': 'stream-high',
+        'display': 'High-Res',
+        'table_name': 'deldem4net20r',
+    },
+]
+
 # END TILER CONFIGURATION
 
 # APP CONFIGURATION

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -60,16 +60,23 @@ a{
 }
 
 #geocode-search-region {
-    display: inline-block;
+  display: inline-block;
 
-    #search-results-container {
-        position: absolute;
-    }
+  #search-results-container {
+    position: absolute;
+  }
 }
 
 #draw-tools-region,
 .draw-tools-container div{
+  display: inline-block;
+
+  // Undo bootstrap input[type="range"] syling
+  #stream-slider {
     display: inline-block;
+    width: auto;
+    vertical-align: bottom;
+  }
 }
 
 //Title Row
@@ -99,4 +106,3 @@ a{
         }
     }
 }
-

--- a/src/mmw/sass/components/_buttons.scss
+++ b/src/mmw/sass/components/_buttons.scss
@@ -178,6 +178,12 @@
   }
 }
 
+.btn-stream-slider{
+  width: 300px;
+  border-radius: 2px;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.74);
+}
+
 //Dropdown Button Classes
 .open > .btn-primary.dropdown-toggle{
   background-color: darken($ui-light, 5%);

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -16,9 +16,15 @@ var dbUser = process.env.MMW_DB_USER,
 // keys (e.g. 0 for 'modeling_district') should be given
 // sequentially).
 var interactivity = {'modeling_district': 'state_short,id'},
-    tables = {0: 'modeling_district'};
+    tables = {
+        0: 'modeling_district',
+        'stream-low': 'deldem4net100r',
+        'stream-medium': 'deldem4net50r',
+        'stream-high': 'deldem4net20r'
+    };
 
 var config = {
+    useProfiler: true,
     base_url: '/:tableId',
     base_url_notable: '/:tableId',
     grainstore: {

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -4,3 +4,21 @@
   line-color: #000;
   line-opacity: 0.618;
 }
+
+@zoomBase: 0.3;
+
+#deldem4net20r,
+#deldem4net50r,
+#deldem4net100r,
+{
+  line-color: #78CAE6;
+  [zoom<=10] { line-width: 1.0 * @zoomBase; }
+  [zoom=11] { line-width: 2.0 * @zoomBase; }
+  [zoom=12] { line-width: 4.0 * @zoomBase; }
+  [zoom=13] { line-width: 6.0 * @zoomBase; }
+  [zoom=14] { line-width: 8.0 * @zoomBase; }
+  [zoom=15] { line-width: 10.0 * @zoomBase; }
+  [zoom=16] { line-width: 12.0 * @zoomBase; }
+  [zoom=17] { line-width: 14.0 * @zoomBase; }
+  [zoom=18] { line-width: 16.0 * @zoomBase; }
+}


### PR DESCRIPTION
### Loading data
 * Get the three zip files from `smb://fileshare/users/lfishgold/mmw_stream_data` These are different than the ones in the original email because I transformed the data to use a different SRS.
 * Unzip and then transform the `.shp` file in each directory to a `.sql` file using `shp2pgsql -g geom DelDem4net20r.shp > DelDem4net20r.sql`, for example.
 * Log into the database using `psql -h localhost -p 5432 -U mmw` on your host machine. 
 * Load the data for each `.sql` file using `\i DelDem4net20r.sql`, for example.
 * Each file takes a long time load, maybe 30 minutes.
 * Reload the tiler VM.
 
### Testing
Initially, the slider should be set to 'Off.' After setting the slider to low, medium, and high resolution stream tiles, you should see lots of blue lines indicating possible streams. The tiler runs very slowly on my machine, and after a while, seems to require a reboot. I increased the number of CPUs to 2 on the services VM, but it didn't seem to help much.

![screen shot 2015-07-14 at 10 34 43 am 2](https://cloud.githubusercontent.com/assets/1896461/8675829/fb565a0c-2a13-11e5-8e0b-b85a6798636d.png)

It would be nice if the line width was a function of the zoom level, but I didn't see any obvious way of doing so.

Connects #3