### PR TITLE
Fix scenario modification popup.

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -490,7 +490,7 @@ var MapView = Marionette.ItemView.extend({
                     return acc.concat(new L.GeoJSON(model.get('shape'), {
                             style: style,
                             onEachFeature: function(feature, layer) {
-                                if (self.interactiveMode) {
+                                if (self.options.interactiveMode) {
                                     var popupContent = new ModificationPopupView({ model: model }).render().el;
                                     layer.bindPopup(popupContent);
                                 }


### PR DESCRIPTION
* The interactiveMode property of the MapView is no longer
a direct property of the view, but is available in the view
options.

**Testing instructions**
- Create a new project with a scenario.
- Add a modification to an editable scenario.
- Click the modification. A pop-up should appear.

Connects to #751