### PR TITLE
Show Compare Map in Screenshot

### DIFF
--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -24,7 +24,7 @@
     .scenario-title{
         text-shadow: 0px 0px 5px black;
         position: absolute;
-        top: 140px;
+        top: 5px;
         z-index: 101;
         left: 15px;
         opacity: 1;
@@ -64,7 +64,7 @@
           }
 
           .fa-minus-square{
-            opacity: 54%!important;
+            opacity: 0.54 !important;
           }
 
           .map-region{

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -15,7 +15,7 @@
     .scenario-overlay{
       position: absolute;
       z-index: 100;
-      height: 18vh;
+      height: 22%;
       width: 100%;
       background-color: black;
       opacity: 0.25;
@@ -68,7 +68,7 @@
           }
 
           .map-region{
-            height: 18vh;
+            height: 22%;
             width: 100%;
 
             .map-container{


### PR DESCRIPTION
## Overview

PhantomJS cannot handle `vh` and `vw` units, thus did not render the map in the Compare page. By replacing those values with percent units, the map renders.

## Testing Instructions

Checkout the branch and ensure that ITSI is correctly configured in your environment as per the README. Then, run `ngrok`:

```
$ ngrok http 8000
```

since we can't use the [Lara Interactive Playground](http://concord-consortium.github.io/lara-interactive-api/) from `localhost:8000`. Then, open the URL of your `ngrok` instance, akin to `https://????????.ngrok.io/?itsi_embed=true` in the iframe area. Navigate to the compare view and take a screenshot. The maps in the screenshot should be correctly rendered:

![image](https://cloud.githubusercontent.com/assets/1430060/9892065/46b14bd2-5bd9-11e5-9b77-a713d643b7d3.png)

Before:
![image](https://cloud.githubusercontent.com/assets/1430060/9944922/40687900-5d58-11e5-92f4-98538ca113c1.png)

After:
![image](https://cloud.githubusercontent.com/assets/1430060/9944901/2526fedc-5d58-11e5-93e6-fd2db32a6b9d.png)

## Notes

The extraneous width in the screenshot comes from the usage of `vw` to fix #642. We will need a solution that handles both cases. Created #808 for that.

Connects #747