### PR TITLE
Make land use and BMP names in the frontend consistent with those in the backend

### DIFF
--- a/src/mmw/apps/core/templates/patterns.html
+++ b/src/mmw/apps/core/templates/patterns.html
@@ -2,7 +2,7 @@
     <defs>
         <!-- LAND COVER TYPES -->
         <!-- Low Intensity Residential-->
-        <pattern height="72" id="fill-lir" overflow="visible" patternUnits="userSpaceOnUse" viewBox="79.59 -151.59 72 72" width="72">
+        <pattern height="72" id="fill-li_residential" overflow="visible" patternUnits="userSpaceOnUse" viewBox="79.59 -151.59 72 72" width="72">
             <g>
                 <polygon fill="#329b9c" points="79.59,-79.59 151.59,-79.59 151.59,-151.59 79.59,-151.59"/>
                 <g>
@@ -135,7 +135,7 @@
             </g>
         </pattern>
         <!-- High Intensity Residential-->
-        <pattern height="72" id="fill-hir" overflow="visible" patternUnits="userSpaceOnUse" viewBox="72.212 -144.212 72 72" width="72">
+        <pattern height="72" id="fill-hi_residential" overflow="visible" patternUnits="userSpaceOnUse" viewBox="72.212 -144.212 72 72" width="72">
             <g>
                 <polygon fill="#39afa1" points="72.212,-72.212 144.212,-72.212 144.212,-144.212 72.212,-144.212"/>
                 <g>
@@ -482,8 +482,8 @@
                 </g>
             </g>
         </pattern>
-        <!-- Forest -->
-        <pattern height="54.001" id="fill-forest" overflow="visible" patternUnits="userSpaceOnUse" viewBox="2.932 -56.828 46.766 54.001" width="46.766">
+        <!-- Deciduous Forest -->
+        <pattern height="54.001" id="fill-deciduous_forest" overflow="visible" patternUnits="userSpaceOnUse" viewBox="2.932 -56.828 46.766 54.001" width="46.766">
             <g>
                 <polygon fill="#53e9b4" points="2.932,-2.826 49.698,-2.826 49.698,-56.828 2.932,-56.828"/>
                 <g>
@@ -545,8 +545,8 @@
                 </g>
             </g>
         </pattern>
-        <!-- Turf Grass -->
-        <pattern height="93" id="fill-turf_grass" overflow="visible" patternUnits="userSpaceOnUse" viewBox="86.002 -93 85.499 93" width="85.499">
+        <!-- Urban Grass aka Turf Grass -->
+        <pattern height="93" id="fill-urban_grass" overflow="visible" patternUnits="userSpaceOnUse" viewBox="86.002 -93 85.499 93" width="85.499">
             <g>
                 <polygon fill="#4aeab3" points="86.002,0 171.501,0 171.501,-93 86.002,-93"/>
                 <g>
@@ -1621,8 +1621,8 @@
                 </g>
             </g>
         </pattern>
-        <!-- Wetlands -->
-        <pattern height="72" id="fill-wetland" overflow="visible" patternUnits="userSpaceOnUse" viewBox="6.5 -72.625 72 72" width="72">
+        <!-- Woody Wetlands -->
+        <pattern height="72" id="fill-woody_wetland" overflow="visible" patternUnits="userSpaceOnUse" viewBox="6.5 -72.625 72 72" width="72">
             <g>
                 <polygon fill="#4ebaea" points="6.5,-0.625 78.5,-0.625 78.5,-72.625 6.5,-72.625"/>
                 <g>
@@ -4272,7 +4272,7 @@
             </g>
         </pattern>
         <!-- Tall Prairie -->
-        <pattern  width="71.998" height="72.002" patternUnits="userSpaceOnUse" id="fill-tg_prairie" viewBox="12.834 -83.002 71.998 72.002" overflow="visible">
+        <pattern  width="71.998" height="72.002" patternUnits="userSpaceOnUse" id="fill-tall_grass_prairie" viewBox="12.834 -83.002 71.998 72.002" overflow="visible">
             <g>
                 <polygon fill="#39afa1" points="12.834,-83.002 84.832,-83.002 84.832,-11 12.834,-11        "/>
                 <g>
