### PR TITLE
Modify conservation practice colors

### DIFF
--- a/src/mmw/apps/core/templates/patterns.html
+++ b/src/mmw/apps/core/templates/patterns.html
@@ -4807,7 +4807,7 @@
         <!-- No Till farming -->
         <pattern height="74.8" id="fill-no_till" overflow="visible" patternUnits="userSpaceOnUse" viewBox="72.15 -74.8 72 74.8" width="72">
             <g>
-                <polygon fill="#53e9b4" points="72.15,-74.8 144.15,-74.8 144.15,0 72.15,0"/>
+                <polygon fill="#CDCD00" points="72.15,-74.8 144.15,-74.8 144.15,0 72.15,0"/>
                 <g>
                     <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-0.85" y2="-0.85"/>
                     <line fill="none" stroke="#231F20" stroke-linecap="square" stroke-width="0.3" x1="144.15" x2="216.15" y1="-2.55" y2="-2.55"/>
@@ -4951,7 +4951,7 @@
         <!-- Cluster Housing -->
         <pattern height="72" id="fill-cluster_housing" overflow="visible" patternUnits="userSpaceOnUse" viewBox="4.145 -78.23 72 72" width="72">
             <g>
-                <polygon fill="#4aeab3" points="4.145,-78.23 76.145,-78.23 76.145,-6.23 4.145,-6.23"/>
+                <polygon fill="#EDE7D9" points="4.145,-78.23 76.145,-78.23 76.145,-6.23 4.145,-6.23"/>
                 <g>
                     <line fill="none" stroke="#231F20" stroke-width="0.3" x1="67.844" x2="71.324" y1="-1.534" y2="-7.609"/>
                     <line fill="none" stroke="#231F20" stroke-width="0.3" x1="69.588" x2="66.107" y1="-8.603" y2="-2.529"/>
@@ -5097,7 +5097,7 @@
         <!-- Rain Garden -->
         <pattern height="72" id="fill-rain_garden" overflow="visible" patternUnits="userSpaceOnUse" viewBox="51.688 -85.483 72 72" width="72">
             <g>
-                <polygon fill="#51dec2" points="51.688,-85.483 123.688,-85.483 123.688,-13.483 51.688,-13.483"/>
+                <polygon fill="#2364AA" points="51.688,-85.483 123.688,-85.483 123.688,-13.483 51.688,-13.483"/>
                 <g>
                     <path d="M119.938-9.983c2.25-0.5,7,0,6,1.75s4,7,4.5,5.5s-2-4.5,0.75-4.75s5.75,3,7.5,3.25s5.5-1.5,3.25-3s-2.75-4.5-5.5-4.25s-7-0.25-6-3" fill="none" stroke="#231F20" stroke-width="0.3"/>
                     <path d="M120.938-12.483c1.75,0.5,5.5,0.25,6,1.75s2.75,2.75,2.75,1.5s-1.75-2.75-1.75-2.75s-4-3.5-2-4" fill="none" stroke="#231F20" stroke-width="0.3"/>
@@ -5239,7 +5239,7 @@
         <!-- Pervious Pavers -->
         <pattern height="72" id="fill-porous_paving" overflow="visible" patternUnits="userSpaceOnUse" viewBox="29.713 -73.775 72 72" width="72">
             <g>
-                <polygon fill="#54d2d0" points="29.713,-73.775 101.713,-73.775 101.713,-1.775 29.713,-1.775"/>
+                <polygon fill="#555555" points="29.713,-73.775 101.713,-73.775 101.713,-1.775 29.713,-1.775"/>
                 <g>
                     <line fill="none" stroke="#000000" stroke-linecap="square" stroke-width="0.3" x1="59.15" x2="59.15" y1="-0.15" y2="-3.65"/>
                 </g>
@@ -5345,7 +5345,7 @@
         <!-- Detention Basin aka Vegitation Infill Basin aka Infiltration Trench-->
         <pattern height="71.606" id="fill-infiltration_trench" overflow="visible" patternUnits="userSpaceOnUse" viewBox="0.305 -71.606 71.606 71.606" width="71.606">
             <g>
-                <polygon fill="#52c6dd" points="0.305,-71.606 71.911,-71.606 71.911,0 0.305,0"/>
+                <polygon fill="#B1C4A1" points="0.305,-71.606 71.911,-71.606 71.911,0 0.305,0"/>
                 <g>
                     <path d="M70.606-52.242c-0.06,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.101-0.07-0.17c0-0.07,0.03-0.141,0.08-0.181c0.08-0.09,0.25-0.09,0.351,0c0.05,0.05,0.069,0.11,0.069,0.181c0,0.059-0.02,0.129-0.069,0.17C70.737-52.273,70.677-52.242,70.606-52.242z" fill="#231F20"/>
                     <path d="M11.356-53.492c-0.069,0-0.13-0.031-0.18-0.08c-0.04-0.041-0.07-0.111-0.07-0.17c0-0.07,0.03-0.131,0.07-0.181c0.101-0.09,0.26-0.09,0.351,0c0.06,0.05,0.079,0.12,0.079,0.181c0,0.059-0.029,0.129-0.069,0.17C11.487-53.523,11.417-53.492,11.356-53.492z" fill="#231F20"/>
