### PR TITLE
Make draw tools configurable

### DIFF
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -116,6 +116,8 @@ def get_client_settings(request):
             'stream_layers': get_layer_config('stream'),
             'boundary_layers': get_layer_config('boundary'),
             'overlay_layers': get_layer_config('overlay'),
+            'draw_tools': settings.DRAW_TOOLS,
+            'map_controls': settings.MAP_CONTROLS,
             'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY
         })
     }

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -4,7 +4,9 @@ var defaultSettings = {
     itsi_embed: false,
     base_layers: {},
     stream_layers: {},
-    boundary_layers: {}
+    boundary_layers: {},
+    draw_tools: [],
+    map_controls: [],
 };
 
 var settings = (function() {

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -118,6 +118,18 @@ describe('Core', function() {
 
     describe('Views', function() {
         describe('MapView', function() {
+            before(function() {
+                // Ensure that map controls are enabled before testing
+
+                settings.set('map_controls', [
+                    'LayerAttribution',
+                    'LayerSelector',
+                    'LocateMeButton',
+                    'StreamControl',
+                    'ZoomControl',
+                ]);
+            });
+
             it('adds layers to the map when the map model attribute areaOfInterest is set', function() {
                 var model = new models.MapModel(),
                     view = new views.MapView({

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -159,14 +159,15 @@ var MapView = Marionette.ItemView.extend({
         var defaultLayer = _.findWhere(settings.get('base_layers'), function(layer) {
                 return layer.default === true;
             }),
-            defaultLayerName = defaultLayer ? defaultLayer['display'] : 'Streets';
+            defaultLayerName = defaultLayer ? defaultLayer['display'] : 'Streets',
+            map_controls = settings.get('map_controls');
 
         _.defaults(options, {
-            addZoomControl: true,
-            addLocateMeButton: true,
-            addLayerSelector: true,
-            addStreamControl: true,
-            showLayerAttribution: true,
+            addZoomControl: _.contains(map_controls, 'ZoomControl'),
+            addLocateMeButton: _.contains(map_controls, 'LocateMeButton'),
+            addLayerSelector: _.contains(map_controls, 'LayerSelector'),
+            addStreamControl: _.contains(map_controls, 'StreamControl'),
+            showLayerAttribution: _.contains(map_controls, 'LayerAttribution'),
             initialLayerName: defaultLayerName,
             interactiveMode: true // True if clicking on map does stuff
         });

--- a/src/mmw/js/src/draw/tests.js
+++ b/src/mmw/js/src/draw/tests.js
@@ -11,6 +11,7 @@ var $ = require('jquery'),
     models = require('./models'),
     utils = require('./utils'),
     views = require('./views'),
+    settings = require('../core/settings'),
     testUtils = require('../core/testUtils');
 
 var sandboxId = 'sandbox',
@@ -25,6 +26,17 @@ var SandboxRegion = Marionette.Region.extend({
 });
 
 describe('Draw', function() {
+    before(function() {
+        // Ensure that draw tools are enabled before testing
+
+        settings.set('draw_tools', [
+            'SelectArea',   // Boundary Selector
+            'Draw',         // Custom Area or 1 Sq Km stamp
+            'PlaceMarker',  // Delineate Watershed
+            'ResetDraw',
+        ]);
+    });
+
     beforeEach(function() {
         $('body').append('<div id="sandbox">');
     });

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -16,7 +16,8 @@ var $ = require('jquery'),
     selectTypeTmpl = require('./templates/selectType.html'),
     drawTmpl = require('./templates/draw.html'),
     resetDrawTmpl = require('./templates/reset.html'),
-    placeMarkerTmpl = require('./templates/placeMarker.html');
+    placeMarkerTmpl = require('./templates/placeMarker.html'),
+    settings = require('../core/settings');
 
 // Responsible for loading and displaying tools for selecting and drawing
 // shapes on the map.
@@ -54,18 +55,27 @@ var ToolbarView = Marionette.LayoutView.extend({
     },
 
     onShow: function() {
-        this.selectTypeRegion.show(new SelectAreaView({
-            model: this.model
-        }));
-        this.drawRegion.show(new DrawView({
-            model: this.model
-        }));
-        this.placeMarkerRegion.show(new PlaceMarkerView({
-            model: this.model
-        }));
-        this.resetRegion.show(new ResetDrawView({
-            model: this.model
-        }));
+        var draw_tools = settings.get('draw_tools');
+        if (_.contains(draw_tools, 'SelectArea')) {
+            this.selectTypeRegion.show(new SelectAreaView({
+                model: this.model
+            }));
+        }
+        if (_.contains(draw_tools, 'Draw')) {
+            this.drawRegion.show(new DrawView({
+                model: this.model
+            }));
+        }
+        if (_.contains(draw_tools, 'PlaceMarker')) {
+            this.placeMarkerRegion.show(new PlaceMarkerView({
+                model: this.model
+            }));
+        }
+        if (_.contains(draw_tools, 'ResetDraw')) {
+            this.resetRegion.show(new ResetDrawView({
+                model: this.model
+            }));
+        }
     }
 });
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -358,3 +358,22 @@ ITSI = {
 # TILER CONFIGURATION
 TILER_HOST = environ.get('MMW_TILER_HOST', 'localhost')
 # END TILER CONFIGURATION
+
+# UI CONFIGURATION
+
+DRAW_TOOLS = [
+    'SelectArea',   # Boundary Selector
+    'Draw',         # Custom Area or 1 Sq Km stamp
+    'PlaceMarker',  # Delineate Watershed
+    'ResetDraw',
+]
+
+MAP_CONTROLS = [
+    'LayerAttribution',
+    'LayerSelector',
+    'LocateMeButton',
+    'StreamControl',
+    'ZoomControl',
+]
+
+# END UI CONFIGURATION

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -74,6 +74,25 @@ PRIVATE_AWS_STORAGE_URL_PROTOCOL = 'https:'
 
 # END Django Storages CONFIGURATION
 
+# UI CONFIGURATION
+
+DRAW_TOOLS = [
+    'SelectArea',   # Boundary Selector
+    'Draw',         # Custom Area or 1 Sq Km stamp
+    # 'PlaceMarker',  # Delineate Watershed
+    'ResetDraw',
+]
+
+MAP_CONTROLS = [
+    'LayerAttribution',
+    'LayerSelector',
+    'LocateMeButton',
+    # 'StreamControl',
+    'ZoomControl',
+]
+
+# END UI CONFIGURATION
+
 # Google API key for production deployment
 GOOGLE_MAPS_API_KEY = 'AIzaSyCXdkywU7rps_i1CeKqWxlBi97vyGeXsqk'
 


### PR DESCRIPTION
## Overview

Add settings to enable or disable drawing tools in the UI.

## Testing Instructions

 * Checkout the branch and open the home page, ensure that you can see all draw tools.
 * Edit the `development.py` settings file and comment out arbitrary tools, reload the home page and see those tools disappear.
 * Run all tests to ensure that disappearing tools don't affect any other behavior.

## Notes

We should probably wait until #770 is in, and then update this branch to adapt to that new placement of the stream slider. But the general idea will be the same and thus can be tested.

Connects #778 