### PR TITLE
Stop editing scenario when clicking outside

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -499,7 +499,7 @@ var ScenariosCollection = Backbone.Collection.extend({
 
         // Bail early if the name actually didn't change.
         if (model.get('name') === newName) {
-            return;
+            return false;
         }
 
         var match = this.find(function(model) {
@@ -507,10 +507,13 @@ var ScenariosCollection = Backbone.Collection.extend({
         });
 
         if (match) {
+            window.alert("There is another scenario with the same name. " +
+                    "Please choose a unique name for this scenario."
+            );
             console.log('This name is already in use.');
-            return;
+            return false;
         } else if (model.get('name') !== newName) {
-            model.set('name', newName);
+            return model.set('name', newName);
         }
     },
 

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -619,11 +619,29 @@ describe('Modeling', function() {
             });
 
             describe('#updateScenarioName', function() {
+                var realAlert, spyAlert;
+
+                // Swap out window.alert so that testing can complete
+                // automatically without the user being prompted that the
+                // scenario name must be unique.
+                before(function() {
+                    realAlert = window.alert;
+                });
+
+                after(function() {
+                    window.alert = realAlert;
+                });
+
+                beforeEach(function() {
+                    window.alert = spyAlert = sinon.spy();
+                });
+
                 it('trims whitespace from the provided new name', function() {
                     var collection = getTestScenarioCollection();
 
                     collection.updateScenarioName(collection.at(0), 'New Name       ');
 
+                    assert.isFalse(spyAlert.called);
                     assert.equal(collection.at(0).get('name'), 'New Name');
                 });
 
@@ -633,6 +651,7 @@ describe('Modeling', function() {
                     // There's already a scenario with the name "New Scenario 1"
                     collection.updateScenarioName(collection.at(0), 'NEW scenArio 1');
 
+                    assert.isTrue(spyAlert.calledOnce);
                     assert.equal(collection.at(0).get('name'), 'Current Conditions');
                 });
 
@@ -642,6 +661,7 @@ describe('Modeling', function() {
                     // There's already a scenario with the name "Current Conditions"
                     collection.updateScenarioName(collection.at(1), 'Current Conditions');
 
+                    assert.isTrue(spyAlert.calledOnce);
                     assert.equal(collection.at(1).get('name'), 'New Scenario 1');
                 });
             });

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -326,7 +326,12 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
     },
 
     renameScenario: function() {
-        var self = this;
+        var self = this,
+            setScenarioName = function(name) {
+                if (!self.model.collection.updateScenarioName(self.model, name)) {
+                    self.render();
+                }
+            };
 
         this.ui.nameField.attr('contenteditable', true).focus();
 
@@ -343,16 +348,12 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
                 // Don't add line returns to the text.
                 e.preventDefault();
 
-                if (self.model.get('name') !== $(this).text() && $(this).text() !== '') {
-                    self.model.collection.updateScenarioName(self.model, $(this).text());
-                } else {
-                    self.render();
-                }
+                setScenarioName($(this).text());
             }
         });
 
         this.ui.nameField.on('blur', function() {
-            self.model.collection.updateScenarioName(self.model, $(this).text());
+            setScenarioName($(this).text());
         });
     },
 


### PR DESCRIPTION
## Overview

Clicking outside the edit area when renaming scenarios was not canceling the edit operation. Now it does.

## Testing Instructions

 1. Open a scenario
 2. Start renaming a scenario, but don't make any changes to the name
 3. Click anywhere outside. The scenario tab should return to its non-editing state.
 4. Start renaming a scenario and make changes.
 5. Click anywhere outside. Your changes should be saved and the tab should return to its non-editing state.

## Demo

![mmw-rename-scenario](https://cloud.githubusercontent.com/assets/1430060/8918687/a136f8dc-3487-11e5-8139-0318e81c07b7.gif)

Connects #510 