### PR TITLE
Update ALLOWED_HOSTS setting

### DIFF
--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -23,6 +23,7 @@ if not instance_metadata:
 # See: https://docs.djangoproject.com/en/1.5/releases/1.5/#allowed-hosts-required-in-production  # NOQA
 ALLOWED_HOSTS = [
     'mmw.azavea.com',
+    'mmw-dev.azavea.com',
     '.elb.amazonaws.com',
     'localhost'
 ]


### PR DESCRIPTION
The new staging environment is under a different domain, so we need to add that domain to Django's `ALLOWED_HOSTS` to avoid HTTP 400 errors.