@@ -4660,7 +4660,7 @@
             </g>
         </pattern>
         <!-- Short Prairie -->
-        <pattern  width="72" height="72" patternUnits="userSpaceOnUse" id="fill-sg_prairie" viewBox="3.026 -74.101 72 72" overflow="visible">
+        <pattern  width="72" height="72" patternUnits="userSpaceOnUse" id="fill-short_grass_prairie" viewBox="3.026 -74.101 72 72" overflow="visible">
            <g>
                 <polygon fill="#4aeab3" points="3.026,-74.101 75.026,-74.101 75.026,-2.101 3.026,-2.101        "/>
                 <g>
@@ -4805,7 +4805,7 @@
         </pattern>
         <!-- CONSERVATION PRACTICES -->
         <!-- No Till farming -->
-        <pattern height="74.8" id="fill-no_till_agriculture" overflow="visible" patternUnits="userSpaceOnUse" viewBox="72.15 -74.8 72 74.8" width="72">
+        <pattern height="74.8" id="fill-no_till" overflow="visible" patternUnits="userSpaceOnUse" viewBox="72.15 -74.8 72 74.8" width="72">
             <g>
                 <polygon fill="#53e9b4" points="72.15,-74.8 144.15,-74.8 144.15,0 72.15,0"/>
                 <g>
@@ -5342,8 +5342,8 @@
                 </g>
             </g>
         </pattern>
-        <!-- Detention Basin -->
-        <pattern height="71.606" id="fill-veg_infil_basin" overflow="visible" patternUnits="userSpaceOnUse" viewBox="0.305 -71.606 71.606 71.606" width="71.606">
+        <!-- Detention Basin aka Vegitation Infill Basin aka Infiltration Trench-->
+        <pattern height="71.606" id="fill-infiltration_trench" overflow="visible" patternUnits="userSpaceOnUse" viewBox="0.305 -71.606 71.606 71.606" width="71.606">
             <g>
                 <polygon fill="#52c6dd" points="0.305,-71.606 71.911,-71.606 71.911,0 0.305,0"/>
                 <g>

--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -78,12 +78,12 @@
 
                     <!-- Land Cover -->
 
-                    <div id="land-lir" role="tabpanel" class="tab-pane active land"> <!-- LIR -->
-                        <img src="{% static 'images/water_balance/art_land_lir.png' %}" alt="low intensity residential">
+                    <div id="land-li_residential" role="tabpanel" class="tab-pane active land"> <!-- LIR -->
+                        <img src="{% static 'images/water_balance/art_land_lir.png' %}" alt="Low-Intensity Residential">
                     </div>
 
-                    <div id="land-hir" role="tabpanel" class="tab-pane land"> <!-- HIR -->
-                        <img src="{% static 'images/water_balance/art_land_hir.png' %}" alt="high intensity residential">
+                    <div id="land-hi_residential" role="tabpanel" class="tab-pane land"> <!-- HIR -->
+                        <img src="{% static 'images/water_balance/art_land_hir.png' %}" alt="High-Intensity Residential">
                     </div>
 
                     <div id="land-commercial" role="tabpanel" class="tab-pane land"> <!-- commercial -->
@@ -94,11 +94,11 @@
                         <img src="{% static 'images/water_balance/art_land_grassland.png' %}" alt="grassland">
                     </div>
 
-                    <div id="land-forest" role="tabpanel" class="tab-pane land"> <!-- forest -->
-                        <img src="{% static 'images/water_balance/art_land_forest.png' %}" alt="forest">
+                    <div id="land-deciduous_forest" role="tabpanel" class="tab-pane land"> <!-- forest -->
+                        <img src="{% static 'images/water_balance/art_land_forest.png' %}" alt="Deciduous Forest">
                     </div>
 
-                    <div id="land-turfGrass" role="tabpanel" class="tab-pane land"> <!-- turfGrass -->
+                    <div id="land-urban_grass" role="tabpanel" class="tab-pane land"> <!-- urban grass -->
                         <img src="{% static 'images/water_balance/art_land_turfGrass.png' %}" alt="Turf Grass">
                     </div>
 
