### PR TITLE
Overlay Alpha

### DIFF
--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -107,7 +107,7 @@ JS_DEPS=(jquery backbone backbone.marionette bootstrap bootstrap-select \
          leaflet leaflet-draw leaflet.locatecontrol leaflet-plugins lodash \
          underscore d3 nunjucks turf-area turf-bbox-polygon turf-buffer \
          turf-destination turf-erase turf-intersect turf-random zeroclipboard \
-	 blueimp-md5 iframe-phone)
+         blueimp-md5 iframe-phone)
 BROWSERIFY_EXT=""
 BROWSERIFY_REQ=""
 for DEP in "${JS_DEPS[@]}"

--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -15,7 +15,7 @@ module.exports = L.Control.Layers.extend({
         this._form = $(container).find('form').get(0);
 
         // Copied directly from the parent class.
-        // makes this work on IE touch devices by stopping it 
+        // makes this work on IE touch devices by stopping it
         // from firing a mouseout event when the touch is released
         container.setAttribute('aria-haspopup', true);
 
@@ -49,6 +49,53 @@ module.exports = L.Control.Layers.extend({
         var container = new LayerControlView({}).render().el;
 
         return container;
+    },
+
+    // Copied verbatim from
+    // https://github.com/Leaflet/Leaflet/blob/master/src/control/Control.Layers.js
+    // except for the two if clauses to (respectively) remove and add
+    // the opacity slider.
+    _onInputClick: function () {
+        var inputs = this._form.getElementsByTagName('input'),
+            input, layer, hasLayer,
+            addedLayers = [],
+            removedLayers = [];
+
+        this._handlingClick = true;
+
+        for (var i = inputs.length - 1; i >= 0; i--) {
+            input = inputs[i];
+            layer = this._layers[input.layerId].layer;
+            hasLayer = this._map.hasLayer(layer);
+
+            if (input.checked && !hasLayer) {
+                addedLayers.push(layer);
+            } else if (!input.checked && hasLayer) {
+                removedLayers.push(layer);
+            }
+        }
+
+        // Bugfix issue 2318: Should remove all old layers before readding new ones
+        for (i = 0; i < removedLayers.length; i++) {
+            var removedLayer = removedLayers[i],
+                removedSlider = removedLayer.slider;
+            this._map.removeLayer(removedLayer);
+            if (removedSlider) {
+                this._map.removeControl(removedSlider);
+            }
+        }
+        for (i = 0; i < addedLayers.length; i++) {
+            var addedLayer = addedLayers[i],
+                addedSlider = addedLayer.slider;
+            this._map.addLayer(addedLayer);
+            if (addedSlider) {
+                this._map.addControl(addedSlider);
+            }
+        }
+
+        this._handlingClick = false;
+
+        this._refocusOnMap();
     }
 });
 

--- a/src/mmw/js/src/core/opacityControl.js
+++ b/src/mmw/js/src/core/opacityControl.js
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2013, Jared Dominguez
+Copyright (c) 2013, LizardTech
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+* Neither the name of LizardTech nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+        Leaflet.OpacityControls, a plugin for adjusting the opacity of a Leaflet map.
+        (c) 2013, Jared Dominguez
+        (c) 2013, LizardTech
+
+        https://github.com/lizardtechblog/Leaflet.OpacityControls
+
+
+Modified by Azavea, 2015.
+*/
+
+'use strict';
+
+var L = require('leaflet'),
+    $ = require('jquery'),
+    Marionette = require('../../shim/backbone.marionette'),
+    sliderTmpl = require('./templates/opacitySlider.html');
+
+module.exports = L.Control.extend({
+    options: {
+        position: 'topright'
+    },
+
+    setOpacityLayer: function (layer) {
+            this.opacityLayer = layer;
+    },
+
+    onAdd: function (map) {
+        var opacity_slider_div = L.DomUtil.create('div', 'opacity_slider_control'),
+            opacityLayer = this.opacityLayer,
+            view = new SliderView().render().el;
+
+        $(view).on('mousedown', function() {
+            map.dragging.disable();
+            map.once('mousedown', function() {
+                map.dragging.enable();
+            });
+        });
+
+        $(view).on('mouseup', function(e) {
+            var slider_value = $(e.toElement).val();
+            opacityLayer.setOpacity(slider_value / 100);
+        });
+
+        $(opacity_slider_div).append(view);
+        $(view).find('input').val(opacityLayer.options.opacity * 100);
+
+        return opacity_slider_div;
+    }
+});
+
+var SliderView = Marionette.ItemView.extend({
+    template: sliderTmpl
+});

--- a/src/mmw/js/src/core/templates/opacitySlider.html
+++ b/src/mmw/js/src/core/templates/opacitySlider.html
@@ -1,0 +1,3 @@
+<div class="btn-md btn-primary">
+  <input type="range" orient="vertical" min="0" max="99" step="3">
+</div>

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -328,11 +328,8 @@ var MapView = Marionette.ItemView.extend({
                                     layer.url + '.png' : layer.url),
                         zIndex = layer.overlay ? 1 : 0;
 
-                    leafletLayer = new L.TileLayer(tileUrl, {
-                        attribution: layer.attribution || '',
-                        maxZoom: layer.maxZoom,
-                        zIndex: zIndex
-                    });
+                    _.defaults(layer, {zIndex: zIndex, attribution: ''});
+                    leafletLayer = new L.TileLayer(tileUrl, layer);
                 }
 
                 layers[layer['display']] = leafletLayer;

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -15,7 +15,8 @@ var L = require('leaflet'),
     modalViews = require('./modals/views'),
     settings = require('./settings'),
     LayerControl = require('./layerControl'),
-    StreamSliderControl = require('./streamSliderControl');
+    StreamSliderControl = require('./streamSliderControl'),
+    OpacityControl = require('./opacityControl');
 
 require('leaflet.locatecontrol');
 require('leaflet-plugins/layer/tile/Google');
@@ -330,6 +331,12 @@ var MapView = Marionette.ItemView.extend({
 
                     _.defaults(layer, {zIndex: zIndex, attribution: ''});
                     leafletLayer = new L.TileLayer(tileUrl, layer);
+                    if (layer.has_opacity_slider) {
+                        var slider = new OpacityControl();
+
+                        slider.setOpacityLayer(leafletLayer);
+                        leafletLayer.slider = slider;
+                    }
                 }
 
                 layers[layer['display']] = leafletLayer;

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -107,6 +107,7 @@ LAYERS = [
         'maxNativeZoom': 13,
         'maxZoom': 18,
         'opacity': 0.618,
+        'has_opacity_slider': True
     },
     {
         'code': 'stream-low',

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -104,6 +104,9 @@ LAYERS = [
         'url': 'https://s3.amazonaws.com/com.azavea.datahub.tms/'
                'nlcd/{z}/{x}/{y}.png',
         'overlay': True,
+        'maxNativeZoom': 13,
+        'maxZoom': 18,
+        'opacity': 0.618,
     },
     {
         'code': 'stream-low',

--- a/src/mmw/sass/components/_inputs.scss
+++ b/src/mmw/sass/components/_inputs.scss
@@ -138,3 +138,12 @@
     to  { width:0; background:transparent; }
   }
 }
+
+input[type=range][orient=vertical]
+{
+    writing-mode: bt-lr; /* IE */
+    -webkit-appearance: slider-vertical; /* WebKit */
+    width: 8px;
+    height: 175px;
+    padding: 0 5px;
+}

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -60,7 +60,7 @@
   "components/slider-native",
   "components/tables";
 
-  /**
+/**
  * Pages
  */
 @import

--- a/src/mmw/sass/opacity-control/Control.Opacity.scss
+++ b/src/mmw/sass/opacity-control/Control.Opacity.scss
@@ -1,0 +1,5 @@
+.opacity_slider_control .ui-slider-range {
+    background-image: none;
+    background-color: #646464;
+    height: 200px;
+}  


### PR DESCRIPTION
This patch adds the capability to give overlay layers independent opacity sliders.  Only the *NLCD* layer has been so-equipped.

Connects #755 

The NLCD overlay layer has also been stretched so that it does not disappear when the user zooms in beyond level 13.

Connects #757 

**To Test**
   * Select the NLCD overlay
   * A slider should appear in the upper-right corner of the map when the layer is toggled on.  That slider will allow you to adjust the opacity of the layer.  The slider will disappear when the layer is toggled off (#755).
   * Zoom in past level 13.  Notice that instead of disappearing, the NLCD tiles are stretched (#757)

**Caveats**
   * Probably needs attention from designer.