### PR TITLE
Update leaflet draw fork to resolve layer bug

### DIFF
--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -1502,8 +1502,8 @@
     },
     "leaflet-draw": {
       "version": "0.2.3",
-      "from": "git://github.com/michaelguild13/Leaflet.draw.git#e2fe3a4",
-      "resolved": "git://github.com/michaelguild13/Leaflet.draw#e2fe3a4c176979235845e8fbb1c5017414035765"
+      "from": "git://github.com/michaelguild13/Leaflet.draw.git#e753b7d",
+      "resolved": "git://github.com/michaelguild13/Leaflet.draw#e753b7d0eb9d1de8864ca85d5dafbf9ac955759c"
     },
     "leaflet-plugins": {
       "version": "1.3.8",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -32,7 +32,7 @@
     "jshint": "2.8.0",
     "jstify": "0.9.0",
     "leaflet": "0.7.3",
-    "leaflet-draw": "git://github.com/michaelguild13/Leaflet.draw#e2fe3a4",
+    "leaflet-draw": "git://github.com/michaelguild13/Leaflet.draw#e753b7d",
     "leaflet-plugins": "git://github.com/azavea/leaflet-plugins#feature/browserify",
     "leaflet.locatecontrol": "0.43.0",
     "livereloadify": "2.0.0",


### PR DESCRIPTION
The touch support fork of Leaflet.Draw was updated to manage event
handlers better which resolves an issue with our basemap layer selector.

Fixes upstream provided via https://github.com/michaelguild13/Leaflet.draw/commit/e753b7d0eb9d1de8864ca85d5dafbf9ac955759c

Connects #559 