### PR TITLE
 Provide a survey of the Area of Interest.

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -18,6 +18,8 @@ graphite_host: "{{ services_ip }}"
 statsite_host: "{{ services_ip }}"
 tiler_host: "{{ lookup('env', 'MMW_TILER_IP') | default('33.33.34.35', true) }}"
 
+geop_host: "{{ lookup('env', 'MMW_GEOPROCESSING_IP') | default('33.33.34.48', true) }}"
+
 celery_log_level: "DEBUG"
 celery_number_of_workers: 2
 celery_processes_per_worker: 1

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -16,6 +16,8 @@ graphite_host: "{{ services_ip }}"
 statsite_host: "{{ services_ip }}"
 tiler_host: "{{ lookup('env', 'MMW_TILER_IP') | default('33.33.34.35', true) }}"
 
+geop_host: "{{ lookup('env', 'MMW_GEOPROCESSING_IP') | default('33.33.34.48', true) }}"
+
 celery_number_of_workers: 2
 celery_processes_per_worker: 1
 

--- a/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
@@ -10,6 +10,7 @@ envdir_config:
   MMW_CACHE_HOST: "{{ redis_host }}"
   MMW_CACHE_PORT: "{{ redis_port }}"
   MMW_TILER_HOST: "{{ tiler_host }}"
