### PR TITLE
Prevent double saving scenarios.

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -298,6 +298,12 @@ var ScenarioModel = Backbone.Model.extend({
             App.currProject.saveProjectAndScenarios();
             return;
         }
+        if (this.isNew() && this.saveCalled) {
+            return;
+        } else if (this.isNew() && !this.saveCalled) {
+            // Makeshift locking mechanism to prevent double saves.
+            this.saveCalled = true;
+        }
         this.save().fail(function() {
             console.log('Failed to save scenario');
         });


### PR DESCRIPTION
We were seeing errors due to events firing very quickly which caused our
scenario to try to save itself twice in rapid succession. This resulted in an
API error. We'd seen similar behavior before with projects. This adds a simple
flag and locking mechanism to prevent the double save.