### PR TITLE
Save scenarios silently

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -497,9 +497,11 @@ var ScenarioModel = Backbone.Model.extend({
             // Makeshift locking mechanism to prevent double saves.
             this.saveCalled = true;
         }
-        this.save().fail(function() {
-            console.log('Failed to save scenario');
-        });
+        // Save silently so server values don't trigger reload
+        this.save(null, { silent: true })
+            .fail(function() {
+                console.log('Failed to save scenario');
+            });
     },
 
     addModification: function(modification) {
@@ -515,7 +517,12 @@ var ScenarioModel = Backbone.Model.extend({
         inputsColl.add(input);
     },
 
-    parse: function(response) {
+    parse: function(response, options) {
+        if (options.silent) {
+            // Don't reload server values
+            return this.attributes;
+        }
+
         this.get('modifications').reset(response.modifications);
         delete response.modifications;
 


### PR DESCRIPTION
## Overview

We trigger scenario saves when there are changes to the scenario name or modifications or inputs, so as to facilitate auto-saving and relieve the user of the responsibility to save manually. Unfortunately, this call to `save` would trigger a call to `parse` which would update the collection attributes with new values received from server, thus triggering many views to refresh.

We only want to update views when loading new values, thus when `parse` is called after a `fetch`. To ensure that `parse` does not affect values after a `save`, we pass in a `silent` option which is inspected within `parse`, and if found we simply return existing values without changing any, which does not trigger a view refresh.

Individual views track specific fields on the scenario, thus they update correctly, and in isolation.

## Testing Instructions

Try changing the precipitation slider quickly. Try changing modifications quickly. Changing inputs and modifications should trigger saves (observable in Network tab of dev tools), but not update the entire UI disruptively.

Observe the spinner on the results tab. The spinner on the results tab should appear and disappear in sync with changes to the charts.

Connects #732
Connects #672