### PR TITLE
 Pre-Columbian scenario

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -11,7 +11,7 @@ import math
 # TODO Remove this when stub task is deleted.
 import time
 
-from tr55.model import simulate_modifications, simulate_cell_day
+from tr55.model import simulate_day
 from tr55.tablelookup import lookup_ki
 
 logger = logging.getLogger(__name__)
@@ -150,14 +150,14 @@ def prepare_census(model_input):
         },
         'modifications': [
             {
-                'bmp': 'no_till',
+                'change': '::no_till',
                 'cell_count': 1,
                 'distribution': {
                     'a:deciduous_forest': {'cell_count': 1},
                 }
             },
             {
-                'reclassification': 'd:rock',
+                'change': 'd:rock:',
                 'cell_count': 1,
                 'distribution': {
                     'a:deciduous_forest': {'cell_count': 1}
@@ -222,12 +222,7 @@ def run_tr55(census, model_input):
     modifications = get_census_modifications(model_input)
     census['modifications'] = modifications
 
-    def simulate_day(cell, cell_count):
-        soil_type, land_use = cell.lower().split(':')
-        et = et_max * lookup_ki(land_use)
-        return simulate_cell_day((precip, et), cell, cell_count)
-
-    model_output = simulate_modifications(census, fn=simulate_day)
+    model_output = simulate_day(census, precip)
 
     return {
         'inputmod_hash': model_input['inputmod_hash'],
@@ -276,7 +271,7 @@ def get_census_modifications(model_input):
     if count > 1:
         modifications = [
             {
-                'reclassification': 'a:chaparral',
+                'change': 'a:chaparral:',
                 'cell_count': count * multiplier,
                 'distribution': {
                     'c:commercial': {'cell_count': count * multiplier},

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -12,7 +12,6 @@ import math
 import time
 
 from tr55.model import simulate_day
-from tr55.tablelookup import lookup_ki
 
 logger = logging.getLogger(__name__)
 
@@ -211,7 +210,6 @@ def run_tr55(census, model_input):
     A thin Celery wrapper around our TR55 implementation.
     """
 
-    et_max = 0.207
     precip = _get_precip_value(model_input)
 
     if precip is None:
@@ -223,6 +221,9 @@ def run_tr55(census, model_input):
     census['modifications'] = modifications
 
     model_output = simulate_day(census, precip)
+    precolumbian_output = simulate_day(census, precip, precolumbian=True)
+    model_output['pc_unmodified'] = precolumbian_output['unmodified']
+    model_output['pc_modified'] = precolumbian_output['modified']
 
     return {
         'inputmod_hash': model_input['inputmod_hash'],

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -46,16 +46,24 @@ var ResultView = Marionette.ItemView.extend({
                     depDisplayNames: ['Infiltration', 'Runoff', 'Evapotranspiration']
                 };
 
-            if (this.scenario.get('is_current_conditions') || this.compareMode) {
+            if (this.compareMode) {
                 // Use the modified results since they are the same as the unmodified results
                 // in Current Conditions, and they are the results we want to show
                 // in compareMode for other scenarios.
                 data = [
-                    getBarData('', 'modified'),
+                    getBarData('', 'modified')
                 ];
-
                 this.$el.addClass('current-conditions');
+            } else if (this.scenario.get('is_current_conditions')) {
+                // Show the unmodified results and the unmodified
+                // Pre-Columbian results.
+                data = [
+                    getBarData('Current Conditions', 'unmodified'),
+                    getBarData('Pre-Columbian', 'pc_unmodified')
+                ];
             } else {
+                // Show the unmodified results and the modified
+                // results.
                 data = [
                     getBarData('Original', 'unmodified'),
                     getBarData('Modified', 'modified')

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -9,4 +9,4 @@ django-registration-redux==1.2
 python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
-tr55==0.1.0
+tr55==0.2.0


### PR DESCRIPTION
This adds a "Pre-Columbian" chart to the "Current Conditions" scenario.

Connects #626

**To Test**
   * Apply the patch
   * Either reprovision the app and the worker, or do a `sudo pip uninstall tr55` `sudo pip install tr55` on both the app and the worker
   * Reload the worker `vagrant reload worker`
   * Go to a project
   * Go to the current conditions scenario.  There should now be a second chart showing the results for the AoI in Pre-Columbian times.
