### PR TITLE
Make "Current Conditions" default new scenario

### DIFF
--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -148,11 +148,11 @@ function setupNewProjectScenarios(project) {
     project.get('scenarios').add([
         new models.ScenarioModel({
             name: 'Current Conditions',
-            is_current_conditions: true
+            is_current_conditions: true,
+            active: true
         }),
         new models.ScenarioModel({
-            name: 'New Scenario',
-            active: true
+            name: 'New Scenario'
         })
         // Silent is set to true because we don't actually want to save the
         // project without some user interaction. This initialization


### PR DESCRIPTION
## Overview

We want Current Conditions to be the first thing users see after the "Analyze" view. The Analyze view represents observed metrics, and the Model view represents calculated metrics. We want the user to see calculated metrics for the current conditions before they start adding modifications.

## Testing Instructions

Create a new project and move the Model view. Ensure that Current Conditions is the active tab.

## Implementation Notes

I tried to create tests (for ensuring that a New Scenario is added, and that Current Conditions is active by default) but couldn't, because the `setupNewProjectScenarios` method is not exposed from `controllers.js` and thus cannot be directly tested, and because the Controller itself is so wired in to the app that it cannot be tested independently.

Should we still add a New Scenario automatically? Or should we allow the user to create one only if they want it?

Connects #628