### PR TITLE
Feature/lol/itsi saved blank project

### DIFF
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -30,9 +30,11 @@ def get_stream_layers():
     return stream_layers
 
 
-def get_client_settings():
+def get_client_settings(request):
+    EMBED_FLAG = settings.ITSI['embed_flag']
     client_settings = {
         'client_settings': json.dumps({
+            EMBED_FLAG: request.session.get(EMBED_FLAG, False),
             'base_layers': settings.BASE_LAYERS,
             'stream_layers': get_stream_layers(),
             'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY
@@ -44,7 +46,7 @@ def get_client_settings():
 def get_context(request):
     context = {}
     context.update(csrf(request))
-    context.update(get_client_settings())
+    context.update(get_client_settings(request))
     return context
 
 

--- a/src/mmw/apps/modeling/migrations/0011_project_null_aoi.py
+++ b/src/mmw/apps/modeling/migrations/0011_project_null_aoi.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.contrib.gis.db.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0010_scenario_inputmod_hash'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='area_of_interest',
+            field=django.contrib.gis.db.models.fields.MultiPolygonField(help_text='Base geometry for all scenarios of project', srid=4326, null=True),
+        )
+    ]

--- a/src/mmw/apps/modeling/migrations/0012_project_activity_flag.py
+++ b/src/mmw/apps/modeling/migrations/0012_project_activity_flag.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0011_project_null_aoi'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='is_activity',
+            field=models.BooleanField(default=False, help_text='Projects with special properties'),
+        )
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -15,6 +15,7 @@ class Project(models.Model):
     name = models.CharField(
         max_length=255)
     area_of_interest = models.MultiPolygonField(
+        null=True,
         help_text='Base geometry for all scenarios of project')
     is_private = models.BooleanField(
         default=True)

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -28,6 +28,9 @@ class Project(models.Model):
         auto_now_add=True)
     modified_at = models.DateTimeField(
         auto_now=True)
+    is_activity = models.BooleanField(
+        default=False,
+        help_text='Projects with special properties')
 
     def __unicode__(self):
         return self.name

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -23,6 +23,10 @@ var App = new Marionette.Application({
             el: '#map'
         });
 
+        this._mapView.on('change:needs_reset', function(needs) {
+            App.currProject.set('needs_reset', needs);
+        });
+
         this.rootView = new views.RootView();
         this.user = new userModels.UserModel({});
 

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -5,6 +5,7 @@ var $ = require('jquery'),
     Marionette = require('../shim/backbone.marionette'),
     views = require('./core/views'),
     models = require('./core/models'),
+    settings = require('./core/settings'),
     userModels = require('./user/models'),
     userViews = require('./user/views');
 