@@ -106,7 +106,7 @@
                         <img src="{% static 'images/water_balance/art_land_pasture.png' %}" alt="pasture">
                     </div>
 
-                    <div id="land-rowCrops" role="tabpanel" class="tab-pane land"> <!-- rowCrops -->
+                    <div id="land-row_crop" role="tabpanel" class="tab-pane land"> <!-- Row Crops -->
                         <img src="{% static 'images/water_balance/art_land_rowCrops.png' %}" alt="Row Crops">
                     </div>
 
@@ -114,11 +114,11 @@
                         <img src="{% static 'images/water_balance/art_land_chaparral.png' %}" alt="chaparral">
                     </div>
 
-                    <div id="land-tallGrass" role="tabpanel" class="tab-pane land"> <!-- tallGrass -->
+                    <div id="land-tall_grass_prairie" role="tabpanel" class="tab-pane land"> <!-- Tall-Grass Prairie -->
                         <img src="{% static 'images/water_balance/art_land_tallGrass.png' %}" alt="Tall Grass Prairie">
                     </div>
 
-                    <div id="land-shortGrass" role="tabpanel" class="tab-pane land"> <!-- shortGrass -->
+                    <div id="land-short_grass_prairie" role="tabpanel" class="tab-pane land"> <!-- Short-Grass Prairie -->
                         <img src="{% static 'images/water_balance/art_land_shortGrass.png' %}" alt="Short Grass Prairie">
                     </div>
 
@@ -203,16 +203,16 @@
 
                 <ul id="thumbs-land" class="nav" role="tablist"> <!-- Landcover Thumbs -->
 
-                    <li id="thumb-lir" class="active"> <!-- LIR Thumb -->
-                        <a href="#land-lir" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_lir.png' %}" alt="Low Intensity Residential" data-container="body" data-toggle="popover" data-placement="left" data-title="Low Intensity Residential" data-content="Areas with a mixture of constructed materials and vegetation. Impervious surfaces account for 20% to 49% percent of total cover. These areas most commonly include single-family housing units.">
+                    <li id="thumb-li_residential" class="active"> <!-- LIR Thumb -->
+                        <a href="#land-li_residential" aria-controls="filter-tab" role="tab" data-toggle="tab">
+                            <img src="{% static 'images/water_balance/thumb_lir.png' %}" alt="Low-Intensity Residential" data-container="body" data-toggle="popover" data-placement="left" data-title="Low Intensity Residential" data-content="Areas with a mixture of constructed materials and vegetation. Impervious surfaces account for 20% to 49% percent of total cover. These areas most commonly include single-family housing units.">
                         </a>
                         <label>LIR</label>
                     </li>
 
-                    <li id="thumb-hir"> <!-- HIR Thumb -->
-                        <a href="#land-hir" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_hir.png' %}" alt="High Intensity Residential" data-container="body" data-toggle="popover" data-placement="left" data-title="High Intensity Residential" data-content="Areas with a mixture of constructed materials and vegetation. Impervious surfaces account for 50% to 79% of the total cover. These areas most commonly include single-family housing units.">
+                    <li id="thumb-hi_residential"> <!-- HIR Thumb -->
+                        <a href="#land-hi_residential" aria-controls="filter-tab" role="tab" data-toggle="tab">
+                            <img src="{% static 'images/water_balance/thumb_hir.png' %}" alt="High-Intensity Residential" data-container="body" data-toggle="popover" data-placement="left" data-title="High Intensity Residential" data-content="Areas with a mixture of constructed materials and vegetation. Impervious surfaces account for 50% to 79% of the total cover. These areas most commonly include single-family housing units.">
                         </a>
                         <label>HIR</label>
                     </li>
@@ -231,15 +231,15 @@
                         <label>Grassland</label>
                     </li>
 
