### PR TITLE
Move alert icon

### DIFF
--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -169,8 +169,8 @@
 
             <div id="water-column-container" class="well-custom"> <!-- Water Column -->
                 <div id="alert">
-                    <svg class="ic_approach" width="80" height="80">
-                        <image xlink:href="{% static 'images/water_balance/art_alert.svg' %}" src="{% static 'images/water_balance/art_alert.svg' %}" width="80" height="80"></image>
+                    <svg class="ic_approach" width="40" height="40">
+                        <image xlink:href="{% static 'images/water_balance/art_alert.svg' %}" src="{% static 'images/water_balance/art_alert.svg' %}" width="40" height="40"></image>
                     </svg>
                 </div>
                 <div id="column-overlay"></div>

--- a/src/mmw/sass/pages/_water-balance.scss
+++ b/src/mmw/sass/pages/_water-balance.scss
@@ -144,10 +144,11 @@
     position: absolute;
     z-index: 1000;
     top: 0;
-    left: 2px;
-    -webkit-animation: breathing 7s ease-out infinite normal;
-    animation: breathing 7s ease-out infinite normal;
+    left: 0;
     display: none;
+    margin-top: -27px;
+    width: 100%;
+    text-align: center;
   }
 
   //Water Column =====================================


### PR DESCRIPTION
The alert icon would often cover the evapotranspiration portion of the stacked bar. I downsized it and moved it up above the bar.

![image](https://cloud.githubusercontent.com/assets/1809908/9891733/85282582-5bd6-11e5-894a-72395f349efa.png)
