### PR TITLE
Ensure "Current Conditions" is first scenario

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -647,9 +647,23 @@ var ScenariosCollection = Backbone.Collection.extend({
     makeFirstScenarioActive: function() {
         var first = this.first();
 
-        if (first) {
-            this.setActiveScenarioByCid(first.cid);
+        if (!first) {
+            // Empty collection, fail fast
+            return;
         }
+
+        if (!first.get('is_current_conditions')) {
+            // First item is not Current Conditions. Find Current Conditions
+            // scenario and make it the first.
+            var currentConditions = this.findWhere({ 'is_current_conditions': true });
+
+            this.remove(currentConditions);
+            this.add(currentConditions, { at: 0 });
+
+            first = currentConditions;
+        }
+
+        this.setActiveScenarioByCid(first.cid);
     },
 
     setActiveScenario: function(scenario) {

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -801,6 +801,22 @@ describe('Modeling', function() {
 
                     assert.isTrue(collection.first().get('active'));
                 });
+
+                it ('sets Current Conditions as the first scenario and activates it', function() {
+                    var collection = getTestScenarioCollection(),
+                        cc = collection.findWhere({ 'is_current_conditions': true });
+
+                    // Set Current Conditions to be the second item
+                    collection.remove(cc);
+                    collection.add(cc, { at: 1 });
+
+                    assert.isFalse(collection.first().get('is_current_conditions'));
+
+                    collection.makeFirstScenarioActive();
+
+                    assert.isTrue(collection.first().get('is_current_conditions'));
+                    assert.isTrue(collection.first().get('active'));
+                });
             });
 
             describe('#setActiveScenario', function() {


### PR DESCRIPTION
## Overview

In some edge cases, the POST requests for non-Current Conditions scenarios would be processed before Current Conditions, resulting in them having a lower `id`, and thus showing up before Current Conditions in the UI.

When loading a new set of scenarios, we check to see if the first one is Current Conditions. If not, we find it and move it to first place.

Also add a test to exercise this new behavior.

## Testing Instructions

### Preparation

Before checking out this branch, use the [following query](http://localhost:5433/) to see if you have any projects in your machine that don't have "Current Conditions" as the first scenario:

```sql
SELECT p.id, p.name, u.username
FROM modeling_scenario s
  INNER JOIN modeling_project p ON s.project_id = p.id
  INNER JOIN auth_user u ON p.user_id = u.id
WHERE s.name != 'Current Conditions'
  AND s.id IN (
    SELECT MIN(id)
    FROM modeling_scenario
    GROUP BY project_id
  )
ORDER BY p.id
```

If you see any, go to that project and ensure that "Current Conditions" is not the first scenario. This can be observed on staging for `project_id` 109.

In case you don't have any such projects, just create a new one and manually update (via SQL using [pgweb](http://localhost:5433)) the `modeling_scenario.created_at` for the "Current Conditions" scenario to be higher than "New Scenario" for this new project:

```sql
UPDATE modeling_scenario
SET created_at = current_timestamp
WHERE id = ?
```

Ensure that now "Current Conditions" is not the first tab in your project.

### Testing

Checkout the branch and run the bundle script: `./scripts/bundle.sh --tests`. Reopen the project chosen above, and ensure that "Current Conditions" is shown as the first tab and is active.

Connects #689 