### PR TITLE
Make asynchronous calls to SJS

### DIFF
--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -4,8 +4,9 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from django.conf import settings
+from celery.exceptions import MaxRetriesExceededError
 
-import httplib
+import requests
 import json
 import re
 
@@ -47,11 +48,37 @@ SOIL_MAPPING = {
 }
 
 
-def histogram(polygons):
+def histogram_start(polygons):
     """
-    Send a list of strings containing a GeoJSON Polygons and/or
-    MultiPolygons to the datahub code, and get back a histogram of
-    the NLCD x SOIL pairs present in that area.
+    Together, histogram_start and histogram_finish implement a
+    function which takes a list of polygons or multipolygons as input,
+    and returns histograms of the NLCD x soil pairs that occur in each
+    shape.
+
+    This is the top-half of the function.
+    """
+    host = settings.GEOP['host']
+    port = settings.GEOP['port']
+    path = settings.GEOP['path']
+    request = settings.GEOP['request'].copy()
+    request['input']['geometry'] = polygons
+    url = "http://%s:%s%s" % (host, port, path)
+
+    post = requests.post(url, data=json.dumps(request))
+    if post.ok:
+        data = post.json()
+    else:
+        raise Exception('Unable to communicate with SJS (top-half).')
+
+    if data['status'] == 'STARTED':
+        return data['result']['jobId']
+    else:
+        raise Exception('Job submission failed.')
+
+
+def histogram_finish(job_id, retry):
+    """
+    This is the bottom-half of the function.
     """
     def dict_to_array(d):
         result = []
@@ -62,24 +89,32 @@ def histogram(polygons):
 
     host = settings.GEOP['host']
     port = settings.GEOP['port']
-    path = settings.GEOP['path']
-    request = settings.GEOP['request'].copy()
-    request['input']['geometry'] = polygons
-    conn = httplib.HTTPConnection("%s:%s" % (host, port))
+    url = "http://%s:%s/jobs/%s" % (host, port, job_id)
 
-    try:
-        conn.request('POST', path, json.dumps(request))
-        data = json.loads(conn.getresponse().read())
-        if data['status'] == 'OK':
-            retval = [dict_to_array(d) for d in data['result']]
+    get = requests.get(url)
+    if get.ok:
+        data = get.json()
+    else:
+        raise Exception('Unable to communicate with SJS (bottom-half).')
+
+    if data['status'] == 'OK':
+        if requests.delete(url).ok:  # job complete, remove
+            return [dict_to_array(d) for d in data['result']]
         else:
-            retval = [[]]
-    except Exception:
-        retval = [[]]
-    finally:
-        conn.close()
-
-    return retval
+            raise Exception('Job completed, unable to delete.')
+    elif data['status'] == 'RUNNING':
+        try:
+            retry()
+        except MaxRetriesExceededError, X:  # job took too long, terminate
+            if requests.delete(url).ok:
+                raise X
+            else:
+                raise Exception('Job timed out, unable to delete.')
+    else:
+        if requests.delete(url).ok:  # job failed, terminate
+            raise Exception('Job failed, deleted.')
+        else:
+            raise Exception('Job failed, unable to delete.')
 
 
 def histogram_to_x(data, nucleus, update_rule, after_rule):
@@ -97,6 +132,10 @@ def histogram_to_x(data, nucleus, update_rule, after_rule):
     after_rule(total, retval)
 
     return retval
+
+
+def data_to_censuses(data):
+    return [data_to_census(subdata) for subdata in data]
 
 
 def data_to_census(data):
@@ -117,35 +156,6 @@ def data_to_census(data):
     nucleus = {'distribution': {}}
 
     return histogram_to_x(data, nucleus, update_rule, after_rule)
