### PR TITLE
Allow boundary dropdown to be clicked.

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -98,11 +98,14 @@ var SelectAreaView = Marionette.ItemView.extend({
     },
 
     onRender: function() {
-        this.ui.helptextIcon.popover({ trigger: 'hover' });
+        this.ui.helptextIcon.popover({
+            trigger: 'hover',
+            viewport: '.container-fluid.top-nav'
+        });
     },
 
     onItemClicked: function(e) {
-        var $el = $(e.target),
+        var $el = $(e.currentTarget),
             endpoint = $el.data('endpoint'),
             tableId = $el.data('tableid'),
             shortDisplay = $el.data('short-display');
@@ -208,7 +211,10 @@ var DrawView = Marionette.ItemView.extend({
     },
 
     onShow: function() {
-        this.ui.helptextIcon.popover({ trigger: 'hover' });
+        this.ui.helptextIcon.popover({
+            trigger: 'hover',
+            viewport: '.container-fluid.top-nav'
+        });
     },
 
     enableStampTool: function() {
@@ -265,7 +271,6 @@ var PlaceMarkerView = Marionette.ItemView.extend({
     },
 
     onShow: function() {
-        // TODO: the viewport setting doesn't appear to be working.
         this.ui.helptextIcon.popover({
             trigger: 'hover',
             viewport: '.container-fluid.top-nav'


### PR DESCRIPTION
Boundary layers were being triggered based on the data attribute of the
clicked element in the dropdown. But since spans were added to the text for
styling this broke the existing functionality. By changing the click handler
to work with the currentTarget (the specific element the event is bound to) we
will always capture the proper element with the data attribute in question.
Also added bounding to the popovers to ensure they stay within the bounds of
the main area.

Connects #719 