### PR TITLE
Unit thresholding in /analyze view

### DIFF
--- a/src/mmw/js/src/analyze/filters.js
+++ b/src/mmw/js/src/analyze/filters.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var nunjucks = require('nunjucks');
+
+nunjucks.env.addFilter('toFixed', function(val, digits) {
+    return val.toFixed(digits);
+});

--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -3,7 +3,7 @@
     <thead>
         <tr>
             <th>Type</th>
-            <th class="text-right">Area (m<sup>2</sup>)</th>
+            <th class="text-right">Area ({{ units }})</th>
             <th class="text-right">Coverage (%)</th>
         </tr>
     </thead>

--- a/src/mmw/js/src/analyze/templates/tableRow.html
+++ b/src/mmw/js/src/analyze/templates/tableRow.html
@@ -1,3 +1,3 @@
 <td>{{ type }}</td>
-<td class="strong text-right">{{ area|round(2)|toLocaleString }}</td>
-<td class="strong text-right">{{ coveragePct }}</td>
+<td class="strong text-right">{{ scaledArea|round(2)|toLocaleString }}</td>
+<td class="strong text-right">{{ coveragePct|toFixed(1) }}</td>

--- a/src/mmw/js/src/core/setup.js
+++ b/src/mmw/js/src/core/setup.js
@@ -18,6 +18,7 @@ require('../../shim/backbone.marionette');
 // Include template filters.
 require('./filters');
 require('../modeling/filters');
+require('../analyze/filters');
 
 require('bootstrap');
 require('bootstrap-select');

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -3,6 +3,8 @@
 var _ = require('underscore'),
     md5 = require('blueimp-md5').md5;
 
+var M2_IN_KM2 = 1000000;
+
 var utils = {
     // Parse query strings for Backbone
     // Takes queryString of format "key1=value1&key2=value2"
@@ -73,6 +75,27 @@ var utils = {
             });
 
         return md5(JSON.stringify(sortedCollection));
+    },
+
+    magnitudeOfArea: function(value) {
+        if (value >= M2_IN_KM2) {
+            return 'km2';
+        } else {
+            return 'm2';
+        }
+    },
+
+    changeOfAreaUnits: function(value, fromUnit, toUnit) {
+        var fromTo = (fromUnit + ':' + toUnit).toLowerCase();
+
+        switch (fromTo) {
+            case 'm2:km2':
+                 return value / M2_IN_KM2;
+            case 'm2:m2':
+                 return value;
+            default:
+                 throw 'Conversion not implemented.';
+        }
     },
 
     convertToMetric: function(value, fromUnit) {


### PR DESCRIPTION
The table is now displayed in units of square kilometers when one or more <use,soil> pairs occupies at least one square kilometer. Otherwise, the table is displayed in units of square meters.

Connects #733

**To Test**
   * Load the `/analyze` page
   * Observe that when the <use,soil> pair with greatest area has area of one square kilometer or greater, the table is displayed in units of square kilometers, otherwise it is displayed in units of square meters.
   * In order to make this observation, it may be necessary to edit the `run_analyze` function in the file `src/mmw/apps/modeling/tasks.py`.

**Square meters:**
![screenshot from 2015-08-31 11 28 23](https://cloud.githubusercontent.com/assets/11281373/9582751/45c279ae-4fd5-11e5-99a0-d7eecdab138f.png)

**Square kilometers:**
![screenshot from 2015-08-31 11 32 39](https://cloud.githubusercontent.com/assets/11281373/9582754/49464fc4-4fd5-11e5-985c-f4fcb6854fab.png)