### PR TITLE
Use Geotrellis to produce TR-55 Input. 

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -18,6 +18,8 @@ graphite_host: "{{ services_ip }}"
 statsite_host: "{{ services_ip }}"
 tiler_host: "{{ lookup('env', 'MMW_TILER_IP') | default('33.33.34.35', true) }}"
 
+geop_host: "{{ lookup('env', 'MMW_GEOPROCESSING_IP') | default('33.33.34.48', true) }}"
+
 celery_log_level: "DEBUG"
 celery_number_of_workers: 2
 celery_processes_per_worker: 1

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -16,6 +16,8 @@ graphite_host: "{{ services_ip }}"
 statsite_host: "{{ services_ip }}"
 tiler_host: "{{ lookup('env', 'MMW_TILER_IP') | default('33.33.34.35', true) }}"
 
+geop_host: "{{ lookup('env', 'MMW_GEOPROCESSING_IP') | default('33.33.34.48', true) }}"
+
 celery_number_of_workers: 2
 celery_processes_per_worker: 1
 

--- a/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
@@ -10,6 +10,7 @@ envdir_config:
   MMW_CACHE_HOST: "{{ redis_host }}"
   MMW_CACHE_PORT: "{{ redis_port }}"
   MMW_TILER_HOST: "{{ tiler_host }}"
