### PR TITLE
Feature/lol/move stream layer tool

### DIFF
--- a/src/mmw/js/src/core/streamSliderControl.js
+++ b/src/mmw/js/src/core/streamSliderControl.js
@@ -1,0 +1,112 @@
+'use strict';
+
+var L = require('leaflet'),
+    Marionette = require('../../shim/backbone.marionette'),
+    streamSliderTmpl = require('./templates/streamSlider.html'),
+    settings = require('./settings');
+
+module.exports = L.Control.extend({
+    options: {
+        position: 'bottomright'
+    },
+
+    initialize: function (foo, options) {
+        L.Util.setOptions(this, options);
+        this.streamFeatures = L.featureGroup();
+    },
+
+    onAdd: function(map) {
+        var container = this.createContainer();
+        // Copied directly from the parent class.
+        if (!L.Browser.touch) {
+            L.DomEvent
+                .disableClickPropagation(container)
+                .disableScrollPropagation(container);
+        } else {
+            L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
+        }
+        this.streamFeatures.addTo(map);
+        return container;
+    },
+
+    createContainer: function() {
+        var container = new StreamSliderView({
+            streamFeatures: this.streamFeatures 
+        }).render().el;
+        return container;
+    }
+});
+
+var StreamSliderView = Marionette.ItemView.extend({
+    template: streamSliderTmpl,
+
+    ui: {
+        close: '.close',
+        controlToggle: '.leaflet-bar-part',
+        slider: '#stream-slider',
+        displayValue: '#stream-value',
+        streamControl: '.leaflet-control-stream'
+    },
+
+    events: {
+        'click @ui.close': 'close',
+        'click @ui.controlToggle': 'toggle',
+        'input @ui.slider': 'onSliderDragged',
+        'change @ui.slider': 'onSliderChanged'
+    },
+
+    initialize: function(options) {
+        this.streamFeatures = options.streamFeatures;
+        this.streamLayers = settings.get('stream_layers');
+    },
+
+    onShow: function() {
+        this.onSliderDragged();
+    },
+
+    getSliderIndex: function() {
+        return parseInt(this.ui.slider.val());
+    },
+
+    getSliderDisplay: function() {
+        var ind = this.getSliderIndex();
+        if (ind === 0) {
+            return 'Off';
+        } else {
+            return this.streamLayers[ind-1].display;
+        }
+    },
+    
+    close: function() {
+        this.$el.find(this.ui.streamControl).hide();
+    },
+
+    toggle: function() {
+        this.$el.find(this.ui.streamControl).toggle();
+    },
+
+    onSliderDragged: function() {
+        // Preview slider value while dragging.
+        this.ui.displayValue.text(this.getSliderDisplay());
+    },
+
+    onSliderChanged: function() {
+        var ind = this.getSliderIndex();
+        clearStreamLayer(this.streamFeatures);
+        if (ind > 0) {
+            var streamLayer = this.streamLayers[ind-1];
+            changeStreamLayer(streamLayer.url, this.streamFeatures);
+        }
+    }
+});
+
+function clearStreamLayer(streamFeatures) {
+    streamFeatures.clearLayers();
+}
+
+function changeStreamLayer(url, streamFeatures) {
+    var streamLayer = new L.TileLayer(url + '.png');
+
+    streamFeatures.addLayer(streamLayer);
+    streamLayer.bringToFront();
+}

--- a/src/mmw/js/src/core/templates/layerControlContainer.html
+++ b/src/mmw/js/src/core/templates/layerControlContainer.html
@@ -1,23 +1,21 @@
-<div>
-    <div class="layer-control-button-container leaflet-control leaflet-bar">
-        <a class="leaflet-bar-part leaflet-bar-part-single" href="#" title="Show layer control">
-            <span class="fa fa-globe"></span>
-        </a>
-    </div>
-    <div class="leaflet-control-layers">
-        <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title">Layers</h4>
-          </div>
-        <ul class="nav nav-tabs" role="tablist">
-            <li role="presentation" class="active"><a href="#basemap-layer-list" aria-controls="basemap" role="tab" data-toggle="tab">Basemap</a></li>
-            <li role="presentation"><a href="#overlays-layer-list" aria-controls="overlays" role="tab" data-toggle="tab">Overlays</a></li>
-        </ul>
-        <form class="leaflet-control-layers-list">
-           <div class="tab-content">
-              <div role="tabpanel" class="tab-pane active" id="basemap-layer-list"></div>
-              <div role="tabpanel" class="tab-pane" id="overlays-layer-list"></div>
-            </div>
-        </form>
-    </div>
+<div class="layer-control-button-container leaflet-control leaflet-bar">
+    <a class="leaflet-bar-part leaflet-bar-part-single" href="#" title="Show layer control">
+        <span class="fa fa-globe"></span>
+    </a>
+</div>
+<div class="leaflet-control-layers">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Layers</h4>
+        </div>
+    <ul class="nav nav-tabs" role="tablist">
+        <li role="presentation" class="active"><a href="#basemap-layer-list" aria-controls="basemap" role="tab" data-toggle="tab">Basemap</a></li>
+        <li role="presentation"><a href="#overlays-layer-list" aria-controls="overlays" role="tab" data-toggle="tab">Overlays</a></li>
+    </ul>
+    <form class="leaflet-control-layers-list">
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="basemap-layer-list"></div>
+            <div role="tabpanel" class="tab-pane" id="overlays-layer-list"></div>
+        </div>
+    </form>
 </div>

