### PR TITLE
Run models from compare views

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -249,7 +249,7 @@ var ChartView = Marionette.ItemView.extend({
     },
 
     addChart: function() {
-        var selector = '#' + this.id() + ' .bar-chart',
+        var chartEl = this.$el.find('.bar-chart').get(0),
             chartData = this.collection.map(function(model) {
                 return model.attributes;
             }),
@@ -263,7 +263,7 @@ var ChartView = Marionette.ItemView.extend({
         if (this.model.get('name') === 'land') {
             chartOptions.useHorizBars = true;
         }
-        chart.makeBarChart(selector, chartData, indVar, depVars, chartOptions);
+        chart.makeBarChart(chartEl, chartData, indVar, depVars, chartOptions);
     }
 });
 

--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var App = require('../app'),
+var _ = require('lodash'),
+    App = require('../app'),
     router = require('../router').router,
     views = require('./views'),
     modelingModels = require('../modeling/models.js');
@@ -8,6 +9,7 @@ var App = require('../app'),
 var CompareController = {
     compare: function(projectId) {
         if (App.currProject) {
+            setupProjectCopy();
             showCompareWindow();
         } else if (projectId) {
             App.currProject = new modelingModels.ProjectModel({
@@ -16,28 +18,96 @@ var CompareController = {
             App.currProject
                 .fetch()
                 .done(function() {
+                    setupProjectCopy();
                     showCompareWindow();
                 });
         }
-        App.currProject.on('change:id', updateUrl);
         // else -- this case is caught by the backend and raises a 404
     },
 
     compareCleanUp: function() {
+        App.user.off('change:guest', saveAfterLogin);
+        App.origProject.off('change:id', updateUrl);
+
+        // Switch back to the origProject so any changes are discarded.
+        App.currProject.off();
+        App.currProject = App.origProject;
+
         App.rootView.footerRegion.empty();
-        App.currProject.off('change:id', updateUrl);
     }
 };
 
+function setupProjectCopy() {
+    /*
+    Create a copy of the project so that:
+      -Changes to the results and inputs are not saved to the server
+      -Changes to the results and inputs are not present after hitting the back button (and project is unsaved).
+       When the user is logged in as a guest, the only copy of the original inputs and results
+       are in App.currProject, and modifying these values in the compare views will result in those new
+       values being back in the modeling views, which is not what we want.
+      -The original project (without changes) is saved when logging in. If the user is a guest,
+       goes into the compare views, and then logs in, the project should be saved with the inputs
+       and results that were present before going to the compare views. This is to enforce the
+       constraint that inputs and results entered in the compare views should never be saved.
+       Without holding onto the original copies of these values, it's not possible to do this.
+     */
+    App.origProject = App.currProject;
+    App.currProject = copyProject(App.origProject);
+
+    App.user.on('change:guest', saveAfterLogin);
+    App.origProject.on('change:id', updateUrl);
+}
+
+// Creates a special-purpose copy of the project
+// for the compare views, since creating a true deep
+// clone is more difficult and unnecessary.
+function copyProject(project) {
+    var scenariosCopy = new modelingModels.ScenariosCollection();
+    project.get('scenarios').forEach(function(scenario) {
+        var scenarioCopy = new modelingModels.ScenarioModel({});
+        scenarioCopy.set({
+            is_current_conditions: scenario.get('is_current_conditions'),
+            modifications: scenario.get('modifications'),
+            modification_hash: scenario.get('modification_hash'),
+            results: new modelingModels.ResultCollection(scenario.get('results').toJSON()),
+            inputs: new modelingModels.ModificationsCollection(scenario.get('inputs').toJSON()),
+            inputmod_hash: scenario.get('inputmod_hash'),
+            allow_save: false
+        });
+        scenarioCopy.get('inputs').on('add', _.debounce(_.bind(scenarioCopy.fetchResults, scenarioCopy), 500));
+        scenariosCopy.add(scenarioCopy);
+    });
+    return new modelingModels.ProjectModel({
+        name: App.origProject.get('name'),
+        area_of_interest: App.origProject.get('area_of_interest'),
+        model_package: App.origProject.get('model_package'),
+        scenarios: scenariosCopy,
+        allow_save: false
+    });
+}
+
+function saveAfterLogin(user, guest) {
+    if (!guest && App.origProject.isNew()) {
+        var user_id = user.get('id');
+        App.origProject.set('user_id', user_id);
+        App.origProject.get('scenarios').each(function(scenario) {
+            scenario.set('user_id', user_id);
+        });
+        // Save the origProject (as opposed to the currProject)
+        // to not include changes to inputs and results.
+        App.origProject.saveProjectAndScenarios();
+    }
+}
+
 function updateUrl() {
     // Use replace: true, so that the back button will work as expected.
-    router.navigate(App.currProject.getCompareUrl(), { replace: true });
+    router.navigate(App.origProject.getCompareUrl(), { replace: true });
 }
 
 function showCompareWindow() {
     var compareWindow = new views.CompareWindow({
-        model: App.currProject
-    });
+            model: App.currProject
+        });
     App.rootView.footerRegion.show(compareWindow);
 }
 

--- a/src/mmw/js/src/compare/templates/compareChart.html
+++ b/src/mmw/js/src/compare/templates/compareChart.html
@@ -1,8 +1,0 @@
-<h3>Model Output</h3>
-<div class="pull-right">
-    <select class="form-control btn btn-small btn-primary">
-        <option>Runoff</option>
-        <option>Water Quality</option>
-    </select>
-</div>
-<div class="chart"></div>

--- a/src/mmw/js/src/compare/templates/compareModeling.html
+++ b/src/mmw/js/src/compare/templates/compareModeling.html
@@ -1,0 +1,19 @@
+<h3>Model Output</h3>
+{% if polling %}
+    <i class="fa fa-circle-o-notch fa-spin"></i>
+{% endif %}
+<div class="pull-right">
+    <select class="form-control btn btn-small btn-primary">
+        {% for result in results %}
+            {% if result.active %}
+                <option value="{{ result.name }}" selected>
+            {% else %}
+                <option value="{{ result.name }}" >
+            {% endif %}
+            {{ result.displayName }}
+                </option>
+        {% endfor %}
+    </select>
+</div>
+<div class="result-region"></div>
+<div class="controls-region"></div>

--- a/src/mmw/js/src/compare/templates/compareScenario.html
+++ b/src/mmw/js/src/compare/templates/compareScenario.html
@@ -2,7 +2,6 @@
     <div class="map-region">
         <div class="map-container"></div>
     </div>
-    <div class="chart-region"></div>
-    <div class="precipitation-region"></div>
+    <div class="modeling-region"></div>
     <div class="modifications-region"></div>
 </div>

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -9,6 +9,7 @@ var d3 = require('d3'),
 // by Mike Bostock http://bost.ocks.org/mike/chart/
 // and http://bl.ocks.org/mbostock/3885304
 
+// el is the DOM element where the chart should be inserted.
 // indVar and depVars represent the independent and dependent variables which are displayed
 // on the x or y axes depending on the orientation of the chart.
 // In general, an independent variable is one that is directly controlled by an experimenter
@@ -18,13 +19,14 @@ var d3 = require('d3'),
 // The optional parameter options has optional properties: horizMargin, vertMargin, useHorizBars,
 // height, width, numYTicks, isPercentage, depAxisLabel, depDisplayNames, and barColors.
 // If height and/or width aren't specified, then they are responsive (ie. set automatically according to the
-// size of the element selected by selector).
+// size of the el).
 // depDisplayNames is the human readable counterpart to depVars.
 // If barColors is supplied, a legend will be drawn using the colors.
-function makeBarChart(selector, data, indVar, depVars, options) {
+function makeBarChart(el, data, indVar, depVars, options) {
     options = options || {};
 
-    var numYTicks = options.numYTicks || 10,
+    var $el = $(el),
+        numYTicks = options.numYTicks || 10,
         hiddenSize = 100,
         horizMargin = options.horizMargin || {top: 20, right: 80, bottom: 40, left: 120},
         vertMargin = options.vertMargin || {top: 20, right: 80, bottom: 30, left: 40},
@@ -81,9 +83,9 @@ function makeBarChart(selector, data, indVar, depVars, options) {
     var computeSizes = function(margin) {
         // containerWidth will be 0 if the chart is in a
         // tab that is currently hidden.
-        containerWidth = options.width || $(selector).get(0).offsetWidth;
+        containerWidth = options.width || el.offsetWidth;
         width = containerWidth - margin.left - margin.right;
-        containerHeight = options.height || $(selector).get(0).offsetHeight;
+        containerHeight = options.height || el.offsetHeight;
         height = containerHeight - margin.top - margin.bottom;
         // Set to legal dummy value if it's non-positive because
         // the container is hidden and containerWidth == 0.
@@ -147,7 +149,7 @@ function makeBarChart(selector, data, indVar, depVars, options) {
             yAxis.ticks(numYTicks);
         }
 
-        svg = d3.select(selector).append('svg')
+        svg = d3.select(el).append('svg')
             .attr('width', containerWidth)
             .attr('height', containerHeight);
 
@@ -205,7 +207,7 @@ function makeBarChart(selector, data, indVar, depVars, options) {
     // Ideas for making d3 charts responsive from
     // http://eyeseast.github.io/visible-data/2013/08/28/responsive-charts-with-d3/
     var resizeVertical = function() {
-        if ($(selector).length > 0) {
+        if ($el.length > 0) {
             computeSizes(vertMargin);
 
             x.rangeRoundBands([0, width * CHART_CONTAINER_PERCENTAGE], 0.1);
@@ -261,7 +263,7 @@ function makeBarChart(selector, data, indVar, depVars, options) {
             .scale(y)
             .orient('left');
 
-        svg = d3.select(selector).append('svg')
+        svg = d3.select(el).append('svg')
             .attr('width', containerWidth)
             .attr('height', containerHeight);
 
@@ -314,7 +316,7 @@ function makeBarChart(selector, data, indVar, depVars, options) {
     };
 
     var resizeHorizontal = function() {
-        if ($(selector).length > 0) {
+        if ($el.length > 0) {
             computeSizes(horizMargin);
 
             x.range([0, width]);
@@ -354,11 +356,11 @@ function makeBarChart(selector, data, indVar, depVars, options) {
         // bar-chart-refresh events occur when a tab in the Analyze view is selected.
         // We need to listen for them since the chart might have been hidden when the last
         // resize occured, in which case the size would have been set to the default.
-        $(selector).on('bar-chart:refresh', resizeHorizontal);
+        $el.on('bar-chart:refresh', resizeHorizontal);
     } else {
         renderVertical();
         $(window).on('resize', resizeVertical);
-        $(selector).on('bar-chart:refresh', resizeVertical);
+        $el.on('bar-chart:refresh', resizeVertical);
     }
 }
 

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -17,7 +17,7 @@ var d3 = require('d3'),
 // a function of the independent variable and is usually represented on the y-axis.
 // If depVars contains > 1 variable, then the function will create a stacked bar chart.
 // The optional parameter options has optional properties: horizMargin, vertMargin, useHorizBars,
-// height, width, numYTicks, isPercentage, depAxisLabel, depDisplayNames, and barColors.
+// height, width, numDepTicks, isPercentage, depAxisLabel, depDisplayNames, and barColors.
 // If height and/or width aren't specified, then they are responsive (ie. set automatically according to the
 // size of the el).
 // depDisplayNames is the human readable counterpart to depVars.
@@ -26,7 +26,7 @@ function makeBarChart(el, data, indVar, depVars, options) {
     options = options || {};
 
     var $el = $(el),
-        numYTicks = options.numYTicks || 10,
+        numDepTicks = options.numDepTicks || 10,
         hiddenSize = 100,
         horizMargin = options.horizMargin || {top: 20, right: 80, bottom: 40, left: 120},
         vertMargin = options.vertMargin || {top: 20, right: 80, bottom: 30, left: 40},
@@ -144,9 +144,9 @@ function makeBarChart(el, data, indVar, depVars, options) {
             .scale(y)
             .orient('left');
         if (options.isPercentage) {
-            yAxis.ticks(numYTicks, '%');
+            yAxis.ticks(numDepTicks, '%');
         } else {
-            yAxis.ticks(numYTicks);
+            yAxis.ticks(numDepTicks);
         }
 
         svg = d3.select(el).append('svg')
@@ -254,9 +254,9 @@ function makeBarChart(el, data, indVar, depVars, options) {
             .orient('bottom')
             .scale(x);
         if (options.isPercentage) {
-            xAxis.ticks(numYTicks, '%');
+            xAxis.ticks(numDepTicks, '%');
         } else {
-            xAxis.ticks(numYTicks);
+            xAxis.ticks(numDepTicks);
         }
 
         yAxis = d3.svg.axis()

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -51,6 +51,7 @@ describe('Core', function() {
             height: displaySandboxHeight,
             width: displaySandboxWidth
         }));
+        this.el = $(displaySandboxSelector).get(0);
     });
 
     afterEach(function() {
@@ -71,7 +72,7 @@ describe('Core', function() {
 
     describe('Chart', function() {
         it('changes size when the browser is resized and height and width are not provided', function() {
-            chart.makeBarChart(displaySandboxSelector, chartData, xValue, yValue);
+            chart.makeBarChart(this.el, chartData, xValue, yValue);
             var $svg = $(displaySandboxSelector).children('svg');
 
             var beforeHeight = $svg.attr('height');
@@ -95,7 +96,7 @@ describe('Core', function() {
                 height: 400,
                 width: 600
             };
-            chart.makeBarChart(displaySandboxSelector, chartData, xValue, yValue, options);
+            chart.makeBarChart(this.el, chartData, xValue, yValue, options);
             var $svg = $(displaySandboxSelector).children('svg');
 
             var beforeHeight = $svg.attr('height');

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -176,7 +176,8 @@ var MapView = Marionette.ItemView.extend({
             addLocateMeButton: true,
             addLayerSelector: true,
             showLayerAttribution: true,
-            initialLayerName: defaultLayerName
+            initialLayerName: defaultLayerName,
+            interactiveMode: true // True if clicking on map does stuff
         });
 
         var map = new L.Map(this.el, {
@@ -189,6 +190,22 @@ var MapView = Marionette.ItemView.extend({
             maxAge = 60000,
             timeout = 30000,
             self = this;
+
+        this.interactiveMode = options.interactiveMode;
+        if (!options.interactiveMode) {
+            // Disable panning and zooming.
+            // http://gis.stackexchange.com/questions/54454/disable-leaflet-interaction-temporary
+            map.dragging.disable();
+            map.touchZoom.disable();
+            map.doubleClickZoom.disable();
+            map.scrollWheelZoom.disable();
+            map.boxZoom.disable();
+            map.keyboard.disable();
+            if (map.tap) {
+                map.tap.disable();
+            }
+            document.getElementById('map').style.cursor='default';
+        }
 
         if (options.addZoomControl) {
             map.addControl(new L.Control.Zoom({position: 'topright'}));
@@ -411,8 +428,10 @@ var MapView = Marionette.ItemView.extend({
                     return acc.concat(new L.GeoJSON(model.get('shape'), {
                             style: style,
                             onEachFeature: function(feature, layer) {
-                                var popupContent = new ModificationPopupView({ model: model }).render().el;
-                                layer.bindPopup(popupContent);
+                                if (self.interactiveMode) {
+                                    var popupContent = new ModificationPopupView({ model: model }).render().el;
+                                    layer.bindPopup(popupContent);
+                                }
                             }
                     }));
                 } catch (ex) {

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -77,7 +77,8 @@ var ProjectModel = Backbone.Model.extend({
         scenarios: null,           // ScenariosCollection
         user_id: 0,                // User that created the project
         is_activity: false,        // Project that persists across routes
-        needs_reset: false         // Should we overwrite project data on next save?
+        needs_reset: false,        // Should we overwrite project data on next save?
+        allow_save: true           // Is allowed to save to the server - false in compare mode
     },
 
     initialize: function() {
@@ -150,7 +151,7 @@ var ProjectModel = Backbone.Model.extend({
     saveCalled: false,
 
     saveProjectAndScenarios: function() {
-        if (!App.user.loggedInUserMatch(this.get('user_id'))) {
+        if (!this.get('allow_save') || !App.user.loggedInUserMatch(this.get('user_id'))) {
             // Fail fast if the user can't save the project.
             return;
         }
@@ -418,7 +419,8 @@ var ScenarioModel = Backbone.Model.extend({
         active: false,
         job_id: null,
         results: null, // ResultCollection
-        census: null // JSON blob
+        census: null, // JSON blob
+        allow_save: true // Is allowed to save to the server - false in compare mode
     },
 
     initialize: function(attrs) {
@@ -460,7 +462,8 @@ var ScenarioModel = Backbone.Model.extend({
     },
 
     attemptSave: function() {
-        if (!App.user.loggedInUserMatch(this.get('user_id'))) {
+        if (!this.get('allow_save') || !App.user.loggedInUserMatch(this.get('user_id'))) {
+            // Fail fast if the user can't save the project.
             return;
         }
         if (!this.get('project')) {

--- a/src/mmw/js/src/modeling/templates/controls/precipitation.html
+++ b/src/mmw/js/src/modeling/templates/controls/precipitation.html
@@ -1,6 +1,6 @@
 <div class="btn-sm btn-primary">
 <label>
-    Precipitation
+    <span class="name">Precipitation</span>
     <input type="range" min="0" max="25" step="0.25" />
     <span class="value"></span></label>
 </div>

--- a/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
+++ b/src/mmw/js/src/modeling/templates/scenarioToolbarTabContent.html
@@ -1,41 +1,43 @@
 <div class="inline controls"></div>
 
-<div id="modification-btn-wrapper"> <!-- Modifications Dropdown -->
-    <div class="dropdown"> <!-- Dropdown Button -->
-        {% if not is_current_conditions %}
-            {% if shapes|length == 0 %}
-                <button class="btn btn-sm btn-default inverted" type="button" disabled="true">
-            {% else %}
-                <button class="btn btn-sm btn-default inverted" type="button" data-toggle="dropdown" aria-expanded="true">
-            {% endif %}
-                    <span id="modification-number"><strong>{{ shapes|length }}</strong></span> Modifications
+{% if not compareMode %}
+    <div id="modification-btn-wrapper"> <!-- Modifications Dropdown -->
+        <div class="dropdown"> <!-- Dropdown Button -->
+            {% if not is_current_conditions %}
+                {% if shapes|length == 0 %}
+                    <button class="btn btn-sm btn-default inverted" type="button" disabled="true">
+                {% else %}
+                    <button class="btn btn-sm btn-default inverted" type="button" data-toggle="dropdown" aria-expanded="true">
+                {% endif %}
+                <span id="modification-number"><strong>{{ shapes|length }}</strong></span> Modifications
                 </button>
-        {% endif %}
-        <div id="modifications" class="dropdown-menu menu-right" role="menu"> <!-- DropdownContent -->
-        {% for controlName, models in groupedShapes %}
-            <div class="pad-1 brd-bottom">
-                <label class="medium">
-                    {% if controlName == 'landcover' %}
-                    Land Cover
-                    {% elif controlName == 'conservation_practice' %}
-                    Conservation Practice
-                    {% endif %}
-                </label>
-                <table id="mod-{{ controlName|lower|replace(' ', '') }}" class="table modifications custom-hover">
-                {% for model in models %}
-                    <tr>
-                        <td>{{ model.get('value')|tr55Name }}</td>
-                        <td class="strong text-right">{{ model.get('area')|round(1)|toLocaleString }} {{ model.get('units') }}</td>
-                        {% if editable %}
-                        <td class="text-right"><button class="btn btn-sm btn-icon dark" type="button" data-delete="{{ model.cid }}">
-                        <i class="fa fa-trash"></i>
-                        </button></td>
-                        {% endif %}
-                    </tr>
+            {% endif %}
+            <div id="modifications" class="dropdown-menu menu-right" role="menu"> <!-- DropdownContent -->
+                {% for controlName, models in groupedShapes %}
+                    <div class="pad-1 brd-bottom">
+                        <label class="medium">
+                            {% if controlName == 'landcover' %}
+                                Land Cover
+                            {% elif controlName == 'conservation_practice' %}
+                                Conservation Practice
+                            {% endif %}
+                        </label>
+                        <table id="mod-{{ controlName|lower|replace(' ', '') }}" class="table modifications custom-hover">
+                            {% for model in models %}
+                                <tr>
+                                    <td>{{ model.get('value')|tr55Name }}</td>
+                                    <td class="strong text-right">{{ model.get('area')|round(1)|toLocaleString }} {{ model.get('units') }}</td>
+                                    {% if editable %}
+                                        <td class="text-right"><button class="btn btn-sm btn-icon dark" type="button" data-delete="{{ model.cid }}">
+                                            <i class="fa fa-trash"></i>
+                                        </button></td>
+                                    {% endif %}
+                                </tr>
+                            {% endfor %}
+                        </table>
+                    </div>
                 {% endfor %}
-                </table>
-            </div>
-        {% endfor %}
-        </div> <!-- End Dropdown Content -->
-    </div> <!-- End Dropdown Button -->
-</div> <!-- Modifications Dropdown -->
+            </div> <!-- End Dropdown Content -->
+        </div> <!-- End Dropdown Button -->
+    </div> <!-- Modifications Dropdown -->
+{% endif %}

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -70,7 +70,7 @@ var ChartView = Marionette.ItemView.extend({
     },
 
     addChart: function() {
-        var selector = '.quality-chart-container .bar-chart',
+        var chartEl = this.$el.find('.bar-chart').get(0),
             chartData = this.collection.map(function(model) {
                 return model.attributes;
             }),
@@ -83,7 +83,7 @@ var ChartView = Marionette.ItemView.extend({
             depVars = ['load'],
             indVar = 'measure';
 
-        chart.makeBarChart(selector, chartData, indVar, depVars, chartOptions);
+        chart.makeBarChart(chartEl, chartData, indVar, depVars, chartOptions);
     }
 });
 

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -32,9 +32,9 @@ var ResultView = Marionette.ItemView.extend({
             };
         }
 
-        var selector = '.runoff-chart-container ' + '.bar-chart';
-        $(selector).empty();
-        var result = this.model.get('result');
+        var chartEl = this.$el.find('.bar-chart').get(0),
+            result = this.model.get('result');
+        $(chartEl).empty();
         if (result) {
             var indVar = 'type',
                 depVars = ['inf', 'runoff', 'et'],
@@ -56,7 +56,7 @@ var ResultView = Marionette.ItemView.extend({
                     getBarData('Modified', 'modified')
                 ];
             }
-            chart.makeBarChart(selector, data, indVar, depVars, options);
+            chart.makeBarChart(chartEl, data, indVar, depVars, options);
         }
     }
 });

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -15,6 +15,7 @@ var ResultView = Marionette.ItemView.extend({
     },
 
     initialize: function(options) {
+        this.compareMode = options.compareMode;
         this.scenario = options.scenario;
     },
 
@@ -45,10 +46,14 @@ var ResultView = Marionette.ItemView.extend({
                     depDisplayNames: ['Infiltration', 'Runoff', 'Evaporation']
                 };
 
-            if (this.scenario.get('is_current_conditions')) {
+            if (this.scenario.get('is_current_conditions') || this.compareMode) {
+                // Use the modified results since they are the same as the unmodified results
+                // in Current Conditions, and they are the results we want to show
+                // in compareMode for other scenarios.
                 data = [
-                    getBarData('', 'unmodified'),
+                    getBarData('', 'modified'),
                 ];
+
                 this.$el.addClass('current-conditions');
             } else {
                 data = [

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -515,7 +515,8 @@ var ToolbarTabContentView = Marionette.CompositeView.extend({
         'click @ui.deleteModification': 'deleteModification'
     },
 
-    initialize: function() {
+    initialize: function(options) {
+        this.compareMode = options.compareMode;
         var modificationsColl = this.model.get('modifications');
         this.listenTo(modificationsColl, 'add remove reset', this.render);
     },
@@ -524,6 +525,7 @@ var ToolbarTabContentView = Marionette.CompositeView.extend({
         var shapes = this.model.get('modifications'),
             groupedShapes = shapes.groupBy('name');
         return {
+            compareMode: this.compareMode,
             shapes: shapes,
             groupedShapes: groupedShapes,
             editable: isEditable(this.model)
@@ -762,28 +764,13 @@ var ResultsTabContentView = Marionette.LayoutView.extend({
 
     onShow: function() {
         var modelPackage = App.currProject.get('model_package'),
-            resultName = this.model.get('name');
-        switch (modelPackage) {
-            case 'tr-55':
-                switch(resultName) {
-                    case 'runoff':
-                        this.resultRegion.show(new tr55RunoffViews.ResultView({
-                            model: this.model,
-                            scenario: this.scenario
-                        }));
-                        break;
-                    case 'quality':
-                        this.resultRegion.show(new tr55QualityViews.ResultView({
-                            model: this.model
-                        }));
-                        break;
-                    default:
-                        console.log('Result not supported.');
-                }
-                break;
-            default:
-                console.log('Model package ' + modelPackage + ' not supported.');
-        }
+            resultName = this.model.get('name'),
+            ResultView = getResultView(modelPackage, resultName);
+
+        this.resultRegion.show(new ResultView({
+            model: this.model,
+            scenario: this.scenario
+        }));
     }
 });
 
@@ -813,6 +800,23 @@ function triggerBarChartRefresh() {
     $('#model-output-wrapper .bar-chart').trigger('bar-chart:refresh');
 }
 
+function getResultView(modelPackage, resultName) {
+    switch (modelPackage) {
+        case 'tr-55':
+            switch(resultName) {
+                case 'runoff':
+                    return tr55RunoffViews.ResultView;
+                case 'quality':
+                    return tr55QualityViews.ResultView;
+                default:
+                    console.log('Result not supported.');
+            }
+            break;
+        default:
+            console.log('Model package ' + modelPackage + ' not supported.');
+    }
+}
+
 module.exports = {
     ModelingResultsWindow: ModelingResultsWindow,
     ModelingHeaderView: ModelingHeaderView,
@@ -820,5 +824,6 @@ module.exports = {
     ScenarioTabPanelsView: ScenarioTabPanelsView,
     ScenarioDropDownMenuView: ScenarioDropDownMenuView,
     ToolbarTabContentView: ToolbarTabContentView,
-    ProjectMenuView: ProjectMenuView
+    ProjectMenuView: ProjectMenuView,
+    getResultView: getResultView
 };

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -49,7 +49,7 @@
           }
 
           .map-region{
-            height: 20%;
+            height: 18vh;
             width: 100%;
 
             .map-container{
@@ -86,21 +86,65 @@
             }
           }
 
-          .chart-region{
+          .modeling-region{
             width: 100%;
-            height: 45%;
+            height: 44vh;
 
-            .chart-container{
+            .modeling-container{
               position: relative;
               width: auto;
               height: 100%;
               padding: 1rem;
+
+              .fa-spin{
+                margin-left: 8px;
+                font-size: 14px;
+                color: rgba(0, 0, 0, 0.54);
+              }
+
+              .result-region{
+                height: 85%;
+
+                .tab-pane{
+                  height: 100%;
+                  .quality-chart-region{
+                    height: 100%;
+                  }
+                }
+              }
+
+              .controls-region{
+                .controls {
+                  .precipitation {
+                    .btn-primary {
+                      padding: 0;
+
+                      label{
+                        display: table;
+                        width: 100%;
+
+                        span{
+                          display: table-cell;
+                          width: 10%;
+                          white-space: nowrap;
+                          padding: 5px;
+                        }
+                        input{
+                          display: table-cell;
+                          width: 100%;
+                          vertical-align: bottom;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
 
           .modifications-region{
             width: 100%;
-            height: 30%;
+            height: 25vh;
 
             .modifications-container{
               position: relative;


### PR DESCRIPTION
The compare views are designed to be read-only in the sense that any changes to the inputs or results are not saved to the project. 

I realize the layout is a bit off -- I'll fix it in a forthcoming commit.

To test:
 * In the modeling views, change the precipitation level on a scenario.
 * Go to the compare views
 * Check that the precipitation value and results were copied over.
 * Change the precip value, and check that new results load. Make sure the spinner appears, and that you can switch to Water Quality results. While Water Quality results are visible, change the precip value and check that it hasn't switched back to the Runoff results.
 * Click back to go to the modeling views, and check that the new results and precip value were *not* copied.
 * The previous steps should work whether logged in or not.
 * Try going to the compare views as a guest and then login. The project should be saved and the URL updated, although any changes introduced by the compare views should not be saved.

Connects #593 