### PR TITLE
Auto Login to ITSI when coming from an activity

### DIFF
--- a/src/mmw/apps/user/middleware.py
+++ b/src/mmw/apps/user/middleware.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.shortcuts import redirect
+
+from apps.user.views import itsi_login
+
+EMBED_FLAG = settings.ITSI['embed_flag']
+LOGIN_URL = reverse(itsi_login)
+
+
+class ItsiAuthenticationMiddleware(object):
+    """
+    Middleware for automatically logging in ITSI users
+    and setting relevant flags.
+    """
+
+    def process_request(self, request):
+        """
+        Check if ITSI EMBED FLAG is set, and if so attempt to log
+        the user in with their ITSI credentials
+        """
+
+        # If flag is not set then return None so Django can proceed
+        # with the request as-is
+        if request.GET.get(EMBED_FLAG, 'false') != 'true':
+            return None
+
+        # Flag is set. Assume user is not logged in. Set session flag and
+        # Redirect them to ITSI LOGIN URL
+        request.session[EMBED_FLAG] = True
+        return redirect(LOGIN_URL)

--- a/src/mmw/apps/user/middleware.py
+++ b/src/mmw/apps/user/middleware.py
@@ -19,7 +19,8 @@ class ItsiAuthenticationMiddleware(object):
     def process_request(self, request):
         """
         Check if ITSI EMBED FLAG is set, and if so attempt to log
-        the user in with their ITSI credentials
+        the user in with their ITSI credentials and redirect them
+        to current page.
         """
 
         # If flag is not set then return None so Django can proceed
@@ -28,6 +29,6 @@ class ItsiAuthenticationMiddleware(object):
             return None
 
         # Flag is set. Assume user is not logged in. Set session flag and
-        # Redirect them to ITSI LOGIN URL
+        # Redirect them to ITSI LOGIN URL, with the current URL to return to
         request.session[EMBED_FLAG] = True
-        return redirect(LOGIN_URL)
+        return redirect('{0}?next={1}'.format(LOGIN_URL, request.path))

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -84,7 +84,10 @@ itsi = ItsiService()
 
 
 def itsi_login(request):
-    redirect_uri = request.build_absolute_uri(reverse('itsi_auth'))
+    redirect_uri = '{0}?next={1}'.format(
+        request.build_absolute_uri(reverse(itsi_auth)),
+        request.GET.get('next', '/')
+    )
     params = {'redirect_uri': redirect_uri}
     auth_url = itsi.get_authorize_url(**params)
 
@@ -108,12 +111,14 @@ def itsi_auth(request):
     user = authenticate(itsi_id=itsi_user['id'])
     if user is not None and user.is_active:
         auth_login(request, user)
-        return redirect('/')
+        return redirect(request.GET.get('next', '/'))
     else:
-        # User did not authenticate. Save their ITSI ID and send to /register
+        # User did not authenticate. Save their ITSI ID and send to /sign-up
         request.session['itsi_id'] = itsi_user['id']
         return redirect(
-            '/sign-up/itsi/{username}/{first_name}/{last_name}'.format(
+            '/sign-up/itsi/{username}/{first_name}/{last_name}?next={0}'
+            .format(
+                request.GET.get('next', '/'),
                 **itsi_user['extra']
             )
         )

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -1,0 +1,34 @@
+"use strict";
+
+var _ = require('underscore');
+
+var utils = {
+    // Parse query strings for Backbone
+    // Takes queryString of format "key1=value1&key2=value2"
+    // Returns object of format {key1: value1, key2: value2}
+    // From http://stackoverflow.com/a/11671457/2053314
+    parseQueryString: function (queryString){
+        var params = {};
+        if(queryString){
+            _.each(
+                _.map(decodeURI(queryString).split(/&/g),function(el){
+                    var aux = el.split('='), o = {};
+                    if(aux.length >= 1){
+                        var val;
+                        if(aux.length === 2) {
+                            val = aux[1];
+                        }
+                        o[aux[0]] = val;
+                    }
+                    return o;
+                }),
+                function(o){
+                    _.extend(params,o);
+                }
+            );
+        }
+        return params;
+    }
+};
+
+module.exports = utils;

--- a/src/mmw/js/src/user/controllers.js
+++ b/src/mmw/js/src/user/controllers.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var App = require('../app'),
+    utils = require('../core/utils'),
     models = require('./models'),
     views = require('./views');
 
@@ -12,13 +13,14 @@ var SignUpController = {
         }).render();
     },
 
-    itsiSignUp: function(username, first_name, last_name) {
+    itsiSignUp: function(username, first_name, last_name, queryParams) {
         new views.ItsiSignUpModalView({
             app: App,
             model: new models.ItsiSignUpFormModel({
                 username: username,
                 first_name: first_name,
-                last_name: last_name
+                last_name: last_name,
+                next: queryParams ? utils.parseQueryString(queryParams).next : '/'
             })
         }).render();
     }

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -217,7 +217,8 @@ var ItsiSignUpFormModel = ModalBaseModel.extend({
         username: null,
         first_name: null,
         last_name: null,
-        agreed: false
+        agreed: false,
+        next: '/'
     },
 
     url: '/user/itsi/sign_up',

--- a/src/mmw/js/src/user/templates/loginModal.html
+++ b/src/mmw/js/src/user/templates/loginModal.html
@@ -26,6 +26,6 @@
     </div>
     <div class="row" id="guest-buttons">
         <button type="button" class="btn btn-lg btn-primary" data-dismiss="modal" id="dismiss-button">Guest</button>
-        <a href="/user/itsi/login" class="btn btn-lg btn-primary">ITSI</a>
+        <button type="button" class="btn btn-lg btn-primary itsi-login">ITSI</button>
     </div>
 {% endblock %}

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -134,13 +134,15 @@ var LoginModalView = ModalBaseView.extend({
         password: '#password',
         signUp: '.sign-up',
         resend: '.resend',
-        forgot: '.forgot'
+        forgot: '.forgot',
+        itsiLogin: '.itsi-login'
     }, ModalBaseView.prototype.ui),
 
     events: _.defaults({
         'click @ui.signUp': 'signUp',
         'click @ui.resend': 'resend',
-        'click @ui.forgot': 'forgot'
+        'click @ui.forgot': 'forgot',
+        'click @ui.itsiLogin': 'itsiLogin'
     }, ModalBaseView.prototype.events),
 
     onModalShown: function() {
@@ -213,6 +215,12 @@ var LoginModalView = ModalBaseView.extend({
                 model: new models.ForgotFormModel({})
             }).render();
         });
+    },
+
+    // Login with ITSI
+    itsiLogin: function() {
+        var loginURL = '/user/itsi/login?next=/' + Backbone.history.getFragment();
+        window.location.href = loginURL;
     }
 });
 
