### PR TITLE
Add debug level logging to Spark Job Server

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.logstash/templates/logstash.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.logstash/templates/logstash.conf.j2
@@ -21,6 +21,16 @@ filter {
       match => [ "timestamp", "E, dd MMM yyyy HH:mm:ss z" ]
     }
   }
+
+  if [type] == "spark-jobserver" {
+    grok {
+      match => { "message" => "%{TIMESTAMP_ISO8601:timestamp}" }
+    }
+
+    date {
+      match => [ "timestamp", "yyyy-MM-dd HH:mm:ss,SSS" ]
+    }
+  }
 }
 
 output {

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
@@ -15,8 +15,11 @@
     - Restart Spark Job Server
 
 - name: Configure Spark Job Server
-  template: src=spark-jobserver.conf.j2
-            dest=/opt/spark-jobserver/spark-jobserver.conf
+  template: src="{{ item }}.j2"
+            dest="/opt/spark-jobserver/{{ item }}"
+  with_items:
+    - spark-jobserver.conf
+    - log4j.properties
   notify:
     - Restart Spark Job Server
 

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/log4j.properties.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/log4j.properties.j2
@@ -1,0 +1,17 @@
+log4j.rootLogger=INFO,console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+
+{% if ['development', 'test'] | some_are_in(group_names) -%}
+log4j.appender.console.Threshold=DEBUG
+log4j.logger.com.amazonaws=DEBUG
+{% else %}
+log4j.appender.console.Threshold=INFO
+log4j.logger.com.amazonaws=WARN
+{% endif %}
+
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d [%t] %-5p %c -  %m%n
+
+log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
+log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
@@ -20,6 +20,7 @@ exec /usr/bin/docker run \
   --env AWS_PROFILE={{ aws_profile }} \
   {% endif -%}
   --volume {{ sjs_home }}/spark-jobserver.conf:{{ sjs_home }}/spark-jobserver.conf \
+  --volume {{ sjs_home }}/log4j.properties:{{ sjs_home }}/log4j.properties \
   --volume {{ sjs_jars_dir }}:{{ sjs_jars_dir }} \
   --volume {{ sjs_filedao_dir }}:{{ sjs_filedao_dir }} \
   {% for k,v in app_config.items() -%}


### PR DESCRIPTION
Adds a Log4j configuration file setup to override the one provided by default in the Spark Job Server container. In development, the overall log level is set to `DEBUG` and the AWS SDK log levels to `DEBUG`. In an AWS deployment, the overall log level is set to `INFO` and the AWS SDK log levels to `WARN`.

Useful information provided:

- Log entries of actual tile URLs being pulled down by GeoTrellis
- Log entries prefixed with timestamps
- Timestamps in logs align in Logstash

---

<img width="1439" alt="discover_-_kibana_4" src="https://cloud.githubusercontent.com/assets/43639/10021400/cba7a9f8-6115-11e5-8283-2e1063314440.png">
