### PR TITLE
Feature/lol/standarize units

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from celery import shared_task
+import json
 import logging
+import math
 
 # TODO Remove this when stub task is deleted.
 import time
@@ -14,9 +16,23 @@ from tr55.tablelookup import lookup_ki
 
 logger = logging.getLogger(__name__)
 
+KG_PER_POUND = 0.453592
+CM_PER_INCH = 2.54
+
 
 @shared_task
 def run_analyze(area_of_interest):
+
+    # Find the width in meters of a pixel at the average lat of the shape.
+    pairs = json.loads(area_of_interest)['coordinates'][0][0]
+    average_lat = reduce(lambda total, p: total+p[1], pairs, 0) / len(pairs)
+
+    # Zoom level is a hard coded value in the geoprocessing library.
+    zoom = 13
+    # See https://msdn.microsoft.com/en-us/library/bb259689.aspx
+    pixel_width = (math.cos(average_lat * math.pi / 180) * 2 * math.pi *
+                   6378137) / (256 * math.pow(2, zoom))
+
     time.sleep(3)
 
     results = [
@@ -114,6 +130,8 @@ def run_analyze(area_of_interest):
         }
     ]
 
+    convert_result_areas(pixel_width, results)
+
     return results
 
 
@@ -163,10 +181,28 @@ def format_quality(model_output):
         measure, code = input
         return {
             'measure': measure,
-            'load': model_output['modified'][code]
+            'load': model_output['modified'][code] * KG_PER_POUND
         }
 
     return map(fn, zip(measures, codes))
+
+
+def format_runoff(model_output):
+    """
+    Convert model output values that are in inches into centimeters.
+    """
+    inch_keys = ['runoff', 'inf', 'et']
+    for key in model_output:
+        for item in inch_keys:
+            model_output[key][item] = model_output[key][item] * CM_PER_INCH
+
+        distribution = model_output[key]['distribution']
+        for k in distribution:
+            for item in inch_keys:
+                model_output[key]['distribution'][k][item] = \
+                    model_output[key]['distribution'][k][item] * CM_PER_INCH
+
+    return model_output
 
 
 @shared_task
@@ -196,7 +232,7 @@ def run_tr55(census, model_input):
     return {
         'inputmod_hash': model_input['inputmod_hash'],
         'census': census,
-        'runoff': model_output,
+        'runoff': format_runoff(model_output),
         'quality': format_quality(model_output)
     }
 
@@ -208,6 +244,18 @@ def _get_precip_value(model_input):
         return precips[0]['value']
     except Exception:
         return None
+
+
+def convert_result_areas(pixel_width, results):
+    """
+    Updates area values on the survey results. The survey gives area as a
+    number of pixels in a geotiff. This converts the area to square meters.
+    """
+    for i in range(len(results)):
+        categories = results[i]['categories']
+        for j in range(len(categories)):
+            categories[j]['area'] = (categories[j]['area'] * pixel_width *
+                                     pixel_width)
 
 
 # TODO: For demonstration purposes.

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -143,7 +143,7 @@ def scenario(request, scen_id):
 def start_analyze(request, format=None):
     user = request.user if request.user.is_authenticated() else None
     created = now()
-    area_of_interest = request.POST
+    area_of_interest = request.POST['area_of_interest']
     job = Job.objects.create(created_at=created, result='', error='',
                              traceback='', user=user, status='started')
 

--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -41,22 +41,22 @@
                 <!-- OUTPUT WELLS -->
 
                 <div id="well-precip" class="well-custom text-center"> <!-- Precip Well -->
-                    <h1 class="precip">8.0"</h1>
+                    <h1 class="precip">0.0 cm</h1>
                     <label>Precipitation</label>
                 </div> <!-- End Precip Well -->
 
                 <div id="well-evapo" class="well-custom text-center"> <!-- Evapotranspiration Well -->
