### PR TITLE
Make tables sortable

### DIFF
--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -100,6 +100,7 @@ CONCAT_VENDOR_CSS_COMMAND="cat \
     ./node_modules/leaflet/dist/leaflet.css \
     ./node_modules/leaflet-draw/dist/leaflet.draw.css \
     ./node_modules/font-awesome/css/font-awesome.min.css \
+    ./node_modules/bootstrap-table/dist/bootstrap-table.min.css \
     > $VENDOR_CSS_FILE"
 
 JS_DEPS=(jquery backbone backbone.marionette bootstrap bootstrap-select \

--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -1,10 +1,10 @@
 <div class="disclaimer">Results are for demonstration purposes only.</div>
-<table class="table custom-hover">
+<table class="table custom-hover" data-toggle="table">
     <thead>
         <tr>
-            <th>Type</th>
-            <th class="text-right">Area ({{ units }})</th>
-            <th class="text-right">Coverage (%)</th>
+            <th data-sortable="true">Type</th>
+            <th class="text-right" data-sortable="true">Area ({{ units }})</th>
+            <th class="text-right" data-sortable="true">Coverage (%)</th>
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -93,8 +93,15 @@ function checkTableHeader(name) {
 
 // Check that all elements in table match the dataset.
 function checkTableBody(subData) {
-    var $rows = $('#' + subData.name + ' table tbody tr');
+    var $rows = $('#' + subData.name + ' table tbody tr:not(.no-records-found)');
+
     $rows.each(function(trInd, tr) {
+        // The bootstrap-table plugin creates rows containing no data,
+        // which must be skipped.
+        if ($(tr).find('td').length === 0) {
+            return;
+        }
+
         // Get elements in dataset into the order in which they are
         // displayed.
         var expectedRowVals = [

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -248,7 +248,11 @@ var TableView = Marionette.CompositeView.extend({
         };
     },
     childViewContainer: 'tbody',
-    template: tableTmpl
+    template: tableTmpl,
+
+    onAttach: function() {
+        $('[data-toggle="table"]').bootstrapTable();
+    }
 });
 
 var ChartView = Marionette.ItemView.extend({

--- a/src/mmw/js/src/core/setup.js
+++ b/src/mmw/js/src/core/setup.js
@@ -22,6 +22,7 @@ require('../analyze/filters');
 
 require('bootstrap');
 require('bootstrap-select');
+require('bootstrap-table/dist/bootstrap-table.js');
 
 var L = require('leaflet');
 require('leaflet-draw');

--- a/src/mmw/js/src/modeling/tr55/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/table.html
@@ -1,9 +1,9 @@
 <div class="disclaimer">Results are for demonstration purposes only.</div>
-<table class="table custom-hover">
+<table class="table custom-hover" data-toggle="table">
     <thead>
         <tr>
-            <th>Quality Measure</th>
-            <th class="text-left">Load (kg)</th>
+            <th data-sortable="true">Quality Measure</th>
+            <th data-sortable="true" class="text-left">Load (kg)</th>
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -69,7 +69,11 @@ var TableRowView = Marionette.ItemView.extend({
 var TableView = Marionette.CompositeView.extend({
     childView: TableRowView,
     childViewContainer: 'tbody',
-    template: tableTmpl
+    template: tableTmpl,
+
+    onAttach: function() {
+        $('[data-toggle="table"]').bootstrapTable();
+    }
 });
 
 var ChartView = Marionette.ItemView.extend({

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -44,6 +44,844 @@
       "from": "bootstrap-select@git://github.com/azavea/bootstrap-select",
       "resolved": "git://github.com/azavea/bootstrap-select#f1755efa102a41e43fc367ba36ce905b8f2b90e1"
     },
+    "bootstrap-table": {
+      "version": "1.8.1",
+      "from": "bootstrap-table@",
+      "dependencies": {
+        "grunt-contrib-copy": {
+          "version": "0.8.1",
+          "from": "grunt-contrib-copy@^0.8.0",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@^1.0.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@^2.1.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@^2.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@^3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@^2.0.0"
+                }
+              }
+            },
+            "file-sync-cmp": {
+              "version": "0.1.1",
+              "from": "file-sync-cmp@^0.1.0"
+            }
+          }
+        },
+        "grunt-contrib-concat": {
+          "version": "0.5.1",
+          "from": "grunt-contrib-concat@^0.5.1",
+          "dependencies": {
+            "chalk": {
+              "version": "0.5.1",
+              "from": "chalk@^0.5.1",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@^1.1.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.0"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@^0.1.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@^0.2.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@^0.3.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@^0.2.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@^0.2.0"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.3.0",
+              "from": "source-map@^0.3.0",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            }
+          }
+        },
+        "grunt-contrib-clean": {
+          "version": "0.6.0",
+          "from": "grunt-contrib-clean@^0.6.0",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@~2.2.1"
+            }
+          }
+        },
+        "grunt-contrib-cssmin": {
+          "version": "0.12.3",
+          "from": "grunt-contrib-cssmin@^0.12.2",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@^1.0.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@^2.1.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.0"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@^2.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@^3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@^2.0.0"
+                }
+              }
+            },
+            "clean-css": {
+              "version": "3.4.1",
+              "from": "clean-css@^3.1.0",
+              "dependencies": {
+                "commander": {
+                  "version": "2.8.1",
+                  "from": "commander@2.8.x",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>= 1.0.0"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "source-map@0.4.x",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "maxmin": {
+              "version": "1.1.0",
+              "from": "maxmin@^1.0.0",
+              "dependencies": {
+                "figures": {
+                  "version": "1.3.5",
+                  "from": "figures@^1.0.1"
+                },
+                "gzip-size": {
+                  "version": "1.0.0",
+                  "from": "gzip-size@^1.0.0",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.5.0",
+                      "from": "concat-stream@^1.4.1",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "typedarray@~0.0.5"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.2",
+                          "from": "readable-stream@~2.0.0",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@~1.0.0"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.2",
+                              "from": "process-nextick-args@~1.0.0"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.1",
+                              "from": "util-deprecate@~1.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "browserify-zlib": {
+                      "version": "0.1.4",
+                      "from": "browserify-zlib@^0.1.4",
+                      "dependencies": {
+                        "pako": {
+                          "version": "0.2.7",
+                          "from": "pako@~0.2.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "pretty-bytes": {
+                  "version": "1.0.4",
+                  "from": "pretty-bytes@^1.0.0",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1"
+                    },
+                    "meow": {
+                      "version": "3.3.0",
+                      "from": "meow@^3.1.0",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "camelcase-keys@^1.0.0",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "camelcase@^1.0.1"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@^1.0.0"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.2",
+                          "from": "indent-string@^1.1.0",
+                          "dependencies": {
+                            "repeating": {
+                              "version": "1.1.3",
+                              "from": "repeating@^1.1.0",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "is-finite@^1.0.0",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "number-is-nan@^1.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@^1.1.0"
+                        },
+                        "object-assign": {
+                          "version": "3.0.0",
+                          "from": "object-assign@^3.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "grunt-contrib-uglify": {
+          "version": "0.8.1",
+          "from": "grunt-contrib-uglify@^0.8.0",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@^1.0.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@^2.1.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@^2.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@^3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@^2.0.0"
+                }
+              }
+            },
+            "maxmin": {
+              "version": "1.1.0",
+              "from": "maxmin@^1.0.0",
+              "dependencies": {
+                "figures": {
+                  "version": "1.3.5",
+                  "from": "figures@^1.0.1"
+                },
+                "gzip-size": {
+                  "version": "1.0.0",
+                  "from": "gzip-size@^1.0.0",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.5.0",
+                      "from": "concat-stream@^1.4.1",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "typedarray@~0.0.5"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.2",
+                          "from": "readable-stream@~2.0.0",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@~1.0.0"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.2",
+                              "from": "process-nextick-args@~1.0.0"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.1",
+                              "from": "util-deprecate@~1.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "browserify-zlib": {
+                      "version": "0.1.4",
+                      "from": "browserify-zlib@^0.1.4",
+                      "dependencies": {
+                        "pako": {
+                          "version": "0.2.7",
+                          "from": "pako@~0.2.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "pretty-bytes": {
+                  "version": "1.0.4",
+                  "from": "pretty-bytes@^1.0.0",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1"
+                    },
+                    "meow": {
+                      "version": "3.3.0",
+                      "from": "meow@^3.1.0",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "camelcase-keys@^1.0.0",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "camelcase@^1.0.1"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@^1.0.0"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.2",
+                          "from": "indent-string@^1.1.0",
+                          "dependencies": {
+                            "repeating": {
+                              "version": "1.1.3",
+                              "from": "repeating@^1.1.0",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "is-finite@^1.0.0",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "number-is-nan@^1.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@^1.1.0"
+                        },
+                        "object-assign": {
+                          "version": "3.0.0",
+                          "from": "object-assign@^3.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.17",
+              "from": "uglify-js@2.4.17",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@~0.2.6"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                },
+                "yargs": {
+                  "version": "1.3.3",
+                  "from": "yargs@~1.3.3"
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@~1.0.0"
+                }
+              }
+            },
+            "uri-path": {
+              "version": "0.0.2",
+              "from": "uri-path@0.0.2"
+            }
+          }
+        },
+        "grunt-contrib-jshint": {
+          "version": "0.10.0",
+          "from": "grunt-contrib-jshint@^0.10.0",
+          "dependencies": {
+            "jshint": {
+              "version": "2.5.11",
+              "from": "jshint@~2.5.0",
+              "dependencies": {
+                "cli": {
+                  "version": "0.6.6",
+                  "from": "cli@0.6.x",
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.2.11",
+                      "from": "glob@~ 3.2.1",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "minimatch@0.3",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.6.5",
+                              "from": "lru-cache@2"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@~1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-browserify": {
+                  "version": "1.1.0",
+                  "from": "console-browserify@1.1.x",
+                  "dependencies": {
+                    "date-now": {
+                      "version": "0.1.4",
+                      "from": "date-now@^0.1.4"
+                    }
+                  }
+                },
+                "exit": {
+                  "version": "0.1.2",
+                  "from": "exit@0.1.x"
+                },
+                "htmlparser2": {
+                  "version": "3.8.3",
+                  "from": "htmlparser2@3.8.x",
+                  "dependencies": {
+                    "domhandler": {
+                      "version": "2.3.0",
+                      "from": "domhandler@2.3"
+                    },
+                    "domutils": {
+                      "version": "1.5.1",
+                      "from": "domutils@1.5",
+                      "dependencies": {
+                        "dom-serializer": {
+                          "version": "0.1.0",
+                          "from": "dom-serializer@0",
+                          "dependencies": {
+                            "domelementtype": {
+                              "version": "1.1.3",
+                              "from": "domelementtype@~1.1.1"
+                            },
+                            "entities": {
+                              "version": "1.1.1",
+                              "from": "entities@~1.1.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "domelementtype@1"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@1.1",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1"
+                        }
+                      }
+                    },
+                    "entities": {
+                      "version": "1.0.0",
+                      "from": "entities@1.0"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@1.0.x",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.5",
+                      "from": "lru-cache@2"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@~1.0.0"
+                    }
+                  }
+                },
+                "shelljs": {
+                  "version": "0.3.0",
+                  "from": "shelljs@0.3.x"
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "from": "strip-json-comments@1.0.x"
+                },
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@1.6.x"
+                }
+              }
+            },
+            "hooker": {
+              "version": "0.2.3",
+              "from": "hooker@~0.2.3"
+            }
+          }
+        },
+        "grunt": {
+          "version": "0.4.5",
+          "from": "grunt@^0.4.5",
+          "dependencies": {
+            "async": {
+              "version": "0.1.22",
+              "from": "async@~0.1.22"
+            },
+            "coffee-script": {
+              "version": "1.3.3",
+              "from": "coffee-script@~1.3.3"
+            },
+            "colors": {
+              "version": "0.6.2",
+              "from": "colors@~0.6.2"
+            },
+            "dateformat": {
+              "version": "1.0.2-1.2.3",
+              "from": "dateformat@1.0.2-1.2.3"
+            },
+            "eventemitter2": {
+              "version": "0.4.14",
+              "from": "eventemitter2@~0.4.13"
+            },
+            "findup-sync": {
+              "version": "0.1.3",
+              "from": "findup-sync@~0.1.2",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@~3.2.9",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.5",
+                          "from": "lru-cache@2"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@~1.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "lodash@~2.4.1"
+                }
+              }
+            },
+            "glob": {
+              "version": "3.1.21",
+              "from": "glob@~3.1.21",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@~1.2.0"
+                },
+                "inherits": {
+                  "version": "1.0.2",
+                  "from": "inherits@1"
+                }
+              }
+            },
+            "hooker": {
+              "version": "0.2.3",
+              "from": "hooker@~0.2.3"
+            },
+            "iconv-lite": {
+              "version": "0.2.11",
+              "from": "iconv-lite@~0.2.11"
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@~0.2.12",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.5",
+                  "from": "lru-cache@2"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@~1.0.0"
+                }
+              }
+            },
+            "nopt": {
+              "version": "1.0.10",
+              "from": "nopt@~1.0.10",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "from": "abbrev@1"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@~2.2.8"
+            },
+            "lodash": {
+              "version": "0.9.2",
+              "from": "lodash@~0.9.2"
+            },
+            "underscore.string": {
+              "version": "2.2.1",
+              "from": "underscore.string@~2.2.1"
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@~1.0.5"
+            },
+            "js-yaml": {
+              "version": "2.0.5",
+              "from": "js-yaml@~2.0.5",
+              "dependencies": {
+                "argparse": {
+                  "version": "0.1.16",
+                  "from": "argparse@~ 0.1.11",
+                  "dependencies": {
+                    "underscore": {
+                      "version": "1.7.0",
+                      "from": "underscore@~1.7.0"
+                    },
+                    "underscore.string": {
+                      "version": "2.4.0",
+                      "from": "underscore.string@~2.4.0"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@~ 1.0.2"
+                }
+              }
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "exit@~0.1.1"
+            },
+            "getobject": {
+              "version": "0.1.0",
+              "from": "getobject@~0.1.0"
+            },
+            "grunt-legacy-util": {
+              "version": "0.2.0",
+              "from": "grunt-legacy-util@~0.2.0"
+            },
+            "grunt-legacy-log": {
+              "version": "0.1.2",
+              "from": "grunt-legacy-log@~0.1.0",
+              "dependencies": {
+                "grunt-legacy-log-utils": {
+                  "version": "0.1.1",
+                  "from": "grunt-legacy-log-utils@^0.1.1"
+                },
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "lodash@~2.4.1"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@~2.3.3"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "browserify": {
       "version": "9.0.3",
       "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -23,6 +23,7 @@
     "blueimp-md5": "1.1.0",
     "bootstrap": "3.3.4",
     "bootstrap-select": "git://github.com/azavea/bootstrap-select",
+    "bootstrap-table": "1.8.1",
     "browserify": "9.0.3",
     "chai": "1.10.0",
     "d3": "3.5.5",

--- a/src/mmw/sass/components/_tables.scss
+++ b/src/mmw/sass/components/_tables.scss
@@ -10,7 +10,7 @@
   }
 
   th, td{
-    padding: 0.8rem 0.4rem!important;
+    padding: 0.8rem 0.4rem;
     line-height: 1!important;
     vertical-align: middle!important;
     border-top: none!important;


### PR DESCRIPTION
The tables on the "analyze" page and the "water quality" tab of the TR-55 page have been made sortable.

Connects #729

Thanks to @kdeloach for help understanding/debugging the behavior of the `bootstrap-table` plugin.

**To Test**
   * Go to the "analyze" page or the "water quality" section of the TR-55 page.
   * Using the new arrows in the head-row of the tables to (re)sort the tables.

![screenshot from 2015-09-01 12 41 42](https://cloud.githubusercontent.com/assets/11281373/9610473/d7a0b4a8-50a7-11e5-8adb-04cc6c955efe.png)

![screenshot from 2015-09-01 12 41 47](https://cloud.githubusercontent.com/assets/11281373/9610474/dc6a1cea-50a7-11e5-9007-eb1bf4b3409f.png)

![screenshot from 2015-09-01 12 41 51](https://cloud.githubusercontent.com/assets/11281373/9610477/df728436-50a7-11e5-9264-b19f4e4a9f3a.png)

![screenshot from 2015-09-01 12 41 55](https://cloud.githubusercontent.com/assets/11281373/9610482/e320cf5c-50a7-11e5-96c4-16f0f3a3f177.png)

![screenshot from 2015-09-01 12 42 08](https://cloud.githubusercontent.com/assets/11281373/9610486/e72f7ada-50a7-11e5-8bc5-ec775626c73c.png)

![screenshot from 2015-09-01 12 42 25](https://cloud.githubusercontent.com/assets/11281373/9610492/ea481c54-50a7-11e5-8d09-a7b627f0731d.png)

![screenshot from 2015-09-01 12 42 29](https://cloud.githubusercontent.com/assets/11281373/9610494/edc7280c-50a7-11e5-8725-12fcbb3fd1b3.png)
