### PR TITLE
Add data load instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,21 @@ After pulling in new commits, you may need to run the following two commands:
 
 ```bash
 $ ./scripts/manage.sh migrate
-$ ./scripts/manage.sh reload_dev_data
 $ ./scripts/bundle.sh
 ```
+
+To load or reload boundary data, from an `app` server, run (`scripts` is not mounted by default to the VM, you may need to copy the file over):
+```bash
+$ ./scripts/setupdb.sh -b
+```
+
+The same script can be used to load the stream network data:
+```bash
+$ ./scripts/setupdb.sh -s
+```
+
+Note that if you receive out of memory errors while loading the data, you may want to increase the RAM on your `services` VM (1512 MB may be all that is necessary).
+
 
 See debug messages from the web app server:
 


### PR DESCRIPTION
Keeps in the instructions up to date with the latest setupdb.sh script usage.