### PR TITLE
Do not show stream control on compare view maps.

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -125,6 +125,7 @@ var CompareScenarioView = Marionette.LayoutView.extend({
             el: $(this.el).find('.map-container').get(),
             addZoomControl: false,
             addLocateMeButton: false,
+            addStreamControl: false,
             addLayerSelector: false,
             showLayerAttribution: false,
             initialLayerName: App.getMapView().getActiveBaseLayerName(),


### PR DESCRIPTION
Found this on dev while testing #781 
![screencap](https://cloud.githubusercontent.com/assets/903219/9790931/b17f1962-57a6-11e5-848c-66a84d40699b.png)


Should now look like this:

![screencap](https://cloud.githubusercontent.com/assets/903219/9790959/d1da97e0-57a6-11e5-9872-e66798de3e29.png)
