### PR TITLE
Clone Projects / Embed in ITSI

### DIFF
--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.conf.urls import patterns, url
-from apps.home.views import home_page, project
+from apps.home.views import home_page, project, project_clone
 
 
 urlpatterns = patterns(
@@ -12,6 +12,8 @@ urlpatterns = patterns(
     url(r'^$', home_page, name='home_page'),
     url(r'^project/$', project, name='project'),
     url(r'^project/(?P<proj_id>[0-9]+)/$', project, name='project'),
+    url(r'^project/(?P<proj_id>[0-9]+)/clone/?$',
+        project_clone, name='project_clone'),
     url(r'^project/(?P<proj_id>[0-9]+)/scenario/(?P<scenario_id>[0-9]+)/$',
         project, name='project'),
     url(r'^analyze$', home_page, name='analyze'),

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -35,6 +35,8 @@ def login(request):
                 auth_login(request, user)
                 response_data['result'] = 'success'
                 response_data['username'] = user.username
+                response_data['itsi'] = \
+                    ItsiUser.objects.filter(user_id=user.id).exists()
                 response_data['guest'] = False
                 response_data['id'] = user.id
             else:
@@ -53,6 +55,8 @@ def login(request):
 
         if user.is_authenticated() and user.is_active:
             response_data['username'] = user.username
+            response_data['itsi'] = \
+                ItsiUser.objects.filter(user_id=user.id).exists()
             response_data['guest'] = False
             response_data['id'] = user.id
         else:
@@ -72,6 +76,7 @@ def logout(request):
 
     if request.is_ajax():
         response_data = {
+            'itsi': False,
             'guest': True,
             'result': 'success',
             'id': 0
@@ -170,9 +175,13 @@ def itsi_sign_up(request):
     user = authenticate(itsi_id=itsi_id)
     auth_login(request, user)
 
-    response_data = {'result': 'success',
-                     'username': user.username,
-                     'guest': False}
+    response_data = {
+        'result': 'success',
+        'username': user.username,
+        'itsi': True,
+        'guest': False,
+        'id': user.id
+    }
     return Response(data=response_data,
                     status=status.HTTP_200_OK)
 

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -33,37 +33,46 @@ def login(request):
         if user is not None:
             if user.is_active:
                 auth_login(request, user)
-                response_data['result'] = 'success'
-                response_data['username'] = user.username
-                response_data['itsi'] = \
-                    ItsiUser.objects.filter(user_id=user.id).exists()
-                response_data['guest'] = False
-                response_data['id'] = user.id
+                response_data = {
+                    'result': 'success',
+                    'username': user.username,
+                    'itsi': ItsiUser.objects.filter(user_id=user.id).exists(),
+                    'guest': False,
+                    'id': user.id
+                }
             else:
-                response_data['errors'] = ['Please activate your account']
-                response_data['guest'] = True
-                response_data['id'] = 0
+                response_data = {
+                    'errors': ['Please activate your account'],
+                    'guest': True,
+                    'id': 0
+                }
                 status_code = status.HTTP_400_BAD_REQUEST
         else:
-            response_data['errors'] = ['Invalid username or password']
-            response_data['guest'] = True
-            response_data['id'] = 0
+            response_data = {
+                'errors': ['Invalid username or password'],
+                'guest': True,
+                'id': 0
+            }
             status_code = status.HTTP_400_BAD_REQUEST
 
     elif request.method == 'GET':
         user = request.user
 
         if user.is_authenticated() and user.is_active:
-            response_data['username'] = user.username
-            response_data['itsi'] = \
-                ItsiUser.objects.filter(user_id=user.id).exists()
-            response_data['guest'] = False
-            response_data['id'] = user.id
+            response_data = {
+                'result': 'success',
+                'username': user.username,
+                'itsi': ItsiUser.objects.filter(user_id=user.id).exists(),
+                'guest': False,
+                'id': user.id
+            }
         else:
-            response_data['guest'] = True
-            response_data['id'] = 0
+            response_data = {
+                'result': 'success',
+                'guest': True,
+                'id': 0
+            }
 
-        response_data['result'] = 'success'
         status_code = status.HTTP_200_OK
 
     return Response(data=response_data, status=status_code)
@@ -76,9 +85,9 @@ def logout(request):
 
     if request.is_ajax():
         response_data = {
+            'result': 'success',
             'itsi': False,
             'guest': True,
-            'result': 'success',
             'id': 0
         }
         return Response(data=response_data)

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -4,6 +4,7 @@ var $ = require('jquery'),
     L = require('leaflet'),
     _ = require('underscore'),
     router = require('../router.js').router,
+    Backbone = require('../../shim/backbone'),
     Marionette = require('../../shim/backbone.marionette'),
     TransitionRegion = require('../../shim/marionette.transition-region'),
     ZeroClipboard = require('zeroclipboard'),
@@ -529,7 +530,29 @@ var ShareModal = BaseModal.extend({
             self.zc.clip(self.$el.find(self.ui.copy.selector));
         });
 
-        this.$el.modal('show');
+        if (this.model.get('is_private')) {
+            var question = 'This project is currently private. ' +
+                    'You must make it public before it can be shared with others. ' +
+                    'Once public, anyone with the URL can access it.',
+                confirm = new ConfirmModal({
+                    model: new Backbone.Model({
+                        question: question,
+                        confirmLabel: 'Make Public',
+                        cancelLabel: 'Cancel'
+                    })
+                });
+
+            confirm.render();
+            confirm.on('confirmation', function() {
+                var project = self.options.app.currProject;
+                project.set('is_private', false);
+                project.saveProjectAndScenarios();
+
+                self.$el.modal('show');
+            });
+        } else {
+            this.$el.modal('show');
+        }
     },
 
     onModalShown: function() {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -527,7 +527,7 @@ var ShareModal = BaseModal.extend({
     onRender: function() {
         var self = this;
         this.$el.on('shown.bs.modal', function() {
-            self.zc.clip(self.$el.find(self.ui.copy.selector));
+            self.zc.clip(self.ui.copy);
         });
 
         if (this.model.get('is_private')) {

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -84,6 +84,13 @@ var ModelingController = {
         App.getMapView().updateModifications(null);
         App.rootView.subHeaderRegion.empty();
         App.rootView.footerRegion.empty();
+    },
+
+    // Since we handle redirects after ITSI sign-up within Backbone,
+    // but project cloning is done only on server side, we redirect
+    // the project cloning route back to the server.
+    projectClone: function() {
+        window.location.replace(window.location.href);
     }
 };
 

--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -21,6 +21,9 @@
                 <li role="presentation"><a role="menuitem" tabindex="-1" id="save-project">Save</a></li>
             {% endif %}
             <li role="presentation"><a role="menuitem" tabindex="-1" id="print-project">Print</a></li>
+            {% if itsi %}
+                <li role="presentation"><a role="menuitem" tabindex="-1" id="itsi-clone">Embed in ITSI</a></li>
+            {% endif %}
         </ul>
     </div>
 </div>

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -200,7 +200,7 @@ describe('Modeling', function() {
 
                 $('#sandbox').html(view.render().el);
 
-                assert.equal($('#sandbox li').length, 3);
+                assert.equal($('#sandbox li').length, preSaveMenuItems.length);
                 $('#sandbox li').each(function() {
                     assert.include(preSaveMenuItems, $(this).text());
                 });
@@ -228,7 +228,7 @@ describe('Modeling', function() {
 
                 $('#sandbox').html(view.render().el);
 
-                assert.equal($('#sandbox li').length, 6);
+                assert.equal($('#sandbox li').length, postSaveMenuItems.length);
                 $('#sandbox li').each(function() {
                     assert.include(postSaveMenuItems, $(this).text());
                 });
@@ -296,7 +296,7 @@ describe('Modeling', function() {
 
                 $('#sandbox').html(view.render().el);
 
-                assert.equal($('#sandbox li').length, 7);
+                assert.equal($('#sandbox li').length, postSaveMenuItems.length);
                 $('#sandbox li').each(function() {
                     assert.include(postSaveMenuItems, $(this).text());
                 });

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -269,6 +269,38 @@ describe('Modeling', function() {
 
                 assert.equal($('#sandbox #project-privacy').text(), 'Make Private');
             });
+
+            it('shows "Embed in ITSI" link only for ITSI users', function() {
+                App.user.set({
+                    id: 1,
+                    itsi: true
+                });
+
+                var project = getTestProject(),
+                    view = new views.ProjectMenuView({ model: project }),
+                    projectResponse = '{"id":21,"user":{"id":1,"username":"test","email":"test@azavea.com"},"scenarios":[],"name":"Test Project","area_of_interest":{},"is_private":true,"model_package":"tr-55","created_at":"2015-06-03T20:09:11.988948Z","modified_at":"2015-06-03T20:09:11.988988Z"}',
+                    postSaveMenuItems = [
+                        'Share',
+                        'Make Public',
+                        'Delete',
+                        'Add Tags',
+                        'Rename',
+                        'Print',
+                        'Embed in ITSI'
+                    ];
+
+                this.server.respondWith('POST', '/api/modeling/projects/',
+                            [ 200, { 'Content-Type': 'application/json' }, projectResponse ]);
+
+                project.save();
+
+                $('#sandbox').html(view.render().el);
+
+                assert.equal($('#sandbox li').length, 7);
+                $('#sandbox li').each(function() {
+                    assert.include(postSaveMenuItems, $(this).text());
+                });
+            });
         });
     });
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -87,7 +87,8 @@ var ProjectMenuView = Marionette.ItemView.extend({
         remove: '#delete-project',
         print: '#print-project',
         save: '#save-project',
-        privacy: '#project-privacy'
+        privacy: '#project-privacy',
+        itsiClone: '#itsi-clone'
     },
 
     events: {
@@ -96,13 +97,15 @@ var ProjectMenuView = Marionette.ItemView.extend({
         'click @ui.share': 'shareProject',
         'click @ui.print': 'printProject',
         'click @ui.save': 'saveProjectOrLoginUser',
-        'click @ui.privacy': 'setProjectPrivacy'
+        'click @ui.privacy': 'setProjectPrivacy',
+        'click @ui.itsiClone': 'getItsiEmbedLink'
     },
 
     template: projectMenuTmpl,
 
     templateHelpers: function() {
         return {
+            itsi: App.user.get('itsi'),
             editable: isEditable(this.model),
             is_new: this.model.isNew()
         };
@@ -132,7 +135,8 @@ var ProjectMenuView = Marionette.ItemView.extend({
                 model: new Backbone.Model({
                     text: 'Project',
                     url: window.location.href,
-                    guest: App.user.get('guest')
+                    guest: App.user.get('guest'),
+                    is_private: this.model.get('is_private')
                 }),
                 app: App
             });
@@ -204,6 +208,23 @@ var ProjectMenuView = Marionette.ItemView.extend({
             self.model.set('is_private', !self.model.get('is_private'));
             self.model.saveProjectAndScenarios();
         });
+    },
+
+    getItsiEmbedLink: function() {
+        var self = this,
+            embedLink = window.location.origin +
+                '/project/' + App.currProject.id + '/clone?itsi_embed=true',
+            modal = new coreViews.ShareModal({
+                model: new Backbone.Model({
+                    text: 'Embed Link',
+                    url: embedLink,
+                    guest: App.user.get('guest'),
+                    is_private: self.model.get('is_private')
+                }),
+                app: App
+            });
+
+        modal.render();
     }
 });
 

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -10,13 +10,10 @@ var router = require('./router').router,
 
 router.addRoute(/^/, DrawController, 'draw');
 router.addRoute(/^analyze/, AnalyzeController, 'analyze');
-router.addRoute(/^project/, ModelingController, 'project');
-router.addRoute('project/:projectId', ModelingController, 'project');
-router.addRoute('project/:projectId/', ModelingController, 'project');
+router.addRoute('project(/:projectId)(/scenario/:scenarioId)(/)', ModelingController, 'project');
 router.addRoute('project/:projectId/clone(/)', ModelingController, 'projectClone');
-router.addRoute('project/:projectId/scenario/:scenarioId/', ModelingController, 'project');
 //TODO Add route for /project/XX/scenario/compare
 router.addRoute(/^compare/, CompareController, 'compare');
-router.addRoute('error(/)(:type)', ErrorController, 'error');
+router.addRoute('error(/:type)(/)', ErrorController, 'error');
 router.addRoute('sign-up(/)', SignUpController, 'signUp');
-router.addRoute('sign-up/itsi(/)(:username)(/:first_name)(/:last_name)', SignUpController, 'itsiSignUp');
+router.addRoute('sign-up/itsi(/:username)(/:first_name)(/:last_name)(/)', SignUpController, 'itsiSignUp');

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -13,6 +13,7 @@ router.addRoute(/^analyze/, AnalyzeController, 'analyze');
 router.addRoute(/^project/, ModelingController, 'project');
 router.addRoute('project/:projectId', ModelingController, 'project');
 router.addRoute('project/:projectId/', ModelingController, 'project');
+router.addRoute('project/:projectId/clone(/)', ModelingController, 'projectClone');
 router.addRoute('project/:projectId/scenario/:scenarioId/', ModelingController, 'project');
 //TODO Add route for /project/XX/scenario/compare
 router.addRoute(/^compare/, CompareController, 'compare');

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -4,6 +4,7 @@ var Backbone = require('../../shim/backbone');
 
 var UserModel = Backbone.Model.extend({
     defaults: {
+        itsi: false,
         guest: true
     },
 


### PR DESCRIPTION
## Overview

A teacher can create a project for an activity, and set it up with the appropriate Area of Interest, Scenarios, Modifications, etc before sharing with students. When the teacher is ready, they can select "Embed in ITSI" from the project dropdown menu, which will open a `shareModal` window with a URL that they can copy and paste in to an ITSI activity.

When a student logs in to the system, and opens that URL, MMW will first log them in (using the `?itsi_embed=true` flag as implemented for #562 in #578), then clone the project in their workspace and load that project.

## Testing Instructions

 1. Log in using the `mmwterence` user (see Wiki for passwords)
 2. Create a new project. Make arbitrary changes to scenarios.
 3. In the project dropdown, click "Embed in ITSI" and copy the link.
 4. Go to ITSI and log out as `mmwterence`, and log in as `tstudent2`. You should still be logged in as `mmwterence` in MMW.
 5. Open a new tab and paste in the link. You should first be logged in as `tstudent2` (and you might be prompted to create an account if it doesn't already exist), then the project should be cloned and you should be redirected to a new project, identical to the first one, but now owned by `tstudent2`.

 * Run all tests.

## Implementation Notes

There are two parts to this PR: one that introduces project cloning functionality, which is in fact available to all users via the `/project/XX/clone` URL, and the second which allows the front-end to distinguish between ITSI and non-ITSI users, so that it may show the link only to the former and not the latter.

~~Since a project _must_ be public before it can be cloned by another user, when the "Copy" button in the Embed in ITSI modal is clicked, we automatically make the project public. However, if the user copies the text directly, then the resulting link will fail. Given this, perhaps we should make the project public as soon as the link is clicked in the menu. Or perhaps prompt the user to explicitly make the project public before they are allowed to get the embed link.~~

Since a project _must_ be public before it can be cloned by another user, when the "Embed in ITSI" link is clicked, we check to see if the project is already public. If it isn't, then we prompt the user to explicitly make it public. Once they do, we show the share modal. This functionality has also been added to the "Share" link, since the same limitation applies there.

Please see commit messages for details.

Connects #560