### PR TITLE
Add boundary name to Analyze window

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -67,6 +67,7 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
             App: App,
             model: new coreModels.AreaOfInterestModel({
                 shape: this.model.get('area_of_interest'),
+                place: App.map.get('areaOfInterestName'),
                 can_go_back: true,
                 next_label: 'Model',
                 url: 'project'

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -11,6 +11,7 @@ var MapModel = Backbone.Model.extend({
         lng: 0,
         zoom: 0,
         areaOfInterest: null,           // GeoJSON
+        areaOfInterestName: '',
         halfSize: false,
         geolocationEnabled: true
     },

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -35,7 +35,8 @@ var DrawController = {
                         can_go_back: false,
                         next_label: 'Analyze',
                         url: 'analyze',
-                        shape: App.map.get('areaOfInterest')
+                        shape: App.map.get('areaOfInterest'),
+                        place: App.map.get('areaOfInterestName')
                     })
             });
 

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -213,9 +213,10 @@ var PlaceMarkerView = Marionette.ItemView.extend({
         'change:toolsEnabled': 'render'
     },
 
-    onItemClicked: function() {
+    onItemClicked: function(e) {
         var self = this,
             map = App.getLeafletMap(),
+            itemName = $(e.target).text(),
             revertLayer = clearAoiLayer();
 
         this.model.disableTools();
@@ -240,7 +241,7 @@ var PlaceMarkerView = Marionette.ItemView.extend({
                     max_radial_length: 0.25
                 });
 
-            addLayer(shape);
+            addLayer(shape, itemName);
             navigateToAnalyze();
         }).fail(function() {
             revertLayer();

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -333,6 +333,7 @@ function getShapeAndAnalyze(e, model, ofg, grid, tableId) {
         maxPolls = 5,
         pollCount = 0,
         deferred = $.Deferred(),
+        shapeName = e.data && e.data.name ? e.data.name : null,
         shapeId = e.data ? e.data.id : null;
 
         if (shapeId) {
@@ -346,7 +347,7 @@ function getShapeAndAnalyze(e, model, ofg, grid, tableId) {
             tableId: tableId,
             shapeId: shapeId
         }).done(function(shape) {
-            addLayer(shape);
+            addLayer(shape, shapeName);
             clearBoundaryLayer(model);
             navigateToAnalyze();
             deferred.resolve();
@@ -397,8 +398,13 @@ function clearBoundaryLayer(model) {
     }
 }
 
-function addLayer(shape) {
+function addLayer(shape, name) {
+    if (!name) {
+        name = 'Selected Area';
+    }
+
     App.map.set('areaOfInterest', shape);
+    App.map.set('areaOfInterestName', name);
 }
 
 function navigateToAnalyze() {


### PR DESCRIPTION
## Overview

Since boundary layers have names, we want to show those names instead of "Selected Area" in the Analyze window.

### Bonus

I also set "Delineate Watershed" dropdown to behave similarly, which sets the name to delineation type used. This is in a separate commit can be easily removed if it is not desired, since it was not asked for in the original issue.

## Testing Instructions

 1. Draw a shape on the map. Analyze window should show "Selected Area".
 2. Select a boundary on the map. Analyze window should show the selected boundary name.
 3. Delineate a watershed on the map. Analyze window should show the method used for delineation.

## Demo

![mmw-analyze-window-label](https://cloud.githubusercontent.com/assets/1430060/8941438/851fb63c-353d-11e5-8d6e-9734b1f6848d.gif)

Connects #612 