### PR TITLE
Add results disclaimer to modeling output.

### DIFF
--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -1,3 +1,4 @@
+<div class="disclaimer">Results are for demonstration purposes only.</div>
 <table class="table custom-hover">
     <thead>
         <tr>

--- a/src/mmw/js/src/compare/templates/compareModeling.html
+++ b/src/mmw/js/src/compare/templates/compareModeling.html
@@ -1,4 +1,4 @@
-<div>
+<div class="header">
     <h3>Model Output</h3>
     {% if polling %}
         <i class="fa fa-circle-o-notch fa-spin"></i>

--- a/src/mmw/js/src/core/templates/barChart.html
+++ b/src/mmw/js/src/core/templates/barChart.html
@@ -1,1 +1,2 @@
+<div class="disclaimer">Results are for demonstration purposes only.</div>
 <div class="bar-chart"></div>

--- a/src/mmw/js/src/modeling/tr55/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/table.html
@@ -1,3 +1,4 @@
+<div class="disclaimer">Results are for demonstration purposes only.</div>
 <table class="table custom-hover">
     <thead>
         <tr>

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -117,3 +117,10 @@ a{
     opacity: 0.8;
 }
 
+.disclaimer {
+  font-style: italic;
+  color: rosybrown;
+  text-align: center;
+  font-size: 15px;
+  clear: both;
+}

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -1,5 +1,5 @@
 .compare-scenarios-container{
-  overflow-x: hidden;
+  overflow: hidden;
   position: absolute;
   top: 0;
   left: 0;
@@ -102,8 +102,16 @@
                 color: rgba(0, 0, 0, 0.54);
               }
 
+              .header{
+                height: 12%;
+              }
+
+              .disclaimer{
+                font-size: 12px;
+              }
+
               .result-region{
-                height: 85%;
+                height: 95%;
 
                 .tab-pane{
                   height: 100%;
@@ -117,7 +125,9 @@
                 .controls {
                   .precipitation {
                     .btn-primary {
+                      z-index: 10;
                       padding: 0;
+                      margin-top: 10px;
 
                       label{
                         display: table;
@@ -145,6 +155,7 @@
           .modifications-region{
             width: 100%;
             height: 25vh;
+            margin-top: 30px;
 
             .modifications-container{
               position: relative;


### PR DESCRIPTION
* Add a disclaimer to the results on the analyze, modeling, and compare
pages that indicate that the results are for demonstration purposes
only.
* Adjust the compare view style to make room for the disclaimer and
ensure that the precipitation control doesn't overlap with the
modification list and is above the other elements on the page.

**Testing Instructions:**

- Visit the analyze, modeling, and compare page and ensure there is a disclaimer above every chart and table.
- Visit the compare page in various browsers and ensure that elements on the page do not overlap and that you can always adjust the precipitation.

![screen shot 2015-08-19 at 11 07 39 am](https://cloud.githubusercontent.com/assets/1042475/9360141/977686cc-4662-11e5-9798-6ca09026f931.png)
![screen shot 2015-08-19 at 11 07 52 am](https://cloud.githubusercontent.com/assets/1042475/9360143/977a1026-4662-11e5-8c52-a3c0f602d1d5.png)
![screen shot 2015-08-19 at 11 07 58 am](https://cloud.githubusercontent.com/assets/1042475/9360142/977a043c-4662-11e5-9067-cbdb5699aa48.png)
![screen shot 2015-08-19 at 11 08 04 am](https://cloud.githubusercontent.com/assets/1042475/9360144/97814d8c-4662-11e5-8622-7490ac3de49b.png)


Connects #693