### PR TITLE
Sort numeric columns numerically

### DIFF
--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -3,8 +3,8 @@
     <thead>
         <tr>
             <th data-sortable="true">Type</th>
-            <th class="text-right" data-sortable="true">Area ({{ units }})</th>
-            <th class="text-right" data-sortable="true">Coverage (%)</th>
+            <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Area ({{ units }})</th>
+            <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Coverage (%)</th>
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -6,6 +6,20 @@ var _ = require('underscore'),
 var M2_IN_KM2 = 1000000;
 
 var utils = {
+    // A numeric comparator for strings.
+    numericSort: function(_x, _y) {
+        var x = parseFloat(_x.toString().replace(/[^0-9.]/g, '')),
+            y = parseFloat(_y.toString().replace(/[^0-9.]/g, ''));
+
+        if (x < y) {
+            return -1;
+        } else if (x === y) {
+            return 0;
+        } else {
+            return 1;
+        }
+    },
+
     // Parse query strings for Backbone
     // Takes queryString of format "key1=value1&key2=value2"
     // Returns object of format {key1: value1, key2: value2}

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var utils = require('./core/utils');
+
 require('./core/setup');
 require('./routes');
 
@@ -28,6 +30,10 @@ App.on('start', function() {
 });
 
 App.start();
+
+// This numeric comparator needs to be attached to window so that it
+// is available for use in templates.
+window.numericSort = utils.numericSort;
 
 //
 // Expose application so we can interact with it via JS console.

--- a/src/mmw/js/src/modeling/tr55/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/table.html
@@ -3,7 +3,7 @@
     <thead>
         <tr>
             <th data-sortable="true">Quality Measure</th>
-            <th data-sortable="true" class="text-left">Load (kg)</th>
+            <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Load (kg)</th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
This patch causes numeric columns of the tables on the `/analyze` and `/project` pages to be sorted numerically instead of lexicographically.

Connects #813