### PR TITLE
Text Changes

### DIFF
--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -54,6 +54,8 @@ var AnalyzeController = {
                 model: createTaskModel(aoi)
             });
 
+        App.state.set('current_page_title', 'Geospatial Analysis');
+
         App.rootView.footerRegion.show(analyzeWindow);
     },
 

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -13,6 +13,7 @@ var App = new Marionette.Application({
     initialize: function() {
         this.restApi = new RestAPI();
         this.map = new models.MapModel();
+        this.state = new models.AppStateModel();
 
         // If in embed mode we are by default in activity mode.
         var activityMode = settings.get('itsi_embed');
@@ -38,8 +39,10 @@ var App = new Marionette.Application({
 
         this.header = new views.HeaderView({
             el: 'header',
-            model: this.user
+            model: this.user,
+            appState: this.state
         });
+
         this.header.render();
 
         // Not set until modeling/controllers.js creates a

--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -23,6 +23,8 @@ var CompareController = {
                 });
         }
         // else -- this case is caught by the backend and raises a 404
+
+        App.state.set('current_page_title', 'Compare');
     },
 
     compareCleanUp: function() {

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -219,10 +219,17 @@ var AreaOfInterestModel = GeoModel.extend({
     }, GeoModel.prototype.defaults)
 });
 
+var AppStateModel = Backbone.Model.extend({
+    defaults: {
+        current_page_title: 'Select Area of Interest'
+    }
+});
+
 module.exports = {
     MapModel: MapModel,
     TaskModel: TaskModel,
     DataCollection: DataCollection,
     GeoModel: GeoModel,
-    AreaOfInterestModel: AreaOfInterestModel
+    AreaOfInterestModel: AreaOfInterestModel,
+    AppStateModel: AppStateModel
 };

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -1,5 +1,5 @@
 <nav id="app-header" class="navbar-watershed">
-    <div class="brand"><a href="#">Model My Watershed</a></div>
+    <div class="brand"><a href="#">Model My Watershed: {{ current_page_title }}</a></div>
     <div class="navigation">
         <ul class="main">
             <li class="header-link"><a href="#">Community</a></li>

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -252,6 +252,20 @@ describe('Core', function() {
                 view.destroy();
             });
         });
