### PR TITLE
Load projects into /compare

### DIFF
--- a/src/mmw/apps/home/tests.py
+++ b/src/mmw/apps/home/tests.py
@@ -36,16 +36,16 @@ class RouteAccessTestCase(TestCase):
 
         self.c.login(username='test', password='test')
 
-    def test_any_user_can_get_model_route_without_project_id(self):
+    def test_any_user_cannot_get_model_route_without_project_id(self):
         response = self.c.get('/project/')
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 404)
 
         self.c.logout()
 
         response = self.c.get('/project/')
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 404)
 
     def test_project_owner_can_get_model_route_with_project_id(self):
         project_id = self.create_private_project()

--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -16,8 +16,9 @@ urlpatterns = patterns(
         project_clone, name='project_clone'),
     url(r'^project/(?P<proj_id>[0-9]+)/scenario/(?P<scenario_id>[0-9]+)/$',
         project, name='project'),
+    url(r'^project/compare/$', project, name='project'),
+    url(r'^project/(?P<proj_id>[0-9]+)/compare/$', project, name='project'),
     url(r'^analyze$', home_page, name='analyze'),
-    url(r'^compare$', home_page, name='compare'),
     url(r'^error', home_page, name='error'),
     url(r'^sign-up', home_page, name='sign_up'),
 )

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -61,6 +61,8 @@ def project(request, proj_id=None, scenario_id=None):
     If not, return a 404. Otherwise, just load the index
     template and the let the front-end handle the route
     and request the project through the API.