-                    <li id="thumb-forest"> <!-- Forest Thumb -->
-                        <a href="#land-forest" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_forest.png' %}" alt="Forest" data-container="body" data-toggle="popover" data-placement="left" data-title="Forest" data-content="Areas dominated by trees generally greater than 5 meters tall, and greater than 20% of total vegetation cover. Neither deciduous nor evergreen species are greater than 75% of total tree cover.">
+                    <li id="thumb-deciduous_forest"> <!-- Deciduous Forest Thumb -->
+                        <a href="#land-deciduous_forest" aria-controls="filter-tab" role="tab" data-toggle="tab">
+                            <img src="{% static 'images/water_balance/thumb_forest.png' %}" alt="Deciduous Forest" data-container="body" data-toggle="popover" data-placement="left" data-title="Forest" data-content="Areas dominated by trees generally greater than 5 meters tall, and greater than 20% of total vegetation cover. Neither deciduous nor evergreen species are greater than 75% of total tree cover.">
                         </a>
                         <label>Forest</label>
                     </li>
 
-                    <li id="thumb-turfGrass"> <!-- TurfGrass Thumb -->
-                        <a href="#land-turfGrass" aria-controls="filter-tab" role="tab" data-toggle="tab">
+                    <li id="thumb-urban_grass"> <!-- Urban Grass Thumb -->
+                        <a href="#land-urban_grass" aria-controls="filter-tab" role="tab" data-toggle="tab">
                             <img src="{% static 'images/water_balance/thumb_turfGrass.png' %}" alt="Turf Grass" data-container="body" data-toggle="popover" data-placement="left" data-title="Turf Grass" data-content="Areas with a mixture of some constructed materials, but mostly vegetation in the form of lawn grasses. Impervious surfaces account for less than 20% of total cover. These areas most commonly include large-lot single-family housing units, parks, golf courses, and vegetation planted in developed settings for recreation, erosion control, or aesthetic purposes.">
                         </a>
                         <label>Turf Grass</label>
@@ -252,8 +252,8 @@
                         <label>Pasture</label>
                     </li>
 
-                    <li id="thumb-rowCrops"> <!-- Row Crops Thumb -->
-                        <a href="#land-rowCrops" aria-controls="filter-tab" role="tab" data-toggle="tab">
+                    <li id="thumb-row_crop"> <!-- Row Crops Thumb -->
+                        <a href="#land-row_crop" aria-controls="filter-tab" role="tab" data-toggle="tab">
                             <img src="{% static 'images/water_balance/thumb_rowCrops.png' %}" alt="Row Crops" data-container="body" data-toggle="popover" data-placement="left" data-title="Row Crops" data-content="Areas used for the production of annual crops, such as corn, soybeans, vegetables, tobacco, and cotton, and also perennial woody crops such as orchards and vineyards. Crop vegetation accounts for greater than 20% of total vegetation. This class also includes all land being actively tilled.">
                         </a>
                         <label>Row Crops</label>
@@ -266,15 +266,15 @@
                         <label>Chaparral</label>
                     </li>
 
-                    <li id="thumb-tallGrass"> <!-- TallGrass Thumb -->
-                        <a href="#land-tallGrass" aria-controls="filter-tab" role="tab" data-toggle="tab">
+                    <li id="thumb-tall_grass_prairie"> <!-- Tall-Grass Thumb -->
+                        <a href="#land-tall_grass_prairie" aria-controls="filter-tab" role="tab" data-toggle="tab">
                             <img src="{% static 'images/water_balance/thumb_tallGrass.png' %}" alt="Tall Grass Prairie" data-container="body" data-toggle="popover" data-placement="left" data-title="Tall Grass Prairie" data-content="Areas dominated by shrubs; less than 5 meters tall with shrub canopy typically greater than 20% of total vegetation. This class includes true shrubs, young trees in an early successional stage or trees stunted from environmental conditions.">
                         </a>
                         <label>Tall Grass Prairie</label>
                     </li>
 
