### PR TITLE
Improve isolation between unit tests

### DIFF
--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -9,24 +9,29 @@ var _ = require('lodash'),
     sinon = require('sinon'),
     models = require('./models'),
     views = require('./views'),
+    App = require('../app'),
+    testUtils = require('../core/testUtils'),
     sandboxTemplate = require('../core/templates/sandbox.html');
 
 var sandboxHeight = '500',
-    sandboxWidth = '700';
+    sandboxWidth = '700',
+    displaySandboxId = 'display-sandbox',
+    displaySandboxSelector = '#' + displaySandboxId;
 
 var SandboxRegion = Marionette.Region.extend({
-    el: '#display-sandbox'
+    el: displaySandboxSelector
 });
 
 describe('Analyze', function() {
     beforeEach(function() {
-        $('#display-sandbox').remove();
+        $(displaySandboxSelector).remove();
         // Use a special sandbox so that we can test responsiveness of chart.
         $('body').append(sandboxTemplate.render({height: sandboxHeight, width: sandboxWidth}));
     });
 
     afterEach(function() {
-        $('#display-sandbox').remove();
+        testUtils.resetApp(App);
+        $(displaySandboxSelector).remove();
     });
 
     describe('DetailsView', function() {
@@ -36,7 +41,6 @@ describe('Analyze', function() {
         });
 
         afterEach(function() {
-            $('#display-sandbox').empty();
             this.server.restore();
         });
 
@@ -66,6 +70,7 @@ function setupViewAndTest(dataSet, testFn, done) {
         });
     view.listenTo(view, 'show', function() {
         testFn(dataSet);
+        view.destroy();
         done();
     });
     sandbox.show(view);

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -15,17 +15,22 @@ var App = new Marionette.Application({
 
         // This view is intentionally not attached to any region.
         this._mapView = new views.MapView({
-            model: this.map
+            model: this.map,
+            el: '#map'
         });
 
         this.rootView = new views.RootView();
         this.user = new userModels.UserModel({});
 
-        var header = new views.HeaderView({
+        this.header = new views.HeaderView({
             el: 'header',
             model: this.user
         });
-        header.render();
+        this.header.render();
+
+        // Not set until modeling/controllers.js creates a
+        // new project.
+        this.currProject = null;
     },
 
     load: function(data) {

--- a/src/mmw/js/src/core/templates/sandbox.html
+++ b/src/mmw/js/src/core/templates/sandbox.html
@@ -1,2 +1,3 @@
 <div id="display-sandbox" style="height:{{ height }}px; width:{{ width }}px; display: block">
+    <div id="map"></div>
 </div>

--- a/src/mmw/js/src/core/testUtils.js
+++ b/src/mmw/js/src/core/testUtils.js
@@ -1,0 +1,36 @@
+"use strict";
+
+var $ = require('jquery');
+
+// Should be called after each unit test.
+function resetApp(app) {
+    app.map.off();
+    app.map = null;
+
+    app._mapView.destroy();
+    // Re-create the map div because it gets destroyed by destroy()
+    $('body').append($('<div id="map"/>').css({
+        display: 'none',
+        position: 'relative'
+    }));
+
+    // Don't destroy the rootView because it is attached to the
+    // body element.
+    //app.rootView.destroy();
+
+    app.user.off();
+    app.user = null;
+
+    app.header.destroy();
+
+    if (app.currProject) {
+        app.currProject.off();
+        app.currProject = null;
+    }
+
+    app.initialize();
+}
+
+module.exports = {
+    resetApp: resetApp
+};

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -1,7 +1,6 @@
 "use strict";
 
-var $ = require('jquery'),
-    L = require('leaflet'),
+var L = require('leaflet'),
     _ = require('underscore'),
     router = require('../router.js').router,
     Marionette = require('../../shim/backbone.marionette'),
@@ -111,10 +110,6 @@ function addLocateMeButton(map, maxZoom, maxAge) {
 // This view houses a Leaflet instance. The map container element must exist
 // in the DOM before initializing.
 var MapView = Marionette.ItemView.extend({
-    ui: {
-        map: '#map'
-    },
-
     modelEvents: {
         'change': 'updateView',
         'change:areaOfInterest': 'updateAreaOfInterest',
@@ -134,7 +129,7 @@ var MapView = Marionette.ItemView.extend({
     _modificationsLayer: null,
 
     initialize: function() {
-        var map = new L.Map('map', { zoomControl: false }),
+        var map = new L.Map(this.el, { zoomControl: false }),
             areaOfInterestLayer = new L.FeatureGroup(),
             modificationsLayer = new L.FeatureGroup(),
             maxZoom = 10,
@@ -192,15 +187,20 @@ var MapView = Marionette.ItemView.extend({
         // supported, nothing more needs to be done since the map has
         // already been centered.
         if (navigator.geolocation) {
-            var options = {
+            var geolocationOptions = {
                 maximumAge : maxAge,
                 timeout : timeout
             };
             navigator.geolocation.getCurrentPosition(
                 geolocation_success,
                 _.noop,
-                options);
+                geolocationOptions
+            );
         }
+    },
+
+    onBeforeDestroy: function() {
+        this._leafletMap.remove();
     },
 
     // Call this so that the geolocation callback will not
@@ -319,9 +319,9 @@ var MapView = Marionette.ItemView.extend({
     toggleMapSize: function() {
         var size = this.model.get('size');
         if (size.half) {
-            $(this.ui.map).addClass('half');
+            this.$el.addClass('half');
         } else {
-            $(this.ui.map).removeClass('half');
+            this.$el.removeClass('half');
         }
 
         this._leafletMap.invalidateSize();

--- a/src/mmw/js/src/draw/tests.js
+++ b/src/mmw/js/src/draw/tests.js
@@ -10,15 +10,18 @@ var $ = require('jquery'),
     App = require('../app'),
     models = require('./models'),
     utils = require('./utils'),
-    views = require('./views');
+    views = require('./views'),
+    testUtils = require('../core/testUtils');
 
-var TEST_SHAPE = {
-    'type': 'MultiPolygon',
-    'coordinates': [[[-5e6, -1e6], [-4e6, 1e6], [-3e6, -1e6]]]
-};
+var sandboxId = 'sandbox',
+    sandboxSelector = '#' + sandboxId,
+    TEST_SHAPE = {
+        'type': 'MultiPolygon',
+        'coordinates': [[[-5e6, -1e6], [-4e6, 1e6], [-3e6, -1e6]]]
+    };
 
 var SandboxRegion = Marionette.Region.extend({
-    el: '#sandbox'
+    el: sandboxSelector
 });
 
 describe('Draw', function() {
@@ -27,8 +30,9 @@ describe('Draw', function() {
     });
 
     afterEach(function() {
-        $('#sandbox').remove();
+        $(sandboxSelector).remove();
         window.location.hash = '';
+        testUtils.resetApp(App);
     });
 
     describe('ToolbarView', function() {
@@ -88,8 +92,6 @@ describe('Draw', function() {
                     success = false;
                 }).
                 always(function() {
-                    App.getLeafletMap().closePopup();
-                    App.getLeafletMap()._panAnim = false;
                     assert.equal(success, false);
                     done();
                 });

--- a/src/mmw/js/src/geocode/tests.js
+++ b/src/mmw/js/src/geocode/tests.js
@@ -9,15 +9,19 @@ var _ = require('lodash'),
     sinon = require('sinon'),
     App = require('../app'),
     views = require('./views'),
-    models = require('./models');
+    models = require('./models'),
+    testUtils = require('../core/testUtils');
+
+var sandboxId = 'sandbox',
+    sandboxSelector = '#' + sandboxId;
 
 describe('Geocoder', function() {
     var MSG_EMPTY = 'No results found.',
         MSG_ERROR = 'Oops! Something went wrong.';
 
     before(function() {
-        if ($('#sandbox').length === 0) {
-            $('<div>', {id: 'sandbox'}).appendTo('body');
+        if ($(sandboxSelector).length === 0) {
+            $('<div>', {id: sandboxId}).appendTo('body');
         }
     });
 
@@ -27,12 +31,13 @@ describe('Geocoder', function() {
     });
 
     afterEach(function() {
-        $('#sandbox').empty();
+        $(sandboxSelector).empty();
         this.server.restore();
+        testUtils.resetApp(App);
     });
 
     after(function() {
-        $('#sandbox').remove();
+        $(sandboxSelector).remove();
     });
 
     describe('SearchBoxView', function() {
@@ -220,7 +225,7 @@ function createView() {
             collection: new models.SuggestionsCollection()
         });
 
-    $('#sandbox').html(view.render().el);
+    $(sandboxSelector).html(view.render().el);
 
     return view;
 }

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var Backbone = require('../../shim/backbone'),
-    _ = require('underscore'),
+    _ = require('lodash'),
     utils = require('../core/utils'),
     App = require('../app'),
     coreModels = require('../core/models');

--- a/src/mmw/js/src/user/tests.js
+++ b/src/mmw/js/src/user/tests.js
@@ -9,18 +9,20 @@ var _ = require('lodash'),
     App = require('../app'),
     views = require('./views'),
     models = require('./models'),
-    coreViews = require('../core/views');
+    coreViews = require('../core/views'),
+    testUtils = require('../core/testUtils');
 
-var ENTER_KEYCODE = 13;
-
+var ENTER_KEYCODE = 13,
+    sandboxId = 'sandbox',
+    sandboxSelector = '#' + sandboxId;
 
 describe('User', function() {
     before(function() {
     });
 
     beforeEach(function() {
-        $('#sandbox').remove();
-        $('<div>', {id: 'sandbox'}).appendTo('body');
+        $(sandboxSelector).remove();
+        $('<div>', {id: sandboxId}).appendTo('body');
 
         this.server = sinon.fakeServer.create();
         this.server.respondImmediately = true;
@@ -28,16 +30,17 @@ describe('User', function() {
 
     afterEach(function() {
         this.server.restore();
+        testUtils.resetApp(App);
     });
 
     after(function() {
-        $('#sandbox').remove();
+        $(sandboxSelector).remove();
     });
 
     describe('LoginView', function() {
         it('creates an error when there is no username', function() {
             var loginView = new views.LoginModalView({
-                el: '#sandbox',
+                el: sandboxSelector,
                 model: new models.LoginFormModel({}),
                 app: App
             }).render();
@@ -51,7 +54,7 @@ describe('User', function() {
 
         it('creates an error when there is no password', function() {
             var loginView = new views.LoginModalView({
-                el: '#sandbox',
+                el: sandboxSelector,
                 model: new models.LoginFormModel({}),
                 app: App
             }).render();
@@ -66,7 +69,7 @@ describe('User', function() {
         it('creates an error when trying to fetch a user with bad credentials', function() {
             this.server.respondWith([400, { 'Content-Type': 'application/json' }, '{"errors": ["Invalid username or password"], "guest": true}']);
             var loginView = new views.LoginModalView({
-                el: '#sandbox',
+                el: sandboxSelector,
                 model: new models.LoginFormModel({}),
                 app: App
             }).render();
@@ -82,7 +85,7 @@ describe('User', function() {
         it ('creates an error when failing to communicate with server', function() {
             this.server.respondWith([500, {}, '']);
             var loginView = new views.LoginModalView({
-                el: '#sandbox',
+                el: sandboxSelector,
                 model: new models.LoginFormModel({}),
                 app: App
             }).render();
@@ -99,7 +102,7 @@ describe('User', function() {
             var username = 'bob';
             this.server.respondWith([200, { 'Content-Type': 'application/json' }, '{"result": "success", "username": "bob" }']);
             var loginView = new views.LoginModalView({
-                el: '#sandbox',
+                el: sandboxSelector,
                 model: new models.LoginFormModel({}),
                 app: App
             }).render();
@@ -119,7 +122,7 @@ describe('User', function() {
             var username = 'john';
             this.server.respondWith([200, { 'Content-Type': 'application/json' }, '{"result": "success", "username": "' + username + '" }']);
             var loginView = new views.LoginModalView({
-                el: '#sandbox',
+                el: sandboxSelector,
                 model: new models.LoginFormModel({}),
                 app: App
             }).render();
@@ -150,7 +153,7 @@ describe('User', function() {
 
         it('should not dismiss the modal form if a non-enter key is pressed', function() {
             var loginView = new views.LoginModalView({
-                el: '#sandbox',
+                el: sandboxSelector,
                 model: new models.LoginFormModel({}),
                 app: App
             }).render();


### PR DESCRIPTION
The main improvements of this PR are to reset the App object after each test, and to pass the MapView a map container id, so it won't conflict with the one that is part of App. Some of the tests had to be updated to accommodate these changes. To test, run the unit tests and trying running the app to make sure it still works. Note that a kludge needed to reset part of the map state (https://github.com/lewfish/model-my-watershed/commit/127f69b17407988abd4e5a9c672164bcf2056001) is no longer necessary. 

Connects #558 