### PR TITLE
Remove duplicate entry for `azavea.java`

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -18,7 +18,6 @@ azavea.elasticsearch,0.2.0
 azavea.logstash,0.1.0
 azavea.kibana,0.3.1
 azavea.collectd,0.2.0
-azavea.java,0.1.1
 azavea.build-essential,0.1.0
 azavea.mapnik,0.1.0
 azavea.beaver,0.1.3


### PR DESCRIPTION
Having two inside `roles.txt` makes the dependency resolver go off all of the time.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/wikiwatershed/model-my-watershed/637)
<!-- Reviewable:end -->
