### PR TITLE
Load school districts

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -9,32 +9,33 @@ usage="$(basename "$0") [-h] [-b] [-s] \n
 where: \n
     -h  show this help text\n
     -b  load/reload boundary data\n
+    -f  load a named boundary sql.gz\n
     -s  load/reload stream data\n
 "
 
 # HTTP accessible storage for initial app data
 FILE_HOST="https://s3.amazonaws.com/data.mmw.azavea.com"
 load_boundary=false
+file_to_load=
 load_stream=false
 
-while getopts ":hbs" opt; do
+while getopts ":hbsf:" opt; do
     case $opt in
         h)
             echo -e $usage
-            exit
-            ;;
+            exit ;;
         b)
-            load_boundary=true
-            ;;
+            load_boundary=true ;;
         s)
-            load_stream=true
-            ;;
+            load_stream=true ;;
+        f)
+            file_to_load=$OPTARG ;;
         \?)
             echo "invalid option: -$OPTARG"
-            exit
-            ;;
+            exit ;;
     esac
 done
+
 # Export settings required to run psql non-interactively
 export PGHOST=$(cat /etc/mmw.d/env/MMW_DB_HOST)
 export PGDATABASE=$(cat /etc/mmw.d/env/MMW_DB_NAME)
@@ -53,9 +54,14 @@ function download_and_load {
     done
 }
 
+if [ ! -z "$file_to_load" ] ; then
+    FILES=("$file_to_load")
+    download_and_load $FILES
+fi
+
 if [ "$load_boundary" = "true" ] ; then
     # Fetch boundary layer sql files
-    FILES=("boundary_district.sql.gz" "boundary_huc12.sql.gz" "boundary_huc10.sql.gz" "boundary_huc08.sql.gz")
+    FILES=("boundary_school_districts.sql.gz", "boundary_district.sql.gz" "boundary_huc12.sql.gz" "boundary_huc10.sql.gz" "boundary_huc08.sql.gz")
 
     download_and_load $FILES
 fi

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -17,12 +17,14 @@ var dbUser = process.env.MMW_DB_USER,
 // N. B. These must be kept in sync with src/mmw/mmw/settings/base.py
 var interactivity = {
         'boundary_district': 'name,id',
+        'boundary_school_district': 'name,id',
         'boundary_huc08': 'name,id',
         'boundary_huc10': 'name,id',
         'boundary_huc12': 'name,id'
     },
     tables = {
         district: 'boundary_district',
+        school: 'boundary_school_district',
         huc8: 'boundary_huc08',
         huc10: 'boundary_huc10',
         huc12: 'boundary_huc12',

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -1,4 +1,5 @@
 #boundary_district,
+#boundary_school_district,
 #boundary_huc08,
 #boundary_huc10,
 #boundary_huc12 {


### PR DESCRIPTION
Update setup script to load a national school district boundary layer.

A new script option `-f` allows you to load up a single, name layer and not have to reload all boundary data sets to add a new one.  For example, from an app server you could run

`./setupdb.sh -f boundary_school_district.sql.gz`

to add just this new dataset.

The data set was sourced as a shapefile from http://nces.ed.gov/programs/edge/geographicDistrictBoundary.aspx and originally processed into PostGIS with the following settings:

```bash
shp2pgsql -s 4269:4326 -d -g geom -I -W "LATIN1" schooldistrict_sy1314_tl14 public.boundary_school_district
```

##### Testing
From you local app server run either 
* `./setupdb.sh -f boundary_school_district.sql.gz` or `./setupdb.sh -d` to load the new dataset
* Test that the tiles can be generated by requesting http://localhost:4000/district/10/300/387.png

Connects #730 and will be used in #629 