-
-
-def json_polygon(polygon):
-    """
-    Utility function whose output is a GeoJSON polygon in a string.
-    """
-    if not isinstance(polygon, (str, unicode)):
-        return json.dumps(polygon)
-    else:
-        return polygon
-
-
-def geojson_to_census(polygon):
-    """
-    Take a Polygon or MultiPolygon either as a string containing
-    GeoJSON or as a Python object -- preferably the former -- and
-    return a TR-55-compatible census.
-    """
-    data = histogram([json_polygon(polygon)])[0]  # one-and-only-one AOI
-    return data_to_census(data)
-
-
-def geojson_to_censuses(polygons):
-    """
-    Similar to the `geojson_to_census` function above, but accepts an
-    list of polygons and returns a list of censuses.
-    """
-    data = histogram([json_polygon(p) for p in polygons])
-    return [data_to_census(subdata) for subdata in data]
 
 
 def data_to_survey(data):
@@ -220,13 +230,3 @@ def data_to_survey(data):
     ]
 
     return histogram_to_x(data, nucleus, update_rule, after_rule)
-
-
-def geojson_to_survey(polygon):
-    """
-    Similar to the `census` function above, but produces a survey of
-    the type expected by the `/analyze` page.
-    """
-
-    data = histogram([json_polygon(polygon)])[0]  # one-and-only-one AOI
-    return data_to_survey(data)

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -182,8 +182,10 @@ def get_job(request, job_uuid, format=None):
     )
 
 
-def _initiate_analyze_job_chain(area_of_interest, job_id):
-    return chain(tasks.run_analyze.s(area_of_interest),
+def _initiate_analyze_job_chain(area_of_interest, job_id, testing=False):
+    return chain(tasks.polygon_to_id.s(area_of_interest),
+                 tasks.id_to_histogram.s(),
+                 tasks.histogram_to_survey.s(),
                  save_job_result.s(job_id, area_of_interest)) \
         .apply_async(link_error=save_job_error.s(job_id))
 
@@ -216,18 +218,15 @@ def _initiate_tr55_job_chain(model_input, job_id):
 def _construct_tr55_job_chain(model_input, job_id):
     job_chain = []
 
-    current_hash = model_input['modification_hash']
-    census = model_input.get('census')
-    census_hash = None
-
-    if census is not None:
-        census_hash = model_input['census'].get('modification_hash')
-
-    if census is None or current_hash != census_hash:
-        job_chain.append(tasks.prepare_census.s(model_input))
-        job_chain.append(tasks.run_tr55.s(model_input))
-    else:
-        job_chain.append(tasks.run_tr55.s(census, model_input))
+    # TODO put this into an if/else block and only do it if the
+    # censuses are not already cached.
+    aoi = model_input.get('area_of_interest')
+    pieces = model_input.get('modification_pieces')
+    polygons = [aoi] + [m['shape']['geometry'] for m in pieces]
+    job_chain.append(tasks.polygons_to_id.s(polygons))
+    job_chain.append(tasks.id_to_histogram.s())
+    job_chain.append(tasks.histograms_to_censuses.s())
+    job_chain.append(tasks.run_tr55.s(model_input))
 
     job_chain.append(save_job_result.s(job_id, model_input))
 

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -73,7 +73,7 @@ var MapModel = Backbone.Model.extend({
 var TaskModel = Backbone.Model.extend({
     defaults: {
         pollInterval: 500,
-        timeout: 15000
+        timeout: 22000
     },
 
     url: function() {

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -359,7 +359,7 @@ ITSI = {
 GEOP = {
     'host': environ.get('MMW_GEOPROCESSING_HOST', 'localhost'),
     'port': environ.get('MMW_GEOPROCESSING_PORT', '8090'),
-    'path': '/jobs?sync=true&context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.SummaryJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
+    'path': '/jobs?context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.SummaryJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
     'request': {
         'input': {
             'geometry': None,


### PR DESCRIPTION
SJS's asynchronous mode is now used.  That works in the following way: after the initial request is made, the requester is given a job ID which it can periodically check until the job has either succeeded or failed.

The polling is done by using a celery task which checks the SJS endpoint to see if the result is ready.  If so, it is returned; if not the task asks to be put back onto the queue and run again in two seconds.

Connects #701
Connects #823

Would like to create separate issues for:
   * Gathering metrics (https://github.com/WikiWatershed/model-my-watershed/issues/871)
   * Caching of censuses (https://github.com/WikiWatershed/model-my-watershed/issues/870)
