### PR TITLE
Feature/lol/group layer selection

### DIFF
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -115,7 +115,8 @@ def get_client_settings(request):
             'base_layers': get_layer_config('basemap'),
             'stream_layers': get_layer_config('stream'),
             'boundary_layers': get_layer_config('boundary'),
-            'overlay_layers': get_layer_config('overlay'),
+            'vector_layers': get_layer_config('vector'),
+            'raster_layers': get_layer_config('raster'),
             'draw_tools': settings.DRAW_TOOLS,
             'map_controls': settings.MAP_CONTROLS,
             'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY

--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -80,6 +80,11 @@ module.exports = L.Control.Layers.extend({
         holder.appendChild(input);
         holder.appendChild(name);
 
+        if (obj.empty) {
+            name.innerHTML = ' None';
+            input.checked = true;
+        }
+
         var container = obj.overlay ? this._overlaysList : this._baseLayersList;
         var subcontainer;
         if (obj.overlayType) {
@@ -111,7 +116,8 @@ module.exports = L.Control.Layers.extend({
         this._layers[id] = {
             layer: layer,
             name: name,
-            overlay: overlay
+            overlay: overlay,
+            empty: layer.options.empty
         };
 
         if (overlay) {

--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -45,6 +45,85 @@ module.exports = L.Control.Layers.extend({
                 $(container).find("#overlays-layer-list").get(0));
     },
 
+    // Overrides the parent class and allows separation of overlay layers
+    // by type.
+    _addItem: function (obj) {
+        var label = document.createElement('label'),
+            checked = this._map.hasLayer(obj.layer),
+            input,
+            controlName = 'leaflet-overlay-layers';
+
+        if (obj.overlay && !obj.overlayType) {
+            input = document.createElement('input');
+            input.type = 'checkbox';
+            input.className = 'leaflet-control-layers-selector';
+            input.defaultChecked = checked;
+        } else if (obj.overlay) {
+            controlName += obj.overlayType;
+            input = this._createRadioElement(controlName, checked, obj.overlayType);
+        } else {
+            input = this._createRadioElement(controlName, checked);
+        }
+
+        input.layerId = L.stamp(obj.layer);
+
+        L.DomEvent.on(input, 'click', this._onInputClick, this);
+
+        var name = document.createElement('span');
+        name.innerHTML = ' ' + obj.name;
+
+        // Helps from preventing layer control flicker when checkboxes are disabled
+        // https://github.com/Leaflet/Leaflet/issues/2771
+        var holder = document.createElement('div');
+
+        label.appendChild(holder);
+        holder.appendChild(input);
+        holder.appendChild(name);
+
+        var container = obj.overlay ? this._overlaysList : this._baseLayersList;
+        var subcontainer;
+        if (obj.overlayType) {
+             subcontainer = document.getElementById('overlay-subclass-' + obj.overlayType);
+             if (subcontainer === null) {
+                 subcontainer = document.createElement('div');
+                 subcontainer.id = 'overlay-subclass-' + obj.overlayType;
+                 container.appendChild(subcontainer);
+
+                 var title = obj.overlayType === 'vector' ? 'Boundary' : 'Coverage';
+                 var textNode = document.createElement('h4');
+                 textNode.innerHTML = title;
+                 subcontainer.appendChild(textNode);
+             }
+             subcontainer.appendChild(label);
+        } else {
+            container.appendChild(label);
+        }
+
+        return label;
+    },
+
+    // Override the parent class and adds new overlayType data.
+    _addLayer: function (layer, name, overlay) {
+        layer.on('add remove', this._onLayerChange, this);
+
+        var id = L.stamp(layer);
+
+        this._layers[id] = {
+            layer: layer,
+            name: name,
+            overlay: overlay
+        };
+
+        if (overlay) {
+             this._layers[id].overlayType = layer.options.vector ? 'vector' : 'raster';
+        }
+
+        if (this.options.autoZIndex && layer.setZIndex) {
+            this._lastZIndex++;
+            layer.setZIndex(this._lastZIndex);
+        }
+    },
+
     _createContainer: function() {
         var container = new LayerControlView({}).render().el;
 

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -188,7 +188,8 @@ var MapView = Marionette.ItemView.extend({
         var map = new L.Map(this.el, {
                 zoomControl: false,
                 attributionControl: options.showLayerAttribution
-            });
+            }),
+            overlayLayers = settings.get('vector_layers').concat(settings.get('raster_layers'))
 
         // Center the map on the U.S.
         map.fitBounds([
@@ -200,7 +201,7 @@ var MapView = Marionette.ItemView.extend({
         this._areaOfInterestLayer = new L.FeatureGroup();
         this._modificationsLayer = new L.FeatureGroup();
         this.baseLayers = this.buildLayers(settings.get('base_layers'));
-        this.overlayLayers = this.buildLayers(settings.get('overlay_layers'));
+        this.overlayLayers = this.buildLayers(overlayLayers);
 
         if (!options.interactiveMode) {
             this.setMapToNonInteractive();

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -189,7 +189,19 @@ var MapView = Marionette.ItemView.extend({
                 zoomControl: false,
                 attributionControl: options.showLayerAttribution
             }),
-            overlayLayers = settings.get('vector_layers').concat(settings.get('raster_layers'))
+            nullVectorLayer = {
+                display: 'nullVector',
+                vector: true,
+                empty: true
+            },
+            nullRasterLayer = {
+                display: 'nullRaster',
+                raster: true,
+                empty: true
+            },
+            vectorLayers = [nullVectorLayer].concat(settings.get('vector_layers')),
+            rasterLayers = [nullRasterLayer].concat(settings.get('raster_layers')),
+            overlayLayers = vectorLayers.concat(rasterLayers);
 
         // Center the map on the U.S.
         map.fitBounds([
@@ -339,7 +351,7 @@ var MapView = Marionette.ItemView.extend({
                     leafletLayer = new L.Google(layer.googleType, {
                         maxZoom: layer.maxZoom
                     });
-                } else {
+                } else if (!layer.empty) {
                     var tileUrl = (layer.url.match(/png/) === null ?
                                     layer.url + '.png' : layer.url),
                         zIndex = layer.overlay ? 1 : 0;
@@ -352,6 +364,8 @@ var MapView = Marionette.ItemView.extend({
                         slider.setOpacityLayer(leafletLayer);
                         leafletLayer.slider = slider;
                     }
+                } else {
+                    leafletLayer = new L.TileLayer('', layer);
                 }
 
                 layers[layer['display']] = leafletLayer;

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -353,34 +353,34 @@ var MapView = Marionette.ItemView.extend({
         var self = this,
             layers = {};
 
-            _.each(layerConfig, function(layer) {
-                var leafletLayer;
+        _.each(layerConfig, function(layer) {
+            var leafletLayer;
 
-                // Check to see if the google api service has been loaded
-                // before creating a google layer
-                if (self._googleMaps && layer.type === 'google') {
-                    leafletLayer = new L.Google(layer.googleType, {
-                        maxZoom: layer.maxZoom
-                    });
-                } else if (!layer.empty) {
-                    var tileUrl = (layer.url.match(/png/) === null ?
-                                    layer.url + '.png' : layer.url),
-                        zIndex = layer.overlay ? 1 : 0;
+            // Check to see if the google api service has been loaded
+            // before creating a google layer
+            if (self._googleMaps && layer.type === 'google') {
+                leafletLayer = new L.Google(layer.googleType, {
+                    maxZoom: layer.maxZoom
+                });
+            } else if (!layer.empty) {
+                var tileUrl = (layer.url.match(/png/) === null ?
+                                layer.url + '.png' : layer.url),
+                    zIndex = layer.overlay ? 1 : 0;
 
-                    _.defaults(layer, {zIndex: zIndex, attribution: ''});
-                    leafletLayer = new L.TileLayer(tileUrl, layer);
-                    if (layer.has_opacity_slider) {
-                        var slider = new OpacityControl();
+                _.defaults(layer, {zIndex: zIndex, attribution: ''});
+                leafletLayer = new L.TileLayer(tileUrl, layer);
+                if (layer.has_opacity_slider) {
+                    var slider = new OpacityControl();
 
-                        slider.setOpacityLayer(leafletLayer);
-                        leafletLayer.slider = slider;
-                    }
-                } else {
-                    leafletLayer = new L.TileLayer('', layer);
+                    slider.setOpacityLayer(leafletLayer);
+                    leafletLayer.slider = slider;
                 }
+            } else {
+                leafletLayer = new L.TileLayer('', layer);
+            }
 
-                layers[layer['display']] = leafletLayer;
-            });
+            layers[layer['display']] = leafletLayer;
+        });
 
         return layers;
     },

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -189,19 +189,7 @@ var MapView = Marionette.ItemView.extend({
                 zoomControl: false,
                 attributionControl: options.showLayerAttribution
             }),
-            nullVectorLayer = {
-                display: 'nullVector',
-                vector: true,
-                empty: true
-            },
-            nullRasterLayer = {
-                display: 'nullRaster',
-                raster: true,
-                empty: true
-            },
-            vectorLayers = [nullVectorLayer].concat(settings.get('vector_layers')),
-            rasterLayers = [nullRasterLayer].concat(settings.get('raster_layers')),
-            overlayLayers = vectorLayers.concat(rasterLayers);
+            overlayLayers = this.prepareOverlayLayers();
 
         // Center the map on the U.S.
         map.fitBounds([
@@ -256,6 +244,29 @@ var MapView = Marionette.ItemView.extend({
 
         map.addLayer(this._areaOfInterestLayer);
         map.addLayer(this._modificationsLayer);
+    },
+
+    prepareOverlayLayers: function() {
+        var nullVectorLayer = {
+                display: 'nullVector',
+                vector: true,
+                empty: true
+            },
+            nullRasterLayer = {
+                display: 'nullRaster',
+                raster: true,
+                empty: true
+            },
+            vectorOverlayLayers = settings.get('vector_layers'),
+            rasterOverlayLayers = settings.get('raster_layers');
+
+        vectorOverlayLayers = !_.isEmpty(vectorOverlayLayers) ?
+                                [nullVectorLayer].concat(vectorOverlayLayers) : [];
+
+        rasterOverlayLayers = !_.isEmpty(rasterOverlayLayers) ?
+                                [nullRasterLayer].concat(rasterOverlayLayers) : [];
+
+        return vectorOverlayLayers.concat(rasterOverlayLayers);
     },
 
     setupGeoLocation: function(maxAge) {

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -24,7 +24,7 @@ LAYERS = [
                     'tier of state government, between the statewide tier '
                     'and the immediately local government tier',
         'boundary': False,
-        'overlay': True,
+        'vector': True,
     },
     {
         'code': 'district',
@@ -40,7 +40,7 @@ LAYERS = [
                     'a congressional district on which to perform water '
                     'quality analysis.',
         'boundary': True,
-        'overlay': True,
+        'vector': True,
     },
     {
         'code': 'huc8',
@@ -55,7 +55,7 @@ LAYERS = [
                     'nationwide. This tool allows you to pick a predefined '
                     'HUC-8 to analyze.',
         'boundary': True,
-        'overlay': True,
+        'vector': True,
     },
     {
         'code': 'huc10',
@@ -70,7 +70,7 @@ LAYERS = [
                     'nationwide. This tool allows you to pick a predefined '
                     'HUC-10 to analyze.',
         'boundary': True,
-        'overlay': True,
+        'vector': True,
     },
     {
         'code': 'huc12',
@@ -86,7 +86,7 @@ LAYERS = [
                     'nationwide. This tool allows you to pick a predefined '
                     'HUC-12 to analyze.',
         'boundary': True,
-        'overlay': True,
+        'vector': True,
     },
     {
         'code': 'school',
@@ -94,7 +94,7 @@ LAYERS = [
         'short_display': 'School Districts',
         'table_name': 'boundary_school_district',
         'helptext': 'U.S. school district boundaries.',
-        'overlay': True,
+        'vector': True,
     },
     {
         'display': 'National Land Cover Database',
@@ -103,7 +103,7 @@ LAYERS = [
                     'land use across the U.S.',
         'url': 'https://s3.amazonaws.com/com.azavea.datahub.tms/'
                'nlcd/{z}/{x}/{y}.png',
-        'overlay': True,
+        'raster': True,
         'maxNativeZoom': 13,
         'maxZoom': 18,
         'opacity': 0.618,


### PR DESCRIPTION
Connects #776 

 * Change layer settings from change for overlay layers in subgroups (raster and vector)
 * Extend leaflet's Layer control to use these special groups to create radios rather than checkboxes.
 * Enable a "no selection" option to disable all overlay layers.

To test:
 * Open the layer control.
 * Switch to the overlays tab.
 * Choose a vector layer.
 * Choose a raster layer.
 * Ensure you can disable both layers.
 * Ensure you cannot enable more than one of each type of layer.
