### PR TITLE
Add custom layer control + overlay layer support

### DIFF
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -114,6 +114,7 @@ def get_client_settings(request):
             'base_layers': get_layer_config('basemap'),
             'stream_layers': get_layer_config('stream'),
             'boundary_layers': get_layer_config('boundary'),
+            'overlay_layers': get_layer_config('overlay'),
             'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY
         })
     }

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -24,6 +24,6 @@ urlpatterns = patterns(
     url(r'start/analyze/$', views.start_analyze, name='start_analyze'),
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),
-    url(r'boundary-layers/((?P<table_id>\w+)/(?P<obj_id>[0-9]+)/|)$',
-        views.boundary_layers, name='boundary_layers'),
+    url(r'boundary-layers/((?P<table_code>\w+)/(?P<obj_id>[0-9]+)/|)$',
+        views.boundary_layer_detail, name='boundary_layer_detail'),
 )

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var $ = require('jquery'),
-    _ = require('lodash'),
     Marionette = require('../shim/backbone.marionette'),
     views = require('./core/views'),
     models = require('./core/models'),
@@ -85,15 +84,8 @@ var App = new Marionette.Application({
 
 function RestAPI() {
     return {
-        getPredefinedShapeTypes: _.memoize(function() {
-            return $.ajax({
-                'url': '/api/modeling/boundary-layers/',
-                'type': 'GET'
-            });
-        }),
-
         getPolygon: function(args) {
-            var url = '/api/modeling/boundary-layers/' + args.tableId + '/' + args.shapeId;
+            var url = '/api/modeling/boundary-layers/' + args.layerCode + '/' + args.shapeId;
             return $.ajax({
                 'url': url,
                 'type': 'GET'

--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var L = require('leaflet'),
+    $ = require('jquery'),
+    Marionette = require('../../shim/backbone.marionette'),
+    layerControlTmpl = require('./templates/layerControlContainer.html');
+
+module.exports = L.Control.Layers.extend({
+    // Somewhat copied from https://github.com/Leaflet/Leaflet/blob/master/src/control/Control.Layers.js,
+    // with modifications to use a customer container element and our own way to toggle visibility.
+    _initLayout: function() {
+        var className = 'leaflet-control-layers',
+            container = this._container = this._createContainer();
+
+        this._form = $(container).find('form').get(0);
+
+        // Copied directly from the parent class.
+        // makes this work on IE touch devices by stopping it 
+        // from firing a mouseout event when the touch is released
+        container.setAttribute('aria-haspopup', true);
+
+        // Copied directly from the parent class.
+        if (!L.Browser.touch) {
+            L.DomEvent
+                .disableClickPropagation(container)
+                .disableScrollPropagation(container);
+        } else {
+            L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
+        }
+
+        // Expand the layer control so that Leaflet
+        // knows it's shown. We don't toggle this, but
+        // instead we toggle visibility using our own
+        // methods.
+        this._expand();
+
+        // Kept around so we don't have to override _update, even though
+        // it's not used in the UI.
+        this._separator = L.DomUtil.create('div', className + '-separator');
+
+        // Add container element for each layer type
+        this._baseLayersList = L.DomUtil.create('div', className + '-base',
+                $(container).find("#basemap-layer-list").get(0));
+        this._overlaysList = L.DomUtil.create('div', className + '-overlay',
+                $(container).find("#overlays-layer-list").get(0));
+    },
+
+    _createContainer: function() {
+        var container = new LayerControlView({}).render().el;
+
+        return container;
+    }
+});
+
+var LayerControlView = Marionette.ItemView.extend({
+    template: layerControlTmpl,
+
+    ui: {
+        close: '.close',
+        controlToggle: '.leaflet-bar-part',
+        layerControl: '.leaflet-control-layers'
+    },
+
+    events: {
+        'click @ui.close': 'close',
+        'click @ui.controlToggle': 'toggle'
+    },
+
+    close: function() {
+        this.$el.find(this.ui.layerControl).hide();
+    },
+
+    toggle: function() {
+        this.$el.find(this.ui.layerControl).toggle();
+    }
+});

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -3,7 +3,8 @@
 var defaultSettings = {
     itsi_embed: false,
     base_layers: {},
-    stream_layers: {}
+    stream_layers: {},
+    boundary_layers: {}
 };
 
 var settings = (function() {

--- a/src/mmw/js/src/core/templates/layerControlContainer.html
+++ b/src/mmw/js/src/core/templates/layerControlContainer.html
@@ -1,0 +1,23 @@
+<div>
+    <div class="layer-control-button-container leaflet-control leaflet-bar">
+        <a class="leaflet-bar-part leaflet-bar-part-single" href="#" title="Show layer control">
+            <span class="fa fa-globe"></span>
+        </a>
+    </div>
+    <div class="leaflet-control-layers">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title">Layers</h4>
+          </div>
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active"><a href="#basemap-layer-list" aria-controls="basemap" role="tab" data-toggle="tab">Basemap</a></li>
+            <li role="presentation"><a href="#overlays-layer-list" aria-controls="overlays" role="tab" data-toggle="tab">Overlays</a></li>
+        </ul>
+        <form class="leaflet-control-layers-list">
+           <div class="tab-content">
+              <div role="tabpanel" class="tab-pane active" id="basemap-layer-list"></div>
+              <div role="tabpanel" class="tab-pane" id="overlays-layer-list"></div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -201,15 +201,19 @@ describe('Core', function() {
 
 
             it('creates a layer selector with the correct items', function() {
-                var baseLayers = {
-                    'A': {
+                var baseLayers = [
+                    {
                         'url': 'https://{s}.tiles.mapbox.com/v3/ctaylor.lg2deoc9/{z}/{x}/{y}.png',
-                        'default': true
+                        'default': true,
+                        'display': 'A',
+                        'basemap': true
                     },
-                    'B': {
-                        'url': 'https://{s}.tiles.mapbox.com/v3/examples.map-i86nkdio/{z}/{x}/{y}.png'
+                    {
+                        'url': 'https://{s}.tiles.mapbox.com/v3/examples.map-i86nkdio/{z}/{x}/{y}.png',
+                        'display': 'B',
+                        'basemap': true
                     }
-                };
+                ];
                 settings.set('base_layers', baseLayers);
 
                 var model = new models.MapModel(),
@@ -223,7 +227,7 @@ describe('Core', function() {
                     }).get();
 
                 assert.equal($layers.length, 2, 'Did not add layer selector');
-                assert.deepEqual(layerNames, _.keys(baseLayers));
+                assert.deepEqual(layerNames, _.pluck(baseLayers, 'display'));
 
                 view.destroy();
             });

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -22,9 +22,7 @@ var DrawController = {
                 model: toolbarModel
             });
 
-        App.restApi.getPredefinedShapeTypes().then(function(data) {
-            toolbarModel.set('predefinedShapeTypes', data);
-        });
+        toolbarModel.set('predefinedShapeTypes', settings.get('boundary_layers'));
 
         App.rootView.geocodeSearchRegion.show(geocodeSearch);
         App.rootView.drawToolsRegion.show(toolbarView);

--- a/src/mmw/js/src/draw/templates/selectType.html
+++ b/src/mmw/js/src/draw/templates/selectType.html
@@ -8,8 +8,8 @@
   {% for item in predefinedShapeTypes %}
       <li role="presentation">
         <a role="menuitem" tabindex="-1" href="#"
-           data-endpoint="{{ item.endpoint }}"
-           data-tableid="{{ item.tableId }}"
+           data-tile-url="{{ item.url }}"
+           data-layer-code="{{ item.code }}"
            data-short-display="{{ item.short_display }}">
           <span>{{ item.display }}</span> <i class="split fa fa-question-circle"
                                              data-content="{{ item.helptext }}"></i>

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -78,7 +78,7 @@ var SelectAreaView = Marionette.ItemView.extend({
     $label: $('#boundary-label'),
 
     ui: {
-        items: '[data-endpoint]',
+        items: '[data-tile-url]',
         button: '#predefined-shape',
         helptextIcon: 'i.split'
     },
@@ -106,12 +106,12 @@ var SelectAreaView = Marionette.ItemView.extend({
 
     onItemClicked: function(e) {
         var $el = $(e.currentTarget),
-            endpoint = $el.data('endpoint'),
-            tableId = $el.data('tableid'),
+            tileUrl = $el.data('tile-url'),
+            layerCode = $el.data('layer-code'),
             shortDisplay = $el.data('short-display');
 
         clearAoiLayer();
-        this.changeOutlineLayer(endpoint, tableId, shortDisplay);
+        this.changeOutlineLayer(tileUrl, layerCode, shortDisplay);
         e.preventDefault();
     },
 
@@ -120,21 +120,22 @@ var SelectAreaView = Marionette.ItemView.extend({
         return !types ? loadingTmpl : selectTypeTmpl;
     },
 
-    changeOutlineLayer: function(endpoint, tableId, shortDisplay) {
+    changeOutlineLayer: function(tileUrl, layerCode, shortDisplay) {
         var self = this,
             ofg = self.model.get('outlineFeatureGroup');
 
-        // Go about the business of adding the ouline and UTFgrid layers.
-        if (endpoint && tableId !== undefined) {
-            var ol = new L.TileLayer(endpoint + '.png'),
-                grid = new L.UtfGrid(endpoint + '.grid.json',
+        // Go about the business of adding the outline and UTFgrid layers.
+        if (tileUrl && layerCode !== undefined) {
+            var ol = new L.TileLayer(tileUrl + '.png'),
+                grid = new L.UtfGrid(tileUrl + '.grid.json',
                                      {
                                          useJsonP: false,
                                          resolution: 4,
                                          maxRequests: 8
                                      });
+
             grid.on('click', function(e) {
-                getShapeAndAnalyze(e, self.model, ofg, grid, tableId, shortDisplay);
+                getShapeAndAnalyze(e, self.model, ofg, grid, layerCode, shortDisplay);
             });
 
             grid.on('mousemove', function(e) {
@@ -390,7 +391,7 @@ function changeStreamLayer(endpoint, model) {
     sl.bringToFront();
 }
 
-function getShapeAndAnalyze(e, model, ofg, grid, tableId, layerName) {
+function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {
     // The shapeId might not be available at the time of the click
     // because the UTF Grid layer might not be loaded yet, so
     // we poll for it.
@@ -409,7 +410,7 @@ function getShapeAndAnalyze(e, model, ofg, grid, tableId, layerName) {
 
     function _getShapeAndAnalyze() {
         App.restApi.getPolygon({
-            tableId: tableId,
+            layerCode: layerCode,
             shapeId: shapeId
         }).done(function(shape) {
             addLayer(shape, shapeName, layerName);
@@ -446,7 +447,6 @@ function getShapeAndAnalyze(e, model, ofg, grid, tableId, layerName) {
 
     return deferred;
 }
-
 
 function clearAoiLayer() {
     App.map.set('areaOfInterest', null);

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -12,6 +12,8 @@ from os import environ
 from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 
+from layer_settings import LAYERS  # NOQA
+
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.
 from django.core.exceptions import ImproperlyConfigured
@@ -117,7 +119,8 @@ CELERY_RESULT_SERIALIZER = 'json'
 CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 STATSD_CELERY_SIGNALS = True
 CELERY_DEFAULT_QUEUE = environ.get('MMW_STACK_COLOR', 'Black').lower()
-CELERY_DEFAULT_ROUTING_KEY = 'task.%s' % environ.get('MMW_STACK_COLOR', 'Black').lower()
+CELERY_DEFAULT_ROUTING_KEY = ('task.%s' %
+                              environ.get('MMW_STACK_COLOR', 'Black').lower())
 # END CELERY CONFIGURATION
 
 
@@ -260,92 +263,6 @@ ROOT_URLCONF = '%s.urls' % SITE_NAME
 # END URL CONFIGURATION
 
 
-# TILER CONFIGURATION
-TILER_HOST = environ.get('MMW_TILER_HOST', 'localhost')
-# END TILER CONFIGURATION
-
-
-# N. B. This must be kept in sync with src/tiler/server.js.  In the
-# dictionary below, the keys are the table ids.  If `json_field` is provided
-# that column will be used for feature lookups, but default to 'geom' if not.
-BOUNDARY_LAYERS = [
-    {
-        'code': 'district',
-        'display': 'Congressional Districts',
-        'short_display': 'Congressional District',
-        'table_name': 'boundary_district',
-        'helptext': 'There are 435 congressional districts in the United ' \
-                    'States House of Representatives, with each one ' \
-                    'representing approximately 700,000 people. In addition ' \
-                    'to the 435 congressional districts, the five inhabited ' \
-                    'U.S. territories and the federal district of Washington, ' \
-                    'D.C. This tool will allow you to select the boundary of ' \
-                    'a congressional district on which to perform water ' \
-                    'quality analysis.'
-    },
-    {
-        'code': 'huc8',
-        'display': 'USGS Subbasin unit (HUC-8)',
-        'short_display': 'Subbasin',
-        'table_name': 'boundary_huc08',
-        'helptext': 'HUC stands for hydrologic unit code. The hydrologic ' \
-                    'unit hierarchy is indicated by the number of digits in ' \
-                    'groups of two (such as HUC-2, HUC-4, and HUC-6) within ' \
-                    'the HUC code. HUC 8 maps the subbasin level, analogous ' \
-                    'to medium-sized river basins. There are about 2200 ' \
-                    'nationwide. This tool allows you to pick a predefined ' \
-                    'HUC-8 to analyze.'
-    },
-    {
-        'code': 'huc10',
-        'display': 'USGS Watershed unit (HUC-10)',
-        'short_display': 'Watershed',
-        'table_name': 'boundary_huc10',
-        'helptext': 'HUC stands for hydrologic unit code. The hydrologic ' \
-                    'unit hierarchy is indicated by the number of digits in ' \
-                    'groups of two (such as HUC-2, HUC-4, and HUC-6) within ' \
-                    'the HUC code. HUC-10 maps the watershed level, typically ' \
-                    'from (160-1010 square km) . There are about 22,000 ' \
-                    'nationwide. This tool allows you to pick a predefined ' \
-                    'HUC-10 to analyze.'
-    },
-    {
-        'code': 'huc12',
-        'display': 'USGS Subwatershed unit (HUC-12)',
-        'short_display': 'Subwatershed',
-        'table_name': 'boundary_huc12',
-        'json_field': 'geom_detailed',
-        'helptext': 'HUC stands for hydrologic unit code. The hydrologic ' \
-                    'unit hierarchy is indicated by the number of digits in ' \
-                    'groups of two (such as HUC-2, HUC-4, and HUC-6) within ' \
-                    'the HUC code. HUC-12 is a more local sub-watershed level ' \
-                    'that captures tributary systems. There are about 90,000 ' \
-                    'nationwide. This tool allows you to pick a predefined ' \
-                    'HUC-12 to analyze.'
-
-    }
-]
-
-STREAM_LAYERS = [
-    {
-        'code': 'stream-low',
-        'display': 'Low-Res',
-        'table_name': 'deldem4net100r',
-    },
-    {
-        'code': 'stream-medium',
-        'display': 'Medium-Res',
-        'table_name': 'deldem4net50r',
-    },
-    {
-        'code': 'stream-high',
-        'display': 'High-Res',
-        'table_name': 'deldem4net20r',
-    },
-]
-
-# END TILER CONFIGURATION
-
 # APP CONFIGURATION
 DJANGO_APPS = (
     # Default Django apps:
@@ -437,29 +354,6 @@ ITSI = {
     'embed_flag': 'itsi_embed',
 }
 
-# Layers must have a maxZoom defined
-BASE_LAYERS = {
-    'Streets': {
-        'type': 'mapbox',
-        'url': 'https://{s}.tiles.mapbox.com/v3/ctaylor.lg2deoc9/{z}/{x}/{y}.png',
-        'attribution': 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">Mapbox</a>',
-        'maxZoom': 18,
-        'default': True,
-    },
-    'Satellite': {
-        'type': 'esri',
-        'url': 'https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-        'attribution': 'Map data from <a href="http://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9">ESRI</a>',
-        'maxZoom': 19
-    },
-    'Satellite with Roads': {
-        'type': 'google',
-        'googleType': 'HYBRID', # can be one of SATELLITE, ROADMAP, HYBRID, TERRAIN,
-        'maxZoom': 18 # Max zoom changes based on available imagery, but this is a safe default
-    },
-    'Terrain': {
-        'type': 'google',
-        'googleType': 'TERRAIN', # can be one of SATELLITE, ROADMAP, HYBRID, TERRAIN,
-        'maxZoom': 20
-    }
-}
+# TILER CONFIGURATION
+TILER_HOST = environ.get('MMW_TILER_HOST', 'localhost')
+# END TILER CONFIGURATION

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -25,6 +25,7 @@ LAYERS = [
                     'a congressional district on which to perform water '
                     'quality analysis.',
         'boundary': True,
+        'overlay': True,
     },
     {
         'code': 'huc8',
@@ -39,6 +40,7 @@ LAYERS = [
                     'nationwide. This tool allows you to pick a predefined '
                     'HUC-8 to analyze.',
         'boundary': True,
+        'overlay': True,
     },
     {
         'code': 'huc10',
@@ -53,6 +55,7 @@ LAYERS = [
                     'nationwide. This tool allows you to pick a predefined '
                     'HUC-10 to analyze.',
         'boundary': True,
+        'overlay': True,
     },
     {
         'code': 'huc12',
@@ -69,6 +72,7 @@ LAYERS = [
                     'HUC-12 to analyze.',
         'aoi': True,
         'boundary': True,
+        'overlay': True,
     },
     {
         'code': 'stream-low',

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -1,0 +1,130 @@
+"""
+Config for boundary (a.k.a AoI) layers, basemaps, overlays,
+and any other layer types.
+
+For layers served from our tiler server, the settings must be kept in sync
+with src/tiler/server.js.  In the dictionary below, the keys are the table ids.
+If `json_field` is provided that column will be used for feature lookups,
+but default to 'geom' if not.
+
+For basemaps, maxZoom must be defined.
+"""
+
+LAYERS = [
+    {
+        'code': 'district',
+        'display': 'Congressional Districts',
+        'short_display': 'Congressional District',
+        'table_name': 'boundary_district',
+        'helptext': 'There are 435 congressional districts in the United '
+                    'States House of Representatives, with each one '
+                    'representing approximately 700,000 people. In addition '
+                    'to the 435 congressional districts, the five inhabited '
+                    'U.S. territories and the federal district of Washington, '
+                    'D.C. This tool will allow you to select the boundary of '
+                    'a congressional district on which to perform water '
+                    'quality analysis.',
+        'boundary': True,
+    },
+    {
+        'code': 'huc8',
+        'display': 'USGS Subbasin unit (HUC-8)',
+        'short_display': 'Subbasin',
+        'table_name': 'boundary_huc08',
+        'helptext': 'HUC stands for hydrologic unit code. The hydrologic '
+                    'unit hierarchy is indicated by the number of digits in '
+                    'groups of two (such as HUC-2, HUC-4, and HUC-6) within '
+                    'the HUC code. HUC 8 maps the subbasin level, analogous '
+                    'to medium-sized river basins. There are about 2200 '
+                    'nationwide. This tool allows you to pick a predefined '
+                    'HUC-8 to analyze.',
+        'boundary': True,
+    },
+    {
+        'code': 'huc10',
+        'display': 'USGS Watershed unit (HUC-10)',
+        'short_display': 'Watershed',
+        'table_name': 'boundary_huc10',
+        'helptext': 'HUC stands for hydrologic unit code. The hydrologic '
+                    'unit hierarchy is indicated by the number of digits in '
+                    'groups of two (such as HUC-2, HUC-4, and HUC-6) within '
+                    'the HUC code. HUC-10 maps the watershed level, typically '
+                    'from (160-1010 square km) . There are about 22,000 '
+                    'nationwide. This tool allows you to pick a predefined '
+                    'HUC-10 to analyze.',
+        'boundary': True,
+    },
+    {
+        'code': 'huc12',
+        'display': 'USGS Subwatershed unit (HUC-12)',
+        'short_display': 'Subwatershed',
+        'table_name': 'boundary_huc12',
+        'json_field': 'geom_detailed',
+        'helptext': 'HUC stands for hydrologic unit code. The hydrologic '
+                    'unit hierarchy is indicated by the number of digits in '
+                    'groups of two (such as HUC-2, HUC-4, and HUC-6) within '
+                    'the HUC code. HUC-12 is a more local sub-watershed level '
+                    'that captures tributary systems. There are about 90,000 '
+                    'nationwide. This tool allows you to pick a predefined '
+                    'HUC-12 to analyze.',
+        'aoi': True,
+        'boundary': True,
+    },
+    {
+        'code': 'stream-low',
+        'display': 'Low-Res',
+        'table_name': 'deldem4net100r',
+        'stream': True,
+    },
+    {
+        'code': 'stream-medium',
+        'display': 'Medium-Res',
+        'table_name': 'deldem4net50r',
+        'stream': True,
+    },
+    {
+        'code': 'stream-high',
+        'display': 'High-Res',
+        'table_name': 'deldem4net20r',
+        'stream': True,
+    },
+    {
+        'type': 'mapbox',
+        'display': 'Streets',
+        'url': 'https://{s}.tiles.mapbox.com/v3/ctaylor.lg2deoc9'
+               '/{z}/{x}/{y}.png',
+        'attribution': 'Map data &copy; <a href="http://openstreetmap.org">'
+                       'OpenStreetMap</a> contributors, '
+                       '<a href="http://creativecommons.org/licenses/by-sa/'
+                       '2.0/">CC-BY-SA</a>, Imagery &copy; '
+                       '<a href="http://mapbox.com">Mapbox</a>',
+        'maxZoom': 18,
+        'default': True,
+        'basemap': True,
+    },
+    {
+        'display': 'Satellite',
+        'type': 'esri',
+        'url': 'https://server.arcgisonline.com/arcgis/rest/services/'
+               'World_Imagery/MapServer/tile/{z}/{y}/{x}',
+        'attribution': 'Map data from <a href="http://www.arcgis.com/home/'
+                       'item.html?id=10df2279f9684e4a9f6a7f08febac2a9">ESRI'
+                       '</a>',
+        'maxZoom': 19,
+        'basemap': True,
+    },
+    {
+        'display': 'Satellite with Roads',
+        'type': 'google',
+        'googleType': 'HYBRID',  # SATELLITE, ROADMAP, HYBRID, or TERRAIN
+        'maxZoom': 18,  # Max zoom changes based on location. Safe default
+        'basemap': True,
+    },
+    {
+        'display': 'Terrain',
+        'type': 'google',
+        'googleType': 'TERRAIN',  # SATELLITE, ROADMAP, HYBRID, or TERRAIN
+        'maxZoom': 20,
+        'basemap': True,
+    }
+]

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -70,8 +70,15 @@ LAYERS = [
                     'that captures tributary systems. There are about 90,000 '
                     'nationwide. This tool allows you to pick a predefined '
                     'HUC-12 to analyze.',
-        'aoi': True,
         'boundary': True,
+        'overlay': True,
+    },
+    {
+        'code': 'school',
+        'display': 'School Districts',
+        'short_display': 'School Districts',
+        'table_name': 'boundary_school_district',
+        'helptext': 'U.S. school district boundaries.',
         'overlay': True,
     },
     {

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -36,3 +36,42 @@
 .leaflet-retina .leaflet-control-layers-toggle{
   background-image: url('../images/layers-2x.png');
 }
+
+.leaflet-control-layers-expanded {
+  padding: 0;
+  background-color: transparent;
+
+  .layer-control-button-container {
+    position: absolute;
+    bottom: 0px;
+    right: 0px;
+    margin-bottom: 0;
+    margin-right: 0;
+  }
+
+  .leaflet-control-layers {
+    min-width: 220px;
+    min-height: 230px;
+    margin-right: 50px;
+    display: none;
+
+    .modal-header {
+      background-color: $ui-primary;
+      color: $paper;
+
+      .modal-title {
+        font-size: 14px;
+       }
+    }
+
+    form {
+      padding: 15px;
+    }
+
+    .close {
+      text-shadow: none;
+      color: $paper;
+      font-size: 18px;
+    }
+  }
+}


### PR DESCRIPTION
Adds a custom layer control to the map, and adds support for overlay layers.

This took a bit longer than I expected because I needed to do some refactoring of how we implemented layer support so that this could be implemented easily. 

See commit messages for details.

This doesn't implement the layer control exactly as it's represented in the visual designs, but I thought that getting that right could be done by UI/UX.

As designed:

![screen shot 2015-08-31 at 5 24 19 pm](https://cloud.githubusercontent.com/assets/1042475/9590829/27853a8c-5005-11e5-8262-e28c31fc5b1d.png)

As implemented:

![screen shot 2015-08-31 at 5 24 41 pm](https://cloud.githubusercontent.com/assets/1042475/9590833/3122129a-5005-11e5-8b23-9f68279e8a50.png)

**Testing instructions**:

- Using the layer control, switch the active base map.
- Activate the "Overlays" tab of the layer control, and turn on and off the overlays for which you've loaded the data.
- Select an AoI.
- Any active overlays should still be on, and the layer control should still be present.

Known issues:

- The control is hidden by the analyze bar that appears when moving back from the analyze page to the draw page after having previously selected an AoI. I started to fix this in this PR, but it's not as simple as it first appears. We may need design support. https://github.com/WikiWatershed/model-my-watershed/issues/742

- The overlay layers that are also used as boundary layers have the same style.  https://github.com/WikiWatershed/model-my-watershed/issues/741

- The boundary label is drawn above map controls. https://github.com/WikiWatershed/model-my-watershed/issues/743

Connects to #629