### PR TITLE
Update boundary layer style

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -147,15 +147,15 @@ var MapView = Marionette.ItemView.extend({
         addLocateMeButton(map, maxZoom, maxAge);
 
         var baseLayers = _.mapObject(settings.get('base_layers'), function(layerData) {
-            if (layerData.googleType) {
-                return new L.Google(layerData.googleType);
-            } else {
-                return new L.TileLayer(layerData.url, {
-                    attribution: layerData.attribution || '',
-                    maxZoom: layerData.maxZoom || 18
-                });
-            }
-        }),
+                if (layerData.googleType) {
+                    return new L.Google(layerData.googleType);
+                } else {
+                    return new L.TileLayer(layerData.url, {
+                        attribution: layerData.attribution || '',
+                        maxZoom: layerData.maxZoom || 18
+                    });
+                }
+            }),
             defaultLayerName = _.findKey(settings.get('base_layers'), function(layerData) {
                 return layerData.default;
             }),

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -306,7 +306,10 @@ var MapView = Marionette.ItemView.extend({
             this.updateAreaOfInterest();
         } else {
             this._areaOfInterestLayer.clearLayers();
-            var layer = new L.GeoJSON(aoi);
+            var layer = new L.GeoJSON(aoi, {
+                style: function() {
+                    return drawUtils.polygonDefaults;
+                }});
             this._areaOfInterestLayer.addLayer(layer);
         }
     },

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -1,11 +1,19 @@
 "use strict";
 
 var $ = require('jquery'),
-    L = require('leaflet');
+    L = require('leaflet'),
+    _ = require('lodash');
+
+var polygonDefaults = {
+        fillColor: '#E77471',
+        color: '#E77471'
+    };
 
 function drawPolygon(map, drawOpts) {
     var defer = $.Deferred(),
-        tool = new L.Draw.Polygon(map, { shapeOptions: drawOpts || {}}),
+        tool = new L.Draw.Polygon(map, {
+            shapeOptions: _.defaults(drawOpts || {}, polygonDefaults)
+        }),
         clearEvents = function() {
             map.off('draw:created');
             map.off('draw:drawstop');
@@ -66,5 +74,6 @@ function cancelDrawing(map) {
 module.exports = {
     drawPolygon: drawPolygon,
     placeMarker: placeMarker,
-    cancelDrawing: cancelDrawing
+    cancelDrawing: cancelDrawing,
+    polygonDefaults: polygonDefaults
 };

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -2,10 +2,20 @@
 #boundary_huc08,
 #boundary_huc10,
 #boundary_huc12 {
-  polygon-fill: #FF0000;
-  polygon-opacity: 0.0;
-  line-color: #000;
-  line-opacity: 0.618;
+  ::case {
+   line-color: #FFF;
+   line-opacity: 0.5;
+   line-width: 3;
+   line-join: round;
+  }
+
+  ::fill  {
+    polygon-opacity: 0.0;
+    line-color: #E77471;
+    line-opacity: 0.75;
+    line-width: 1.5;
+    line-join: round;
+  }
 }
 
 @zoomBase: 0.3;


### PR DESCRIPTION
* Update boundary color to provide more contrast across multiple
basemaps.
* Remove unused fill style.

**To Test:**

- Reload the tiler VM or run `./scripts/debugtiler.sh`.
- Load the app and select one of the tile layers.
- See how the tiles look across different basemaps.

Connects to #636