### PR TITLE
Remember current project while navigating.

### DIFF
--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -23,7 +23,7 @@ var AnalyzeController = {
         if (settings.get('activityMode')) {
             // Only one project allowed in Activity Mode. Save current project
             // and if in embedded mode, update interactive state for container.
-            var project = App.currProject,
+            var project = App.currentProject,
                 map = App.map;
 
             if (project && project.get('scenarios').isEmpty()) {
@@ -43,7 +43,7 @@ var AnalyzeController = {
             // Multiple projects allowed in Regular Mode. Nullify current
             // project since a new one will be created and saved by the
             // Modelling Controller.
-            App.currProject = null;
+            App.currentProject = null;
         }
     },
 

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -30,7 +30,7 @@ var App = new Marionette.Application({
         });
 
         this._mapView.on('change:needs_reset', function(needs) {
-            App.currProject.set('needs_reset', needs);
+            App.currentProject.set('needs_reset', needs);
         });
 
         this.rootView = new views.RootView();
@@ -44,7 +44,7 @@ var App = new Marionette.Application({
 
         // Not set until modeling/controllers.js creates a
         // new project.
-        this.currProject = null;
+        this.currentProject = null;
     },
 
     load: function(data) {

--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -8,14 +8,14 @@ var _ = require('lodash'),
 
 var CompareController = {
     compare: function(projectId) {
-        if (App.currProject) {
+        if (App.currentProject) {
             setupProjectCopy();
             showCompareWindow();
         } else if (projectId) {
-            App.currProject = new modelingModels.ProjectModel({
+            App.currentProject = new modelingModels.ProjectModel({
                 id: projectId
             });
-            App.currProject
+            App.currentProject
                 .fetch()
                 .done(function() {
                     setupProjectCopy();
@@ -30,8 +30,8 @@ var CompareController = {
         App.origProject.off('change:id', updateUrl);
 
         // Switch back to the origProject so any changes are discarded.
-        App.currProject.off();
-        App.currProject = App.origProject;
+        App.currentProject.off();
+        App.currentProject = App.origProject;
 
         App.rootView.footerRegion.empty();
     }
@@ -43,7 +43,7 @@ function setupProjectCopy() {
       -Changes to the results and inputs are not saved to the server
       -Changes to the results and inputs are not present after hitting the back button (and project is unsaved).
        When the user is logged in as a guest, the only copy of the original inputs and results
-       are in App.currProject, and modifying these values in the compare views will result in those new
+       are in App.currentProject, and modifying these values in the compare views will result in those new
        values being back in the modeling views, which is not what we want.
       -The original project (without changes) is saved when logging in. If the user is a guest,
        goes into the compare views, and then logs in, the project should be saved with the inputs
@@ -51,8 +51,8 @@ function setupProjectCopy() {
        constraint that inputs and results entered in the compare views should never be saved.
        Without holding onto the original copies of these values, it's not possible to do this.
      */
-    App.origProject = App.currProject;
-    App.currProject = copyProject(App.origProject);
+    App.origProject = App.currentProject;
+    App.currentProject = copyProject(App.origProject);
 
     App.user.on('change:guest', saveAfterLogin);
     App.origProject.on('change:id', updateUrl);
@@ -93,7 +93,7 @@ function saveAfterLogin(user, guest) {
         App.origProject.get('scenarios').each(function(scenario) {
             scenario.set('user_id', user_id);
         });
-        // Save the origProject (as opposed to the currProject)
+        // Save the origProject (as opposed to the currentProject)
         // to not include changes to inputs and results.
         App.origProject.saveProjectAndScenarios();
     }
@@ -106,7 +106,7 @@ function updateUrl() {
 
 function showCompareWindow() {
     var compareWindow = new views.CompareWindow({
-            model: App.currProject
+            model: App.currentProject
         });
     App.rootView.footerRegion.show(compareWindow);
 }

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -220,7 +220,7 @@ var CompareModelingView = Marionette.LayoutView.extend({
     },
 
     showResult: function() {
-        var modelPackage = App.currProject.get('model_package'),
+        var modelPackage = App.currentProject.get('model_package'),
             resultModel = this.model.get('results').getActive(),
             ResultView = modelingViews.getResultView(modelPackage, resultModel.get('name'));
 

--- a/src/mmw/js/src/core/itsiEmbed.js
+++ b/src/mmw/js/src/core/itsiEmbed.js
@@ -43,7 +43,7 @@ var ItsiEmbed = function(App) {
             interactiveState.route &&
             interactiveState.route !== Backbone.history.getFragment()) {
 
-            App.currProject = null;
+            App.currentProject = null;
             router.navigate(interactiveState.route, { trigger: true });
         }
     };

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -150,7 +150,7 @@ var ShareView = ModalBaseView.extend({
 
             confirm.render();
             confirm.on('confirmation', function() {
-                var project = self.options.app.currProject;
+                var project = self.options.app.currentProject;
                 project.set('is_private', false);
                 project.saveProjectAndScenarios();
 

--- a/src/mmw/js/src/core/testUtils.js
+++ b/src/mmw/js/src/core/testUtils.js
@@ -23,9 +23,9 @@ function resetApp(app) {
 
     app.header.destroy();
 
-    if (app.currProject) {
-        app.currProject.off();
-        app.currProject = null;
+    if (app.currentProject) {
+        app.currentProject.off();
+        app.currentProject = null;
     }
 
     if (app.itsi) {

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -62,7 +62,7 @@ var DrawController = {
  */
 function enableSingleProjectModeIfActivity() {
     if (settings.get('activityMode')) {
-        if (!App.currProject) {
+        if (!App.currentProject) {
             var project = new modelingModels.ProjectModel({
                 name: 'New Activity',
                 created_at: Date.now(),
@@ -71,7 +71,7 @@ function enableSingleProjectModeIfActivity() {
                 is_activity: true,
                 needs_reset: true
             });
-            App.currProject = project;
+            App.currentProject = project;
         }
     }
 }

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -449,10 +449,15 @@ function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {
 }
 
 function clearAoiLayer() {
+    var projectNumber = App.projectNumber;
+
     App.map.set('areaOfInterest', null);
+    App.projectNumber = undefined;
+
     return function revertLayer() {
         var previousShape = App.map.previous('areaOfInterest');
         App.map.set('areaOfInterest', previousShape);
+        App.projectNumber = projectNumber;
     };
 }
 

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -25,7 +25,7 @@ var ModelingController = {
                 id: projectId
             });
 
-            App.currProject = project;
+            App.currentProject = project;
 
             project
                 .fetch()
@@ -57,8 +57,8 @@ var ModelingController = {
                     updateItsiFromEmbedMode();
                 });
         } else {
-            if (App.currProject && settings.get('activityMode')) {
-                project = App.currProject;
+            if (App.currentProject && settings.get('activityMode')) {
+                project = App.currentProject;
                 // Reset flag is set so clear off old project data.
                 if (project.get('needs_reset')) {
                     project.set({
@@ -107,7 +107,7 @@ var ModelingController = {
                     updateUrl();
                 }
             } else {
-                if (!App.currProject) {
+                if (!App.currentProject) {
                     // Only make new project if this is the first time
                     // hitting the modeling views.
                     project = new models.ProjectModel({
@@ -118,10 +118,10 @@ var ModelingController = {
                         scenarios: new models.ScenariosCollection()
                     });
 
-                    App.currProject = project;
+                    App.currentProject = project;
                     setupNewProjectScenarios(project);
                 } else {
-                    project = App.currProject;
+                    project = App.currentProject;
                     updateUrl();
                 }
 
@@ -135,8 +135,8 @@ var ModelingController = {
     },
 
     projectCleanUp: function() {
-        App.currProject.off('change:id', updateUrl);
-        App.currProject.get('scenarios').off('change:activeScenario change:id', updateScenario);
+        App.currentProject.off('change:id', updateUrl);
+        App.currentProject.get('scenarios').off('change:activeScenario change:id', updateScenario);
         App.getMapView().updateModifications(null);
         App.rootView.subHeaderRegion.empty();
         App.rootView.footerRegion.empty();
@@ -155,7 +155,7 @@ var ModelingController = {
             id: projectId
         });
 
-        App.currProject = project;
+        App.currentProject = project;
 
         project
             .fetch()
@@ -176,7 +176,7 @@ var ModelingController = {
                 }
             })
             .fail(function() {
-                App.currProject = null;
+                App.currentProject = null;
             })
             .always(function() {
                 router.navigate('/', { trigger: true });
@@ -192,7 +192,7 @@ function updateItsiFromEmbedMode() {
 
 function updateUrl() {
     // Use replace: true, so that the back button will work as expected.
-    router.navigate(App.currProject.getReferenceUrl(), { replace: true });
+    router.navigate(App.currentProject.getReferenceUrl(), { replace: true });
     updateItsiFromEmbedMode();
 }
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -477,8 +477,8 @@ var ScenarioModel = Backbone.Model.extend({
         this.get('inputs').on('add', debouncedFetchResults);
         this.get('modifications').on('add remove', debouncedFetchResults);
 
-        this.set('taskModel', App.currProject.createTaskModel());
-        this.set('results', App.currProject.createTaskResultCollection());
+        this.set('taskModel', App.currentProject.createTaskModel());
+        this.set('results', App.currentProject.createTaskResultCollection());
     },
 
     attemptSave: function() {
@@ -488,7 +488,7 @@ var ScenarioModel = Backbone.Model.extend({
         }
         if (!this.get('project')) {
             // TODO replace this with radio/wreqr or something less problematic than the global.
-            App.currProject.saveProjectAndScenarios();
+            App.currentProject.saveProjectAndScenarios();
             return;
         }
         if (this.isNew() && this.saveCalled) {
@@ -588,7 +588,7 @@ var ScenarioModel = Backbone.Model.extend({
                         inputs: self.get('inputs').toJSON(),
                         modifications: self.get('modifications').toJSON(),
                         modification_pieces: modifyModifications(self.get('modifications'), self.get('modification_hash')),
-                        area_of_interest: App.currProject.get('area_of_interest'),
+                        area_of_interest: App.currentProject.get('area_of_interest'),
                         census: self.get('census'),
                         inputmod_hash: self.get('inputmod_hash'),
                         modification_hash: self.get('modification_hash')

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -27,9 +27,9 @@ describe('Modeling', function() {
 
     beforeEach(function() {
         // ScenarioModel.initialize() expects
-        // App.currProject to be set, and uses it to determine the
+        // App.currentProject to be set, and uses it to determine the
         // taskModel and modelPackage to use.
-        App.currProject = new models.ProjectModel();
+        App.currentProject = new models.ProjectModel();
 
         this.server = sinon.fakeServer.create();
         this.server.respondImmediately = true;
@@ -595,11 +595,11 @@ describe('Modeling', function() {
                                      new models.ModificationsCollection(mocks.scenarios.sample.modifications).toJSON(),
                                      'Should set modifications from argument to initialize');
                     assert.deepEqual(this.model.get('taskModel').toJSON(),
-                                     App.currProject.createTaskModel().toJSON(),
-                                     'Should have set taskModel from App.currProject');
+                                     App.currentProject.createTaskModel().toJSON(),
+                                     'Should have set taskModel from App.currentProject');
                     assert.deepEqual(this.model.get('results').toJSON(),
-                                     App.currProject.createTaskResultCollection().toJSON(),
-                                     'Should have set results from App.currProject');
+                                     App.currentProject.createTaskResultCollection().toJSON(),
+                                     'Should have set results from App.currentProject');
                 });
 
                 it('sets hashes', function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -215,7 +215,7 @@ var ProjectMenuView = Marionette.ItemView.extend({
     getItsiEmbedLink: function() {
         var self = this,
             embedLink = window.location.origin +
-                '/project/' + App.currProject.id + '/clone?itsi_embed=true',
+                '/project/' + App.currentProject.id + '/clone?itsi_embed=true',
             modal = new modalViews.ShareView({
                 model: new modalModels.ShareModel({
                     text: 'Embed Link',
@@ -389,7 +389,7 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
                     text: 'Scenario',
                     url: window.location.href,
                     guest: App.user.get('guest'),
-                    is_private: App.currProject.get('is_private')
+                    is_private: App.currentProject.get('is_private')
                 }),
                 app: App
             });
@@ -763,7 +763,7 @@ var ResultsTabContentView = Marionette.LayoutView.extend({
     },
 
     onShow: function() {
-        var modelPackage = App.currProject.get('model_package'),
+        var modelPackage = App.currentProject.get('model_package'),
             resultName = this.model.get('name'),
             ResultView = getResultView(modelPackage, resultName);
 


### PR DESCRIPTION
It is now possible to navigate away from the /project page using the UI arrow buttons then return (using the UI arrow buttons) back to the project on which you have been working.

Connects #690

**To Test**
   * Do some activities which take you to the `/project` page.
   * Navigate away from the project page using the UI arrow buttons (back to the `/analyze` page or back to the root page), then back to the `/project` page.
   * You should find yourself back on the project that you were on when you left.

**Caveats**
   * I originally wanted to be able to take you back to the scenario that you had been working on, but unfortunately,this seems difficult.  One cannot set the scenario unless the DOM is in particular state: I am not able to give a precise description of this state and moreover I do not know how to wait for such a state without polling, which is a no-no (the usual expedient of releasing a lock within the `onShow`, `onRender` and `onAttach` functions of the views which create the DOM elements which I believe are required did not work).