@@ -6101,7 +6101,7 @@
         <!-- Cisterine -->
         <pattern height="72" id="fill-green_roof" overflow="visible" patternUnits="userSpaceOnUse" viewBox="0.379 -72.688 72 72" width="72">
             <g>
-                <polygon fill="#4ebaea" points="0.379,-72.688 72.379,-72.688 72.379,-0.688 0.379,-0.688"/>
+                <polygon fill="#9ABD52" points="0.379,-72.688 72.379,-72.688 72.379,-0.688 0.379,-0.688"/>
                 <g>
                     <path d="M56.81,0c-0.1,0-0.199-0.04-0.26-0.11c-0.07-0.069-0.109-0.17-0.109-0.271c0-0.1,0.039-0.189,0.109-0.26c0.13-0.129,0.391-0.14,0.53,0c0.07,0.07,0.11,0.16,0.11,0.26c0,0.101-0.04,0.201-0.11,0.271C57.01-0.04,56.92,0,56.81,0z" fill="#231F20"/>
                     <path d="M4.13-0.561c-0.1,0-0.2-0.039-0.27-0.119C3.79-0.74,3.75-0.84,3.75-0.939c0-0.101,0.04-0.191,0.11-0.261c0.13-0.14,0.39-0.14,0.529,0C4.46-1.131,4.5-1.04,4.5-0.939c0,0.1-0.04,0.199-0.11,0.27C4.32-0.6,4.229-0.561,4.13-0.561z" fill="#231F20"/>

--- a/src/mmw/js/src/modeling/modificationConfig.json
+++ b/src/mmw/js/src/modeling/modificationConfig.json
@@ -72,29 +72,29 @@
     },
     "cluster_housing": {
         "name": "Cluster Housing",
-        "color": "#4aeab3"
+        "color": "#777777"
     },
     "green_roof": {
         "name": "Green Roof",
         "summary": "Green Roof Summary...",
-        "color": "#4ebaea"
+        "color": "#9ABD52"
     },
     "no_till": {
         "name": "No-Till Agriculture",
         "shortName": "No-Till Ag",
-        "color": "#53e9b4"
+        "color": "#CDCD00"
     },
     "porous_paving": {
         "name": "Porous Paving",
-        "color": "#54d2d0"
+        "color": "#D3D3D3"
     },
     "rain_garden": {
         "name": "Rain Garden",
-        "color": "#51dec2"
+        "color": "#2364AA"
     },
     "infiltration_trench": {
         "name": "Vegetation Infiltration Basin",
         "shortName": "Veg Basin",
-        "color": "#52c6dd"
+        "color": "#B1C4A1"
     }
 }

