### PR TITLE
Stop polling for Celery job if job fails.

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -165,11 +165,13 @@ var TaskModel = Backbone.Model.extend({
             self.fetch()
                 .done(function(response) {
                     console.log('Polling ' + self.url());
-                    if (response.status !== 'complete') {
+                    if (response.status === 'started') {
                         elapsed = elapsed + self.get('pollInterval');
                         window.setTimeout(getResults, self.get('pollInterval'));
-                    } else {
+                    } else if (response.status === 'complete') {
                         defer.resolve(response);
+                    } else { // Captures 'failed' and anything else
+                        defer.reject(response);
                     }
                 })
                 .fail(defer.reject);

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -73,7 +73,7 @@ var MapModel = Backbone.Model.extend({
 var TaskModel = Backbone.Model.extend({
     defaults: {
         pollInterval: 500,
-        timeout: 10000
+        timeout: 15000
     },
 
     url: function() {


### PR DESCRIPTION
* Adjust the client-side polling logic to stop polling Celery if the
the job being polled has failed. The response from Celery is a
200 even if the job completes, which is why the errors/failed jobs
were not being caught by the fail function of the polling promise.

The change in 9c5659d is needed for testing, otherwise the client-side timeout will be reached before the job has failed. It doesn't necessarily need to be included, though it will probably be increasing due to #826.

**Testing:**

- Open a new terminal window and run `scripty debugcelery`.
- Visit the MMW homepage.
- Open the JS debugger.
- Draw a large AoI thats at least covers half of PA.
- Watch the Celery log and the console log. After about 10 seconds, Celery should report #811.
- At this time, the app should stop polling and show the error message, even though the timeout hasn't been hit. If it's hard to see. Increase the client-side timeout to something much higher, like one minute. 

Connects to #815