### PR TITLE
Synchronize precipitation sliders in Compare View

### DIFF
--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -4,9 +4,15 @@ var _ = require('lodash'),
     App = require('../app'),
     router = require('../router').router,
     views = require('./views'),
-    modelingModels = require('../modeling/models.js');
+    modelingModels = require('../modeling/models.js'),
+    modelingControls = require('../modeling/controls'),
+    synchronizer = modelingControls.PrecipitationSynchronizer;
 
 var CompareController = {
+    comparePrepare: function() {
+        synchronizer.on();
+    },
+
     compare: function(projectId) {
         if (App.currentProject) {
             setupProjectCopy();
@@ -28,6 +34,7 @@ var CompareController = {
     },
 
     compareCleanUp: function() {
+        synchronizer.off();
         App.user.off('change:guest', saveAfterLogin);
         App.origProject.off('change:id', updateUrl);
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -8,12 +8,14 @@ var _ = require('lodash'),
     coreViews = require('../core/views'),
     modelingModels = require('../modeling/models'),
     modelingViews = require('../modeling/views'),
+    modelingControls = require('../modeling/controls'),
     modConfigUtils = require('../modeling/modificationConfigUtils'),
     compareWindowTmpl = require('./templates/compareWindow.html'),
     compareScenariosTmpl = require('./templates/compareScenarios.html'),
     compareScenarioTmpl = require('./templates/compareScenario.html'),
     compareModelingTmpl = require('./templates/compareModeling.html'),
-    compareModificationsTmpl = require('./templates/compareModifications.html');
+    compareModificationsTmpl = require('./templates/compareModifications.html'),
+    synchronizer = modelingControls.PrecipitationSynchronizer;
 
 var CompareWindow = Marionette.LayoutView.extend({
     //model: modelingModels.ProjectModel,
@@ -87,6 +89,7 @@ var CompareWindow = Marionette.LayoutView.extend({
             model: this.model,
             collection: this.model.get('scenarios')
          }));
+        synchronizer.sync();
     }
 });
 

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -106,6 +106,69 @@ var ConservationPracticeView = ModificationsView.extend({
     }
 });
 
+var PrecipitationSynchronizer = (function() {
+    var isEnabled = false,
+        precipViews = [];
+
+    // Add a view to the list of views to be kept syncrhonized
+    function add(precipView) {
+        if (isEnabled) {
+            precipViews.push(precipView);
+        }
+    }
+
+    // Remove a view from the list
+    function remove(precipView) {
+        if (isEnabled) {
+            precipViews = _.without(precipViews, precipView);
+        }
+    }
+
+    // Turn synchronization on
+    function on() {
+        precipViews = [];
+        isEnabled = true;
+    }
+
+    // Turn synchronization off
+    function off() {
+        isEnabled = false;
+        precipViews = [];
+    }
+
+    // Synchronize the group to the given slider
+    function syncTo(precipView) {
+        if (isEnabled) {
+            var value = precipView.ui.slider.val();
+            isEnabled = false;
+            precipViews.forEach(function(otherPrecipView) {
+                var otherValue = otherPrecipView.ui.slider.val();
+                if (otherValue !== value) {
+                    otherPrecipView.ui.slider.val(value);
+                    otherPrecipView.onSliderChanged();
+                }
+            });
+            isEnabled = true;
+        }
+    }
+
+    // Synchronize the group to the first slider
+    function sync() {
+        if (precipViews.length > 0) {
+            syncTo(precipViews[0]);
+        }
+    }
+
+    return {
+        add: add,
+        remove: remove,
+        on: on,
+        off: off,
+        sync: sync,
+        syncTo: syncTo
+    };
+})();
+
 var PrecipitationView = ControlView.extend({
     template: precipitationTmpl,
 
@@ -141,7 +204,16 @@ var PrecipitationView = ControlView.extend({
                 name: this.getControlName(),
                 value: imperialValue
             });
+        PrecipitationSynchronizer.syncTo(this);
         this.addOrReplaceInput(modification);
+    },
+
+    onAttach: function() {
+        PrecipitationSynchronizer.add(this);
+    },
+
+    onBeforeDestroy: function() {
+        PrecipitationSynchronizer.remove(this);
     },
 
     onRender: function() {
@@ -172,5 +244,6 @@ module.exports = {
     LandCoverView: LandCoverView,
     ConservationPracticeView: ConservationPracticeView,
     PrecipitationView: PrecipitationView,
-    getControlView: getControlView
+    getControlView: getControlView,
+    PrecipitationSynchronizer: PrecipitationSynchronizer
 };


### PR DESCRIPTION
This patch exports a new object from the file `src/modeling/controls.js` which contains functions which can be used to keep precipitation sliders in sync.

Connects #771

**To Test**
   * Create a project with multiple scenarios
   * Go to the compare view
   * Move the precipitation slider around -- all should stay in sync

**Caveats**
   * If you have too many scenarios, it might overwhelm the worker and cause you to not get results