### PR TITLE
Preserve original ordering of Collections

### DIFF
--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -67,9 +67,8 @@ var utils = {
 
                 return sorted;
             },
-            // Sort the collection by given sortKey and convert
-            // each model to a sorted array
-            sortedCollection = collection.sort().map(function(model) {
+            // Convert each model to a sorted array
+            sortedCollection = collection.map(function(model) {
                 return objectToSortedArray(model.toJSON());
             });
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -22,11 +22,7 @@ var ModelPackageControlModel = Backbone.Model.extend({
 });
 
 var ModelPackageControlsCollection = Backbone.Collection.extend({
-    model: ModelPackageControlModel,
-
-    comparator: function(model) {
-        return model.get('name');
-    }
+    model: ModelPackageControlModel
 });
 
 var ModelPackageModel = Backbone.Model.extend();
@@ -53,10 +49,6 @@ var ResultModel = Backbone.Model.extend({
 
 var ResultCollection = Backbone.Collection.extend({
     model: ResultModel,
-
-    comparator: function(model) {
-        return model.get('name');
-    },
 
     setPolling: function(polling) {
         this.forEach(function(resultModel) {
@@ -254,16 +246,7 @@ var ModificationModel = coreModels.GeoModel.extend({
 });
 
 var ModificationsCollection = Backbone.Collection.extend({
-    model: ModificationModel,
-
-    comparator: function(model) {
-        // Even though model.get('area') is a numeric value, passing it
-        // along with the others here causes a string comparison. But that's
-        // alright, because we only want to sort consistently, not actually
-        // by area, and it serves as a tie-breaker when the other values are
-        // identical.
-        return [model.get('name'), model.get('value'), model.get('area')];
-    }
+    model: ModificationModel
 });
 
 var ScenarioModel = Backbone.Model.extend({

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -429,27 +429,6 @@ describe('Modeling', function() {
             });
         });
 
-        describe('ModificationCollection', function() {
-            it('sorts modifications correctly', function() {
-                var collection = new models.ModificationsCollection();
-
-                collection.add(mocks.modifications.sample1);
-                collection.add(mocks.modifications.sample2);
-                collection.add(mocks.modifications.sample3);
-
-                var collectionOrder = collection.pluck('area'),
-                    knownOrder = [
-                        (new models.ModificationModel(mocks.modifications.sample2)).get('area'),
-                        (new models.ModificationModel(mocks.modifications.sample1)).get('area'),
-                        (new models.ModificationModel(mocks.modifications.sample3)).get('area')
-                    ];
-
-                assert.deepEqual(collectionOrder, knownOrder,
-                    'Collection was not sorted correctly'
-                );
-            });
-        });
-
         describe('ScenarioModel', function() {
             // TODO: Add tests for existing methods.
 
@@ -475,8 +454,8 @@ describe('Modeling', function() {
                     modificationsOne.add(new models.ModificationModel(mocks.modifications.sample1));
                     modificationsOne.add(new models.ModificationModel(mocks.modifications.sample2));
 
-                    modificationsTwo.add(new models.ModificationModel(mocks.modifications.sample2));
                     modificationsTwo.add(new models.ModificationModel(mocks.modifications.sample1OutOfOrder));
+                    modificationsTwo.add(new models.ModificationModel(mocks.modifications.sample2));
 
                     var hashOne = utils.getCollectionHash(modificationsOne),
                         hashTwo = utils.getCollectionHash(modificationsTwo);
@@ -505,7 +484,7 @@ describe('Modeling', function() {
 
                     var mod = new models.ModificationModel(mocks.modifications.sample2);
                     model.get('modifications').add(mod);
-                    assert.equal(model.get('modification_hash'), 'dcda6a697d33a3bc95c95cc401e774bb');
+                    assert.equal(model.get('modification_hash'), 'a862ae12206d895501bb85c3edcdb467');
 
                     model.get('modifications').remove(mod);
                     assert.equal(model.get('modification_hash'), '40c4fdd89b06a0e9b7e1c3c5c2bd1f17');


### PR DESCRIPTION
For the purpose of producing consistent MD5 hashes for caching, #567
added code for keeping many Collections in an internally sorted order
in 220a6e8. The actual order (usually the order in which they were added
to the collection) was not meaningful at the time.

Now, however, we are solving problems which do require us to respect the
order in which models are added to the collection, e.g. #641. Thus, we
undo automatic sorting and also remove tests for it. We adjust some more
tests to respect the order of models within a collection, but still test
that models with differently sorted keys are still evaluated the same.

Since Collections are stringified to Arrays and not Objects in JSON, the
sorting there should be preserved automatically, without us having to
sort each Collection. Thus, this change should not affect the stability
of our caching approach.

Connects #624 
Connects #641 