### PR TITLE
Add NLCD layer as an overlay layer.

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -315,11 +315,13 @@ var MapView = Marionette.ItemView.extend({
                     });
                 } else {
                     var tileUrl = (layer.url.match(/png/) === null ?
-                                    layer.url + '.png' : layer.url);
+                                    layer.url + '.png' : layer.url),
+                        zIndex = layer.overlay ? 1 : 0;
 
                     leafletLayer = new L.TileLayer(tileUrl, {
                         attribution: layer.attribution || '',
-                        maxZoom: layer.maxZoom
+                        maxZoom: layer.maxZoom,
+                        zIndex: zIndex
                     });
                 }
 

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -82,6 +82,15 @@ LAYERS = [
         'overlay': True,
     },
     {
+        'display': 'National Land Cover Database',
+        'short_display': 'NLCD',
+        'helptext': 'National Land Cover Database defines'
+                    'land use across the U.S.',
+        'url': 'https://s3.amazonaws.com/com.azavea.datahub.tms/'
+               'nlcd/{z}/{x}/{y}.png',
+        'overlay': True,
+    },
+    {
         'code': 'stream-low',
         'display': 'Low-Res',
         'table_name': 'deldem4net100r',


### PR DESCRIPTION
* Add the National Land Cover Database layer as an overlay layer
option.

![screen shot 2015-09-02 at 11 56 10 am](https://cloud.githubusercontent.com/assets/1042475/9636485/a043edd2-5169-11e5-85ed-c5b17593d343.png)

**Testing Instructions**

- Verify that the layer control overlay tab contains the NLCD as a option and that turning it on adds tiles at zoom levels <= 13.

**Known issues**

Updated #741 with NLCD visibility issues.

Connects to #601