### PR TITLE
After SJS HTTP socket binds, wait an additional second

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.geoprocessing/templates/upstart-geoprocessing.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.geoprocessing/templates/upstart-geoprocessing.conf.j2
@@ -10,6 +10,8 @@ script
   set -e
   set -x
 
+  sleep 1
+
   if ! curl --silent --retry 3 "http://{{ sjs_host }}:{{ sjs_port }}/jars" | grep -q "geoprocessing-${GEOPROCESSING_JAR_VERSION}";
   then
     curl --silent \


### PR DESCRIPTION
We were attempting to `POST` the SJS job JAR too quickly after the SJS service starts. This adds a one second sleep before we attempt the first `POST` (in addition to the `nc` in a loop at the end of the SJS service definition waiting for a successful connection to port 8090).