### PR TITLE
Add utfgrid interactivity to boundary layers

### DIFF
--- a/src/mmw/apps/home/templates/home/home.html
+++ b/src/mmw/apps/home/templates/home/home.html
@@ -12,6 +12,7 @@
     </div>
 
     <div id="map"></div>
+    <div id="boundary-label"></div>
 
 {% endblock content %}
 

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -106,3 +106,14 @@ a{
         }
     }
 }
+
+#boundary-label{
+    display: none;
+    padding: 5px;
+    background-color: $ui-secondary;
+    color: $paper;
+    position: absolute;
+    z-index: 1;
+    opacity: 0.8;
+}
+


### PR DESCRIPTION
Add a custom label for each feature of each boundary layer.

To test, turn on boundary layers and notice the name displayed on hover.  Reset, turn on other drawing tools, etc, to see the label turn on/off appropriately.

Known issues:
* Congressional Districts name do not appear (#576)
* Extreme right-hand side features will eventually clip the label.  I don't see this as too egregious of a problem at the moment, since the user needs only to pan the map.  If we get feedback regarding it, we can just buffer the `x` position to the width of the label.

Connects #583 