### PR TITLE
Make stream layer visible after switching base layer

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -258,6 +258,7 @@ function changeStreamLayer(endpoint, model) {
         sl = new L.TileLayer(endpoint + '.png');
 
     sfg.addLayer(sl);
+    sl.bringToFront();
 }
 
 function getShapeAndAnalyze(e, model, ofg, grid, tableId) {


### PR DESCRIPTION
To test:

 * Turn on a stream layer
 * Switch base map 
 * Ensure that stream layer is still showing
 * Also check that Congressional Districts layer works alongside stream layer

Connects #582 