+
+        describe('HeaderView', function() {
+            it('shows the current page', function() {
+                var appState = new models.AppStateModel({
+                        current_page_title: 'Test Page'
+                    }),
+                    header = new views.HeaderView({
+                        model: App.user,
+                        appState: appState
+                    }).render();
+
+                assert.include(header.$el.find('.brand').text(), 'Test Page');
+            });
+        });
     });
 
     describe('Models', function() {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -53,6 +53,19 @@ var HeaderView = Marionette.ItemView.extend({
         'change': 'render'
     },
 
+    initialize: function() {
+        this.appState = this.options.appState;
+        this.listenTo(this.appState, 'change', this.render);
+    },
+
+    templateHelpers: function() {
+        var self = this;
+
+        return {
+            'current_page_title': self.appState.get('current_page_title')
+        };
+    },
+
     showLogin: function() {
         // Defer requiring app until needed as it is not defined when
         // core.views are initialized (they are required in app.js)

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -45,6 +45,7 @@ var DrawController = {
             App.rootView.footerRegion.show(aoiView);
         }
 
+        App.state.set('current_page_title', 'Choose Area of Interest');
     },
 
     drawCleanUp: function() {

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -9,34 +9,6 @@ var $ = require('jquery'),
     views = require('./views'),
     models = require('./models');
 
-function makeProject(lock) {
-    var project = new models.ProjectModel({
-        name: 'Untitled Project',
-        created_at: Date.now(),
-        area_of_interest: App.map.get('areaOfInterest'),
-        area_of_interest_name: App.map.get('areaOfInterestName'),
-        scenarios: new models.ScenariosCollection()
-    });
-    lock.resolve();
-    return project;
-}
-
-function reinstateProject(number, lock) {
-    var project = new models.ProjectModel({id: App.projectNumber});
-
-    project
-        .fetch()
-        .done(function() {
-            App.map.set({
-                'areaOfInterest': project.get('area_of_interest'),
-                'areaOfInterestName': project.get('area_of_interest_name')
-            });
-            lock.resolve();
-        });
-
-    return project;
-}
-
 var ModelingController = {
     projectPrepare: function(projectId) {
         if (!projectId && !App.map.get('areaOfInterest')) {
@@ -276,6 +248,35 @@ function initViews(project) {
     App.rootView.subHeaderRegion.show(modelingHeader);
     App.rootView.footerRegion.show(modelingResultsWindow);
 }
+
+function makeProject(lock) {
+    var project = new models.ProjectModel({
+        name: 'Untitled Project',
+        created_at: Date.now(),
+        area_of_interest: App.map.get('areaOfInterest'),
+        area_of_interest_name: App.map.get('areaOfInterestName'),
+        scenarios: new models.ScenariosCollection()
+    });
+    lock.resolve();
+    return project;
+}
+
+function reinstateProject(number, lock) {
+    var project = new models.ProjectModel({id: App.projectNumber});
+
+    project
+        .fetch()
+        .done(function() {
+            App.map.set({
+                'areaOfInterest': project.get('area_of_interest'),
+                'areaOfInterestName': project.get('area_of_interest_name')
+            });
+            lock.resolve();
+        });
+
+    return project;
+}
+
 
 module.exports = {
     ModelingController: ModelingController

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -139,6 +139,8 @@ var ModelingController = {
                 });
             }
         }
+
+        App.state.set('current_page_title', 'Model');
     },
 
     projectCleanUp: function() {

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -56,16 +56,16 @@ var ResultView = Marionette.ItemView.extend({
                 this.$el.addClass('current-conditions');
             } else if (this.scenario.get('is_current_conditions')) {
                 // Show the unmodified results and the unmodified
-                // Pre-Columbian results.
+                // Pre-Columbian (a.k.a. "100% Forest") results.
                 data = [
                     getBarData('Current Conditions', 'unmodified'),
-                    getBarData('Pre-Columbian', 'pc_unmodified')
+                    getBarData('100% Forest', 'pc_unmodified')
                 ];
             } else {
                 // Show the unmodified results and the modified
                 // results.
                 data = [
-                    getBarData('Original', 'unmodified'),
+                    getBarData('Current Conditions', 'unmodified'),
                     getBarData('Modified', 'modified')
                 ];
             }

--- a/src/mmw/js/src/user/tests.js
+++ b/src/mmw/js/src/user/tests.js
@@ -127,7 +127,8 @@ describe('User', function() {
                 app: App
             }).render();
             var header = new coreViews.HeaderView({
-                model: App.user
+                model: App.user,
+                appState: App.state
             }).render();
 
             // Activate modal and make sure it is visible.


### PR DESCRIPTION
Update modeling bar chart titles and show the page title in the header. See commit messages for details.

**Testing instructions:**

Bar chart titles
- Create a new project or open an existing one.
- Verify that the second chart for the current conditions scenario is titled "100% Forest"
- Verify that the first chart for any other scenario is titled "Current Conditions".

Page header
- On each page of the app, verify that the title is shown in the header.
- Visit the project page directly and verify that the page title is in the header.

While it is helpful to add a title to each page, I think the current location is problematic. It feels like the title should be on a line below the app title or otherwise differentiated. In it's current placement, it looks like it's the subtitle to the app, rather than the bread crumb or current location. cc @jfrankl.

![screen shot 2015-09-08 at 5 05 51 pm](https://cloud.githubusercontent.com/assets/1042475/9747502/e4032a9c-564b-11e5-8b17-cfbb69276087.png)

Connects to #767