-                    <li id="thumb-shortGrass"> <!-- ShortGrass Thumb -->
-                        <a href="#land-shortGrass" aria-controls="filter-tab" role="tab" data-toggle="tab">
+                    <li id="thumb-short_grass_prairie"> <!-- Short-Grass Thumb -->
+                        <a href="#land-short_grass_prairie" aria-controls="filter-tab" role="tab" data-toggle="tab">
                             <img src="{% static 'images/water_balance/thumb_shortGrass.png' %}" alt="Short Grass Prairie" data-container="body" data-toggle="popover" data-placement="left" data-title="Short Grass Prairie" data-content="Areas dominated by shrubs less than 20 centimeters tall with shrub canopy typically greater than 20% of total vegetation. This type is often co-associated with grasses, sedges, herbs, and non-vascular vegetation.">
                         </a>
                         <label>Short Grass Prairie</label>

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -231,7 +231,7 @@ describe('Core', function() {
         describe('ModificationPopupView', function() {
             it('deletes the modification it is associated with when the delete button is clicked', function() {
                 var model = new Backbone.Model({
-                        value: 'lir',
+                        value: 'li_residential',
                         shape: {},
                         area: 100,
                         units: 'm<sup>2</sup>',

--- a/src/mmw/js/src/modeling/mocks.js
+++ b/src/mmw/js/src/modeling/mocks.js
@@ -310,7 +310,7 @@ var polygons = {
 var modifications = {
     sample1: {
         "name":"Land Cover",
-        "value":"lir",
+        "value":"li_residential",
         "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-76.00479125976562,40.19251207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]]}},
         "area":10977.041602204828,
         "units":"acres"
@@ -321,7 +321,7 @@ var modifications = {
         "name":"Land Cover",
         "units":"acres",
         "shape":{"type":"Feature","geometry":{"coordinates":[[[-76.00479125976562,40.19251207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]], "type":"Polygon"},"properties":{}},
-        "value":"lir"
+        "value":"li_residential"
     },
 
     sample2: {
@@ -335,7 +335,7 @@ var modifications = {
     // Identical to sample1 except has a slightly smaller area
     sample3: {
         "name":"Land Cover",
-        "value":"lir",
+        "value":"li_residential",
         "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-76.00479125976562,40.19252207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]]}},
         "area":10777.041602204828,
         "units":"acres"

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -381,6 +381,29 @@ var ModificationsCollection = Backbone.Collection.extend({
     model: ModificationModel
 });
 
+/**
+ * A function to allow scenarios created with the old names to
+ * continue to function.  This can perhaps be removed after a period
+ * of time.
+*/
+function oldToNewName(modKey) {
+    var translationMatrix = {
+        'lir': 'li_residential',
+        'hir': 'hi_residential',
+        'forest': 'deciduous_forest',
+        'turf_grass': 'urban_grass',
+        'tg_prairie': 'tall_grass_prairie',
+        'sg_prairie': 'short_grass_prairie',
+        'veg_infil_basin': 'infiltration_trench',
+        'no_till_agriculture': 'no_till'
+    };
+    if (modKey in translationMatrix) {
+        return translationMatrix[modKey];
+    } else {
+        return modKey;
+    }
+}
+
 var ScenarioModel = Backbone.Model.extend({
     urlRoot: '/api/modeling/scenarios/',
 
@@ -411,6 +434,12 @@ var ScenarioModel = Backbone.Model.extend({
                     value: 0.984252 // equal to 2.5 cm.
                 }
             ]
+        });
+
+        // Change old names to new ones.  This could eventually be
+        // removed when enough of old scenarios have been upgraded.
+        _.forEach(attrs.modifications, function(m) {
+            m.value = oldToNewName(m.value);
         });
 
         this.set('inputs', new ModificationsCollection(attrs.inputs));

--- a/src/mmw/js/src/modeling/modificationConfig.json
+++ b/src/mmw/js/src/modeling/modificationConfig.json
@@ -14,8 +14,9 @@
         "summary": "This category includes areas of bedrock, desert pavement, scarps, talus, slides, volcanic material, glacial debris, sand dunes, strip mines, gravel pits and other accumulations of earthen material. Generally, vegetation accounts for less than 15% of total cover.",
         "color": "#f1edd9"
     },
-    "forest": {
-        "name": "Forest",
+    "deciduous_forest": {
+        "name": "Deciduous Forest",
+        "shortName": "Forest",
         "summary": "This category includes areas that are covered by vegetation with more than 20% of the land surface covered by trees that are taller than 5 meters.",
         "color": "#53e9b4"
     },
@@ -24,14 +25,14 @@
         "summary": "This category includes areas where grasses and weedy (herbaceous) plants cover more than 80% of the ground area. These areas are not intensively managed but may be used for grazing animals.",
         "color": "#54d2d0"
     },
-    "hir": {
-        "name": "High Intensity Residential",
+    "hi_residential": {
+        "name": "High-Intensity Residential",
         "shortName": "HIR",
         "summary": "This category includes areas with apartment complexes or row houses. The amount of area that is covered by hard surfaces like roads, driveways and roofs is between 80% and 100%. No more than 20% of the area is covered with vegetation.",
         "color": "#39afa1"
     },
-    "lir": {
-        "name": "Low Intensity Residential",
+    "li_residential": {
+        "name": "Low-Intensity Residential",
         "shortName": "LIR",
         "summary": "This category includes areas with single-family houses on single lots. The amount of area that is covered by hard surfaces like roads, driveways, and roofs, is between 30% and 80% of the land surface. The remaining 20% to 80% is covered with vegetation.",
         "color": "#329b9c"
@@ -46,25 +47,26 @@
         "summary": "This category includes areas that are planted for annual crops such as corn, soybeans, vegetables and cotton. It also includes orchards and vineyards and actively tilled (plowed) land.",
         "color": "#52c6dd"
     },
-    "sg_prairie": {
-        "name": "Short Grass Prairie",
+    "short_grass_prairie": {
+        "name": "Short-Grass Prairie",
         "shortName": "Short Prairie",
         "summary": "This category includes areas of grasses, legumes, or grass-legume mixtures planted for livestock grazing or the production of seed or hay crops, typically on a perennial cycle. Pasture/hay vegetation accounts for greater than 20% of total vegetation.",
         "color": "#4aeab3"
     },
-    "tg_prairie": {
-        "name": "Tall Grass Prairie",
+    "tall_grass_prairie": {
+        "name": "Tall-Grass Prairie",
         "shortName": "Tall Prairie",
         "summary": "This category includes areas with a mixture of some constructed materials, but mostly vegetation in the form of lawn grasses. Impervious surfaces account for less than 20% of total cover. These areas most commonly include large-lot single-family housing units, parks, golf courses, and vegetation planted in developed settings for recreation, erosion control, or aesthetic purposes.",
         "color": "#39afa1"
     },
-    "turf_grass": {
+    "urban_grass": {
         "name": "Turf Grass",
         "summary": "This category includes areas that are primarily lawn grasses planted and maintained for recreation, aesthetic purposes and erosion control. Examples include parks, lawns, golf courses, and grassy areas in developments.",
         "color": "#4aeab3"
     },
-    "wetland": {
-        "name": "Wetland",
+    "woody_wetland": {
+        "name": "Woody Wetland",
+	"shortName": "Wetland",
         "summary": "This category includes areas where forest or shrubland vegetation accounts for greater than 20% of vegetative cover and the soil or substrate is periodically saturated with or covered with water.",
         "color": "#4ebaea"
     },
@@ -77,7 +79,7 @@
         "summary": "Green Roof Summary...",
         "color": "#4ebaea"
     },
-    "no_till_agriculture": {
+    "no_till": {
         "name": "No-Till Agriculture",
         "shortName": "No-Till Ag",
         "color": "#53e9b4"
@@ -90,7 +92,7 @@
         "name": "Rain Garden",
         "color": "#51dec2"
     },
-    "veg_infil_basin": {
+    "infiltration_trench": {
         "name": "Vegetation Infiltration Basin",
         "shortName": "Veg Basin",
         "color": "#52c6dd"

--- a/src/mmw/js/src/modeling/modificationConfigUtils.js
+++ b/src/mmw/js/src/modeling/modificationConfigUtils.js
@@ -11,7 +11,7 @@ function resetConfig() {
     modificationConfig = require('./modificationConfig.json');
 }
 
-// modKey should be a key in modificationsConfig (eg. 'turf_grass').
+// modKey should be a key in modificationsConfig (eg. 'urban_grass').
 function getHumanReadableName(modKey) {
     if (modificationConfig[modKey]) {
         return modificationConfig[modKey].name;

--- a/src/mmw/js/src/modeling/templates/controls/conservationPractice.html
+++ b/src/mmw/js/src/modeling/templates/controls/conservationPractice.html
@@ -8,12 +8,12 @@
         <div class="pad-1"> <!-- Dropdown Content -->
             <ul class="row">
                 {{ utils.thumb('rain_garden') }}
-                {{ utils.thumb('veg_infil_basin') }}
+                {{ utils.thumb('infiltration_trench') }}
                 {{ utils.thumb('porous_paving') }}
             </ul>
             <ul class="row">
                 {{ utils.thumb('green_roof') }}
-                {{ utils.thumb('no_till_agriculture') }}
+                {{ utils.thumb('no_till') }}
                 {{ utils.thumb('cluster_housing') }}
             </ul>
         </div> <!-- End Dropdown Content -->

--- a/src/mmw/js/src/modeling/templates/controls/landCover.html
+++ b/src/mmw/js/src/modeling/templates/controls/landCover.html
@@ -7,21 +7,21 @@
     <div id="land-tools" class="dropdown-menu menu-left" role="menu"> <!-- Dropdown -->
         <div class="pad-1"> <!-- Dropdown Content -->
             <ul class="row">
-                {{ utils.thumb('lir') }}
-                {{ utils.thumb('hir') }}
+                {{ utils.thumb('li_residential') }}
+                {{ utils.thumb('hi_residential') }}
                 {{ utils.thumb('commercial') }}
-                {{ utils.thumb('forest') }}
+                {{ utils.thumb('deciduous_forest') }}
             </ul>
             <ul class="row">
-                {{ utils.thumb('turf_grass') }}
+                {{ utils.thumb('urban_grass') }}
                 {{ utils.thumb('pasture') }}
                 {{ utils.thumb('grassland') }}
                 {{ utils.thumb('row_crop') }}
             </ul>
             <ul class="row">
                 {{ utils.thumb('chaparral') }}
-                {{ utils.thumb('tg_prairie') }}
-                {{ utils.thumb('sg_prairie') }}
+                {{ utils.thumb('tall_grass_prairie') }}
+                {{ utils.thumb('short_grass_prairie') }}
                 {{ utils.thumb('desert') }}
             </ul>
         </div> <!-- End Dropdown Content -->

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -184,7 +184,7 @@ describe('Modeling', function() {
 
             it('lists all of the modifications and their area', function() {
                 this.model.get('modifications').add([this.modsModel1, this.modsModel2]);
-                assert.equal($('#sandbox #mod-landcover tr td:first-child').text(), 'Low Intensity Residential');
+                assert.equal($('#sandbox #mod-landcover tr td:first-child').text(), 'Low-Intensity Residential');
                 assert.equal($('#sandbox #mod-landcover tr td:nth-child(2)').text(), '44.4 km2');
                 assert.equal($('#sandbox #mod-conservationpractice tr td:first-child').text(), 'Rain Garden');
                 assert.equal($('#sandbox #mod-conservationpractice tr td:nth-child(2)').text(), '106.4 km2');
@@ -645,14 +645,14 @@ describe('Modeling', function() {
                     });
 
                     model.updateModificationHash();
-                    assert.equal(model.get('modification_hash'), '40c4fdd89b06a0e9b7e1c3c5c2bd1f17');
+                    assert.equal(model.get('modification_hash'), '5e02dc1cf4b55bdb209683473f6dac45');
 
                     var mod = new models.ModificationModel(mocks.modifications.sample2);
                     model.get('modifications').add(mod);
-                    assert.equal(model.get('modification_hash'), 'a862ae12206d895501bb85c3edcdb467');
+                    assert.equal(model.get('modification_hash'), '3f9403253db86e2ceff2291e04044d3d');
 
                     model.get('modifications').remove(mod);
-                    assert.equal(model.get('modification_hash'), '40c4fdd89b06a0e9b7e1c3c5c2bd1f17');
+                    assert.equal(model.get('modification_hash'), '5e02dc1cf4b55bdb209683473f6dac45');
                 });
 
                 it('is called when the modifications for a scenario changes', function() {

--- a/src/mmw/js/src/water_balance/models.js
+++ b/src/mmw/js/src/water_balance/models.js
@@ -2,18 +2,18 @@
 
 var WaterBalanceModel = {
     landMap: {
-        'urban_grass': ['turfGrass'],
-        'tall_grass_prairie': ['tallGrass'],
-        'li_residential': ['lir'],
-        'hi_residential': ['hir'],
+        'urban_grass': ['urban_grass'],
+        'tall_grass_prairie': ['tall_grass_prairie'],
+        'li_residential': ['li_residential'],
+        'hi_residential': ['hi_residential'],
         'commercial': ['commercial'],
         'desert': ['desert'],
-        'deciduous_forest': ['forest'],
+        'deciduous_forest': ['deciduous_forest'],
         'chaparral': ['chaparral'],
         'grassland': ['grassland'],
         'pasture': ['pasture'],
-        'short_grass_prairie': ['shortGrass'],
-        'row_crop': ['rowCrops']
+        'short_grass_prairie': ['short_grass_prairie'],
+        'row_crop': ['row_crop']
     },
 
     soilMap: [

--- a/src/mmw/js/src/water_balance/models.js
+++ b/src/mmw/js/src/water_balance/models.js
@@ -1,21 +1,6 @@
 "use strict";
 
 var WaterBalanceModel = {
-    landMap: {
-        'urban_grass': ['urban_grass'],
-        'tall_grass_prairie': ['tall_grass_prairie'],
-        'li_residential': ['li_residential'],
-        'hi_residential': ['hi_residential'],
-        'commercial': ['commercial'],
-        'desert': ['desert'],
-        'deciduous_forest': ['deciduous_forest'],
-        'chaparral': ['chaparral'],
-        'grassland': ['grassland'],
-        'pasture': ['pasture'],
-        'short_grass_prairie': ['short_grass_prairie'],
-        'row_crop': ['row_crop']
-    },
-
     soilMap: [
         'sand',
         'loam',
@@ -31,30 +16,28 @@ var WaterBalanceModel = {
             return Math.round(parseFloat(x) * 10) / 10;
         }
 
-        function processLine(soil, lands, precip) {
+        function processLine(soil, land, precip) {
             if (!model[soil]) {
                 model[soil] = {};
             }
-            lands.forEach(function(land) {
-                if (!model[soil][land]) {
-                    model[soil][land] = {};
-                }
-                model[soil][land][precip] = {
-                    'et': round(line[3]),
-                    'i' : round(line[4]),
-                    'r' : round(line[5])
-                };
-            });
+            if (!model[soil][land]) {
+                model[soil][land] = {};
+            }
+            model[soil][land][precip] = {
+                'et': round(line[3]),
+                'i' : round(line[4]),
+                'r' : round(line[5])
+            };
         }
 
         for (var j = 1; j < lines.length; j++) {
             var line = lines[j].split(',');
             var soil = this.soilMap[line[2]];
-            var lands = this.landMap[line[1]];
+            var land = line[1];
             var precip = line[0];
 
-            if (soil && lands && precip) {
-                processLine(soil, lands, precip);
+            if (soil && land && precip) {
+                processLine(soil, land, precip);
             }
         }
 


### PR DESCRIPTION
The internal names for various land uses and BMPs have been changed to be consistent with those found in the TR-55 module.

   * [lh]ir -> (li|hi)_residential
   * forest -> deciduous_forest
   * turf(Grass|_grass) -> urban_grass
   * wetland -> woody_wetland
   * ((tg|sg)_prairie|(tall|Short)Grass) -> (tall|short)_grass_prairie
   * no_till_agriculture -> no_till
   * veg_infil_basin -> infiltration_trench
   * rowCrops -> row_crop

Connects #662

**To test**
   * Bring up some previously-created projects and scenarios and make sure that they still work as expected
   * Create some new projects and scenarios and make sure that they work as expected
   * Add some land uses and/or BMPs to an existing scenario and confirm that this mixed scenario works as intended
   * Play with the micro-app and make sure that it still behaves as expected
