### PR TITLE
Fix Safari infinte location request loop.

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -265,11 +265,17 @@ var MapView = Marionette.ItemView.extend({
                 maximumAge : maxAge,
                 timeout : timeout
             };
-            navigator.geolocation.getCurrentPosition(
-                geolocation_success,
-                _.noop,
-                geolocationOptions
-            );
+
+            // Wait a bit and then get the location. Suppresses issues on Safari
+            // in which immediately requesting the location results in an
+            // infinite request loop for geolocation permissions.
+            setTimeout(function() {
+                navigator.geolocation.getCurrentPosition(
+                    geolocation_success,
+                    _.noop,
+                    geolocationOptions
+                );
+            }, 500);
         }
     },
 


### PR DESCRIPTION
In some cases, it seems requesting geolocation at page load will cause Safari
to continue to ask for location permission in an infinite loop.
https://stackoverflow.com/questions/27150465/
The solution to this seems to be triggering the location request based on some
user event or supplying a short delay to allow whatever is causing Safari the
issue time to resolve itself.

Connects #691 

To test:

 * Open the application in Safari
 * Click allow location
 * Ensure that this happens only once. 