+  MMW_GEOPROCESSING_HOST: "{{ geop_host }}"
   MMW_ITSI_CLIENT_ID: "{{ itsi_client_id }}"
   MMW_ITSI_SECRET_KEY: "{{ itsi_secret_key }}"
   MMW_ITSI_BASE_URL: "{{ itsi_base_url }}"

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+from django.conf import settings
+
+import httplib
+import json
+
+
+NLCD_MAPPING = {
+    11: ['water', 'Water'],
+    21: ['urban_grass', 'Urban-Grass/Tall-Grass Prairie'],
+    22: ['li_residential', 'Low-Intensity Residential'],
+    23: ['hi_residential', 'High-Intensity Residential'],
+    24: ['commercial', 'Commercial/Industrial/Transportation'],
+    31: ['rock', 'Rock/Sand/Clay/Desert'],
+    41: ['deciduous_forest', 'Deciduous Forest'],
+    42: ['evergreen_forest', 'Evergreen Forest'],
+    43: ['mixed_forest', 'Mixed Forest'],
+    52: ['chaparral', 'Chaparral'],
+    71: ['grassland', 'Grassland'],
+    81: ['pasture', 'Pasture/Hay/Short-Grass Prairie'],
+    82: ['row_crop', 'Row Crop'],
+    90: ['woody_wetland', 'Woody Wetland'],
+    95: ['herbaceous_wetland', 'Herbaceous Wetland']
+}
+
+SOIL_MAPPING = {
+    1: ['a', 'A'],
+    2: ['b', 'B'],
+    3: ['c', 'C'],
+    4: ['d', 'D']
+}
+
+
+def geotrellis(polygon):
+    """
+    Send a string containing a GeoJSON Polygon, MultiPolygon, or
+    GeometryCollection (containing only Polygons and Multipolygons) to
+    Geotrellis and get back a histogram of NLCD x SOIL pairs present
+    in that area.
+    """
+    host = settings.GEOP['host']
+    conn = httplib.HTTPConnection(host)
+    try:
+        conn.request('POST', '', polygon, {'Content-type': 'application/json'})
+        response = conn.getresponse()
+        data = response.read()
+        conn.close()
+        return data
+    except Exception:
+        conn.close()
+        return []
+
+
+def geojson_to_x(data, nucleus, update_rule, after_rule):
+    """
+    Transform raw Geotrellis histogram output into an object of the
+    desired form (dictated by the last three arguments).
+    """
+    retval = nucleus
+    total = 0
+
+    for [[nlcd, soil], count] in data:
+        total += count
+        update_rule(nlcd, soil, count, retval)
+
+    after_rule(total, retval)
+
+    return retval
+
+
+def data_to_census(data):
+    """
+    Turn raw data from Geotrellis into a census.
+    """
+    def update_rule(nlcd, soil, count, census):
+        dist = census['distribution']
+        if nlcd in NLCD_MAPPING and soil in SOIL_MAPPING:
+            nlcd_str = NLCD_MAPPING[nlcd][0]
+            soil_str = SOIL_MAPPING[soil][0]
+            key_str = '%s:%s' % (soil_str, nlcd_str)
+            dist[key_str] = {'cell_count': count}
+
+    def after_rule(count, census):
+        census['cell_count'] = count
+
+    nucleus = {'distribution': {}}
+
+    return geojson_to_x(data, nucleus, update_rule, after_rule)
+
+
+def geojson_to_census(polygon):
+    """
+    Take a Polygon or MultiPolygon either as a string containing
+    GeoJSON or as a Python object -- preferably the former -- and
+    return a TR-55-compatible census.
+    """
+    if not isinstance(polygon, str) and not isinstance(polygon, unicode):
+        polygon = json.dumps(polygon)
+    data = json.loads(geotrellis(polygon))
+    return data_to_census(data)
+
+
+def geojson_to_censuses(polygons):
+    """
+    Similar to the `census` function above, but accepts a
+    GeometryCollection of Polygons and/or MultiPolygons and returns a
+    list of censuses.
+    """
+    if not isinstance(polygons, str)and not isinstance(polygons, unicode):
+        polygons = json.dumps(polygons)
+    data = json.loads(geotrellis(polygons))
+    return [data_to_census(subdata) for subdata in data]
+
+
+def geojson_to_survey(polygon):
+    """
+    Similar to the `census` function above, but produces a survey of
+    the type expected by the `/analyze` page.
+    """
+    def update_category(string, count, categories):
+        if string in categories:
+            entry = categories[string]
+            entry['area'] += count
+        else:
+            categories[string] = {
+                'type': string,
+                'area': count,
+                'coverage': None
+            }
+
+    def update_pcts(entry, count):
+        area = entry['area']
+        entry['coverage'] = float(area) / count
+        return entry
+
+    def update_rule(nlcd, soil, count, survey):
+        landCategories = survey[0]['categories']
+        soilCategories = survey[1]['categories']
+        if nlcd in NLCD_MAPPING:
+            update_category(NLCD_MAPPING[nlcd][1], count, landCategories)
+        else:
+            update_category('?', count, landCategories)
+        if soil in SOIL_MAPPING:
+            update_category(SOIL_MAPPING[soil][1], count, soilCategories)
+        else:
+            update_category('?', count, soilCategories)
+
+    def after_rule(count, survey):
+        land = survey[0]['categories'].iteritems()
+        soil = survey[1]['categories'].iteritems()
+        survey[0]['categories'] = [update_pcts(v, count) for k, v in land]
+        survey[1]['categories'] = [update_pcts(v, count) for k, v in soil]
+
+    nucleus = [
+        {
+            'name': 'land',
+            'displayName': 'Land',
+            'categories': {}
+        },
+        {
+            'name': 'soil',
+            'displayName': 'Soil',
+            'categories': {}
+        }
+    ]
+
+    if not isinstance(polygon, str) and not isinstance(polygon, unicode):
+        polygon = json.dumps(polygon)
+    data = json.loads(geotrellis(polygon))
+    return geojson_to_x(data, nucleus, update_rule, after_rule)

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -11,17 +11,17 @@ import json
 
 NLCD_MAPPING = {
     11: ['water', 'Water'],
-    21: ['urban_grass', 'Urban-Grass/Tall-Grass Prairie'],
-    22: ['li_residential', 'Low-Intensity Residential'],
-    23: ['hi_residential', 'High-Intensity Residential'],
-    24: ['commercial', 'Commercial/Industrial/Transportation'],
-    31: ['rock', 'Rock/Sand/Clay/Desert'],
+    21: ['urban_grass', 'Urban- or Tall-Grass'],
+    22: ['li_residential', 'Low-Intensity Res.'],
+    23: ['hi_residential', 'High-Intensity Res.'],
+    24: ['industrial', 'Industrial &c.'],
+    31: ['desert', 'Desert &c.'],
     41: ['deciduous_forest', 'Deciduous Forest'],
     42: ['evergreen_forest', 'Evergreen Forest'],
     43: ['mixed_forest', 'Mixed Forest'],
     52: ['chaparral', 'Chaparral'],
     71: ['grassland', 'Grassland'],
-    81: ['pasture', 'Pasture/Hay/Short-Grass Prairie'],
+    81: ['pasture', 'Pasture &c.'],
     82: ['row_crop', 'Row Crop'],
     90: ['woody_wetland', 'Woody Wetland'],
     95: ['herbaceous_wetland', 'Herbaceous Wetland']

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -6,115 +6,41 @@ from __future__ import absolute_import
 from celery import shared_task
 import logging
 
-# TODO Remove this when stub task is deleted.
-import time
+from apps.modeling.geoprocessing import geojson_to_survey
 
 from tr55.model import simulate_modifications, simulate_cell_day
 from tr55.tablelookup import lookup_ki
 
 logger = logging.getLogger(__name__)
 
+FE_BE_MAP = {
+    'lir':                 'li_residential',
+    'hir':                 'hi_residential',
+    'commercial':          'commercial',
+    'forest':              'mixed_forest',
+    'turf_grass':          'urban_grass',
+    'pasture':             'pasture',
+    'grassland':           'grassland',
+    'row_crop':            'row_crop',
+    'chaparral':           'chaparral',
+    'tg_prairie':          'tall_grass_prairie',
+    'sg_prairie':          'short_grass_prairie',
+    'desert':              'desert',
+    'rain_garden':         'rain_garden',
+    'veg_infil_basin':     'infiltration_trench',
+    'porous_paving':       'porous_paving',
+    'green_roof':          'green_roof',
+    'no_till_agriculture': 'no_till',
+    'cluster_housing':     'cluster_housing'
+}
+
 
 @shared_task
 def run_analyze(area_of_interest):
-    time.sleep(3)
-
-    results = [
-        {
-            "name": "land",
-            "displayName": "Land",
-            "categories": [
-                {
-                    "type": "Water",
-                    "area": 21,
-                    "coverage": 0.01
-                },
-                {
-                    "type": "Developed: Open",
-                    "area": 5041,
-                    "coverage": .263
-                },
-                {
-                    "type": "Developed: Low",
-                    "area": 5181,
-                    "coverage": .271
-                },
-                {
-                    "type": "Developed: Medium",
-                    "area": 3344,
-                    "coverage": .175
-                },
-                {
-                    "type": "Developed: High",
-                    "area": 1103,
-                    "coverage": .058
-                },
-                {
-                    "type": "Bare Soil",
-                    "area": 19,
-                    "coverage": .001
-                },
-                {
-                    "type": "Forest",
-                    "area": 1804,
-                    "coverage": .094
-                },
-                {
-                    "type": "Deciduous Forest",
-                    "area": 1103,
-                    "coverage": .058
-                },
-                {
-                    "type": "Evergreen Forest",
-                    "area": 19,
-                    "coverage": .001
-                },
-                {
-                    "type": "Mixed Forest",
-                    "area": 1804,
-                    "coverage": .094
-                },
-                {
-                    "type": "Dwarf Scrub",
-                    "area": 1103,
-                    "coverage": .058
-                },
-                {
-                    "type": "Moss",
-                    "area": 19,
-                    "coverage": .001
-                },
-                {
-                    "type": "Pasture",
-                    "area": 1804,
-                    "coverage": .094
-                }
-            ]
-        },
-        {
-            "name": "soil",
-            "displayName": "Soil",
-            "categories": [
-                {
-                    "type": "Clay",
-                    "area": 21,
-                    "coverage": 0.01
-                },
-                {
-                    "type": "Silt",
-                    "area": 5041,
-                    "coverage": .263
-                },
-                {
-                    "type": "Sand",
-                    "area": 21,
-                    "coverage": .271
-                },
-            ]
-        }
-    ]
-
-    return results
+    """
+    Call geotrellis and return a survey of the area of interest.
+    """
+    return geojson_to_survey(area_of_interest)
 
 
 @shared_task

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 from apps.core.models import Job
 from apps.modeling import views
+from apps.modeling import geoprocessing
 from django.contrib.auth.models import User
 
 from django.test import TestCase
@@ -12,6 +13,42 @@ from django.test.utils import override_settings
 from django.utils.timezone import now
 
 from rest_framework.test import APIClient
+
+import json
+
+
+class ExerciseGeoprocessing(TestCase):
+    def setUp(self):
+        self.polygon = """
+{
+    "type": "MultiPolygon",
+    "coordinates": [
+        [
+            [
+                [-75.61614990234375, 39.78426800449774],
+                [-75.67245483398438, 39.715638134796336],
+                [-75.56808471679688, 39.743098286948275],
+                [-75.61614990234375, 39.78426800449774]
+            ]
+        ]
+    ]
+}
+"""
+
+    def test_geotrellis_good(self):
+        actual = geoprocessing.geotrellis(self.polygon)
+        expected = "[[[90, 4], 140], [[41, 4], 967], [[23, 2], 6763], [[81, 3], 203], [[52, 2], 1430], [[42, 2], 1286], [[31, 3], 48], [[24, 3], 472], [[21, 2], 18212], [[42, 3], 41], [[22, 4], 409], [[23, 4], 327], [[82, 3], 113], [[43, 3], 1208], [[82, 2], 49], [[43, 0], 151], [[90, 3], 6507], [[81, 2], 1160], [[21, 3], 5958], [[11, 3], 26], [[24, 0], 5436], [[52, 4], 103], [[31, 2], 128], [[52, 0], 130], [[42, 4], 37], [[11, 2], 97], [[22, 0], 12904], [[22, 2], 20604], [[81, 4], 63], [[23, 3], 1664], [[21, 4], 1316], [[43, 2], 1398], [[43, 4], 128], [[41, 3], 7080], [[24, 4], 80], [[42, 0], 191], [[90, 0], 137], [[22, 3], 2967], [[52, 3], 728], [[11, 0], 1736], [[41, 0], 862], [[41, 2], 12140], [[21, 0], 8088], [[90, 2], 1425], [[23, 0], 4382], [[24, 2], 1787]]"  # noqa
+        self.assertEqual(json.loads(actual), json.loads(expected), "Discrepant answer from Geotrellis")  # noqa
+
+    def test_geotrellis_bad(self):
+        actual = geoprocessing.geotrellis('this is not valid geojson')
+        expected = "Invalid or no GeoJSON."
+        self.assertEqual(actual, expected, "Discrepant answer from Geotrellis")
+
+    def test_survey(self):
+        actual = geoprocessing.geojson_to_survey(self.polygon)
+        expected = '[{"displayName": "Land", "name": "land", "categories": [{"type": "Urban- or Tall-Grass", "coverage": 0.25613170482373493, "area": 33574}, {"type": "Low-Intensity Res.", "coverage": 0.2813832668350104, "area": 36884}, {"type": "Deciduous Forest", "coverage": 0.1605800993278965, "area": 21049}, {"type": "Water", "coverage": 0.014182070628084924, "area": 1859}, {"type": "Mixed Forest", "coverage": 0.022009291964510493, "area": 2885}, {"type": "Industrial &c.", "coverage": 0.05931446967905341, "area": 7775}, {"type": "Desert &c.", "coverage": 0.001342681242895614, "area": 176}, {"type": "Woody Wetland", "coverage": 0.06262539956210282, "area": 8209}, {"type": "High-Intensity Res.", "coverage": 0.10021284549248174, "area": 13136}, {"type": "Evergreen Forest", "coverage": 0.011862893935810682, "area": 1555}, {"type": "Pasture &c.", "coverage": 0.010878769615733783, "area": 1426}, {"type": "Chaparral", "coverage": 0.01824062983956485, "area": 2391}, {"type": "Row Crop", "coverage": 0.0012358770531198267, "area": 162}]}, {"displayName": "Soil", "name": "soil", "categories": [{"type": "C", "coverage": 0.2060939419137785, "area": 27015}, {"type": "B", "coverage": 0.5071596951503269, "area": 66479}, {"type": "D", "coverage": 0.02723506839282581, "area": 3570}, {"type": "?", "coverage": 0.2595112945430688, "area": 34017}]}]'  # noqa
+        self.assertEqual(actual, json.loads(expected), "Discrepant survey.")
 
 
 class TaskRunnerTestCase(TestCase):

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -143,7 +143,7 @@ def scenario(request, scen_id):
 def start_analyze(request, format=None):
     user = request.user if request.user.is_authenticated() else None
     created = now()
-    area_of_interest = request.POST
+    area_of_interest = request.POST['area_of_interest']
     job = Job.objects.create(created_at=created, result='', error='',
                              traceback='', user=user, status='started')
 

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -40,19 +40,21 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
         var self = this;
 
         if (!this.model.get('result')) {
-            var taskHelper = {
-                pollSuccess: function() {
-                    self.showDetailsRegion();
-                },
+            var aoi = JSON.stringify(this.model.get('area_of_interest')),
+                taskHelper = {
+                    pollSuccess: function() {
+                        self.showDetailsRegion();
+                    },
 
-                pollFailure: function() {
-                    self.showErrorMessage();
-                },
+                    pollFailure: function() {
+                        self.showErrorMessage();
+                    },
 
-                startFailure: function() {
-                    self.showErrorMessage();
-                }
-            };
+                    startFailure: function() {
+                        self.showErrorMessage();
+                    },
+                    postData: {'area_of_interest': aoi}
+                };
             this.model.start(taskHelper);
         } else {
             this.lock = $.Deferred();

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -403,6 +403,11 @@ ITSI = {
     'embed_flag': 'itsi_embed',
 }
 
+# Geoprocessing Settings
+GEOP = {
+    'host': environ.get('MMW_GEOPROCESSING_HOST', 'localhost')
+}
+
 BASE_LAYERS = {
     'Mapbox Roads': {
         'url': 'https://{s}.tiles.mapbox.com/v3/ctaylor.lg2deoc9/{z}/{x}/{y}.png',


### PR DESCRIPTION
**Back-end**

Use Geotrellis to compute a survey of the area of interest that is compatible with that expected by the `/analyze` page.

**Front-end**

The `run_analyze` function was receiving an object with nothing in it.  It needs access to the area of interest in order to provide a survey.

Connects #569

**Caveats**
   1. The introduces a new environment variable `MMW_GEOPROCESSING_HOST`.
   1. The test extent  (shown below) is very small.  You will receive null results for any portion of the area of interest that does not intersect with  the test extent.
![extent](https://cloud.githubusercontent.com/assets/11281373/8754911/d1676686-2c94-11e5-8804-089387e8b6fa.png)
   1. Some of the tiles do not have a soil classification (their value is "(null)" instead of "A" or "C/D" or the like).  All such tiles have been given a soil value of "?".  We will eventually have to come up with a strategy for dealing with these, because they make up a significant percentage of the tiles.
   1. They very first interaction with Geotrellis after the VMs have been (re)started seems to always fail (timeout?).

**Non-scientific validation**
There could be some issues with the alignment of the data.  For example, the two areas of interest below give 0% water and 11% water, respectively.

![screenshot from 2015-07-17 15 10 28](https://cloud.githubusercontent.com/assets/11281373/8755126/9314e8ca-2c96-11e5-8954-22b8568dbcff.png)

![screenshot from 2015-07-17 15 11 26](https://cloud.githubusercontent.com/assets/11281373/8755125/9168aaca-2c96-11e5-90fe-a18cad215c05.png)

**To test**
   1. Draw an area of interest that intersects with the test extent.
![aoi](https://cloud.githubusercontent.com/assets/11281373/8754947/234f5db4-2c95-11e5-9ee3-ae153264a452.png)
   2. You should get back a survey of the area of interest.  Click on the "land" and "soil" tabs to examine it.
![land](https://cloud.githubusercontent.com/assets/11281373/8754958/3ccc7682-2c95-11e5-81fd-9b31202cb881.png)
![soil](https://cloud.githubusercontent.com/assets/11281373/8754959/3ecc49da-2c95-11e5-8b2d-38a0ea933b6e.png)