--- a/src/mmw/js/src/core/templates/streamSlider.html
+++ b/src/mmw/js/src/core/templates/streamSlider.html
@@ -1,17 +1,15 @@
-<div>
-    <div class="leaflet-control-stream-container leaflet-control leaflet-bar">
-        <a class="leaflet-bar-part leaflet-bar-part-single" href="#" title="Show stream control">
-            <span class="fa fa-random"></span>
-        </a>
+<div class="leaflet-control-stream-container leaflet-control leaflet-bar">
+    <a class="leaflet-bar-part leaflet-bar-part-single" href="#" title="Show stream control">
+        <span class="fa fa-random"></span>
+    </a>
+</div>
+<div class="leaflet-control-stream">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Streams</h4>
     </div>
-    <div class="leaflet-control-stream">
-        <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title">Streams</h4>
-        </div>
-        <form>
-            <input id="stream-slider" type="range" min="0" max="3" step="1" value="0">
-            <span id="stream-value">Off</span>
-        </form>
-    </div>
+    <form>
+        <input id="stream-slider" type="range" min="0" max="3" step="1" value="0">
+        <span id="stream-value">Off</span>
+    </form>
 </div>

--- a/src/mmw/js/src/core/templates/streamSlider.html
+++ b/src/mmw/js/src/core/templates/streamSlider.html
@@ -1,0 +1,17 @@
+<div>
+    <div class="leaflet-control-stream-container leaflet-control leaflet-bar">
+        <a class="leaflet-bar-part leaflet-bar-part-single" href="#" title="Show stream control">
+            <span class="fa fa-random"></span>
+        </a>
+    </div>
+    <div class="leaflet-control-stream">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title">Streams</h4>
+        </div>
+        <form>
+            <input id="stream-slider" type="range" min="0" max="3" step="1" value="0">
+            <span id="stream-value">Off</span>
+        </form>
+    </div>
+</div>

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -14,7 +14,8 @@ var L = require('leaflet'),
     modalModels = require('./modals/models'),
     modalViews = require('./modals/views'),
     settings = require('./settings'),
-    LayerControl = require('./layerControl');
+    LayerControl = require('./layerControl'),
+    StreamSliderControl = require('./streamSliderControl');
 
 require('leaflet.locatecontrol');
 require('leaflet-plugins/layer/tile/Google');
