### PR TITLE
Save the AOI name with the project.

### DIFF
--- a/src/mmw/apps/modeling/migrations/0013_project_area_of_interest_name.py
+++ b/src/mmw/apps/modeling/migrations/0013_project_area_of_interest_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0012_project_activity_flag'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='area_of_interest_name',
+            field=models.CharField(help_text='A human name for the area of interest', max_length=255, null=True),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -17,6 +17,10 @@ class Project(models.Model):
     area_of_interest = models.MultiPolygonField(
         null=True,
         help_text='Base geometry for all scenarios of project')
+    area_of_interest_name = models.CharField(
+        null=True,
+        max_length=255,
+        help_text='A human name for the area of interest')
     is_private = models.BooleanField(
         default=True)
     model_package = models.CharField(

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -121,6 +121,7 @@ var CompareScenarioView = Marionette.LayoutView.extend({
     onShow: function() {
         this.mapModel = new coreModels.MapModel({});
         this.mapModel.set('areaOfInterest', this.projectModel.get('area_of_interest'));
+        this.mapModel.set('areaOfInterestName', this.projectModel.get('area_of_interest_name'));
         this.mapView = new coreViews.MapView({
             model: this.mapModel,
             el: $(this.el).find('.map-container').get(),

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -120,8 +120,10 @@ var CompareScenarioView = Marionette.LayoutView.extend({
 
     onShow: function() {
         this.mapModel = new coreModels.MapModel({});
-        this.mapModel.set('areaOfInterest', this.projectModel.get('area_of_interest'));
-        this.mapModel.set('areaOfInterestName', this.projectModel.get('area_of_interest_name'));
+        this.mapModel.set({
+            'areaOfInterest': this.projectModel.get('area_of_interest'),
+            'areaOfInterestName': this.projectModel.get('area_of_interest_name')
+        });
         this.mapView = new coreViews.MapView({
             model: this.mapModel,
             el: $(this.el).find('.map-container').get(),

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -442,8 +442,10 @@ function addLayer(shape, name) {
         name = 'Selected Area';
     }
 
-    App.map.set('areaOfInterest', shape);
-    App.map.set('areaOfInterestName', name);
+    App.map.set({
+        'areaOfInterest': shape,
+        'areaOfInterestName': name
+    });
 }
 
 function navigateToAnalyze() {

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -30,6 +30,7 @@ var ModelingController = {
                 .fetch()
                 .done(function() {
                     App.map.set('areaOfInterest', project.get('area_of_interest'));
+                    App.map.set('areaOfInterestName', project.get('area_of_interest_name'));
                     initScenarioEvents(project);
                     initViews(project);
                     if (scenarioParam) {
@@ -61,6 +62,7 @@ var ModelingController = {
                 if (project.get('needs_reset')) {
                     project.set('user_id', App.user.get('id'));
                     project.set('area_of_interest', App.map.get('areaOfInterest'));
+                    project.set('area_of_interest', App.map.get('areaOfInterestName'));
                     project.set('needs_reset', false);
 
                     // Clear current scenarios and start over.
@@ -109,6 +111,7 @@ var ModelingController = {
                         name: 'Untitled Project',
                         created_at: Date.now(),
                         area_of_interest: App.map.get('areaOfInterest'),
+                        area_of_interest_name: App.map.get('areaOfInterestName'),
                         scenarios: new models.ScenariosCollection()
                     });
 

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -29,8 +29,10 @@ var ModelingController = {
             project
                 .fetch()
                 .done(function() {
-                    App.map.set('areaOfInterest', project.get('area_of_interest'));
-                    App.map.set('areaOfInterestName', project.get('area_of_interest_name'));
+                    App.map.set({
+                        'areaOfInterest': project.get('area_of_interest'),
+                        'areaOfInterestName': project.get('area_of_interest_name')
+                    });
                     initScenarioEvents(project);
                     initViews(project);
                     if (scenarioParam) {
@@ -60,10 +62,12 @@ var ModelingController = {
                 project = App.currProject;
                 // Reset flag is set so clear off old project data.
                 if (project.get('needs_reset')) {
-                    project.set('user_id', App.user.get('id'));
-                    project.set('area_of_interest', App.map.get('areaOfInterest'));
-                    project.set('area_of_interest', App.map.get('areaOfInterestName'));
-                    project.set('needs_reset', false);
+                    project.set({
+                        'user_id': App.user.get('id'),
+                        'area_of_interest': App.map.get('areaOfInterest'),
+                        'area_of_interest_name': App.map.get('areaOfInterestName'),
+                        'needs_reset': false
+                    });
 
                     // Clear current scenarios and start over.
                     // Must convert to an array first to avoid conflicts with

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -71,13 +71,14 @@ var ProjectModel = Backbone.Model.extend({
 
     defaults: {
         name: '',
-        created_at: null,          // Date
-        area_of_interest: null,    // GeoJSON
-        model_package: '',         // Package name
-        scenarios: null,           // ScenariosCollection
-        user_id: 0,                // User that created the project
-        is_activity: false,        // Project that persists across routes
-        needs_reset: false         // Should we overwrite project data on next save?
+        created_at: null,            // Date
+        area_of_interest: null,      // GeoJSON
+        area_of_interest_name: null, // Human readable string for AOI.
+        model_package: '',           // Package name
+        scenarios: null,             // ScenariosCollection
+        user_id: 0,                  // User that created the project
+        is_activity: false,          // Project that persists across routes
+        needs_reset: false           // Should we overwrite project data on next save?
     },
 
     initialize: function() {
@@ -494,7 +495,7 @@ var ScenarioModel = Backbone.Model.extend({
 
     setResults: function() {
         var rawServerResults = this.get('taskModel').get('result');
-        if (rawServerResults === "" || rawServerResults === null) {
+        if (rawServerResults === '' || rawServerResults === null) {
             this.get('results').setNullResults();
         } else {
             var serverResults = JSON.parse(rawServerResults);


### PR DESCRIPTION
We had not been saving the AOI name when saving the project. As a result, if
you reloaded a project and then went back to analyze mode, the name would be
blank. This change allows the AOI name to be persisted as part of the modeling
project and then restores it to the map when the project is reloaded.

Connects #648 

To test:
 * Run migrations
 * Log in and start a project. Note the AOI name on the analyze view.
 * After the project is saved, refresh the page.
 * Hit the back button in the UI to get you to the analyze view.
 * Ensure the name above the area calculation for the AOI matches what you'd previously seen.