### PR TITLE
Allow ITSI users to clone projects via UI

### DIFF
--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -12,6 +12,9 @@
                         <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
+                        {% if itsi %}
+                            <li><a href="#" class="clone-project">Clone Project</a></li>
+                        {% endif %}
                         <li><a href="#">Profile</a></li>
                         <li><a href="/user/logout" class="user-logout">Logout</a></li>
                     </ul>

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var L = require('leaflet'),
+    $ = require('jquery'),
     _ = require('underscore'),
     router = require('../router.js').router,
     Marionette = require('../../shim/backbone.marionette'),
@@ -54,12 +55,14 @@ var HeaderView = Marionette.ItemView.extend({
 
     ui: {
         login: '.show-login',
-        logout: '.user-logout'
+        logout: '.user-logout',
+        cloneProject: '.clone-project'
     },
 
     events: {
         'click @ui.login': 'showLogin',
-        'click @ui.logout': 'userLogout'
+        'click @ui.logout': 'userLogout',
+        'click @ui.cloneProject': 'cloneProject'
     },
 
     modelEvents: {
@@ -78,6 +81,35 @@ var HeaderView = Marionette.ItemView.extend({
         this.model.logout().done(function() {
             router.navigate('', {trigger: true});
         });
+    },
+
+    cloneProject: function() {
+        event.preventDefault();
+        var view = new modalViews.InputView({
+            model: new modalModels.InputModel({
+                title: 'Clone Project',
+                fieldLabel: 'Project ID'
+            })
+        });
+
+        view.on('update', function(projectId) {
+            var cloneUrlFragment = '/project/' + projectId + '/clone',
+                cloneUrl = window.location.origin + cloneUrlFragment,
+                testUrl = '/api/modeling/projects/' + projectId;
+
+            $.ajax(testUrl)
+                .done(function() {
+                    window.location.replace(cloneUrl);
+                })
+                .fail(function() {
+                    window.alert(
+                        'There was an error trying to clone that project. ' +
+                        'Please ensure that the project ID is valid and ' +
+                        'that you have permission to view the project.'
+                    );
+                });
+        });
+        view.render();
     }
 
 });


### PR DESCRIPTION
## Overview

Create a new "Clone Project" link in the user drop-down for ITSI users that allows them to specify a project ID and clone it.

This is required because users won't be able to paste in a URL when the app is embedded inside an activity.

## Testing Instructions

 1. Log in as an ITSI user.
 2. Open the user drop-down in the header
 3. Click "Clone Project"
 4. Enter the project ID of a project you have access to. In reality this will be supplied by the teacher in the assignment.
 5. The project should now be cloned into your account.

Connects #560 
Connects #564 