### PR TITLE
Analysis results coded to NLCD colors

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -269,7 +269,13 @@ var ChartView = Marionette.ItemView.extend({
     addChart: function() {
         var chartEl = this.$el.find('.bar-chart').get(0),
             chartData = this.collection.map(function(model) {
-                return model.attributes;
+                var attrs = model.attributes;
+                return {
+                    area: attrs.area,
+                    coverage: attrs.coverage,
+                    type: attrs.type,
+                    className: attrs.nlcd ? 'nlcd-' + attrs.nlcd : null
+                };
             }),
             chartOptions = {
                 isPercentage: true,

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -294,7 +294,10 @@ function makeBarChart(el, data, indVar, depVars, options) {
         barGroups = chartGroup.selectAll('.bar')
                 .data(data)
                 .enter().append('g')
-                .attr('class', 'g')
+                .attr('class', function(d) { 
+                    return d.className ? d.className : ''; 
+                })
+                .classed('g', true)
                 .attr('transform', function(d) {
                     return 'translate(0,' + y(d[indVar]) + ')';
                 });

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -47,3 +47,17 @@
     display: none;
   }
 }
+
+// Official NLCD legend colors for classes selected for display
+.nlcd-11 .bar { fill: #5475A8; }
+.nlcd-21 .bar { fill: #E8D1D1; }
+.nlcd-22 .bar { fill: #E29E8C; }
+.nlcd-23 .bar { fill: #ff0000; }
+.nlcd-24 .bar { fill: #B50000; }
+.nlcd-31 .bar { fill: #D2CDC0; }
+.nlcd-41 .bar { fill: #85C77E; }
+.nlcd-52 .bar { fill: #DCCA8F; }
+.nlcd-71 .bar { fill: #FDE9AA; }
+.nlcd-81 .bar { fill: #FBF65D; }
+.nlcd-82 .bar { fill: #CA9146; }
+.nlcd-90 .bar { fill: #C8E6F8; }


### PR DESCRIPTION
Allows NLCD colors to be applied to the bar chart for analysis results.  The Analyze endpoint will need to include NLCD type (may be a representive type, see #765).  Only the 12 NLCD classes to be included in MMW are provided, and the hover highlight effect was left in place, can be tweaked as needed. 

New Issue to add this feature to the real service: #786

##### Testing
* Restart your worker `celeryd` service
* Define an area of interest and notice several bars in the chart are the corresponding NLCD color
* Check the soil chart, notice the the default color is used 

Connects #774 