-                    <h1 class="evapo">3.0"</h1>
+                    <h1 class="evapo">0.0 cm</h1>
                     <label>Evapotranspiration</label>
                 </div> <!-- End Evapotranspiration Well -->
 
                 <div id="well-runoff" class="well-custom text-center"> <!-- Runoff Well -->
-                    <h1 class="runoff">4.0"</h1>
+                    <h1 class="runoff">0.0 cm</h1>
                     <label>Runoff</label>
                 </div> <!-- End Runoff Well -->
 
                 <div id="well-infil" class="well-custom text-center"> <!-- Infiltration Well -->
-                    <h1 class="infil">3.0"</h1>
+                    <h1 class="infil">0.0 cm</h1>
                     <label>Infiltration</label>
                 </div> <!-- End Infiltration Well -->
 
@@ -169,7 +169,7 @@
                 <label>Water Column</label>
             </div> <!-- End Water Column -->
 
-        </div> <!-- End anvas -->
+        </div> <!-- End Canvas -->
 
         <!-- SIDEBAR -->
 

--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -2,8 +2,8 @@
     <thead>
         <tr>
             <th>Type</th>
-            <th class="text-right">Area</th>
-            <th class="text-right">Coverage</th>
+            <th class="text-right">Area (m<sup>2</sup>)</th>
+            <th class="text-right">Coverage (%)</th>
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/analyze/templates/tableRow.html
+++ b/src/mmw/js/src/analyze/templates/tableRow.html
@@ -1,3 +1,3 @@
 <td>{{ type }}</td>