@@ -163,6 +164,7 @@ var MapView = Marionette.ItemView.extend({
             addZoomControl: true,
             addLocateMeButton: true,
             addLayerSelector: true,
+            addStreamControl: true,
             showLayerAttribution: true,
             initialLayerName: defaultLayerName,
             interactiveMode: true // True if clicking on map does stuff
@@ -191,6 +193,14 @@ var MapView = Marionette.ItemView.extend({
 
         if (options.addLayerSelector) {
             this.layerControl = new LayerControl(this.baseLayers, this.overlayLayers, {
+                autoZIndex: false,
+                position: 'bottomright',
+                collapsed: false
+            }).addTo(map);
+        }
+
+        if (options.addStreamControl) {
+            this.layerControl = new StreamSliderControl({
                 autoZIndex: false,
                 position: 'bottomright',
                 collapsed: false

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -16,9 +16,7 @@ var $ = require('jquery'),
     selectTypeTmpl = require('./templates/selectType.html'),
     drawTmpl = require('./templates/draw.html'),
     resetDrawTmpl = require('./templates/reset.html'),
-    streamSliderTmpl = require('./templates/streamSlider.html'),
-    placeMarkerTmpl = require('./templates/placeMarker.html'),
-    settings = require('../core/settings');
+    placeMarkerTmpl = require('./templates/placeMarker.html');
 
 // Responsible for loading and displaying tools for selecting and drawing
 // shapes on the map.
@@ -66,9 +64,6 @@ var ToolbarView = Marionette.LayoutView.extend({
             model: this.model
         }));
         this.resetRegion.show(new ResetDrawView({
-            model: this.model
-        }));
-        this.streamRegion.show(new StreamSliderView({
             model: this.model
         }));
     }
@@ -329,67 +324,6 @@ var ResetDrawView = Marionette.ItemView.extend({
         clearBoundaryLayer(this.model);
     }
 });
-
-var StreamSliderView = Marionette.ItemView.extend({
-    template: streamSliderTmpl,
-
-    ui: {
-        slider: '#stream-slider',
-        displayValue: '#stream-value'
-    },
-
-    events: {
-        'input @ui.slider': 'onSliderDragged',
-        'change @ui.slider': 'onSliderChanged'
-    },
-
-    initialize: function() {
-        this.streamLayers = settings.get('stream_layers');
-    },
-
-    onShow: function() {
-        this.onSliderDragged();
-    },
-
-    getSliderIndex: function() {
-        return parseInt(this.ui.slider.val());
-    },
-
-    getSliderDisplay: function() {
-        var ind = this.getSliderIndex();
-        if (ind === 0) {
-            return 'Off';
-        } else {
-            return this.streamLayers[ind-1].display;
-        }
-    },
-
-    onSliderDragged: function() {
-        // Preview slider value while dragging.
-        this.ui.displayValue.text(this.getSliderDisplay());
-    },
-
-    onSliderChanged: function() {
-        var ind = this.getSliderIndex();
-        clearStreamLayer(this.model);
-        if (ind > 0) {
-            var streamLayer = this.streamLayers[ind-1];
-            changeStreamLayer(streamLayer.url, this.model);
-        }
-    }
-});
-
-function clearStreamLayer(model) {
-    model.get('streamFeatureGroup').clearLayers();
-}
-
-function changeStreamLayer(url, model) {
-    var sfg = model.get('streamFeatureGroup'),
-        sl = new L.TileLayer(url + '.png');
-
-    sfg.addLayer(sl);
-    sl.bringToFront();
-}
 
 function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {
     // The shapeId might not be available at the time of the click

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -374,7 +374,7 @@ var StreamSliderView = Marionette.ItemView.extend({
         clearStreamLayer(this.model);
         if (ind > 0) {
             var streamLayer = this.streamLayers[ind-1];
-            changeStreamLayer(streamLayer.endpoint, this.model);
+            changeStreamLayer(streamLayer.url, this.model);
         }
     }
 });
@@ -383,9 +383,9 @@ function clearStreamLayer(model) {
     model.get('streamFeatureGroup').clearLayers();
 }
 
-function changeStreamLayer(endpoint, model) {
+function changeStreamLayer(url, model) {
     var sfg = model.get('streamFeatureGroup'),
-        sl = new L.TileLayer(endpoint + '.png');
+        sl = new L.TileLayer(url + '.png');
 
     sfg.addLayer(sl);
     sl.bringToFront();

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -40,48 +40,23 @@
 .leaflet-control-layers-expanded {
   padding: 0;
   background-color: transparent;
+}
 
-  .layer-control-button-container {
-    position: absolute;
-    bottom: 0px;
-    right: 0px;
-    margin-bottom: 0;
-    margin-right: 0;
-  }
-
+.leaflet-control {
   .leaflet-control-layers {
     min-width: 220px;
     min-height: 230px;
     margin-right: 50px;
     display: none;
-
-    .modal-header {
-      background-color: $ui-primary;
-      color: $paper;
-
-      .modal-title {
-        font-size: 14px;
-       }
-    }
-
-    form {
-      padding: 15px;
-    }
-
-    .close {
-      text-shadow: none;
-      color: $paper;
-      font-size: 18px;
-    }
   }
-}
 
-.leaflet-control-stream {
-  min-width: 220px;
-  min-height: 100px;
-  margin-right: 50px;
-  background-color: #fff;
-  display: none;
+  .leaflet-control-stream {
+    min-width: 220px;
+    min-height: 100px;
+    margin-right: 50px;
+    background-color: #fff;
+    display: none;
+  }
 
   .modal-header {
     background-color: $ui-primary;

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -75,3 +75,30 @@
     }
   }
 }
+
+.leaflet-control-stream {
+  min-width: 220px;
+  min-height: 100px;
+  margin-right: 50px;
+  background-color: #fff;
+  display: none;
+
+  .modal-header {
+    background-color: $ui-primary;
+    color: $paper;
+
+    .modal-title {
+      font-size: 14px;
+     }
+  }
+
+  form {
+    padding: 15px;
+  }
+
+  .close {
+    text-shadow: none;
+    color: $paper;
+    font-size: 18px;
+  }
+}


### PR DESCRIPTION
Connects #763

Provides a custom leaflet control to show and hide the stream selector.

To test:
 * Find the new map control and click it.
 * Move slider back and forth.
 * Ensure streams appear.

Notes:
 * Need a custom icon to match the mocks. Used some "streamy" looking arrows for the time being.
 * Controls jump upon opening. Could use some designer love to prevent this.