### PR TITLE
Add scenario name to compare view.

### DIFF
--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -66,6 +66,7 @@ function copyProject(project) {
     project.get('scenarios').forEach(function(scenario) {
         var scenarioCopy = new modelingModels.ScenarioModel({});
         scenarioCopy.set({
+            name: scenario.get('name'),
             is_current_conditions: scenario.get('is_current_conditions'),
             modifications: scenario.get('modifications'),
             modification_hash: scenario.get('modification_hash'),

--- a/src/mmw/js/src/compare/templates/compareScenario.html
+++ b/src/mmw/js/src/compare/templates/compareScenario.html
@@ -1,4 +1,6 @@
 <div class="compare-column">
+    <div class="scenario-overlay"></div>
+    <div class="scenario-title">{{ scenarioName }}</div>
     <div class="map-region">
         <div class="map-container"></div>
     </div>

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -97,6 +97,12 @@ var CompareScenarioView = Marionette.LayoutView.extend({
 
     template: compareScenarioTmpl,
 
+    templateHelpers: function() {
+        return {
+            scenarioName: this.model.get('name')
+        };
+    },
+
     regions: {
         mapRegion: '.map-region',
         modelingRegion: '.modeling-region',

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -12,6 +12,25 @@
   .compare-table{
     height: 100%;
 
+    .scenario-overlay{
+      position: absolute;
+      z-index: 100;
+      height: 18vh;
+      width: 100%;
+      background-color: black;
+      opacity: 0.25;
+    }
+
+    .scenario-title{
+        text-shadow: 0px 0px 5px black;
+        position: absolute;
+        top: 140px;
+        z-index: 101;
+        left: 15px;
+        opacity: 1;
+        color: white;
+    }
+
     tbody{
       tr{
         height: 100%;


### PR DESCRIPTION
The wireframes show the scenario name as an overlay on the map. Here we add
the scenario name to each scenario model passed into the compare view and
then create an overlay over the map view that includes then text.

Connects #781 

To test:
 * Create a project.
 * Name the scenarios.
 * Move to compare view. 
 * Ensure names are visible:

![screencap](https://cloud.githubusercontent.com/assets/903219/9771336/633cbd52-5703-11e5-96fb-45efdc05d720.png)