@@ -335,11 +343,6 @@ var ItsiSignUpModalView = ModalBaseView.extend({
         this.ui.username.focus();
     },
 
-    onModalHidden: function() {
-        ModalBaseView.prototype.onModalHidden.apply(this, arguments);
-        router.navigate('', { trigger: true });
-    },
-
     onValidationError: function() {
         this.ui.username.focus();
     },
@@ -373,6 +376,20 @@ var ItsiSignUpModalView = ModalBaseView.extend({
             'username': response.username,
             'guest': false
         });
+
+        var next = this.model.get('next');
+        if (next !== '/') {
+            // Must remove leading slash, add trailing slash
+            // otherwise Backbone.router.navigate does not function properly
+            if (next[0] === "/") {
+                next = next.substring(1);
+            }
+            if (next[next.length - 1] !== "/") {
+                next = next + "/";
+            }
+        }
+
+        router.navigate(next, { trigger: true });
     }
 });
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -247,6 +247,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
+    'apps.user.middleware.ItsiAuthenticationMiddleware',
 )
 # END MIDDLEWARE CONFIGURATION
 
@@ -358,6 +359,7 @@ ITSI = {
     'authorize_url': 'auth/concord_id/authorize',
     'access_token_url': 'auth/concord_id/access_token',
     'user_json_url': 'auth/concord_id/user.json',
+    'embed_flag': 'itsi_embed',
 }
 
 BASE_LAYERS = {


### PR DESCRIPTION
## Overview

When a user initially accesses a URL from within an activity in the ITSI portal, we can have the portal append a flag to the URL indicating that they are coming from the portal. Currently, we assume this flag to be a ~~`?initialize_itsi=true`~~ `?itsi_embed=true` query parameter. This is configurable in the ITSI ~~`url_flag`~~ `embed_flag` setting in `base.py`.

We intercept all requests to check if this query parameter exists. If it does not, we do nothing. ~~If it does, we see if the user is already logged in, and if so, do they have an ITSI account. If they do, we do nothing.~~ Otherwise, we attempt to log them in automatically via the portal. Since they are already logged in, the redirection will be transparent and they will be returned to the initial request path after the oAuth dance is done. If there is any error during this, they will instead be redirected to `/error/itsi`.

In case they don't yet have an MMW account corresponding to their ITSI account, they will be prompted to sign up, after which they will be returned to the initial request path.

## Testing Instructions

 1. Go to the home page of the app. Log out.
 2. Go to ~~`/?initialize_itsi=true`~~ [`/?itsi_embed=true`](http://localhost:8000/?itsi_embed=true). An attempt should be made to automatically log you in to ITSI. If it is successful, you should be returned to ~~`/?initialize_itsi=true`~~ [`/`](http://localhost:8000/).
 3. Go to a public project, for example `/project/1/scenario/2`. Log out of your ITSI account. Go to the same project, but this time add the parameter: ~~`/project/1/scenario/2?initialize_itsi=true`~~ `/project/1/scenario/2?itsi_embed=true`. You should be automatically logged in and returned to the original URL.
 4. Try doing that with a private project. You will first be logged in to ITSI, then you should get a `404`.
 5. Delete your ITSI account from the database:

    ```sql
    DELETE FROM user_itsiuser WHERE user_id IN (
        SELECT id FROM auth_user WHERE username = 'tstudent2'
    );
    DELETE FROM auth_user WHERE username = 'tstudent2';
    ```

  Then try accessing the public project. You should be prompted to sign up as a new user, after which you should be returned to the original project.
 6. When logged in as one ITSI user in the system, `tstudent2`, log in to MMW. Then go back to ITSI and log out, and log in as another ITSI user `mmwterence`. Then come back to MMW and add the [`/?itsi_embed=true`](http://localhost:8000/?itsi_embed=true) flag. You should be logged in as the current ITSI user, namely `mmwterence`.

## Questions

 * ~~Currently, after logging in with ITSI, we **always** set the `initialize_itsi` flag. Should we always do this, or only when they are coming in from the ITSI portal?~~
 * ~~Currently, we only check if they are logged in with an ITSI account. Should we try and check to see if they are logged in as the same user as they are in ITSI? For example, a teacher might have a dummy student account to check what things look like from that perspective, and may forget to log out. They may be logged in with the dummy student account in MMW even if they are logged in as themselves in ITSI.  
  However, that would require some refactoring, since currently we use the fact that the logged in user is an ITSI user to escape the loop of always checking against the portal, since the `intialize_itsi` flag is set even when returning after logging in, to facilitate behavior expected in #560 and #561.~~

Connects #562 