### PR TITLE
Use layer max zoom levels + layer name change

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -78,6 +78,7 @@ var HeaderView = Marionette.ItemView.extend({
 
     userLogout: function(event) {
         event.preventDefault();
+
         this.model.logout().done(function() {
             router.navigate('', {trigger: true});
         });
@@ -85,6 +86,7 @@ var HeaderView = Marionette.ItemView.extend({
 
     cloneProject: function() {
         event.preventDefault();
+
         var view = new modalViews.InputView({
             model: new modalModels.InputModel({
                 title: 'Clone Project',
@@ -111,7 +113,6 @@ var HeaderView = Marionette.ItemView.extend({
         });
         view.render();
     }
-
 });
 
 // Init the locate plugin button and add it to the map.
@@ -192,6 +193,7 @@ var MapView = Marionette.ItemView.extend({
             self = this;
 
         this.interactiveMode = options.interactiveMode;
+
         if (!options.interactiveMode) {
             // Disable panning and zooming.
             // http://gis.stackexchange.com/questions/54454/disable-leaflet-interaction-temporary
@@ -201,15 +203,18 @@ var MapView = Marionette.ItemView.extend({
             map.scrollWheelZoom.disable();
             map.boxZoom.disable();
             map.keyboard.disable();
+
             if (map.tap) {
                 map.tap.disable();
             }
+
             document.getElementById('map').style.cursor='default';
         }
 
         if (options.addZoomControl) {
             map.addControl(new L.Control.Zoom({position: 'topright'}));
         }
+
         if (options.addLocateMeButton) {
             addLocateMeButton(map, maxZoom, maxAge);
         }
@@ -231,9 +236,11 @@ var MapView = Marionette.ItemView.extend({
 
         var initialLayer = this.baseLayers[options.initialLayerName] ||
                            this.baseLayers[defaultLayerName];
+
         if (initialLayer) {
             map.addLayer(initialLayer);
         }
+
         map.addLayer(areaOfInterestLayer);
         map.addLayer(modificationsLayer);
 
@@ -282,9 +289,11 @@ var MapView = Marionette.ItemView.extend({
     getActiveBaseLayerName: function() {
         var activeBaseLayerName,
             self = this;
+
         activeBaseLayerName = _.findKey(self.baseLayers, function(layer) {
             return self._leafletMap.hasLayer(layer);
         });
+
         return activeBaseLayerName;
     },
 
@@ -294,6 +303,7 @@ var MapView = Marionette.ItemView.extend({
 
     aoiChangeWarning: _.debounce(function() {
         var activityMode = settings.get('activityMode');
+
         // Fail fast.
         if (this._didRevert || !activityMode) {
             this._didRevert = false;
@@ -318,6 +328,7 @@ var MapView = Marionette.ItemView.extend({
                 self._areaOfInterestSet = false;
                 self.trigger('change:needs_reset', true);
             });
+
             clearProject.on('deny', function() {
                 var map = self._leafletMap;
                 self._didRevert = true;
@@ -380,6 +391,7 @@ var MapView = Marionette.ItemView.extend({
 
     toggleMask: function() {
         var aoi = this.model.get('areaOfInterest');
+
         if (!aoi) {
             return;
         }
@@ -401,6 +413,7 @@ var MapView = Marionette.ItemView.extend({
         this.disableGeolocation();
         this.model.restructureAoI();
         var areaOfInterest = this.model.get('areaOfInterest');
+
         if (!areaOfInterest) {
             this._areaOfInterestLayer.clearLayers();
         } else {
@@ -452,6 +465,7 @@ var MapView = Marionette.ItemView.extend({
 
     toggleMapSize: function() {
         var size = this.model.get('size');
+
         if (size.half) {
             this.$el.addClass('half');
         } else {
@@ -467,12 +481,12 @@ var MapView = Marionette.ItemView.extend({
 
     fitToAoi: function() {
         var areaOfInterest = this.model.get('areaOfInterest');
+
         if (areaOfInterest) {
             var layer = new L.GeoJSON(areaOfInterest);
             this._leafletMap.fitBounds(layer.getBounds(), { reset: true });
         }
     }
-
 });
 
 // Apply a mask over the entire map excluding bounds/shape specified.

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -18,24 +18,6 @@ var L = require('leaflet'),
 require('leaflet.locatecontrol');
 require('leaflet-plugins/layer/tile/Google');
 
-/**
- * A basic view for showing a static message.
- */
-var StaticView = Marionette.ItemView.extend({
-    initialize: function(options) {
-        if (options.message) {
-            this.message = options.message;
-        }
-    },
-    template: function(model) {
-        return model.message;
-    },
-    templateHelpers: function() {
-        return { message: this.message };
-    },
-    message: ''
-});
-
 var RootView = Marionette.LayoutView.extend({
     el: 'body',
     regions: {
@@ -580,7 +562,6 @@ module.exports = {
     HeaderView: HeaderView,
     MapView: MapView,
     RootView: RootView,
-    StaticView: StaticView,
     AreaOfInterestView: AreaOfInterestView,
     ModificationPopupView: ModificationPopupView
 };

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -230,7 +230,11 @@ var MapView = Marionette.ItemView.extend({
         map.addLayer(areaOfInterestLayer);
         map.addLayer(modificationsLayer);
 
-        map.setView([40.1, -75.7], 10); // center the map
+        // Center the map on the U.S.
+        map.fitBounds([
+            [24.2, -126.4],
+            [49.8, -66.0]
+        ]);
 
         // Keep the map model up-to-date with the position of the map
         this.listenTo(map, 'moveend', this.updateMapModelPosition);
@@ -265,9 +269,9 @@ var MapView = Marionette.ItemView.extend({
             if (self.model.get('geolocationEnabled')) {
                 var lng = position.coords.longitude,
                     lat = position.coords.latitude,
-                    maxZoom = initialLayer.options.maxZoom || 18;
+                    zoom = 12; // Regional zoom level
 
-                map.setView([lat, lng], maxZoom);
+                map.setView([lat, lng], zoom);
             }
         }
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -403,18 +403,24 @@ ITSI = {
     'embed_flag': 'itsi_embed',
 }
 
+# Layers must have a maxZoom defined
 BASE_LAYERS = {
     'Mapbox Roads': {
+        'type': 'mapbox',
         'url': 'https://{s}.tiles.mapbox.com/v3/ctaylor.lg2deoc9/{z}/{x}/{y}.png',
         'attribution': 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">Mapbox</a>',
         'maxZoom': 18,
         'default': True,
     },
     'ESRI World Imagery': {
+        'type': 'esri',
         'url': 'https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
         'attribution': 'Map data from <a href="http://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9">ESRI</a>',
+        'maxZoom': 19
     },
     'Google Hybrid': {
-        'googleType': 'HYBRID' # can be one of SATELLITE, ROADMAP, HYBRID, TERRAIN
+        'type': 'google',
+        'googleType': 'HYBRID', # can be one of SATELLITE, ROADMAP, HYBRID, TERRAIN,
+        'maxZoom': 18 # Max zoom changes based on available imagery, but this is a safe default
     },
 }

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -405,22 +405,27 @@ ITSI = {
 
 # Layers must have a maxZoom defined
 BASE_LAYERS = {
-    'Mapbox Roads': {
+    'Streets': {
         'type': 'mapbox',
         'url': 'https://{s}.tiles.mapbox.com/v3/ctaylor.lg2deoc9/{z}/{x}/{y}.png',
         'attribution': 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">Mapbox</a>',
         'maxZoom': 18,
         'default': True,
     },
-    'ESRI World Imagery': {
+    'Satellite': {
         'type': 'esri',
         'url': 'https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
         'attribution': 'Map data from <a href="http://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9">ESRI</a>',
         'maxZoom': 19
     },
-    'Google Hybrid': {
+    'Satellite with Roads': {
         'type': 'google',
         'googleType': 'HYBRID', # can be one of SATELLITE, ROADMAP, HYBRID, TERRAIN,
         'maxZoom': 18 # Max zoom changes based on available imagery, but this is a safe default
     },
+    'Terrain': {
+        'type': 'google',
+        'googleType': 'TERRAIN', # can be one of SATELLITE, ROADMAP, HYBRID, TERRAIN,
+        'maxZoom': 20
+    }
 }


### PR DESCRIPTION
Uses the maximum zoom level of each layer instead of a fixed value for all. Also changes the layer names to be generic and adds the Google Terrain layer.

See commit messages for details.

**Testing different maximum zoom level**
- Keep the default basemap.
- Center the map on City Hall.
- Switch to the "Satellite" basemap.
- You should be able to zoom one level closer.
- Switch back to the "Streets" basemap.
- You should be zoomed out one level further than before, and zooming in should not be available.
- Switch to the "Satelitte with Streets" basemap.
- You should be able to zoom in two levels.
- Switch back to the "Streets" basemap.
- You should be zoomed out two levels further than before, and zooming in should be not be available.

**Testing base layer name changes**
- You should see non-branded names in the layer selector, like so:

![screen shot 2015-08-18 at 1 59 48 pm](https://cloud.githubusercontent.com/assets/1042475/9338191/65c36674-45b1-11e5-90e1-6e069839bf46.png)

Connects to #692 
Connects to #696 