@@ -12,6 +13,9 @@ var App = new Marionette.Application({
     initialize: function() {
         this.restApi = new RestAPI();
         this.map = new models.MapModel();
+
+        // If in embed mode we are by default in activity mode.
+        this.activityMode = settings.getSettings().itsi_embed;
 
         // This view is intentionally not attached to any region.
         this._mapView = new views.MapView({

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -15,7 +15,8 @@ var App = new Marionette.Application({
         this.map = new models.MapModel();
 
         // If in embed mode we are by default in activity mode.
-        this.activityMode = settings.getSettings().itsi_embed;
+        var activityMode = settings.get('itsi_embed');
+        settings.set('activityMode', activityMode);
 
         // This view is intentionally not attached to any region.
         this._mapView = new views.MapView({

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -14,8 +14,18 @@ var _ = require('underscore'),
 var ModalBaseView = Marionette.ItemView.extend({
     className: BASIC_MODAL_CLASS,
 
-    attributes: {
-        'tabindex': '-1'
+    attributes: function() {
+        var defaults = { 'tabindex': '-1' },
+            feedbackRequired = {
+                'data-backdrop': 'static',
+                'data-keyboard': 'false'
+            };
+
+        // If feedback is required, we don't allow the user to get away from
+        // the modal without clicking confirm or deny. This way we ensure we
+        // get an event one way or another.
+        // http://getbootstrap.com/javascript/#modals-options
+        return this.model.get('feedbackRequired') ? _.extend(defaults, feedbackRequired) : defaults;
     },
 
     events: {

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -55,16 +55,22 @@ var ConfirmView = ModalBaseView.extend({
     template: modalConfirmTmpl,
 
     ui: {
-        confirmation: '.confirm'
+        confirmation: '.confirm',
+        deny: '.btn-default'
     },
 
     events: _.defaults({
-        'click @ui.confirmation': 'primaryAction'
+        'click @ui.confirmation': 'primaryAction',
+        'click @ui.deny': 'dismissAction'
     }, ModalBaseView.prototype.events),
 
     primaryAction: function() {
         this.triggerMethod('confirmation');
         this.hide();
+    },
+
+    dismissAction: function() {
+        this.triggerMethod('deny');
     }
 });
 

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -12,7 +12,8 @@ var MapModel = Backbone.Model.extend({
         zoom: 0,
         areaOfInterest: null,           // GeoJSON
         halfSize: false,
-        geolocationEnabled: true
+        geolocationEnabled: true,
+        previousAreaOfInterest: null
     },
 
     revertMaskLayer: function() {
@@ -44,6 +45,18 @@ var MapModel = Backbone.Model.extend({
 
             this.set('areaOfInterest', aoi);
         }
+    },
+
+    stashAOI: function() {
+        // Since we oscillate between an area of interest and a blank map, stash
+        // non-null AOI.
+        if (!_.isNull(this.get('areaOfInterest'))) {
+            this.set('previousAreaOfInterest', _.clone(this.get('areaOfInterest')));
+        }
+    },
+
+    revertAOI: function() {
+        this.set('areaOfInterest', _.clone(this.get('previousAreaOfInterest')));
     },
 
     setHalfSize: function(fit) {

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -5,15 +5,24 @@ var defaultSettings = {
     stream_layers: {}
 };
 
-function setSettings(key, value) {
-    defaultSettings[key] = value;
+var settings = (function() {
+    return window.clientSettings ? window.clientSettings : defaultSettings;
+})();
+
+function set(key, value) {
+    settings[key] = value;
+    return value;
 }
 
-function getSettings() {
-    return window.clientSettings ? window.clientSettings : defaultSettings;
+function get(key) {
+    try {
+        return settings[key];
+    } catch (exc) {
+        return undefined;
+    }
 }
 
 module.exports = {
-    getSettings: getSettings,
-    setSettings: setSettings
+    get: get,
+    set: set
 };

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -209,7 +209,7 @@ describe('Core', function() {
                         'url': 'https://{s}.tiles.mapbox.com/v3/examples.map-i86nkdio/{z}/{x}/{y}.png'
                     }
                 };
-                settings.setSettings('base_layers', baseLayers);
+                settings.set('base_layers', baseLayers);
 
                 var model = new models.MapModel(),
                     view = new views.MapView({

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -31,6 +31,17 @@ var utils = {
         return params;
     },
 
+    /**
+     * Returns the value of a query param from the URL if it exists or null:
+     * https://stackoverflow.com/questions/901115
+     */
+    getParameterByName: function(name) {
+        name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+        var regex = new RegExp('[\\?&]' + name + '=([^&#]*)'),
+            results = regex.exec(location.search);
+        return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+    },
+
     // Convert a backbone collection into a canonical MD5 hash
     getCollectionHash: function(collection) {
         // JSON objects are not guaranteed consistent order in string

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -8,22 +8,22 @@ var utils = {
     // Takes queryString of format "key1=value1&key2=value2"
     // Returns object of format {key1: value1, key2: value2}
     // From http://stackoverflow.com/a/11671457/2053314
-    parseQueryString: function (queryString){
+    parseQueryString: function(queryString) {
         var params = {};
-        if(queryString){
+        if (queryString) {
             _.each(
-                _.map(decodeURI(queryString).split(/&/g),function(el){
+                _.map(decodeURI(queryString).split(/&/g), function(el) {
                     var aux = el.split('='), o = {};
-                    if(aux.length >= 1){
+                    if (aux.length >= 1) {
                         var val;
-                        if(aux.length === 2) {
+                        if (aux.length === 2) {
                             val = aux[1];
                         }
                         o[aux[0]] = val;
                     }
                     return o;
                 }),
-                function(o){
+                function(o) {
                     _.extend(params,o);
                 }
             );

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -231,10 +231,12 @@ var MapView = Marionette.ItemView.extend({
             clearProject.on('confirmation', function() {
                 self._didRevert = false;
                 self._areaOfInterestSet = false;
+                self.trigger('change:needs_reset', true);
             });
             clearProject.on('deny', function() {
                 var map = self._leafletMap;
                 self._didRevert = true;
+                self.trigger('change:needs_reset', false);
                 self.model.revertAOI();
                 self.updateAreaOfInterest();
                 drawUtils.cancelDrawing(map);

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -224,8 +224,9 @@ var MapView = Marionette.ItemView.extend({
                     model: new modalModels.ConfirmModel({
                         question: 'If you change the selected area you will lose your current work.',
                         confirmLabel: 'Make Changes',
-                        cancelLabel: 'Cancel'
-                    })
+                        cancelLabel: 'Cancel',
+                        feedbackRequired: true
+                    }),
                 });
 
             clearProject.render();

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -9,7 +9,9 @@ var L = require('leaflet'),
     modificationConfigUtils = require('../modeling/modificationConfigUtils'),
     headerTmpl = require('./templates/header.html'),
     modificationPopupTmpl = require('./templates/modificationPopup.html'),
-    areaOfInterestTmpl = require('../core/templates/areaOfInterestHeader.html'),
+    areaOfInterestTmpl = require('./templates/areaOfInterestHeader.html'),
+    modalModels = require('./modals/models'),
+    modalViews = require('./modals/views'),
     settings = require('./settings');
 
 require('leaflet.locatecontrol');
@@ -128,6 +130,10 @@ var MapView = Marionette.ItemView.extend({
     // L.FeatureGroup instance.
     _modificationsLayer: null,
 
+    // Flag used to determine if AOI change should trigger a prompt.
+    _areaOfInterestSet: false,
+    _didRevert: false,
+
     initialize: function() {
         var map = new L.Map(this.el, { zoomControl: false }),
             areaOfInterestLayer = new L.FeatureGroup(),
@@ -169,6 +175,7 @@ var MapView = Marionette.ItemView.extend({
         // Keep the map model up-to-date with the position of the map
         this.listenTo(map, 'moveend', this.updateMapModelPosition);
         this.listenTo(map, 'zoomend', this.updateMapModelZoom);
+        this.listenTo(this.model, 'change:areaOfInterest', this.aoiChangeWarning);
 
         this._leafletMap = map;
         this._areaOfInterestLayer = areaOfInterestLayer;
@@ -202,6 +209,41 @@ var MapView = Marionette.ItemView.extend({
     onBeforeDestroy: function() {
         this._leafletMap.remove();
     },
+
+    aoiChangeWarning: _.debounce(function() {
+        if (this._didRevert) {
+            this._didRevert = false;
+            return;
+        }
+
+        if (this._areaOfInterestSet) {
+            var self = this,
+                clearProject = new modalViews.ConfirmView({
+                    model: new modalModels.ConfirmModel({
+                        question: 'If you change the selected area you will lose your current work.',
+                        confirmLabel: 'Make Changes',
+                        cancelLabel: 'Cancel'
+                    })
+                });
+
+            clearProject.render();
+
+            clearProject.on('confirmation', function() {
+                self._didRevert = false;
+                self._areaOfInterestSet = false;
+            });
+            clearProject.on('deny', function() {
+                var map = self._leafletMap;
+                self._didRevert = true;
+                self.model.revertAOI();
+                self.updateAreaOfInterest();
+                drawUtils.cancelDrawing(map);
+            });
+        }
+
+        this.model.stashAOI();
+        this._areaOfInterestSet = true;
+    }, 100, { leading: false, trailing: true }),
 
     // Call this so that the geolocation callback will not
     // reposition the map. Should be called after the map has been repositioned

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -146,7 +146,7 @@ var MapView = Marionette.ItemView.extend({
         map.addControl(new L.Control.Zoom({position: 'topright'}));
         addLocateMeButton(map, maxZoom, maxAge);
 
-        var baseLayers = _.mapObject(settings.getSettings().base_layers, function(layerData) {
+        var baseLayers = _.mapObject(settings.get('base_layers'), function(layerData) {
             if (layerData.googleType) {
                 return new L.Google(layerData.googleType);
             } else {
@@ -156,7 +156,7 @@ var MapView = Marionette.ItemView.extend({
                 });
             }
         }),
-            defaultLayerName = _.findKey(settings.getSettings().base_layers, function(layerData) {
+            defaultLayerName = _.findKey(settings.get('base_layers'), function(layerData) {
                 return layerData.default;
             }),
             defaultLayer = baseLayers[defaultLayerName];
@@ -211,7 +211,9 @@ var MapView = Marionette.ItemView.extend({
     },
 
     aoiChangeWarning: _.debounce(function() {
-        if (this._didRevert) {
+        var activityMode = settings.get('activityMode');
+        // Fail fast.
+        if (this._didRevert || !activityMode) {
             this._didRevert = false;
             return;
         }

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -5,6 +5,7 @@ var App = require('../app'),
     views = require('./views'),
     coreModels = require('../core/models'),
     coreViews = require('../core/views'),
+    settings = require('../core/settings'),
     modelingModels = require('../modeling/models'),
     models = require('./models');
 
@@ -61,7 +62,7 @@ var DrawController = {
  * save during this session.
  */
 function enableSingleProjectModeIfActivity() {
-    if (App.activityMode) {
+    if (settings.get('activityMode')) {
         if (!App.currProject) {
             var project = new modelingModels.ProjectModel({
                 name: 'New Activity',

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -68,7 +68,8 @@ function enableSingleProjectModeIfActivity() {
                 created_at: Date.now(),
                 area_of_interest: null,
                 scenarios: new modelingModels.ScenariosCollection(),
-                is_activity: true
+                is_activity: true,
+                needs_reset: true
             });
             project.save();
             App.currProject = project;

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -4,7 +4,6 @@ var App = require('../app'),
     geocoder = require('../geocode/views'),
     views = require('./views'),
     coreModels = require('../core/models'),
-    coreUtils = require('../core/utils'),
     coreViews = require('../core/views'),
     modelingModels = require('../modeling/models'),
     models = require('./models');
@@ -29,7 +28,7 @@ var DrawController = {
         App.rootView.geocodeSearchRegion.show(geocodeSearch);
         App.rootView.drawToolsRegion.show(toolbarView);
 
-        enableSingleProjectMode();
+        enableSingleProjectModeIfActivity();
 
         if (App.map.get('areaOfInterest')) {
             var aoiView = new coreViews.AreaOfInterestView({
@@ -56,20 +55,20 @@ var DrawController = {
 };
 
 /**
- * If itsi flag is set, prepare a project immedialty upon visiting the page.
- * This will be the only project the user can save during this session.
+ * If we are in embed mode then the project is an activity and we want to keep
+ * the same project reguardless of changes to the AOI. This prepares a project
+ * immedialty upon visiting the page and will be the only project the user can
+ * save during this session.
  */
-function enableSingleProjectMode() {
-    if (coreUtils.getParameterByName('initialize_itsi') === 'true') {
-
-        App.singleProjectMode = true;
-
+function enableSingleProjectModeIfActivity() {
+    if (App.activityMode) {
         if (!App.currProject) {
             var project = new modelingModels.ProjectModel({
                 name: 'New Activity',
                 created_at: Date.now(),
                 area_of_interest: null,
-                scenarios: new modelingModels.ScenariosCollection()
+                scenarios: new modelingModels.ScenariosCollection(),
+                is_activity: true
             });
             project.save();
             App.currProject = project;

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -4,7 +4,9 @@ var App = require('../app'),
     geocoder = require('../geocode/views'),
     views = require('./views'),
     coreModels = require('../core/models'),
+    coreUtils = require('../core/utils'),
     coreViews = require('../core/views'),
+    modelingModels = require('../modeling/models'),
     models = require('./models');
 
 
@@ -26,6 +28,8 @@ var DrawController = {
 
         App.rootView.geocodeSearchRegion.show(geocodeSearch);
         App.rootView.drawToolsRegion.show(toolbarView);
+
+        enableSingleProjectMode();
 
         if (App.map.get('areaOfInterest')) {
             var aoiView = new coreViews.AreaOfInterestView({
@@ -50,6 +54,28 @@ var DrawController = {
         App.rootView.footerRegion.empty();
     }
 };
+
+/**
+ * If itsi flag is set, prepare a project immedialty upon visiting the page.
+ * This will be the only project the user can save during this session.
+ */
+function enableSingleProjectMode() {
+    if (coreUtils.getParameterByName('initialize_itsi') === 'true') {
+
+        App.singleProjectMode = true;
+
+        if (!App.currProject) {
+            var project = new modelingModels.ProjectModel({
+                name: 'New Activity',
+                created_at: Date.now(),
+                area_of_interest: null,
+                scenarios: new modelingModels.ScenariosCollection()
+            });
+            project.save();
+            App.currProject = project;
+        }
+    }
+}
 
 module.exports = {
     DrawController: DrawController

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -278,7 +278,7 @@ var StreamSliderView = Marionette.ItemView.extend({
     },
 
     initialize: function() {
-        this.streamLayers = settings.getSettings().stream_layers;
+        this.streamLayers = settings.get('stream_layers');
     },
 
     onShow: function() {

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -20,7 +20,7 @@ App.on('start', function() {
     Backbone.history.start({ pushState: true });
 
     // Show login modal only if landing on home page
-    if (Backbone.history.getFragment() === "") {
+    if (Backbone.history.getFragment() === '') {
         this.getUserOrShowLogin();
     } else {
         this.user.fetch();

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -3,6 +3,7 @@
 var $ = require('jquery'),
     _ = require('lodash'),
     App = require('../app'),
+    settings = require('../core/settings'),
     router = require('../router').router,
     views = require('./views'),
     models = require('./models');
@@ -45,11 +46,11 @@ var ModelingController = {
 
                     // If this project is an activity then the application's behaior changes.
                     if (project.get('is_activity')) {
-                        App.activityMode = true;
+                        settings.set('activityMode', true);
                     }
                 });
         } else {
-            if (App.currProject && App.activityMode) {
+            if (App.currProject && settings.get('activityMode')) {
                 project = App.currProject;
                 // Reset flag is set so clear off old project data.
                 if (project.get('needs_reset')) {

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -79,7 +79,8 @@ var ProjectModel = Backbone.Model.extend({
         area_of_interest: null,    // GeoJSON
         model_package: '',         // Package name
         scenarios: null,           // ScenariosCollection
-        user_id: 0                 // User that created the project
+        user_id: 0,                // User that created the project
+        is_activity: false         // Project that persists across routes
     },
 
     initialize: function() {

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -3,6 +3,7 @@
 var Backbone = require('../../shim/backbone'),
     _ = require('lodash'),
     utils = require('../core/utils'),
+    settings = require('../core/settings'),
     App = require('../app'),
     coreModels = require('../core/models');
 
@@ -100,7 +101,7 @@ var ProjectModel = Backbone.Model.extend({
 
         // If activity mode is enabled make sure to initialize the project as
         // an activity.
-        this.set('is_activity', App.activityMode);
+        this.set('is_activity', settings.get('activityMode'));
 
         this.listenTo(this.get('scenarios'), 'add', this.addIdsToScenarios, this);
         this.on('change:name', this.saveProjectAndScenarios, this);

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -80,7 +80,8 @@ var ProjectModel = Backbone.Model.extend({
         model_package: '',         // Package name
         scenarios: null,           // ScenariosCollection
         user_id: 0,                // User that created the project
-        is_activity: false         // Project that persists across routes
+        is_activity: false,        // Project that persists across routes
+        needs_reset: false         // Should we overwrite project data on next save?
     },
 
     initialize: function() {
@@ -96,6 +97,10 @@ var ProjectModel = Backbone.Model.extend({
         this.set('model_package', 'tr-55');
 
         this.set('user_id', App.user.get('id'));
+
+        // If activity mode is enabled make sure to initialize the project as
+        // an activity.
+        this.set('is_activity', App.activityMode);
 
         this.listenTo(this.get('scenarios'), 'add', this.addIdsToScenarios, this);
         this.on('change:name', this.saveProjectAndScenarios, this);


### PR DESCRIPTION
In some cases we want a project to be saved as soon as the user lands on the
site. This is determined by the addition of a URL query parameter. If this
parameter is set, a project will be instantly created and saved. If the user
designates an area of interest and then models it everything will be saved. If
they then move back out and redraw, the same project will be used and the data
will be overwritten.

Connects #561 

To test:

 * Alter `src/mmw/apps/home/views.py` and set `EMBED_FLAG: True` in `def get_client_settings(request):`
 * Visit localhost:8000
 * Check DB, you should see the new project has been save.
 * Draw AOI, and move to modeling page.
 * Create scenarios as normal and ensure they are saved.
 * Back up to analyze mode and return to the project. Everything should remain unchanged.
 * Back up the initial screen and then navigate back to the project. Everything should remain unchanged. 
 * Back up to the main drawing page and click a drawing tool.
 * You should be prompted about the possible hazards.
 * Cancel out. Move back to project page. The project should be unchanged.
 * Back up to the main drawing page and click a drawing tool.
 * Agree to make the changes.
 * Move back to modeling page. The new data should be saved.
 * Create scenarios as normal and ensure they are saved.
 * Reload page at the project URL and ensure that it properly reloads.
 * After reloading, you should remain in "activity mode" which has the same properties as described above.
 * Disable the hard coded value in `src/mmw/apps/home/views.py` 
 * Reload the URL for the project you created. This should have an is_activity flag set on it. Loading this should load the page in "activity mode."