### PR TITLE
Extend log aggregation support for Spark Job Server

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.beaver/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.beaver/tasks/main.yml
@@ -3,11 +3,13 @@
   template: src="{{ item }}.conf.j2"
             dest="{{ beaver_conf_dir }}/conf.d/{{ item }}"
   with_items:
-    - nginx
-    - django
-    - gunicorn
-    - windshaft
     - celery
+    - django
+    - docker
+    - gunicorn
+    - nginx
+    - spark-jobserver
+    - windshaft
   notify:
     - Restart Beaver
 

--- a/deployment/ansible/roles/model-my-watershed.beaver/templates/docker.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.beaver/templates/docker.conf.j2
@@ -1,0 +1,3 @@
+[/var/log/upstart/docker.log]
+type: docker
+tags: docker,beaver

--- a/deployment/ansible/roles/model-my-watershed.beaver/templates/spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.beaver/templates/spark-jobserver.conf.j2
@@ -1,0 +1,3 @@
+[/var/log/upstart/spark-jobserver.log]
+type: spark-jobserver
+tags: spark-jobserver,beaver


### PR DESCRIPTION
Take care of shipping Docker daemon and Spark Job Server logs to Logstash for later analysis.

Attempts to resolve #783.

---

<img width="1439" alt="discover_-_kibana_4" src="https://cloud.githubusercontent.com/assets/43639/9906190/0f3f42d4-5c57-11e5-9775-6793f7f6d039.png">

<img width="1437" alt="discover_-_kibana_4" src="https://cloud.githubusercontent.com/assets/43639/9906215/2654e5be-5c57-11e5-8f9f-20bddbb816a7.png">