-<td class="strong text-right">{{ area }}</td>
-<td class="strong text-right">{{ coverage }}</td>
+<td class="strong text-right">{{ areaTrimmed }}</td>
+<td class="strong text-right">{{ coveragePct }}</td>

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -99,8 +99,8 @@ function checkTableBody(subData) {
         // displayed.
         var expectedRowVals = [
             subData.categories[trInd].type,
-            subData.categories[trInd].area,
-            subData.categories[trInd].coverage
+            (subData.categories[trInd].area).toFixed(1),
+            (subData.categories[trInd].coverage * 100).toFixed(1)
         ];
         expectedRowVals = _.map(expectedRowVals, function(val) {
             return String(val);

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -84,7 +84,7 @@ function checkTable(data) {
 }
 
 function checkTableHeader(name) {
-    var expectedHeaderLabels = ['Type', 'Area', 'Coverage'];
+    var expectedHeaderLabels = ['Type', 'Area (m2)', 'Coverage (%)'];
     var headerLabels = $('#' + name + ' table thead tr th').map(function() {
         return $(this).text();
     }).get();

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -40,19 +40,22 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
         var self = this;
 
         if (!this.model.get('result')) {
-            var taskHelper = {
-                pollSuccess: function() {
-                    self.showDetailsRegion();
-                },
+            var aoi = JSON.stringify(this.model.get('area_of_interest')),
+                taskHelper = {
+                    pollSuccess: function() {
+                        self.showDetailsRegion();
+                    },
 
-                pollFailure: function() {
-                    self.showErrorMessage();
-                },
+                    pollFailure: function() {
+                        self.showErrorMessage();
+                    },
 
-                startFailure: function() {
-                    self.showErrorMessage();
-                }
-            };
+                    startFailure: function() {
+                        self.showErrorMessage();
+                    },
+
+                    postData: {'area_of_interest': aoi}
+                };
             this.model.start(taskHelper);
         } else {
             this.lock = $.Deferred();

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -221,7 +221,14 @@ var TabContentsView = Marionette.CollectionView.extend({
 
 var TableRowView = Marionette.ItemView.extend({
     tagName: 'tr',
-    template: tableRowTmpl
+    template: tableRowTmpl,
+        templateHelpers: function() {
+        return {
+            // Convert coverage to percentage for display.
+            coveragePct: (this.model.get('coverage') * 100).toFixed(1),
+            areaTrimmed: this.model.get('area').toFixed(1)
+        };
+    }
 });
 
 var TableView = Marionette.CompositeView.extend({

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -73,6 +73,54 @@ var utils = {
             });
 
         return md5(JSON.stringify(sortedCollection));
+    },
+
+    convertToMetric: function(value, fromUnit) {
+        fromUnit = fromUnit.toLowerCase();
+        switch (fromUnit) {
+            case 'in':
+                // return cm.
+                return value * 2.54;
+
+            case 'ft':
+                // return meters.
+                return value * 0.3048;
+
+            case 'mi':
+                // return Km.
+                return value * 1.60934;
+
+            case 'lb':
+                // return Kg.
+                return value * 0.453592;
+
+            default:
+                throw 'Conversion not implemented.';
+        }
+    },
+
+    convertToImperial: function(value, fromUnit) {
+        fromUnit = fromUnit.toLowerCase();
+        switch (fromUnit) {
+            case 'cm':
+                // return in.
+                return value * 0.393701;
+
+            case 'm':
+                // return feet.
+                return value * 3.28084;
+
+            case 'km':
+                // return miles.
+                return value * 0.621371;
+
+            case 'kg':
+                // return Lbs.
+                return value * 2.20462;
+
+            default:
+                throw 'Conversion not implemented.';
+        }
     }
 };
 

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -87,11 +87,11 @@ var utils = {
                 return value * 0.3048;
 
             case 'mi':
-                // return Km.
+                // return km.
                 return value * 1.60934;
 
             case 'lb':
-                // return Kg.
+                // return kg.
                 return value * 0.453592;
 
             default:

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -225,7 +225,7 @@ var DrawView = Marionette.ItemView.extend({
                 bounds = L.latLngBounds(swNe),
                 box = turfBboxPolygon(bounds.toBBoxString().split(','));
 
-            addLayer(box, '1 Square Km');
+            addLayer(box, '1 Square km');
             navigateToAnalyze();
         }).fail(function() {
             revertLayer();

--- a/src/mmw/js/src/main_water_balance.js
+++ b/src/mmw/js/src/main_water_balance.js
@@ -39,10 +39,10 @@ var initialize = function(model) {
 
         var result = model[soil][land][precip];
 
-        $precipText.text(precip + '"');
-        $evapoText.text(result.et + '"');
-        $runoffText.text(result.r + '"');
-        $infilText.text(result.i + '"');
+        $precipText.text(convertToMetric(precip) + 'cm');
+        $evapoText.text(convertToMetric(result.et) + 'cm');
+        $runoffText.text(convertToMetric(result.r) + 'cm');
+        $infilText.text(convertToMetric(result.i) + 'cm');
 
         var total = parseFloat(result.et) + parseFloat(result.r) + parseFloat(result.i);
         $et.css('height', (100 * result.et / total) + '%');
@@ -61,6 +61,11 @@ var initialize = function(model) {
             'border-bottom-left-radius': bottomRadius,
             'border-bottom-right-radius': bottomRadius
         });
+    };
+
+    var convertToMetric = function(value) {
+        // 2.54 cm per inch.
+        return (value * 2.54).toFixed(1);
     };
 
     // Wire up events

--- a/src/mmw/js/src/main_water_balance.js
+++ b/src/mmw/js/src/main_water_balance.js
@@ -39,10 +39,10 @@ var initialize = function(model) {
 
         var result = model[soil][land][precip];
 
-        $precipText.text(convertToMetric(precip) + 'cm');
-        $evapoText.text(convertToMetric(result.et) + 'cm');
-        $runoffText.text(convertToMetric(result.r) + 'cm');
-        $infilText.text(convertToMetric(result.i) + 'cm');
+        $precipText.text(convertToMetric(precip) + ' cm');
+        $evapoText.text(convertToMetric(result.et) + ' cm');
+        $runoffText.text(convertToMetric(result.r) + ' cm');
+        $infilText.text(convertToMetric(result.i) + ' cm');
 
         var total = parseFloat(result.et) + parseFloat(result.r) + parseFloat(result.i);
         $et.css('height', (100 * result.et / total) + '%');

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -6,6 +6,7 @@ var $ = require('jquery'),
     Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
     drawUtils = require('../draw/utils'),
+    coreUtils = require('../core/utils'),
     models = require('./models'),
     modificationConfigUtils = require('./modificationConfigUtils'),
     landCoverTmpl = require('./templates/controls/landCover.html'),
@@ -134,9 +135,11 @@ var PrecipitationView = ControlView.extend({
 
     onSliderChanged: function() {
         var value = parseFloat(this.ui.slider.val()),
+            // Model expects Imperial inputs.
+            imperialValue = coreUtils.convertToImperial(value, 'cm'),
             modification = new models.ModificationModel({
                 name: this.getControlName(),
-                value: value
+                value: imperialValue
             });
         this.addOrReplaceInput(modification);
     },
@@ -145,6 +148,9 @@ var PrecipitationView = ControlView.extend({
         var model = this.controlModel,
             value = model && model.get('value') || 0;
 
+        // Model values are stored in Imperial and need to be displayed as
+        // metric.
+        value = coreUtils.convertToMetric(value, 'in');
         this.ui.slider.val(value);
         this.ui.displayValue.text(this.getDisplayValue(value));
     }

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -123,7 +123,7 @@ var PrecipitationView = ControlView.extend({
     },
 
     getDisplayValue: function(value) {
-        return value.toFixed(1) + '"';
+        return value.toFixed(2) + 'cm';
     },
 
     onSliderDragged: function() {

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -124,7 +124,7 @@ var PrecipitationView = ControlView.extend({
     },
 
     getDisplayValue: function(value) {
-        return value.toFixed(2) + 'cm';
+        return value.toFixed(2) + ' cm';
     },
 
     onSliderDragged: function() {

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -276,7 +276,7 @@ var ScenarioModel = Backbone.Model.extend({
             inputs: [
                 {
                     name: 'precipitation',
-                    value: 1.0
+                    value: 0.984252 // equal to 2.5 cm.
                 }
             ]
         });

--- a/src/mmw/js/src/modeling/templates/controls/precipitation.html
+++ b/src/mmw/js/src/modeling/templates/controls/precipitation.html
@@ -1,6 +1,6 @@
 <div class="btn-sm btn-primary">
 <label>
     Precipitation
-    <input type="range" min="0" max="10" step="0.1" />
+    <input type="range" min="0" max="25" step="0.25" />
     <span class="value"></span></label>
 </div>

--- a/src/mmw/js/src/modeling/tr55/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/table.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th>Quality Measure</th>
-            <th class="text-left">Load (lbs)</th>
+            <th class="text-left">Load (Kg)</th>
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/modeling/tr55/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/table.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th>Quality Measure</th>
-            <th class="text-left">Load (Kg)</th>
+            <th class="text-left">Load (kg)</th>
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -76,7 +76,7 @@ var ChartView = Marionette.ItemView.extend({
             }),
             chartOptions = {
                 isPercentage: false,
-                depAxisLabel: 'Load (lbs)',
+                depAxisLabel: 'Load (Kg)',
                 useHorizBars: true,
                 horizMargin: {top: 20, right: 80, bottom: 40, left: 150}
             },

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -76,7 +76,7 @@ var ChartView = Marionette.ItemView.extend({
             }),
             chartOptions = {
                 isPercentage: false,
-                depAxisLabel: 'Load (Kg)',
+                depAxisLabel: 'Load (kg)',
                 useHorizBars: true,
                 horizMargin: {top: 20, right: 80, bottom: 40, left: 150}
             },


### PR DESCRIPTION
Connects #632 

* Converts all display units to metric.
* Inputs to TR55 from front end remain in Imperial but display in metric.
* Job results that show pixel counts are converted to area based on approximate latitude.
* Micro site updates.
* Precipitation slider starts with 2.5 cm rather than 1 inch.

To test:

* Use site, as per normal. Note any numeric values that show on the screen and check that they are in metric.