### PR TITLE
Correct slider values in ITSI screenshots

### DIFF
--- a/src/mmw/js/src/core/opacityControl.js
+++ b/src/mmw/js/src/core/opacityControl.js
@@ -57,6 +57,7 @@ module.exports = L.Control.extend({
     onAdd: function (map) {
         var opacity_slider_div = L.DomUtil.create('div', 'opacity_slider_control'),
             opacityLayer = this.opacityLayer,
+            initial_value = opacityLayer.options.opacity * 100,
             view = new SliderView().render().el;
 
         $(view).on('mousedown', function() {
@@ -67,12 +68,16 @@ module.exports = L.Control.extend({
         });
 
         $(view).on('mouseup', function(e) {
-            var slider_value = $(e.toElement).val();
+            var el = $(e.toElement),
+                slider_value = el.val();
             opacityLayer.setOpacity(slider_value / 100);
+            el.attr('value', slider_value);
         });
 
         $(opacity_slider_div).append(view);
-        $(view).find('input').val(opacityLayer.options.opacity * 100);
+        $(view).find('input')
+            .val(initial_value)
+            .attr('value', initial_value);
 
         return opacity_slider_div;
     }

--- a/src/mmw/js/src/core/streamSliderControl.js
+++ b/src/mmw/js/src/core/streamSliderControl.js
@@ -97,6 +97,7 @@ var StreamSliderView = Marionette.ItemView.extend({
             var streamLayer = this.streamLayers[ind-1];
             changeStreamLayer(streamLayer.url, this.streamFeatures);
         }
+        this.ui.slider.attr('value', ind);
     }
 });
 

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -130,6 +130,7 @@ var PrecipitationView = ControlView.extend({
     onSliderDragged: function() {
         // Preview slider value while dragging.
         var value = parseFloat(this.ui.slider.val());
+        this.ui.slider.attr('value', value);
         this.ui.displayValue.text(this.getDisplayValue(value));
     },
 
@@ -152,6 +153,7 @@ var PrecipitationView = ControlView.extend({
         // metric.
         value = coreUtils.convertToMetric(value, 'in');
         this.ui.slider.val(value);
+        this.ui.slider.attr('value', value);
         this.ui.displayValue.text(this.getDisplayValue(value));
     }
 });


### PR DESCRIPTION
## Overview

The PhantomJS parser assigns a default mid-point value to sliders when no "value" attribute is present on the input tag. We add that attribute and ensure that it is updated every time the value changes for all three sliders: precipitation, stream, and opacity.

## Testing Instructions

Checkout the branch and ensure that ITSI is correctly configured in your environment as per the README. Then, run `ngrok`:

```
$ ngrok http 8000
```

since we can't use the [Lara Interactive Playground](http://concord-consortium.github.io/lara-interactive-api/) from `localhost:8000`. Then, open the URL of your `ngrok` instance, akin to `https://????????.ngrok.io/?itsi_embed=true` in the iframe area. Navigate to the project details / modeling screen, and take a screenshot. The slider values in the screenshot should be correctly rendered:

![image](https://cloud.githubusercontent.com/assets/1430060/9892065/46b14bd2-5bd9-11e5-9b77-a713d643b7d3.png)

![image](https://cloud.githubusercontent.com/assets/1430060/9892076/581de740-5bd9-11e5-87a9-70306bd47a6f.png)

Also test the compare view, the stream slider, and the opacity slider.

Connects #747, partially.