+
+    If proj_id is not specified, then throw a 404 error.
     """
 
     if proj_id:
@@ -69,7 +71,9 @@ def project(request, proj_id=None, scenario_id=None):
         if project.user != request.user and project.is_private:
             raise Http404
 
-    return render_to_response('home/home.html', get_context(request))
+        return render_to_response('home/home.html', get_context(request))
+    else:
+        raise Http404
 
 
 def project_clone(request, proj_id=None):

--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -4,7 +4,8 @@ var _ = require('underscore'),
     App = require('../app'),
     router = require('../router').router,
     views = require('./views'),
-    models = require('./models');
+    models = require('./models'),
+    settings = require('../core/settings');
 
 var AnalyzeController = {
     analyzePrepare: function() {
@@ -17,6 +18,10 @@ var AnalyzeController = {
         // analyze mode
         if (!App.map.get('maskLayerApplied')) {
             App.map.set('maskLayerApplied', true);
+        }
+
+        if (!settings.get('activityMode')) {
+            App.currProject = null;
         }
     },
 

--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -1,68 +1,45 @@
 "use strict";
 
-var _ = require('underscore'),
-    App = require('../app'),
+var App = require('../app'),
+    router = require('../router').router,
     views = require('./views'),
     modelingModels = require('../modeling/models.js');
 
-function makeTestProject() {
-    App.currProject = new modelingModels.ProjectModel({
-        'name': 'Test Project'
-    });
-    var modifications = [
-        {
-            'name': 'landcover',
-            'value':'commercial',
-            'shape': {
-                'type':'Feature',
-                'properties': {},
-                'geometry': {
-                    'type':'Polygon',
-                    'coordinates':[[[-75.29891967773438,39.968174500886306],[-75.31986236572266,39.94396289639476],[-75.28690338134766,39.94080422911384],[-75.29891967773438,39.968174500886306]]]}},
-            'type':'',
-            'area':4.104278178806597,
-            'units':'km<sup>2</sup>'
-        },
-        {
-            'name':'conservation_practice',
-            'value':'veg_infil_basin',
-            'shape': {
-                'type':'Feature',
-                'properties':{},
-                'geometry':{
-                    'type':'Polygon',
-                    'coordinates':[[[-75.22991180419922,39.95580659996906],[-75.2511978149414,39.93869836991711],[-75.21343231201172,39.935802707704816],[-75.22991180419922,39.95580659996906]]]}},
-            'type': '',
-            'area':3.361859935949525,
-            'units':'km<sup>2</sup>'
-        }];
-    modifications = modifications.concat(modifications);
-    modifications = modifications.concat(modifications);
-    var scenarios = new modelingModels.ScenariosCollection(
-            _.map(_.range(0,7), function(scenarioInd) {
-                return new modelingModels.ScenarioModel({
-                    name: 'Scenario ' + scenarioInd,
-                    modifications: modifications
-                });
-            }));
-    App.currProject.set('scenarios', scenarios);
-    return App.currProject;
-}
-
 var CompareController = {
-    compare: function() {
-        var compareWindow = new views.CompareWindow({
-            model: makeTestProject()
-        });
-
-        App.rootView.footerRegion.show(compareWindow);
+    compare: function(projectId) {
+        if (App.currProject) {
+            showCompareWindow();
+        } else if (projectId) {
+            App.currProject = new modelingModels.ProjectModel({
+                id: projectId
+            });
+            App.currProject
+                .fetch()
+                .done(function() {
+                    showCompareWindow();
+                });
+        }
+        App.currProject.on('change:id', updateUrl);
+        // else -- this case is caught by the backend and raises a 404
     },
 
     compareCleanUp: function() {
         App.rootView.footerRegion.empty();
+        App.currProject.off('change:id', updateUrl);
     }
-
 };
+
+function updateUrl() {
+    // Use replace: true, so that the back button will work as expected.
+    router.navigate(App.currProject.getCompareUrl(), { replace: true });
+}
+
+function showCompareWindow() {
+    var compareWindow = new views.CompareWindow({
+        model: App.currProject
+    });
+    App.rootView.footerRegion.show(compareWindow);
+}
 
 module.exports = {
     CompareController: CompareController

--- a/src/mmw/js/src/compare/templates/compareMap.html
+++ b/src/mmw/js/src/compare/templates/compareMap.html
@@ -1,4 +1,0 @@
-<div class="scenario-title">
-    <h3 class="light">{{ name }}</h3>
-</div>
-<div class="map"></div>

--- a/src/mmw/js/src/compare/templates/compareScenario.html
+++ b/src/mmw/js/src/compare/templates/compareScenario.html
@@ -1,5 +1,7 @@
 <div class="compare-column">
-    <div class="map-region"></div>
+    <div class="map-region">
+        <div class="map-container"></div>
+    </div>
     <div class="chart-region"></div>
     <div class="precipitation-region"></div>
     <div class="modifications-region"></div>

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -225,7 +225,12 @@ var DrawView = Marionette.ItemView.extend({
                 bounds = L.latLngBounds(swNe),
                 box = turfBboxPolygon(bounds.toBBoxString().split(','));
 
-            addLayer(box, '1 Square km');
+            // Convert coordinates from using strings to floats so that backend can parse them.
+            box.geometry.coordinates[0] = _.map(box.geometry.coordinates[0], function(coord) {
+                return [parseFloat(coord[0]), parseFloat(coord[1])];
+            });
+
+            addLayer(box, '1 Square Km');
             navigateToAnalyze();
         }).fail(function() {
             revertLayer();

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -237,6 +237,18 @@ var ProjectModel = Backbone.Model.extend({
             return root + modelPart + scenarioPart;
         }
         return root;
+    },
+
+    getCompareUrl: function() {
+        // Return a url fragment that can access the compare view.
+        var root = '/project/',
+            id = this.get('id'),
+            url = root + 'compare';
+
+        if (id) {
+            url = root + id + '/compare';
+        }
+        return url;
     }
 });
 

--- a/src/mmw/js/src/modeling/templates/scenariosBar.html
+++ b/src/mmw/js/src/modeling/templates/scenariosBar.html
@@ -10,5 +10,5 @@
 </div>
 <div class="fade-tabs"></div>
 <div class="compare-top-btn">
-    <a href="compare" class="btn btn-compare"><i class="fa fa-th"></i> Compare</a>
+    <a data-url={{ compareUrl }} class="btn btn-compare"><i class="fa fa-th"></i> Compare</a>
 </div>

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -57,7 +57,10 @@ describe('Modeling', function() {
         describe('ScenariosView', function() {
             it('adds a new scenario when the plus button is clicked', function() {
                 var collection = getTestScenarioCollection(),
-                    view = new views.ScenariosView({ collection: collection });
+                    view = new views.ScenariosView({
+                        collection: collection,
+                        projectModel: new models.ProjectModel()
+                    });
 
                 $(sandboxSelector).html(view.render().el);
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -41,6 +41,7 @@ var ModelingHeaderView = Marionette.LayoutView.extend({
         // If the user changes, we should refresh all the views because they
         // have user contextual controls.
         this.listenTo(App.user, 'change', this.reRender);
+        this.listenTo(this.model, 'change:id', this.reRender);
         this.listenTo(App.user, 'change:guest', this.saveAfterLogin);
     },
 
@@ -52,7 +53,8 @@ var ModelingHeaderView = Marionette.LayoutView.extend({
 
         this.scenariosRegion.empty();
         this.scenariosRegion.show(new ScenariosView({
-            collection: this.model.get('scenarios')
+            collection: this.model.get('scenarios'),
+            projectModel: this.model
         }));
 
         this.toolbarRegion.empty();
@@ -235,12 +237,19 @@ var ScenariosView = Marionette.LayoutView.extend({
     collection: models.ScenariosCollection,
     template: scenariosBarTmpl,
 
+    initialize: function(options) {
+        this.projectModel = options.projectModel;
+    },
+
     templateHelpers: function() {
         // Check the first scenario in the collection as a proxy for the
         // entire collection.
-        var scenario = this.collection.first();
+        var scenario = this.collection.first(),
+            compareUrl = this.projectModel.getCompareUrl();
+
         return {
-            editable: isEditable(scenario)
+            editable: isEditable(scenario),
+            compareUrl: compareUrl
         };
     },
 

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -12,8 +12,8 @@ router.addRoute(/^/, DrawController, 'draw');
 router.addRoute(/^analyze/, AnalyzeController, 'analyze');
 router.addRoute('project(/:projectId)(/scenario/:scenarioId)(/)', ModelingController, 'project');
 router.addRoute('project/:projectId/clone(/)', ModelingController, 'projectClone');
-//TODO Add route for /project/XX/scenario/compare
-router.addRoute(/^compare/, CompareController, 'compare');
+router.addRoute('project(/:projectId)(/scenario/:scenarioId)(/)', ModelingController, 'project');
+router.addRoute('project(/:projectId)/compare(/)', CompareController, 'compare');
 router.addRoute('error(/:type)(/)', ErrorController, 'error');
 router.addRoute('sign-up(/)', SignUpController, 'signUp');
 router.addRoute('sign-up/itsi(/:username)(/:first_name)(/:last_name)(/)', SignUpController, 'itsiSignUp');


### PR DESCRIPTION
Situations to test:
 * As a guest, switch the base layer. In the modeling view, add a few modifications to a scenario, and click compare.You should see the modifications, AOI, correct extent on the map and the selected base layer for that scenario. The url should be `/project/compare`. Clicking back should lead to `/project` and the same project should be loaded (ie. it shouldn't create a new one). Clicking back again (using the browser's back button or the modeling view's back button) should lead to `/analyze`.
 * As a guest, in the modeling view, log in, and then click compare. The url should be `/project/project_id/compare`. Clicking back should lead to `/project/project_id/scenario/scenario_id`. Clicking back again should lead to `/analyze`.
 * Do the same thing except directly visit the URL `/project/project_id/compare`. It should work the same as above.
 * Directly visit the URL `/project/compare`. It should give a 404 error.
 * As a guest, in the modeling view, click compare. Then log in. This should save the project, and update the url to `/project/project_id/compare`. Clicking back should lead to `/project/project_id/scenario/scenario_id`. Clicking back again should lead to `/analyze`.

Known bug: If you are in `/project/project_id/scenario/scenario_id` and then hit the browser's back button, and then the browser's forward button, there is a problem loading the modeling view. This behavior also doesn't work on the develop branch. I'll see if I can figure it out, but if not, I'll make an issue for it.

Connects #594 