### PR TITLE
Use data from S3.

### DIFF
--- a/src/geop/processing/src/main/scala/com/azavea/mmw/Histogram.scala
+++ b/src/geop/processing/src/main/scala/com/azavea/mmw/Histogram.scala
@@ -2,6 +2,8 @@ package com.azavea.mmw
 
 import geotrellis.vector._
 import geotrellis.vector.io.json._
+import geotrellis.vector.reproject._
+import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.histogram._
 import geotrellis.raster.rasterize.{Rasterizer, Callback}
@@ -26,8 +28,8 @@ object Histogram {
         val localHistogram = mutable.Map[(Int, Int), Int]()
 
         clipped match {
-          case PolygonResult(p) =>
-            Rasterizer.foreachCellByPolygon(p, rasterExtent)(
+          case PolygonResult(pr) =>
+            Rasterizer.foreachCellByPolygon(pr, rasterExtent)(
               new Callback {
                 def apply(col: Int, row: Int): Unit = {
                   val nlcdType = nlcdTile.get(col,row)

--- a/src/geop/project/Build.scala
+++ b/src/geop/project/Build.scala
@@ -10,7 +10,7 @@ object Version {
   def either(environmentVariable: String, default: String): String =
     Properties.envOrElse(environmentVariable, default)
 
-  val geotrellis  = "0.10.0-SNAPSHOT"
+  val geotrellis  = "0.10.0-M1"
   val scala       = "2.10.5"
   val spray       = "1.3.1"
   val akka        = "2.3.9"


### PR DESCRIPTION
This patch modifies the Scala code to use the NLCD data stored in S3 instead of the small, local test extent.  Since we do not yet have soil data, it passes the NLCD data through a function to produce deterministic but pseudo-random soil values.

Connect #570

**To build and run the service:**
First, put S3 credentials in environment or in ~/.aws/credentials, then type:
```
cd src/geop
./sbt 'project services' compile assembly
$SPARK_HOME/bin/spark-submit services/target/scala-2.10/mmw-services-assembly-0.0.1.jar
```

**To test the service:**
Post a valid geojson polygon (such as this one https://gist.github.com/jamesmcclain/42ec932910b1014d7137), multipolygon, or geometry collection of polygons and/or multipolygons to the endpoint:
```
% wget localhost:8107 --post-file=polygon.json -O -
--2015-07-27 18:45:00--  http://localhost:8107/
Resolving localhost (localhost)... 127.0.0.1
Connecting to localhost (localhost)|127.0.0.1|:8107... connected.
HTTP request sent, awaiting response... 200 OK
Length: 241 [application/json]
Saving to: ‘STDOUT’

[[[82, 4], 1408], [[52, 2], 7493], [[21, 1], 89141], [[42, 4], 4979], [[22, 1], 45787], [[23, 3], 13818], [[31, 4], 147], [[71, 3], 343], [[41, 1], 49996], [[43, 4], 5434], [[11, 0], 1290], [[90, 2], 7764], [[24, 2], 2399], [[81, 1], 11965]]
2015-07-27 18:45:07 (39.4 MB/s) - written to stdout [241/241]
```
