### PR TITLE
Pad results in /analyze table

### DIFF
--- a/src/mmw/js/src/analyze/templates/tableRow.html
+++ b/src/mmw/js/src/analyze/templates/tableRow.html
@@ -1,3 +1,3 @@
 <td>{{ type }}</td>
-<td class="strong text-right">{{ scaledArea|round(2)|toLocaleString }}</td>
+<td class="strong text-right">{{ scaledArea|round(2)|toLocaleString(2) }}</td>
 <td class="strong text-right">{{ coveragePct|toFixed(1) }}</td>

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -106,7 +106,7 @@ function checkTableBody(subData) {
         // displayed.
         var expectedRowVals = [
             subData.categories[trInd].type,
-            subData.categories[trInd].area.toLocaleString('en'),
+            subData.categories[trInd].area.toLocaleString('en', {minimumFractionDigits: 2}),
             (subData.categories[trInd].coverage * 100).toFixed(1)
         ];
         expectedRowVals = _.map(expectedRowVals, function(val) {

--- a/src/mmw/js/src/core/filters.js
+++ b/src/mmw/js/src/core/filters.js
@@ -4,6 +4,10 @@ var nunjucks = require('nunjucks');
 
 nunjucks.env = new nunjucks.Environment();
 
-nunjucks.env.addFilter('toLocaleString', function(val) {
-    return val.toLocaleString('en');
+nunjucks.env.addFilter('toLocaleString', function(val, n) {
+    if (n) {
+        return val.toLocaleString('en', {minimumFractionDigits: n});
+    } else {
+        return val.toLocaleString('en');
+    }
 });


### PR DESCRIPTION
Values in the "Area" column of the `/analyze` table are now padded to at least two digits.

**To Test**
   * Click around until you find an AoI where some of the values in the "Area" column end in zeros  (you may have to try a few times before you can find one).  Previously, those would have had zero or one digit after the decimal point.

![screenshot from 2015-09-22 15 19 33](https://cloud.githubusercontent.com/assets/11281373/10029147/6a50157c-613e-11e5-956a-2f4620fa070c.png)


Connects #812