### PR TITLE
Allow AMI lookup to filter by users with execute bit

### DIFF
--- a/deployment/cfn/application.py
+++ b/deployment/cfn/application.py
@@ -193,8 +193,7 @@ class Application(StackNode):
         try:
             app_server_ami_id = self.get_input('AppServerAMI')
         except MKUnresolvableInputError:
-            app_server_ami_id = get_recent_ami(self.aws_profile, 'mmw-app-*',
-                                               owner='self')
+            app_server_ami_id = get_recent_ami(self.aws_profile, 'mmw-app-*')
 
         return app_server_ami_id
 

--- a/deployment/cfn/data_plane.py
+++ b/deployment/cfn/data_plane.py
@@ -193,8 +193,7 @@ class DataPlane(StackNode):
             monitoring_ami_id = self.get_input('BastionHostAMI')
         except MKUnresolvableInputError:
             monitoring_ami_id = get_recent_ami(self.aws_profile,
-                                               'mmw-monitoring-*',
-                                               owner='self')
+                                               'mmw-monitoring-*')
 
         return monitoring_ami_id
 

--- a/deployment/cfn/tiler.py
+++ b/deployment/cfn/tiler.py
@@ -182,8 +182,7 @@ class Tiler(StackNode):
             tile_server_ami_id = self.get_input('TileServerAMI')
         except MKUnresolvableInputError:
             tile_server_ami_id = get_recent_ami(self.aws_profile,
-                                                'mmw-tiler-*',
-                                                owner='self')
+                                                'mmw-tiler-*')
 
         return tile_server_ami_id
 

--- a/deployment/cfn/utils/cfn.py
+++ b/deployment/cfn/utils/cfn.py
@@ -51,11 +51,17 @@ def get_subnet_cidr_block():
         current += 1
 
 
-def get_recent_ami(aws_profile, ami_name, owner="self"):
+def get_recent_ami(aws_profile, ami_name, owner="self", executable_by="self"):
     conn = boto.connect_ec2(profile_name=aws_profile)
-    images = conn.get_all_images(owners=owner, filters={
-        'name': ami_name
-    })
+    filters = {'name': ami_name}
+
+    # Filter images by owned by self first.
+    images = conn.get_all_images(owners=owner, filters=filters)
+
+    # If no images are owned by self, look for images self can execute.
+    if not images:
+        images = conn.get_all_images(executable_by=executable_by,
+                                     filters=filters)
 
     return sorted(filter(lambda i: True if 'beta' not in i.name else False,
                          images),

--- a/deployment/cfn/worker.py
+++ b/deployment/cfn/worker.py
@@ -189,8 +189,7 @@ class Worker(StackNode):
             worker_ami_id = self.get_input('WorkerAMI')
         except MKUnresolvableInputError:
             worker_ami_id = get_recent_ami(self.aws_profile,
-                                           'mmw-worker-*',
-                                           owner='self')
+                                           'mmw-worker-*')
 
         return worker_ami_id
 


### PR DESCRIPTION
By default, AMI lookups were occurring based on account ownership. This doesn't work for AMI sharing because the account making use of shared AMIs doesn't own them, instead it only has execute privileges. This updates the filter so that if the account looking up AMIs does not own any AMIs, it'll fall back to looking for AMIs it can execute.