### PR TITLE
ITSI Activity Interaction

### DIFF
--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -105,7 +105,7 @@ CONCAT_VENDOR_CSS_COMMAND="cat \
 JS_DEPS=(jquery backbone backbone.marionette bootstrap bootstrap-select \
          leaflet leaflet-draw leaflet.locatecontrol leaflet-plugins lodash \
          underscore d3 nunjucks turf-area turf-bbox-polygon turf-buffer \
-         turf-destination turf-random zeroclipboard blueimp-md5)
+         turf-destination turf-random zeroclipboard blueimp-md5 iframe-phone)
 BROWSERIFY_EXT=""
 BROWSERIFY_REQ=""
 for DEP in "${JS_DEPS[@]}"

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -6,6 +6,7 @@ var $ = require('jquery'),
     views = require('./core/views'),
     models = require('./core/models'),
     settings = require('./core/settings'),
+    itsi = require('./core/itsiEmbed'),
     userModels = require('./user/models'),
     userViews = require('./user/views');
 
@@ -17,6 +18,11 @@ var App = new Marionette.Application({
         // If in embed mode we are by default in activity mode.
         var activityMode = settings.get('itsi_embed');
         settings.set('activityMode', activityMode);
+
+        // Initialize embed interface if in activity mode
+        if (activityMode) {
+            this.itsi = new itsi.ItsiEmbed();
+        }
 
         // This view is intentionally not attached to any region.
         this._mapView = new views.MapView({

--- a/src/mmw/js/src/core/itsiEmbed.js
+++ b/src/mmw/js/src/core/itsiEmbed.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash'),
     iframePhone = require('iframe-phone'),
+    App = require('../app.js'),
     EMBED_FLAG = 'itsi_embed',
     QUERY_SUFFIX = EMBED_FLAG + '=true';
 
@@ -22,8 +23,31 @@ var ItsiEmbed = function() {
         this.phone.post('interactiveState', this.interactiveState);
     };
 
+    this.loadInteractive = function(interactiveState) {
+        if (interactiveState && interactiveState.url) {
+            // Only redirect if different URL
+            if (window.location.href !== interactiveState.url) {
+                if (App.currProject &&
+                    !App.currProject.isNew() &&
+                    !App.currProject.get('area_of_interest')) {
+                    // Delete automatically created new project
+                    App.currProject
+                        .destroy()
+                        .always(function() {
+                            // Redirect after deletion
+                            window.location.href = interactiveState.url;
+                        });
+                } else {
+                    // No current project, just redirect
+                    window.location.href = interactiveState.url;
+                }
+            }
+        }
+    };
+
     this.phone.addListener('getLearnerUrl', _.bind(this.setLearnerUrl, this));
     this.phone.addListener('getInteractiveState', _.bind(this.setLearnerUrl, this));
+    this.phone.addListener('loadInteractive', _.bind(this.loadInteractive, this));
     this.phone.initialize();
 };
 

--- a/src/mmw/js/src/core/itsiEmbed.js
+++ b/src/mmw/js/src/core/itsiEmbed.js
@@ -18,9 +18,21 @@ var ItsiEmbed = function() {
             this.url = url + (url.indexOf('?') > 0 ? '&' : '?') + QUERY_SUFFIX;
             this.interactiveState = { url: this.url };
         }
+        
+        this.sendLearnerUrl();
+    };
 
+    this.sendLearnerUrl = function() {
         this.phone.post('setLearnerUrl', this.url);
         this.phone.post('interactiveState', this.interactiveState);
+    };
+
+    this.sendLearnerUrlOnlyFromProjectView = function() {
+        var projectRegex = /project\/\d+/;
+
+        if (projectRegex.test(this.url)) {
+            this.sendLearnerUrl();
+        }
     };
 
     this.loadInteractive = function(interactiveState) {
@@ -45,8 +57,8 @@ var ItsiEmbed = function() {
         }
     };
 
-    this.phone.addListener('getLearnerUrl', _.bind(this.setLearnerUrl, this));
-    this.phone.addListener('getInteractiveState', _.bind(this.setLearnerUrl, this));
+    this.phone.addListener('getLearnerUrl', _.bind(this.sendLearnerUrlOnlyFromProjectView, this));
+    this.phone.addListener('getInteractiveState', _.bind(this.sendLearnerUrlOnlyFromProjectView, this));
     this.phone.addListener('loadInteractive', _.bind(this.loadInteractive, this));
     this.phone.initialize();
 };

--- a/src/mmw/js/src/core/itsiEmbed.js
+++ b/src/mmw/js/src/core/itsiEmbed.js
@@ -10,15 +10,20 @@ var ItsiEmbed = function() {
 
     this.url = window.location.href + '?' + QUERY_SUFFIX;
 
+    this.interactiveState = { url: this.url };
+
     this.setLearnerUrl = function(url) {
         if (url) {
             this.url = url + (url.indexOf('?') > 0 ? '&' : '?') + QUERY_SUFFIX;
+            this.interactiveState = { url: this.url };
         }
 
         this.phone.post('setLearnerUrl', this.url);
+        this.phone.post('interactiveState', this.interactiveState);
     };
 
     this.phone.addListener('getLearnerUrl', _.bind(this.setLearnerUrl, this));
+    this.phone.addListener('getInteractiveState', _.bind(this.setLearnerUrl, this));
     this.phone.initialize();
 };
 

--- a/src/mmw/js/src/core/itsiEmbed.js
+++ b/src/mmw/js/src/core/itsiEmbed.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var _ = require('lodash'),
+    iframePhone = require('iframe-phone'),
+    EMBED_FLAG = 'itsi_embed',
+    QUERY_SUFFIX = EMBED_FLAG + '=true';
+
+var ItsiEmbed = function() {
+    this.phone = new iframePhone.getIFrameEndpoint();
+
+    this.url = window.location.href + '?' + QUERY_SUFFIX;
+
+    this.setLearnerUrl = function(url) {
+        if (url) {
+            this.url = url + (url.indexOf('?') > 0 ? '&' : '?') + QUERY_SUFFIX;
+        }
+
+        this.phone.post('setLearnerUrl', this.url);
+    };
+
+    this.phone.addListener('getLearnerUrl', _.bind(this.setLearnerUrl, this));
+    this.phone.initialize();
+};
+
+module.exports = {
+    ItsiEmbed: ItsiEmbed
+};

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var defaultSettings = {
+    itsi_embed: false,
     base_layers: {},
     stream_layers: {}
 };

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -44,9 +44,14 @@ var ModelingController = {
                     }
                     project.fetchResultsIfNeeded();
 
-                    // If this project is an activity then the application's behaior changes.
+                    // If this project is an activity then the application's behavior changes.
                     if (project.get('is_activity')) {
                         settings.set('activityMode', true);
+                    }
+
+                    // Send URL to parent if in embed mode
+                    if (settings.get('itsi_embed')) {
+                        App.itsi.setLearnerUrl(window.location.href);
                     }
                 });
         } else {
@@ -95,6 +100,9 @@ var ModelingController = {
                     initViews(project);
                     project.fetchResultsIfNeeded();
                     router.navigate(project.getReferenceUrl());
+                    if (settings.get('itsi_embed')) {
+                        App.itsi.setLearnerUrl(window.location.href);
+                    }
                 }
             } else {
                 project = new models.ProjectModel({
@@ -110,6 +118,9 @@ var ModelingController = {
                 setupNewProjectScenarios(project);
                 project.on('change:id', function() {
                     router.navigate(project.getReferenceUrl());
+                    if (settings.get('itsi_embed')) {
+                        App.itsi.setLearnerUrl(window.location.href);
+                    }
                 });
 
                 initScenarioEvents(project);
@@ -141,6 +152,9 @@ function initScenarioEvents(project) {
     scenariosColl.on('change:activeScenario change:id', function(scenario) {
         mapView.updateModifications(scenario.get('modifications'));
         router.navigate(project.getReferenceUrl());
+        if (settings.get('itsi_embed')) {
+            App.itsi.setLearnerUrl(window.location.href);
+        }
     });
 }
 

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -1052,6 +1052,11 @@
       "from": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz"
     },
+    "iframe-phone": {
+      "version": "1.1.3",
+      "from": "git://github.com/concord-consortium/iframe-phone#v1.1.3",
+      "resolved": "git://github.com/concord-consortium/iframe-phone#200f47f43ee32d640868072c17de4a675e16d96a"
+    },
     "jquery": {
       "version": "2.1.3",
       "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -27,6 +27,7 @@
     "chai": "1.10.0",
     "d3": "3.5.5",
     "font-awesome": "4.3.0",
+    "iframe-phone": "git://github.com/concord-consortium/iframe-phone#v1.1.3",
     "jquery": "2.1.3",
     "jshint": "2.8.0",
     "jstify": "0.9.0",


### PR DESCRIPTION
## Overview

ITSI uses [LARA](https://github.com/concord-consortium/LARA) for all their teacher / learner activities. MMW will be embedded as in iframe within such an activity. In order to save state and update the activity with MMW's state as a user progresses through the workflow, we must tell ITSI of the most relevant URL for the user which will be used to resume their session should they return at a later date. Using the [iFrame Phone](https://github.com/concord-consortium/iframe-phone) library, we can send the most recent URL to the parent frame.

## Testing Instructions

 1. Login as an ITSI user to MMW and create a project
 2. Go to http://concord-consortium.github.io/lara-interactive-api/ and in the "Interactive Source" text box, paste in the URL of the project you created in Step 1, with the additional suffix of `?itsi_embed=true` which enables the interface and press <kbd>Enter</kbd>:  
  ![image](https://cloud.githubusercontent.com/assets/1430060/8885448/9a210940-322d-11e5-8b8b-f4a8a503cd35.png)
 3. You should see the parent frame log the incoming message:  
  ![image](https://cloud.githubusercontent.com/assets/1430060/8885461/ce826404-322d-11e5-80bd-dc30c366039c.png)
 4. Click "getLearnerUrl" in the parent frame. You should see a similar message appear in the log:  
  ![image](https://cloud.githubusercontent.com/assets/1430060/8911962/82ccd2ce-345d-11e5-8adf-50d86dabdcce.png)

## Notes

This needs to be tested inside an actual activity with the proper workflow to see if it is enough to send the learner URL, or if we must send something for `saveInteractive` and `loadInteractive` calls as well. If we are unable to test this on our own, we may need to ask for Scott's help.

Connects #563 