### PR TITLE
Add NLCD Analysis colors to chart

### DIFF
--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -171,10 +171,12 @@ def data_to_survey(data):
     def update_rule(nlcd, soil, count, survey):
         landCategories = survey[0]['categories']
         soilCategories = survey[1]['categories']
+
         if nlcd in NLCD_MAPPING:
             update_category(NLCD_MAPPING[nlcd][1], count, landCategories)
         else:
             update_category('?', count, landCategories)
+
         if soil in SOIL_MAPPING:
             update_category(SOIL_MAPPING[soil][1], count, soilCategories)
         else:

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -184,15 +184,21 @@ def data_to_survey(data):
 
     def after_rule(count, survey):
         nlcd_names = [v[1] for v in NLCD_MAPPING.values()]
+        nlcd_keys = NLCD_MAPPING.keys()
         used_nlcd_names = [k for k in survey[0]['categories'].keys()]
 
-        for i in nlcd_names:
-            if (i not in used_nlcd_names):
-                survey[0]['categories'][i] = {
-                    'type': i,
+        for index, name in enumerate(nlcd_names):
+            nlcd = nlcd_keys[index]
+
+            if (name not in used_nlcd_names):
+                survey[0]['categories'][name] = {
+                    'type': name,
                     'coverage': None,
-                    'area': 0
+                    'area': 0,
+                    'nlcd': nlcd
                 }
+            else:
+                survey[0]['categories'][name]['nlcd'] = nlcd
 
         land = survey[0]['categories'].iteritems()
         soil = survey[1]['categories'].iteritems()

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -204,81 +204,97 @@ class ExerciseGeoprocessing(TestCase):
                 "name": "land",
                 "categories": [
                     {
+                        "nlcd": 90,
                         "type": "Woody Wetlands",
                         "coverage": 0.03213078618662748,
                         "area": 4373
                     },
                     {
+                        "nlcd": 23,
                         "type": "Developed, Medium Intensity",
                         "coverage": 0.057817781043350475,
                         "area": 7869
                     },
                     {
+                        "nlcd": 31,
                         "type": "Barren Land (Rock/Sand/Clay)",
                         "coverage": 0.0006024981631153563,
                         "area": 82
                     },
                     {
+                        "nlcd": 22,
                         "type": "Developed, Low Intensity",
                         "coverage": 0.19052902277736958,
                         "area": 25931
                     },
                     {
+                        "nlcd": 95,
                         'type': 'Emergent Herbaceous Wetlands',
                         'coverage': 0.0,
                         'area': 0
                     },
                     {
+                        "nlcd": 41,
                         "type": "Deciduous Forest",
                         "coverage": 0.20648052902277736,
                         "area": 28102
                     },
                     {
+                        "nlcd": 11,
                         "type": "Open Water",
                         "coverage": 0.005349008082292432,
                         "area": 728
                     },
                     {
+                        "nlcd": 43,
                         "type": "Mixed Forest",
                         "coverage": 0.022299779573842764,
                         "area": 3035
                     },
                     {
+                        "nlcd": 12,
                         'type': 'Perennial Ice/Snow',
                         'coverage': 0.0,
                         'area': 0
                     },
                     {
+                        "nlcd": 24,
                         "type": "Developed, High Intensity",
                         "coverage": 0.009639970609845701,
                         "area": 1312
                     },
                     {
+                        "nlcd": 52,
                         "type": "Shrub/Scrub",
                         "coverage": 0.03096987509184423,
                         "area": 4215
                     },
                     {
+                        "nlcd": 82,
                         "type": "Cultivated Crops",
                         "coverage": 0.005811903012490816,
                         "area": 791
                     },
                     {
+                        "nlcd": 71,
                         "type": "Grassland/Herbaceous",
                         "coverage": 0.0014033798677443056,
                         "area": 191
                     },
                     {
+                        "nlcd": 42,
                         "type": "Evergreen Forest",
                         "coverage": 0.020543717854518737,
                         "area": 2796
                     },
                     {
+                        "nlcd": 21,
                         "type": "Developed, Open Space",
                         "coverage": 0.3669654665686995,
                         "area": 49944
                     },
                     {
+                        "nlcd": 81,
                         "type": "Pasture/Hay",
                         "coverage": 0.04945628214548126,
                         "area": 6731


### PR DESCRIPTION
Adds the NLCD code to the census output so that the chart will display the appropriate class color.

##### Test
* Navigate to a small area with several land types available
* Draw an area
* See that the reported land types are coded to their correct legend color (http://www.mrlc.gov/nlcd11_leg.php)

![screenshot from 2015-09-22 11 13 15](https://cloud.githubusercontent.com/assets/1014341/10022572/8b7f1dce-611b-11e5-8f81-71aff4d25c12.png)


Connects #786 