--- a/src/mmw/js/src/modeling/modificationConfig.json
+++ b/src/mmw/js/src/modeling/modificationConfig.json
@@ -2,99 +2,99 @@
     "chaparral": {
         "name": "Chaparral",
         "summary": "This category includes areas dominated by shrubs; less than 5 meters tall with shrub canopy typically greater than 20% of total vegetation. This class includes true shrubs, young trees in an early successional stage or trees stunted from environmental conditions.",
-        "color": "#e2d9b5"
+        "strokeColor": "#e2d9b5"
     },
     "commercial": {
         "name": "Commercial",
         "summary": "This category includes any area that is entirely paved and is not residential. It includes roads, railroads, shopping centers, and factories.",
-        "color": "#40c2a8"
+        "strokeColor": "#40c2a8"
     },
     "desert": {
         "name": "Desert",
         "summary": "This category includes areas of bedrock, desert pavement, scarps, talus, slides, volcanic material, glacial debris, sand dunes, strip mines, gravel pits and other accumulations of earthen material. Generally, vegetation accounts for less than 15% of total cover.",
-        "color": "#f1edd9"
+        "strokeColor": "#f1edd9"
     },
     "deciduous_forest": {
         "name": "Deciduous Forest",
         "shortName": "Forest",
         "summary": "This category includes areas that are covered by vegetation with more than 20% of the land surface covered by trees that are taller than 5 meters.",
-        "color": "#53e9b4"
+        "strokeColor": "#53e9b4"
     },
     "grassland": {
         "name": "Grassland",
         "summary": "This category includes areas where grasses and weedy (herbaceous) plants cover more than 80% of the ground area. These areas are not intensively managed but may be used for grazing animals.",
-        "color": "#54d2d0"
+        "strokeColor": "#54d2d0"
     },
     "hi_residential": {
         "name": "High-Intensity Residential",
         "shortName": "HIR",
         "summary": "This category includes areas with apartment complexes or row houses. The amount of area that is covered by hard surfaces like roads, driveways and roofs is between 80% and 100%. No more than 20% of the area is covered with vegetation.",
-        "color": "#39afa1"
+        "strokeColor": "#39afa1"
     },
     "li_residential": {
         "name": "Low-Intensity Residential",
         "shortName": "LIR",
         "summary": "This category includes areas with single-family houses on single lots. The amount of area that is covered by hard surfaces like roads, driveways, and roofs, is between 30% and 80% of the land surface. The remaining 20% to 80% is covered with vegetation.",
-        "color": "#329b9c"
+        "strokeColor": "#329b9c"
     },
     "pasture": {
         "name": "Pasture",
         "summary": "This category includes vegetation such as grasses with clover or other vegetation that is planted for grazing cattle, horses or other farm animals or to provide hay or feed for grazing animals.",
-        "color": "#51dec2"
+        "strokeColor": "#51dec2"
     },
     "row_crop": {
         "name": "Row Crop",
         "summary": "This category includes areas that are planted for annual crops such as corn, soybeans, vegetables and cotton. It also includes orchards and vineyards and actively tilled (plowed) land.",
-        "color": "#52c6dd"
+        "strokeColor": "#52c6dd"
     },
     "short_grass_prairie": {
         "name": "Short-Grass Prairie",
         "shortName": "Short Prairie",
         "summary": "This category includes areas of grasses, legumes, or grass-legume mixtures planted for livestock grazing or the production of seed or hay crops, typically on a perennial cycle. Pasture/hay vegetation accounts for greater than 20% of total vegetation.",
-        "color": "#4aeab3"
+        "strokeColor": "#4aeab3"
     },
     "tall_grass_prairie": {
         "name": "Tall-Grass Prairie",
         "shortName": "Tall Prairie",
         "summary": "This category includes areas with a mixture of some constructed materials, but mostly vegetation in the form of lawn grasses. Impervious surfaces account for less than 20% of total cover. These areas most commonly include large-lot single-family housing units, parks, golf courses, and vegetation planted in developed settings for recreation, erosion control, or aesthetic purposes.",
-        "color": "#39afa1"
+        "strokeColor": "#39afa1"
     },
     "urban_grass": {
         "name": "Turf Grass",
         "summary": "This category includes areas that are primarily lawn grasses planted and maintained for recreation, aesthetic purposes and erosion control. Examples include parks, lawns, golf courses, and grassy areas in developments.",
-        "color": "#4aeab3"
+        "strokeColor": "#4aeab3"
     },
     "woody_wetland": {
         "name": "Woody Wetland",
 	"shortName": "Wetland",
         "summary": "This category includes areas where forest or shrubland vegetation accounts for greater than 20% of vegetative cover and the soil or substrate is periodically saturated with or covered with water.",
-        "color": "#4ebaea"
+        "strokeColor": "#4ebaea"
     },
     "cluster_housing": {
         "name": "Cluster Housing",
-        "color": "#777777"
+        "strokeColor": "#777777"
     },
     "green_roof": {
         "name": "Green Roof",
         "summary": "Green Roof Summary...",
-        "color": "#9ABD52"
+        "strokeColor": "#9ABD52"
     },
     "no_till": {
         "name": "No-Till Agriculture",
         "shortName": "No-Till Ag",
-        "color": "#CDCD00"
+        "strokeColor": "#CDCD00"
     },
     "porous_paving": {
         "name": "Porous Paving",
-        "color": "#D3D3D3"
+        "strokeColor": "#D3D3D3"
     },
     "rain_garden": {
         "name": "Rain Garden",
-        "color": "#2364AA"
+        "strokeColor": "#2364AA"
     },
     "infiltration_trench": {
         "name": "Vegetation Infiltration Basin",
         "shortName": "Veg Basin",
-        "color": "#B1C4A1"
+        "strokeColor": "#B1C4A1"
     }
 }

--- a/src/mmw/js/src/modeling/modificationConfigUtils.js
+++ b/src/mmw/js/src/modeling/modificationConfigUtils.js
@@ -42,9 +42,9 @@ function getHumanReadableSummary(modKey) {
 }
 
 var getDrawOpts = function(modKey) {
-    if (modKey && modificationConfig[modKey] && modificationConfig[modKey].color) {
+    if (modKey && modificationConfig[modKey] && modificationConfig[modKey].strokeColor) {
         return {
-            color: modificationConfig[modKey].color,
+            color: modificationConfig[modKey].strokeColor,
             opacity: 1,
             weight: 3,
             fillColor: 'url(#fill-' + modKey + ')',

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -363,7 +363,7 @@ describe('Modeling', function() {
                     name: 'name2',
                     shortName: 'shortName2',
                     summary: 'summary2',
-                    color: '#000'
+                    strokeColor: '#000'
                 }
             };
             modConfigUtils.setConfig(this.config);


### PR DESCRIPTION
* Use colors for the conservation practice tools that may better match
what those practices look like in the real world, without too closely
colliding with colors from the NLCD standard legend.

Connects to #697 

<img width="832" alt="screen shot 2015-08-19 at 4 44 46 pm" src="https://cloud.githubusercontent.com/assets/1042475/9368912/1cde65a6-4694-11e5-92ad-aea74135c0ad.png">
<img width="833" alt="screen shot 2015-08-19 at 4 45 01 pm" src="https://cloud.githubusercontent.com/assets/1042475/9368911/1cdcd092-4694-11e5-9aa8-3759bfddfda2.png">

