### PR TITLE
Defer saving projects in Embed Mode until AoI is available

### DIFF
--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -20,7 +20,29 @@ var AnalyzeController = {
             App.map.set('maskLayerApplied', true);
         }
 
-        if (!settings.get('activityMode')) {
+        if (settings.get('activityMode')) {
+            // Only one project allowed in Activity Mode. Save current project
+            // and if in embedded mode, update interactive state for container.
+            var project = App.currProject,
+                map = App.map;
+
+            if (project && project.get('scenarios').isEmpty()) {
+                project.set({
+                    'area_of_interest': map.get('areaOfInterest'),
+                    'area_of_interest_name': map.get('areaOfInterestName')
+                });
+                project
+                    .save()
+                    .done(function() {
+                        if (settings.get('itsi_embed')) {
+                            App.itsi.setLearnerUrl('project/' + project.id + '/draw');
+                        }
+                    });
+            }
+        } else {
+            // Multiple projects allowed in Regular Mode. Nullify current
+            // project since a new one will be created and saved by the
+            // Modelling Controller.
             App.currProject = null;
         }
     },

--- a/src/mmw/js/src/core/itsiEmbed.js
+++ b/src/mmw/js/src/core/itsiEmbed.js
@@ -37,25 +37,13 @@ var ItsiEmbed = function(App) {
     };
 
     this.loadInteractive = function(interactiveState) {
-        if (interactiveState) {
-            // Only redirect if route specified and different
-            if (interactiveState.route &&
-                interactiveState.route !== Backbone.history.getFragment()) {
-                if (App.currProject &&
-                    !App.currProject.isNew() &&
-                    !App.currProject.get('area_of_interest')) {
-                    // Delete automatically created new project
-                    App.currProject
-                        .destroy()
-                        .always(function() {
-                            // Redirect after deletion
-                            router.navigate(interactiveState.route, { trigger: true });
-                        });
-                } else {
-                    // No current project, just redirect
-                    router.navigate(interactiveState.route, { trigger: true });
-                }
-            }
+        // Only redirect if route specified and different
+        if (interactiveState &&
+            interactiveState.route &&
+            interactiveState.route !== Backbone.history.getFragment()) {
+
+            App.currProject = null;
+            router.navigate(interactiveState.route, { trigger: true });
         }
     };
 

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -50,7 +50,6 @@ var DrawController = {
     },
 
     drawCleanUp: function() {
-        App.map.off('change:areaOfInterest', saveProjectOnAoIUpdate);
         App.rootView.geocodeSearchRegion.empty();
         App.rootView.drawToolsRegion.empty();
         App.rootView.footerRegion.empty();
@@ -74,23 +73,7 @@ function enableSingleProjectModeIfActivity() {
                 is_activity: true,
                 needs_reset: true
             });
-            project.save();
             App.currProject = project;
-        }
-
-        App.map.on('change:areaOfInterest', saveProjectOnAoIUpdate);
-    }
-}
-
-function saveProjectOnAoIUpdate(map) {
-    var project = App.currProject;
-
-    if (project && project.get('scenarios').isEmpty()) {
-        project.set('area_of_interest', map.get('areaOfInterest'));
-        project.save();
-
-        if (settings.get('itsi_embed')) {
-            App.itsi.setLearnerUrl('project/' + project.id + '/draw');
         }
     }
 }

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -160,7 +160,10 @@ var ModelingController = {
         project
             .fetch()
             .done(function() {
-                App.map.set('areaOfInterest', project.get('area_of_interest'));
+                App.map.set({
+                    'areaOfInterest': project.get('area_of_interest'),
+                    'areaOfInterestName': project.get('area_of_interest_name')
+                });
                 if (project.get('scenarios').isEmpty()) {
                     // No scenarios available. Set the `needs_reset` flag so
                     // that this project is properly initialized by the


### PR DESCRIPTION
## Overview

Previously we would save a new project as soon as the app initialized in embed mode. This had the effect of creating a number of empty projects when the app was loading an existing project. We would delete this empty project before loading the specified one.

Now, we still create the project as soon as the app starts, but defer saving it to the database until an Area of Interest has been drawn and the user lands in the Analyze view. This ensures that the project is always saved as soon as an AoI is available, which is fine since we're not tracking any other changes that we could restore (such as the maps zoom or location, or values in the search box).

This further simplifies the loading logic, since now we don't have to check for and delete an existing project. We simply reset `currProject` and navigate to given route, and let the controllers handle the rest.

## Testing Instructions

If an activity is not setup in ITSI, do so according to instructions in #675. Then:

 1. Log in to [ITSI](https://learn.staging.concord.org/) as `tstudent2` and open the activity
 2. Open Chrome dev tools, go to the Network tab, and filter by XHR and "ngrok":  
  ![image](https://cloud.githubusercontent.com/assets/1430060/9235897/96da03f4-410f-11e5-97a8-212916a8334d.png)
 3. Star the interactive. Observe network traffic. No new project should be saved, and you should not see a `POST` to `/projects`
 4. Draw an AoI. Now the project should save, and you should see a `POST` to `/projects`. The interactive state should also be saved.
 5. Refresh the page and start the interactive. Observer network traffic. Your old project should load, but no new project should save.
 6. Proceed to the modeling stage. Your existing project should be saved with a `PUT`, and new scenarios should be created.
 7. Refresh the page and start the interactive. Observer network traffic. Your old project should load, but no new project should save.

## Notes

Once #674 gets merged, this code should be updated to [save](https://github.com/rajadain/model-my-watershed/blob/refactor/itsi-activity-saving/src/mmw/js/src/analyze/controllers.js#L30) and [load](https://github.com/rajadain/model-my-watershed/blob/refactor/itsi-activity-saving/src/mmw/js/src/modeling/controllers.js#L156) the Area of Interest Name.

Since now we only always save after an AoI is available, should we revert the database constraint change made in #610 that made AoI a nullable field?

Connects #681 