### PR TITLE
Update ITSI with URL of new project upon creation

### DIFF
--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -100,6 +100,8 @@ var ModelingController = {
                         // Now render.
                         initViews(project);
                         project.fetchResultsIfNeeded();
+
+                        updateUrl();
                     });
                 } else {
                     initViews(project);


### PR DESCRIPTION
## Overview

Previously, the project ID would be available to the app but not present in the URL, resulting in a use case when a student who has progressed to the project stage closes the window and returns to the draw stage, since the project URL was never updated / communicated to the containing activity. By ensuring that the project URL is updated as soon as the project stage is entered, we avoid that use case.

## Testing Instructions

 1. Checkout the branch and run [`ngrok http 8000`](https://ngrok.com)
 2. Go to the [LARA Sandbox](http://concord-consortium.github.io/lara-interactive-api/)
 3. Put in your `ngrok` URL `https://????????.ngrok.io/?itsi_embed=true` and load MMW in the iframe
 4. Login as an ITSI user `mmwterence` or `tstudent2`
 5. Create an AoI and move to the Analyze stage
 6. Move to the Project stage
 7. Ensure that you see a similar message in the parent log window:  

        App: interactiveState called with: {"route":"project/277"}

## Demo

![image](https://cloud.githubusercontent.com/assets/1430060/10000599/2ed9e19a-606b-11e5-9a0d-1ffcfc83c5d2.png)

Connects #804