### PR TITLE
Add Google Analytics

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -12,6 +12,16 @@
     <link rel="icon" type="image/png" href="{% static 'favicon@2x.png' %}" sizes="32x32">
     <link rel="stylesheet" href="{% static 'css/vendor.css' %}" />
     <link rel="stylesheet" href="{% static 'css/main.css' %}" />
+    <!-- Google Analytics -->
+    <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '{{ GOOGLE_ANALYTICS_ACCOUNT }}', 'auto');
+        ga('send', 'pageview');
+    </script>
 </head>
 
 <body>

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -8,6 +8,7 @@ from urlparse import urljoin
 
 from django.http import Http404
 from django.shortcuts import render_to_response, get_object_or_404, redirect
+from django.template import RequestContext
 from django.template.context_processors import csrf
 from django.conf import settings
 
@@ -123,7 +124,7 @@ def get_client_settings(request):
 
 
 def get_context(request):
-    context = {}
+    context = RequestContext(request)
     context.update(csrf(request))
     context.update(get_client_settings(request))
 

--- a/src/mmw/mmw/context_processors.py
+++ b/src/mmw/mmw/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def google_analytics_account(request):
+    return {'GOOGLE_ANALYTICS_ACCOUNT': settings.GOOGLE_ANALYTICS_ACCOUNT}

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -225,6 +225,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.tz',
     'django.contrib.messages.context_processors.messages',
     'django.core.context_processors.request',
+    'mmw.context_processors.google_analytics_account',
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders

--- a/src/mmw/mmw/settings/development.py
+++ b/src/mmw/mmw/settings/development.py
@@ -74,3 +74,6 @@ DEBUG_TOOLBAR_CONFIG = {
 
 # API key for testing/development
 GOOGLE_MAPS_API_KEY = 'AIzaSyB0D5gjoIHpmy-xdP2cr_0I-E7K6s_L0k4'
+
+# azaveadev@azavea.com account
+GOOGLE_ANALYTICS_ACCOUNT = 'UA-67319750-1'

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -76,3 +76,6 @@ PRIVATE_AWS_STORAGE_URL_PROTOCOL = 'https:'
 
 # Google API key for production deployment
 GOOGLE_MAPS_API_KEY = 'AIzaSyCXdkywU7rps_i1CeKqWxlBi97vyGeXsqk'
+
+# Stroud account
+GOOGLE_ANALYTICS_ACCOUNT = 'UA-47047573-7'

--- a/src/mmw/mmw/settings/test.py
+++ b/src/mmw/mmw/settings/test.py
@@ -30,3 +30,6 @@ REST_FRAMEWORK = {
 
 # API key for testing/development
 GOOGLE_MAPS_API_KEY = 'AIzaSyB0D5gjoIHpmy-xdP2cr_0I-E7K6s_L0k4'
+
+# azaveadev@azavea.com account
+GOOGLE_ANALYTICS_ACCOUNT = 'UA-67319750-1'


### PR DESCRIPTION
* Add Google Analytics snippet to base template.
* Use context processor to add Google Analytics account
to request context based on environment settings.

**Testing instructions:**
- Verify that the Google Analytics snippet is present on the homepage and the project page when visited directly.
- Verify that the account number is populated in the Google Analytics snippet and matches the value from the `development.py` settings file.

Connects to #698