### PR TITLE
Allow tile requests to cache image and grid

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -24,3 +24,5 @@ celery_processes_per_worker: 1
 
 itsi_base_url: "https://learn.staging.concord.org/"
 itsi_secret_key: "{{ lookup('env', 'MMW_ITSI_SECRET_KEY') }}"
+
+tilecache_bucket_name: "{{ lookup('env', 'MMW_TILECACHE_BUCKET') | default('', true) }}"

--- a/deployment/ansible/group_vars/packer
+++ b/deployment/ansible/group_vars/packer
@@ -17,3 +17,4 @@ graphite_host: "monitoring.service.mmw.internal"
 statsite_host: "monitoring.service.mmw.internal"
 
 itsi_base_url: "https://learn.staging.concord.org/"
+tilecache_bucket_name: ""

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -21,3 +21,5 @@ celery_processes_per_worker: 1
 
 itsi_base_url: "https://learn.staging.concord.org/"
 itsi_secret_key: "{{ lookup('env', 'MMW_ITSI_SECRET_KEY') }}"
+
+tilecache_bucket_name: "tilecache.mmw-dev.azavea.com"

--- a/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
@@ -14,3 +14,4 @@ envdir_config:
   MMW_ITSI_SECRET_KEY: "{{ itsi_secret_key }}"
   MMW_ITSI_BASE_URL: "{{ itsi_base_url }}"
   MMW_STACK_COLOR: "{{ stack_color }}"
+  MMW_TILECACHE_BUCKET: "{{ tilecache_bucket_name }}"

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -118,8 +118,9 @@ var SelectAreaView = Marionette.ItemView.extend({
         // Go about the business of adding the ouline and UTFgrid layers.
         if (endpoint && tableId !== undefined) {
             var ol = new L.TileLayer(endpoint + '.png'),
-                grid = new L.UtfGrid(endpoint + '.grid.json?callback={cb}',
+                grid = new L.UtfGrid(endpoint + '.grid.json',
                                      {
+                                         useJsonP: false,
                                          resolution: 4,
                                          maxRequests: 8
                                      });

--- a/src/tiler/npm-shrinkwrap.json
+++ b/src/tiler/npm-shrinkwrap.json
@@ -2,6 +2,28 @@
   "name": "mmw_tiler",
   "version": "1.0.0",
   "dependencies": {
+    "aws-sdk": {
+      "version": "2.1.45",
+      "from": "aws-sdk@2.1.45",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.45.tgz",
+      "dependencies": {
+        "sax": {
+          "version": "0.5.3",
+          "from": "sax@0.5.3",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz"
+        },
+        "xml2js": {
+          "version": "0.2.8",
+          "from": "xml2js@0.2.8",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz"
+        },
+        "xmlbuilder": {
+          "version": "0.4.2",
+          "from": "xmlbuilder@0.4.2",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+        }
+      }
+    },
     "windshaft": {
       "version": "0.36.0",
       "from": "windshaft@0.36.0",

--- a/src/tiler/package.json
+++ b/src/tiler/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "server.js",
   "dependencies": {
-    "windshaft": "0.36.0"
+    "windshaft": "0.36.0",
+    "aws-sdk": "2.1.45"
   },
   "devDependencies": {
     "supervisor": "^0.6.0"


### PR DESCRIPTION
If not receiving requests from localhost and assuming the AWS
credentials are provided to the AWS SDK, write the response of
all requests to a specified S3 bucket that in practice will serve
as a downstream cache provider for images and utfgrids.

#### Testing
As this functionality is not designed to work while in development, the steps are initially a bit kludgy to test.

1. Provision the tiler with the cache bucket name set:
    `MMW_TILECACHE_BUCKET="tilecache.mmw-dev.azavea.com" vagrant up tiler --provision`
1. [Provide the AWS credentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) to the SDK on the tiler 
1. Set the TILER_HOST setting in base.py to the s3 static website root: `tilecache.mmw-dev.azavea.com.s3-website-us-east-1.amazonaws.com`
1. Hang in there, just a few more steps.
1. Fire up `ngrok 4000` to be able to proxy requests to your local dev tiler
1. Note the hostname from above and update the `tilecache-mmw-dev.azavea.com` S3 bucket static website Routing Rules HostName property to refer to it.
![screenshot from 2015-08-27 11 29 21](https://cloud.githubusercontent.com/assets/1014341/9524862/2fd10738-4caf-11e5-902d-fd77ddf5c691.png)
1. Fire up `scripty debugtiler`
1. Make some tile requests from the app and then notice the creation of layer/z/x/y.png & grid objects in the s3 buckets.  Running `debugtiler` should indicate that subsequent requests aren't making it to the tiler.

#### Overview
As described in #447, the tiler will write to an s3 bucket which serves as cache for rendered tiles, and set up for serving over HTTP.  Routing rules will redirect requests made to s3 to a tiler endpoint, which will serve the tile and write the output to s3, preventing subsequent requests to render that tile.  Deleting the layer directory in S3 will effectively clear the cache and have them be generated again.

In a future commit, the configuration of the s3 bucket will be scripted in CloudFormation so that the upstream `HostName` value can be updated during deployment to the appropriate color stack tiler.  The TILER_URL setting will also be set to a CloudFront endpoint that will be backed by the s3 website endpoint.  This will be taken care of in a future issue when there is more bandwidth.

Connects #447 