+  MMW_GEOPROCESSING_HOST: "{{ geop_host }}"
   MMW_ITSI_CLIENT_ID: "{{ itsi_client_id }}"
   MMW_ITSI_SECRET_KEY: "{{ itsi_secret_key }}"
   MMW_ITSI_BASE_URL: "{{ itsi_base_url }}"

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+from django.conf import settings
+
+import httplib
+import json
+
+
+NLCD_MAPPING = {
+    11: ['water', 'Water'],
+    21: ['urban_grass', 'Urban-Grass/Tall-Grass Prairie'],
+    22: ['li_residential', 'Low-Intensity Residential'],
+    23: ['hi_residential', 'High-Intensity Residential'],
+    24: ['commercial', 'Commercial/Industrial/Transportation'],
+    31: ['rock', 'Rock/Sand/Clay/Desert'],
+    41: ['deciduous_forest', 'Deciduous Forest'],
+    42: ['evergreen_forest', 'Evergreen Forest'],
+    43: ['mixed_forest', 'Mixed Forest'],
+    52: ['chaparral', 'Chaparral'],
+    71: ['grassland', 'Grassland'],
+    81: ['pasture', 'Pasture/Hay/Short-Grass Prairie'],
+    82: ['row_crop', 'Row Crop'],
+    90: ['woody_wetland', 'Woody Wetland'],
+    95: ['herbaceous_wetland', 'Herbaceous Wetland']
+}
+
+SOIL_MAPPING = {
+    1: ['a', 'A'],
+    2: ['b', 'B'],
+    3: ['c', 'C'],
+    4: ['d', 'D']
+}
+
+
+def geotrellis(polygon):
+    """
+    Send a string containing a GeoJSON Polygon, MultiPolygon, or
+    GeometryCollection (containing only Polygons and Multipolygons) to
+    Geotrellis and get back a histogram of NLCD x SOIL pairs present
+    in that area.
+    """
+    host = settings.GEOP['host']
+    conn = httplib.HTTPConnection(host)
+    try:
+        conn.request('POST', '', polygon, {'Content-type': 'application/json'})
+        response = conn.getresponse()
+        data = response.read()
+        conn.close()
+        return data
+    except Exception:
+        conn.close()
+        return []
+
+
+def geojson_to_x(data, nucleus, update_rule, after_rule):
+    """
+    Transform raw Geotrellis histogram output into an object of the
+    desired form (dictated by the last three arguments).
+    """
+    retval = nucleus
+    total = 0
+
+    for [[nlcd, soil], count] in data:
+        total += count
+        update_rule(nlcd, soil, count, retval)
+
+    after_rule(total, retval)
+
+    return retval
+
+
+def data_to_census(data):
+    """
+    Turn raw data from Geotrellis into a census.
+    """
+    def update_rule(nlcd, soil, count, census):
+        dist = census['distribution']
+        if nlcd in NLCD_MAPPING and soil in SOIL_MAPPING:
+            nlcd_str = NLCD_MAPPING[nlcd][0]
+            soil_str = SOIL_MAPPING[soil][0]
+            key_str = '%s:%s' % (soil_str, nlcd_str)
+            dist[key_str] = {'cell_count': count}
+
+    def after_rule(count, census):
+        census['cell_count'] = count
+
+    nucleus = {'distribution': {}}
+
+    return geojson_to_x(data, nucleus, update_rule, after_rule)
+
+
+def geojson_to_census(polygon):
+    """
+    Take a Polygon or MultiPolygon either as a string containing
+    GeoJSON or as a Python object -- preferably the former -- and
+    return a TR-55-compatible census.
+    """
+    if not isinstance(polygon, str) and not isinstance(polygon, unicode):
+        polygon = json.dumps(polygon)
+    data = json.loads(geotrellis(polygon))
+    return data_to_census(data)
+
+
+def geojson_to_censuses(polygons):
+    """
+    Similar to the `census` function above, but accepts a
+    GeometryCollection of Polygons and/or MultiPolygons and returns a
+    list of censuses.
+    """
+    if not isinstance(polygons, str)and not isinstance(polygons, unicode):
+        polygons = json.dumps(polygons)
+    data = json.loads(geotrellis(polygons))
+    return [data_to_census(subdata) for subdata in data]
+
+
+def geojson_to_survey(polygon):
+    """
+    Similar to the `census` function above, but produces a survey of
+    the type expected by the `/analyze` page.
+    """
+    def update_category(string, count, categories):
+        if string in categories:
+            entry = categories[string]
+            entry['area'] += count
+        else:
+            categories[string] = {
+                'type': string,
+                'area': count,
+                'coverage': None
+            }
+
+    def update_pcts(entry, count):
+        area = entry['area']
+        entry['coverage'] = float(area) / count
+        return entry
+
+    def update_rule(nlcd, soil, count, survey):
+        landCategories = survey[0]['categories']
+        soilCategories = survey[1]['categories']
+        if nlcd in NLCD_MAPPING:
+            update_category(NLCD_MAPPING[nlcd][1], count, landCategories)
+        else:
+            update_category('?', count, landCategories)
+        if soil in SOIL_MAPPING:
+            update_category(SOIL_MAPPING[soil][1], count, soilCategories)
+        else:
+            update_category('?', count, soilCategories)
+
+    def after_rule(count, survey):
+        land = survey[0]['categories'].iteritems()
+        soil = survey[1]['categories'].iteritems()
+        survey[0]['categories'] = [update_pcts(v, count) for k, v in land]
+        survey[1]['categories'] = [update_pcts(v, count) for k, v in soil]
+
+    nucleus = [
+        {
+            'name': 'land',
+            'displayName': 'Land',
+            'categories': {}
+        },
+        {
+            'name': 'soil',
+            'displayName': 'Soil',
+            'categories': {}
+        }
+    ]
+
+    if not isinstance(polygon, str) and not isinstance(polygon, unicode):
+        polygon = json.dumps(polygon)
+    data = json.loads(geotrellis(polygon))
+    return geojson_to_x(data, nucleus, update_rule, after_rule)

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -11,17 +11,17 @@ import json
 
 NLCD_MAPPING = {
     11: ['water', 'Water'],
-    21: ['urban_grass', 'Urban-Grass/Tall-Grass Prairie'],
-    22: ['li_residential', 'Low-Intensity Residential'],
-    23: ['hi_residential', 'High-Intensity Residential'],
-    24: ['commercial', 'Commercial/Industrial/Transportation'],
-    31: ['rock', 'Rock/Sand/Clay/Desert'],
+    21: ['urban_grass', 'Urban- or Tall-Grass'],
+    22: ['li_residential', 'Low-Intensity Res.'],
+    23: ['hi_residential', 'High-Intensity Res.'],
+    24: ['industrial', 'Industrial &c.'],
+    31: ['desert', 'Desert &c.'],
     41: ['deciduous_forest', 'Deciduous Forest'],
     42: ['evergreen_forest', 'Evergreen Forest'],
     43: ['mixed_forest', 'Mixed Forest'],
     52: ['chaparral', 'Chaparral'],
     71: ['grassland', 'Grassland'],
-    81: ['pasture', 'Pasture/Hay/Short-Grass Prairie'],
+    81: ['pasture', 'Pasture &c.'],
     82: ['row_crop', 'Row Crop'],
     90: ['woody_wetland', 'Woody Wetland'],
     95: ['herbaceous_wetland', 'Herbaceous Wetland']

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -6,10 +6,10 @@ from __future__ import absolute_import
 from celery import shared_task
 import logging
 
-from apps.modeling.geoprocessing import geojson_to_survey
+from apps.modeling.geoprocessing import geojson_to_survey, \
+    geojson_to_census, geojson_to_censuses
 
-from tr55.model import simulate_modifications, simulate_cell_day
-from tr55.tablelookup import lookup_ki
+from tr55.model import simulate_day
 
 logger = logging.getLogger(__name__)
 
@@ -48,34 +48,10 @@ def prepare_census(model_input):
     """
     Call geotrellis and calculate the tile data for use in the TR55 model.
     """
-
-    # TODO actually call geotrellis with model_input
-    census = {
-        'cell_count': 100,
-        'distribution': {
-            'c:commercial': {'cell_count': 70},
-            'a:deciduous_forest': {'cell_count': 30}
-        },
-        'modifications': [
-            {
-                'bmp': 'no_till',
-                'cell_count': 1,
-                'distribution': {
-                    'a:deciduous_forest': {'cell_count': 1},
-                }
-            },
-            {
-                'reclassification': 'd:rock',
-                'cell_count': 1,
-                'distribution': {
-                    'a:deciduous_forest': {'cell_count': 1}
-                }
-            }
-        ],
-        'modification_hash': model_input['modification_hash']
-    }
-
-    return census
+    if 'area_of_interest' in model_input:
+        return geojson_to_census(model_input['area_of_interest'])
+    else:
+        raise Exception('No Area of Interest')
 
 
 def format_quality(model_output):
@@ -100,24 +76,15 @@ def run_tr55(census, model_input):
     """
     A thin Celery wrapper around our TR55 implementation.
     """
-
-    et_max = 0.207
     precip = _get_precip_value(model_input)
 
     if precip is None:
         raise Exception('No precipitation value defined')
 
-    # TODO: These next two lines are just for
-    # demonstration purposes.
     modifications = get_census_modifications(model_input)
     census['modifications'] = modifications
 
-    def simulate_day(cell, cell_count):
-        soil_type, land_use = cell.lower().split(':')
-        et = et_max * lookup_ki(land_use)
-        return simulate_cell_day((precip, et), cell, cell_count)
-
-    model_output = simulate_modifications(census, fn=simulate_day)
+    model_output = simulate_day(census, precip)
 
     return {
         'census': census,
@@ -135,30 +102,24 @@ def _get_precip_value(model_input):
         return None
 
 
-# TODO: For demonstration purposes.
 def get_census_modifications(model_input):
-    """
-    For each modification that was drawn, replace
-    a cell of commercial with a cell of
-    chaparral. This has the effect of improving
-    infiltration and evapotranspiration.
-    """
-    multiplier = 4
-    count = len(model_input['modifications'])
-    modifications = []
+    def change_key(modification):
+        name = modification['name']
+        value = FE_BE_MAP[modification['value']]
 
-    # Percipiation is in modifications, so even if
-    # there are no modifications, there will be one element
-    # for percipitation.
-    if count > 1:
-        modifications = [
-            {
-                'reclassification': 'a:chaparral',
-                'cell_count': count * multiplier,
-                'distribution': {
-                    'c:commercial': {'cell_count': count * multiplier},
-                }
-            }
-        ]
+        if name == 'landcover':
+            return {'change': ':%s:' % value}
+        elif name == 'conservation_practice':
+            return {'change': '::%s' % value}
+
+    raw_mods = model_input['modifications']
+    changes = [change_key(m) for m in raw_mods]
+    modifications = geojson_to_censuses({
+        'type': 'GeometryCollection',
+        'geometries': [m['shape']['geometry'] for m in raw_mods]
+    })
+
+    for (m, c) in zip(modifications, changes):
+        m.update(c)
 
     return modifications

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -6,115 +6,41 @@ from __future__ import absolute_import
 from celery import shared_task
 import logging
 
-# TODO Remove this when stub task is deleted.
-import time
+from apps.modeling.geoprocessing import geojson_to_survey
 
 from tr55.model import simulate_modifications, simulate_cell_day
 from tr55.tablelookup import lookup_ki
 
 logger = logging.getLogger(__name__)
 
+FE_BE_MAP = {
+    'lir':                 'li_residential',
+    'hir':                 'hi_residential',
+    'commercial':          'commercial',
+    'forest':              'mixed_forest',
+    'turf_grass':          'urban_grass',
+    'pasture':             'pasture',
+    'grassland':           'grassland',
+    'row_crop':            'row_crop',
+    'chaparral':           'chaparral',
+    'tg_prairie':          'tall_grass_prairie',
+    'sg_prairie':          'short_grass_prairie',
+    'desert':              'desert',
+    'rain_garden':         'rain_garden',
+    'veg_infil_basin':     'infiltration_trench',
+    'porous_paving':       'porous_paving',
+    'green_roof':          'green_roof',
+    'no_till_agriculture': 'no_till',
+    'cluster_housing':     'cluster_housing'
+}
+
 
 @shared_task
 def run_analyze(area_of_interest):
-    time.sleep(3)
-
-    results = [
-        {
-            "name": "land",
-            "displayName": "Land",
-            "categories": [
-                {
-                    "type": "Water",
-                    "area": 21,
-                    "coverage": 0.01
-                },
-                {
-                    "type": "Developed: Open",
-                    "area": 5041,
-                    "coverage": .263
-                },
-                {
-                    "type": "Developed: Low",
-                    "area": 5181,
-                    "coverage": .271
-                },
-                {
-                    "type": "Developed: Medium",
-                    "area": 3344,
-                    "coverage": .175
-                },
-                {
-                    "type": "Developed: High",
-                    "area": 1103,
-                    "coverage": .058
-                },
-                {
-                    "type": "Bare Soil",
-                    "area": 19,
-                    "coverage": .001
-                },
-                {
-                    "type": "Forest",
-                    "area": 1804,
-                    "coverage": .094
-                },
-                {
-                    "type": "Deciduous Forest",
-                    "area": 1103,
-                    "coverage": .058
-                },
-                {
-                    "type": "Evergreen Forest",
-                    "area": 19,
-                    "coverage": .001
-                },
-                {
-                    "type": "Mixed Forest",
-                    "area": 1804,
-                    "coverage": .094
-                },
-                {
-                    "type": "Dwarf Scrub",
-                    "area": 1103,
-                    "coverage": .058
-                },
-                {
-                    "type": "Moss",
-                    "area": 19,
-                    "coverage": .001
-                },
-                {
-                    "type": "Pasture",
-                    "area": 1804,
-                    "coverage": .094
-                }
-            ]
-        },
-        {
-            "name": "soil",
-            "displayName": "Soil",
-            "categories": [
-                {
-                    "type": "Clay",
-                    "area": 21,
-                    "coverage": 0.01
-                },
-                {
-                    "type": "Silt",
-                    "area": 5041,
-                    "coverage": .263
-                },
-                {
-                    "type": "Sand",
-                    "area": 21,
-                    "coverage": .271
-                },
-            ]
-        }
-    ]
-
-    return results
+    """
+    Call geotrellis and return a survey of the area of interest.
+    """
+    return geojson_to_survey(area_of_interest)
 
 
 @shared_task

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 from apps.core.models import Job
 from apps.modeling import views
+from apps.modeling import geoprocessing
 from django.contrib.auth.models import User
 
 from django.test import TestCase
@@ -12,6 +13,42 @@ from django.test.utils import override_settings
 from django.utils.timezone import now
 
 from rest_framework.test import APIClient
+
+import json
+
+
+class ExerciseGeoprocessing(TestCase):
+    def setUp(self):
+        self.polygon = """
+{
+    "type": "MultiPolygon",
+    "coordinates": [
+        [
+            [
+                [-75.61614990234375, 39.78426800449774],
+                [-75.67245483398438, 39.715638134796336],
+                [-75.56808471679688, 39.743098286948275],
+                [-75.61614990234375, 39.78426800449774]
+            ]
+        ]
+    ]
+}
+"""
+
+    def test_geotrellis_good(self):
+        actual = geoprocessing.geotrellis(self.polygon)
+        expected = "[[[90, 4], 140], [[41, 4], 967], [[23, 2], 6763], [[81, 3], 203], [[52, 2], 1430], [[42, 2], 1286], [[31, 3], 48], [[24, 3], 472], [[21, 2], 18212], [[42, 3], 41], [[22, 4], 409], [[23, 4], 327], [[82, 3], 113], [[43, 3], 1208], [[82, 2], 49], [[43, 0], 151], [[90, 3], 6507], [[81, 2], 1160], [[21, 3], 5958], [[11, 3], 26], [[24, 0], 5436], [[52, 4], 103], [[31, 2], 128], [[52, 0], 130], [[42, 4], 37], [[11, 2], 97], [[22, 0], 12904], [[22, 2], 20604], [[81, 4], 63], [[23, 3], 1664], [[21, 4], 1316], [[43, 2], 1398], [[43, 4], 128], [[41, 3], 7080], [[24, 4], 80], [[42, 0], 191], [[90, 0], 137], [[22, 3], 2967], [[52, 3], 728], [[11, 0], 1736], [[41, 0], 862], [[41, 2], 12140], [[21, 0], 8088], [[90, 2], 1425], [[23, 0], 4382], [[24, 2], 1787]]"  # noqa
+        self.assertEqual(json.loads(actual), json.loads(expected), "Discrepant answer from Geotrellis")  # noqa
+
+    def test_geotrellis_bad(self):
+        actual = geoprocessing.geotrellis('this is not valid geojson')
+        expected = "Invalid or no GeoJSON."
+        self.assertEqual(actual, expected, "Discrepant answer from Geotrellis")
+
+    def test_survey(self):
+        actual = geoprocessing.geojson_to_survey(self.polygon)
+        expected = '[{"displayName": "Land", "name": "land", "categories": [{"type": "Urban- or Tall-Grass", "coverage": 0.25613170482373493, "area": 33574}, {"type": "Low-Intensity Res.", "coverage": 0.2813832668350104, "area": 36884}, {"type": "Deciduous Forest", "coverage": 0.1605800993278965, "area": 21049}, {"type": "Water", "coverage": 0.014182070628084924, "area": 1859}, {"type": "Mixed Forest", "coverage": 0.022009291964510493, "area": 2885}, {"type": "Industrial &c.", "coverage": 0.05931446967905341, "area": 7775}, {"type": "Desert &c.", "coverage": 0.001342681242895614, "area": 176}, {"type": "Woody Wetland", "coverage": 0.06262539956210282, "area": 8209}, {"type": "High-Intensity Res.", "coverage": 0.10021284549248174, "area": 13136}, {"type": "Evergreen Forest", "coverage": 0.011862893935810682, "area": 1555}, {"type": "Pasture &c.", "coverage": 0.010878769615733783, "area": 1426}, {"type": "Chaparral", "coverage": 0.01824062983956485, "area": 2391}, {"type": "Row Crop", "coverage": 0.0012358770531198267, "area": 162}]}, {"displayName": "Soil", "name": "soil", "categories": [{"type": "C", "coverage": 0.2060939419137785, "area": 27015}, {"type": "B", "coverage": 0.5071596951503269, "area": 66479}, {"type": "D", "coverage": 0.02723506839282581, "area": 3570}, {"type": "?", "coverage": 0.2595112945430688, "area": 34017}]}]'  # noqa
+        self.assertEqual(actual, json.loads(expected), "Discrepant survey.")
 
 
 class TaskRunnerTestCase(TestCase):

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -50,6 +50,11 @@ class ExerciseGeoprocessing(TestCase):
         expected = '[{"displayName": "Land", "name": "land", "categories": [{"type": "Urban- or Tall-Grass", "coverage": 0.25613170482373493, "area": 33574}, {"type": "Low-Intensity Res.", "coverage": 0.2813832668350104, "area": 36884}, {"type": "Deciduous Forest", "coverage": 0.1605800993278965, "area": 21049}, {"type": "Water", "coverage": 0.014182070628084924, "area": 1859}, {"type": "Mixed Forest", "coverage": 0.022009291964510493, "area": 2885}, {"type": "Industrial &c.", "coverage": 0.05931446967905341, "area": 7775}, {"type": "Desert &c.", "coverage": 0.001342681242895614, "area": 176}, {"type": "Woody Wetland", "coverage": 0.06262539956210282, "area": 8209}, {"type": "High-Intensity Res.", "coverage": 0.10021284549248174, "area": 13136}, {"type": "Evergreen Forest", "coverage": 0.011862893935810682, "area": 1555}, {"type": "Pasture &c.", "coverage": 0.010878769615733783, "area": 1426}, {"type": "Chaparral", "coverage": 0.01824062983956485, "area": 2391}, {"type": "Row Crop", "coverage": 0.0012358770531198267, "area": 162}]}, {"displayName": "Soil", "name": "soil", "categories": [{"type": "C", "coverage": 0.2060939419137785, "area": 27015}, {"type": "B", "coverage": 0.5071596951503269, "area": 66479}, {"type": "D", "coverage": 0.02723506839282581, "area": 3570}, {"type": "?", "coverage": 0.2595112945430688, "area": 34017}]}]'  # noqa
         self.assertEqual(actual, json.loads(expected), "Discrepant survey.")
 
+    def test_census(self):
+        actual = geoprocessing.geojson_to_census(self.polygon)
+        expected = '{"distribution": {"b:industrial": {"cell_count": 1787}, "b:deciduous_forest": {"cell_count": 12140}, "c:row_crop": {"cell_count": 113}, "b:mixed_forest": {"cell_count": 1398}, "c:evergreen_forest": {"cell_count": 41}, "b:urban_grass": {"cell_count": 18212}, "b:water": {"cell_count": 97}, "c:pasture": {"cell_count": 203}, "d:urban_grass": {"cell_count": 1316}, "d:industrial": {"cell_count": 80}, "b:woody_wetland": {"cell_count": 1425}, "b:hi_residential": {"cell_count": 6763}, "c:li_residential": {"cell_count": 2967}, "d:li_residential": {"cell_count": 409}, "b:pasture": {"cell_count": 1160}, "c:chaparral": {"cell_count": 728}, "c:hi_residential": {"cell_count": 1664}, "c:desert": {"cell_count": 48}, "c:water": {"cell_count": 26}, "b:row_crop": {"cell_count": 49}, "c:deciduous_forest": {"cell_count": 7080}, "d:woody_wetland": {"cell_count": 140}, "c:industrial": {"cell_count": 472}, "d:pasture": {"cell_count": 63}, "c:urban_grass": {"cell_count": 5958}, "b:desert": {"cell_count": 128}, "d:chaparral": {"cell_count": 103}, "c:mixed_forest": {"cell_count": 1208}, "b:li_residential": {"cell_count": 20604}, "d:mixed_forest": {"cell_count": 128}, "c:woody_wetland": {"cell_count": 6507}, "d:hi_residential": {"cell_count": 327}, "d:deciduous_forest": {"cell_count": 967}, "b:evergreen_forest": {"cell_count": 1286}, "b:chaparral": {"cell_count": 1430}, "d:evergreen_forest": {"cell_count": 37}}, "cell_count": 131081}'  # noqa
+        self.assertEqual(actual, json.loads(expected), "Discrepant census.")
+
 
 class TaskRunnerTestCase(TestCase):
     def setUp(self):
@@ -124,9 +129,8 @@ class TaskRunnerTestCase(TestCase):
 
         with self.assertRaises(Exception) as context:
             views._initiate_tr55_job_chain(model_input, self.job.id)
-
         self.assertEqual(str(context.exception),
-                         'No precipitation value defined',
+                         'No Area of Interest',
                          'Unexpected exception occurred')
 
     def test_tr55_chain_skips_census_if_census_is_up_to_date(self):

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -143,7 +143,7 @@ def scenario(request, scen_id):
 def start_analyze(request, format=None):
     user = request.user if request.user.is_authenticated() else None
     created = now()
-    area_of_interest = request.POST
+    area_of_interest = request.POST['area_of_interest']
     job = Job.objects.create(created_at=created, result='', error='',
                              traceback='', user=user, status='started')
 

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -40,19 +40,21 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
         var self = this;
 
         if (!this.model.get('result')) {
-            var taskHelper = {
-                pollSuccess: function() {
-                    self.showDetailsRegion();
-                },
+            var aoi = JSON.stringify(this.model.get('area_of_interest')),
+                taskHelper = {
+                    pollSuccess: function() {
+                        self.showDetailsRegion();
+                    },
 
-                pollFailure: function() {
-                    self.showErrorMessage();
-                },
+                    pollFailure: function() {
+                        self.showErrorMessage();
+                    },
 
-                startFailure: function() {
-                    self.showErrorMessage();
-                }
-            };
+                    startFailure: function() {
+                        self.showErrorMessage();
+                    },
+                    postData: {'area_of_interest': aoi}
+                };
             this.model.start(taskHelper);
         } else {
             this.lock = $.Deferred();

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -403,6 +403,11 @@ ITSI = {
     'embed_flag': 'itsi_embed',
 }
 
+# Geoprocessing Settings
+GEOP = {
+    'host': environ.get('MMW_GEOPROCESSING_HOST', 'localhost')
+}
+
 BASE_LAYERS = {
     'Mapbox Roads': {
         'url': 'https://{s}.tiles.mapbox.com/v3/ctaylor.lg2deoc9/{z}/{x}/{y}.png',

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -9,4 +9,4 @@ django-registration-redux==1.2
 python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
-tr55==0.1.0
+git+https://github.com/jamesmcclain/tr-55.git@feature/change-input-format


### PR DESCRIPTION
Connects #585

**To Test**

   1. Do all of the things needed to run https://github.com/WikiWatershed/model-my-watershed/pull/589
   2. Reprovision `app` and `worker`, or manually update the TR-55 code on those two VMs (`sudo pip uninstall tr55` then `sudo pip install 'git+https://github.com/jamesmcclain/tr-55.git'`).

**Caveats**

   1. Many of the caveats which apply to https://github.com/WikiWatershed/model-my-watershed/pull/589 also apply here, in particular the small size of the test area.
   2. Do not overlap reclassifications and/or BMPs.  There is no fundamental reason why these cannot overlap on the user's screen, but they must be provided to the code as a non-intersecting collection, which the current front-end code does not do.  At present, overlaps cause undefined results.
   3. Certain BMPS like "infiltration basins" and "porous paving" are virtually unusable because they are restricted to certain soil types.  Since you cannot tell which areas are allowed and which aren't chances are using either of those BMPs will raise an error.
   4. The water quality results may or may not be valid: those calculations need to know the area of a tile, and the value currently being used may not be correct.

![screenshot from 2015-07-23 15 13 36](https://cloud.githubusercontent.com/assets/11281373/8859856/00a0ce84-314e-11e5-9a81-fedd832a6336.png)

![screenshot from 2015-07-23 15 13 06](https://cloud.githubusercontent.com/assets/11281373/8859864/03e53724-314e-11e5-8df2-0b77bbcd4954.png)

![screenshot from 2015-07-23 15 14 03](https://cloud.githubusercontent.com/assets/11281373/8859867/09a2c1c2-314e-11e5-9ec7-cffa076b40a4.png)

![screenshot from 2015-07-23 15 14 32](https://cloud.githubusercontent.com/assets/11281373/8859873/14478ed2-314e-11e5-8e5d-9ef661d40880.png)
