### PR TITLE
Replace livereloadify with livereload

### DIFF
--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -4,27 +4,27 @@
   "dependencies": {
     "backbone": {
       "version": "1.1.2",
-      "from": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz",
+      "from": "backbone@1.1.2",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz"
     },
     "backbone.marionette": {
       "version": "2.4.1",
-      "from": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.1.tgz",
+      "from": "backbone.marionette@2.4.1",
       "resolved": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.1.tgz",
       "dependencies": {
         "backbone.babysitter": {
-          "version": "0.1.8",
-          "from": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz",
-          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz"
+          "version": "0.1.6",
+          "from": "backbone.babysitter@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.6.tgz"
         },
         "backbone.wreqr": {
-          "version": "1.3.3",
-          "from": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz"
+          "version": "1.3.1",
+          "from": "backbone.wreqr@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.1.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "from": "underscore@>=1.4.4 <=1.6.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
@@ -36,115 +36,137 @@
     },
     "bootstrap": {
       "version": "3.3.4",
-      "from": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz",
+      "from": "bootstrap@3.3.4",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz"
     },
     "bootstrap-select": {
       "version": "1.6.4",
-      "from": "bootstrap-select@git://github.com/azavea/bootstrap-select",
+      "from": "../../tmp/npm-3496-25385efb/1430415914259-0.019491331884637475/f1755efa102a41e43fc367ba36ce905b8f2b90e1",
       "resolved": "git://github.com/azavea/bootstrap-select#f1755efa102a41e43fc367ba36ce905b8f2b90e1"
     },
     "bootstrap-table": {
       "version": "1.8.1",
-      "from": "bootstrap-table@",
+      "from": "bootstrap-table@1.8.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.8.1.tgz",
       "dependencies": {
         "grunt-contrib-copy": {
           "version": "0.8.1",
-          "from": "grunt-contrib-copy@^0.8.0",
+          "from": "grunt-contrib-copy@0.8.1",
+          "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.8.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@^1.0.0",
+              "from": "chalk@1.1.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0"
+                  "from": "ansi-styles@2.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2"
+                  "from": "escape-string-regexp@1.0.3",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
+                  "from": "has-ansi@2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0"
+                      "from": "ansi-regex@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
+                  "from": "strip-ansi@3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0"
+                      "from": "ansi-regex@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@^2.0.0"
+                  "from": "supports-color@2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "file-sync-cmp": {
               "version": "0.1.1",
-              "from": "file-sync-cmp@^0.1.0"
+              "from": "file-sync-cmp@0.1.1",
+              "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
             }
           }
         },
         "grunt-contrib-concat": {
           "version": "0.5.1",
-          "from": "grunt-contrib-concat@^0.5.1",
+          "from": "grunt-contrib-concat@0.5.1",
+          "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.5.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@^0.5.1",
+              "from": "chalk@0.5.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0"
+                  "from": "ansi-styles@1.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.0"
+                  "from": "escape-string-regexp@1.0.3",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "has-ansi@0.1.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0"
+                      "from": "ansi-regex@0.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "strip-ansi@0.3.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0"
+                      "from": "ansi-regex@0.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0"
+                  "from": "supports-color@0.2.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.3.0",
-              "from": "source-map@^0.3.0",
+              "from": "source-map@0.3.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4"
+                  "from": "amdefine@1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             }
@@ -152,77 +174,93 @@
         },
         "grunt-contrib-clean": {
           "version": "0.6.0",
-          "from": "grunt-contrib-clean@^0.6.0",
+          "from": "grunt-contrib-clean@0.6.0",
+          "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@~2.2.1"
+              "from": "rimraf@2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
         },
         "grunt-contrib-cssmin": {
           "version": "0.12.3",
-          "from": "grunt-contrib-cssmin@^0.12.2",
+          "from": "grunt-contrib-cssmin@0.12.3",
+          "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.12.3.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@^1.0.0",
+              "from": "chalk@1.1.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0"
+                  "from": "ansi-styles@2.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.0"
+                  "from": "escape-string-regexp@1.0.3",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
+                  "from": "has-ansi@2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0"
+                      "from": "ansi-regex@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
+                  "from": "strip-ansi@3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0"
+                      "from": "ansi-regex@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@^2.0.0"
+                  "from": "supports-color@2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "clean-css": {
               "version": "3.4.1",
-              "from": "clean-css@^3.1.0",
+              "from": "clean-css@3.4.1",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.1.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@2.8.x",
+                  "from": "commander@2.8.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>= 1.0.0"
+                      "from": "graceful-readlink@1.0.1",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "source-map@0.4.x",
+                  "from": "source-map@0.4.4",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4"
+                      "from": "amdefine@1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
@@ -230,51 +268,63 @@
             },
             "maxmin": {
               "version": "1.1.0",
-              "from": "maxmin@^1.0.0",
+              "from": "maxmin@1.1.0",
+              "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
               "dependencies": {
                 "figures": {
                   "version": "1.3.5",
-                  "from": "figures@^1.0.1"
+                  "from": "figures@1.3.5",
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "gzip-size": {
                   "version": "1.0.0",
-                  "from": "gzip-size@^1.0.0",
+                  "from": "gzip-size@1.0.0",
+                  "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.5.0",
-                      "from": "concat-stream@^1.4.1",
+                      "from": "concat-stream@1.5.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1"
+                          "from": "inherits@2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "typedarray@~0.0.5"
+                          "from": "typedarray@0.0.6",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "2.0.2",
-                          "from": "readable-stream@~2.0.0",
+                          "from": "readable-stream@2.0.2",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0"
+                              "from": "core-util-is@1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1"
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "process-nextick-args": {
                               "version": "1.0.2",
-                              "from": "process-nextick-args@~1.0.0"
+                              "from": "process-nextick-args@1.0.2",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@~0.10.x"
+                              "from": "string_decoder@0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "util-deprecate": {
                               "version": "1.0.1",
-                              "from": "util-deprecate@~1.0.1"
+                              "from": "util-deprecate@1.0.1",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                             }
                           }
                         }
@@ -282,11 +332,13 @@
                     },
                     "browserify-zlib": {
                       "version": "0.1.4",
-                      "from": "browserify-zlib@^0.1.4",
+                      "from": "browserify-zlib@0.1.4",
+                      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                       "dependencies": {
                         "pako": {
                           "version": "0.2.7",
-                          "from": "pako@~0.2.0"
+                          "from": "pako@0.2.7",
+                          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
                         }
                       }
                     }
@@ -294,45 +346,55 @@
                 },
                 "pretty-bytes": {
                   "version": "1.0.4",
-                  "from": "pretty-bytes@^1.0.0",
+                  "from": "pretty-bytes@1.0.4",
+                  "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
                   "dependencies": {
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "get-stdin@^4.0.1"
+                      "from": "get-stdin@4.0.1",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     },
                     "meow": {
                       "version": "3.3.0",
-                      "from": "meow@^3.1.0",
+                      "from": "meow@3.3.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
                           "version": "1.0.0",
-                          "from": "camelcase-keys@^1.0.0",
+                          "from": "camelcase-keys@1.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                           "dependencies": {
                             "camelcase": {
                               "version": "1.2.1",
-                              "from": "camelcase@^1.0.1"
+                              "from": "camelcase@1.2.1",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                             },
                             "map-obj": {
                               "version": "1.0.1",
-                              "from": "map-obj@^1.0.0"
+                              "from": "map-obj@1.0.1",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                             }
                           }
                         },
                         "indent-string": {
                           "version": "1.2.2",
-                          "from": "indent-string@^1.1.0",
+                          "from": "indent-string@1.2.2",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                           "dependencies": {
                             "repeating": {
                               "version": "1.1.3",
-                              "from": "repeating@^1.1.0",
+                              "from": "repeating@1.1.3",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@^1.0.0",
+                                  "from": "is-finite@1.0.1",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@^1.0.0"
+                                      "from": "number-is-nan@1.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
                                 }
@@ -342,11 +404,13 @@
                         },
                         "minimist": {
                           "version": "1.2.0",
-                          "from": "minimist@^1.1.0"
+                          "from": "minimist@1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
                         "object-assign": {
                           "version": "3.0.0",
-                          "from": "object-assign@^3.0.0"
+                          "from": "object-assign@3.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                         }
                       }
                     }
@@ -358,93 +422,114 @@
         },
         "grunt-contrib-uglify": {
           "version": "0.8.1",
-          "from": "grunt-contrib-uglify@^0.8.0",
+          "from": "grunt-contrib-uglify@0.8.1",
+          "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.8.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@^1.0.0",
+              "from": "chalk@1.1.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0"
+                  "from": "ansi-styles@2.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2"
+                  "from": "escape-string-regexp@1.0.3",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
+                  "from": "has-ansi@2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0"
+                      "from": "ansi-regex@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
+                  "from": "strip-ansi@3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0"
+                      "from": "ansi-regex@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@^2.0.0"
+                  "from": "supports-color@2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "maxmin": {
               "version": "1.1.0",
-              "from": "maxmin@^1.0.0",
+              "from": "maxmin@1.1.0",
+              "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
               "dependencies": {
                 "figures": {
                   "version": "1.3.5",
-                  "from": "figures@^1.0.1"
+                  "from": "figures@1.3.5",
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "gzip-size": {
                   "version": "1.0.0",
-                  "from": "gzip-size@^1.0.0",
+                  "from": "gzip-size@1.0.0",
+                  "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.5.0",
-                      "from": "concat-stream@^1.4.1",
+                      "from": "concat-stream@1.5.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1"
+                          "from": "inherits@2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "typedarray@~0.0.5"
+                          "from": "typedarray@0.0.6",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "2.0.2",
-                          "from": "readable-stream@~2.0.0",
+                          "from": "readable-stream@2.0.2",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0"
+                              "from": "core-util-is@1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1"
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "process-nextick-args": {
                               "version": "1.0.2",
-                              "from": "process-nextick-args@~1.0.0"
+                              "from": "process-nextick-args@1.0.2",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@~0.10.x"
+                              "from": "string_decoder@0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "util-deprecate": {
                               "version": "1.0.1",
-                              "from": "util-deprecate@~1.0.1"
+                              "from": "util-deprecate@1.0.1",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                             }
                           }
                         }
@@ -452,11 +537,13 @@
                     },
                     "browserify-zlib": {
                       "version": "0.1.4",
-                      "from": "browserify-zlib@^0.1.4",
+                      "from": "browserify-zlib@0.1.4",
+                      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                       "dependencies": {
                         "pako": {
                           "version": "0.2.7",
-                          "from": "pako@~0.2.0"
+                          "from": "pako@0.2.7",
+                          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
                         }
                       }
                     }
@@ -464,45 +551,55 @@
                 },
                 "pretty-bytes": {
                   "version": "1.0.4",
-                  "from": "pretty-bytes@^1.0.0",
+                  "from": "pretty-bytes@1.0.4",
+                  "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
                   "dependencies": {
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "get-stdin@^4.0.1"
+                      "from": "get-stdin@4.0.1",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     },
                     "meow": {
                       "version": "3.3.0",
-                      "from": "meow@^3.1.0",
+                      "from": "meow@3.3.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
                           "version": "1.0.0",
-                          "from": "camelcase-keys@^1.0.0",
+                          "from": "camelcase-keys@1.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                           "dependencies": {
                             "camelcase": {
                               "version": "1.2.1",
-                              "from": "camelcase@^1.0.1"
+                              "from": "camelcase@1.2.1",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                             },
                             "map-obj": {
                               "version": "1.0.1",
-                              "from": "map-obj@^1.0.0"
+                              "from": "map-obj@1.0.1",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                             }
                           }
                         },
                         "indent-string": {
                           "version": "1.2.2",
-                          "from": "indent-string@^1.1.0",
+                          "from": "indent-string@1.2.2",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                           "dependencies": {
                             "repeating": {
                               "version": "1.1.3",
-                              "from": "repeating@^1.1.0",
+                              "from": "repeating@1.1.3",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@^1.0.0",
+                                  "from": "is-finite@1.0.1",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@^1.0.0"
+                                      "from": "number-is-nan@1.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
                                 }
@@ -512,11 +609,13 @@
                         },
                         "minimist": {
                           "version": "1.2.0",
-                          "from": "minimist@^1.1.0"
+                          "from": "minimist@1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
                         "object-assign": {
                           "version": "3.0.0",
-                          "from": "object-assign@^3.0.0"
+                          "from": "object-assign@3.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                         }
                       }
                     }
@@ -527,68 +626,83 @@
             "uglify-js": {
               "version": "2.4.17",
               "from": "uglify-js@2.4.17",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.17.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@~0.2.6"
+                  "from": "async@0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.34",
                   "from": "source-map@0.1.34",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4"
+                      "from": "amdefine@1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 },
                 "yargs": {
                   "version": "1.3.3",
-                  "from": "yargs@~1.3.3"
+                  "from": "yargs@1.3.3",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@~1.0.0"
+                  "from": "uglify-to-browserify@1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 }
               }
             },
             "uri-path": {
               "version": "0.0.2",
-              "from": "uri-path@0.0.2"
+              "from": "uri-path@0.0.2",
+              "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-0.0.2.tgz"
             }
           }
         },
         "grunt-contrib-jshint": {
           "version": "0.10.0",
-          "from": "grunt-contrib-jshint@^0.10.0",
+          "from": "grunt-contrib-jshint@0.10.0",
+          "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
           "dependencies": {
             "jshint": {
               "version": "2.5.11",
-              "from": "jshint@~2.5.0",
+              "from": "jshint@2.5.11",
+              "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
               "dependencies": {
                 "cli": {
                   "version": "0.6.6",
-                  "from": "cli@0.6.x",
+                  "from": "cli@0.6.6",
+                  "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "3.2.11",
-                      "from": "glob@~ 3.2.1",
+                      "from": "glob@3.2.11",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@2"
+                          "from": "inherits@2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "minimatch": {
                           "version": "0.3.0",
-                          "from": "minimatch@0.3",
+                          "from": "minimatch@0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.6.5",
-                              "from": "lru-cache@2"
+                              "from": "lru-cache@2.6.5",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.1",
-                              "from": "sigmund@~1.0.0"
+                              "from": "sigmund@1.0.1",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                             }
                           }
                         }
@@ -598,41 +712,50 @@
                 },
                 "console-browserify": {
                   "version": "1.1.0",
-                  "from": "console-browserify@1.1.x",
+                  "from": "console-browserify@1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
                   "dependencies": {
                     "date-now": {
                       "version": "0.1.4",
-                      "from": "date-now@^0.1.4"
+                      "from": "date-now@0.1.4",
+                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                     }
                   }
                 },
                 "exit": {
                   "version": "0.1.2",
-                  "from": "exit@0.1.x"
+                  "from": "exit@0.1.2",
+                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
                 },
                 "htmlparser2": {
                   "version": "3.8.3",
-                  "from": "htmlparser2@3.8.x",
+                  "from": "htmlparser2@3.8.3",
+                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
                   "dependencies": {
                     "domhandler": {
                       "version": "2.3.0",
-                      "from": "domhandler@2.3"
+                      "from": "domhandler@2.3.0",
+                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                     },
                     "domutils": {
                       "version": "1.5.1",
-                      "from": "domutils@1.5",
+                      "from": "domutils@1.5.1",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                       "dependencies": {
                         "dom-serializer": {
                           "version": "0.1.0",
-                          "from": "dom-serializer@0",
+                          "from": "dom-serializer@0.1.0",
+                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                           "dependencies": {
                             "domelementtype": {
                               "version": "1.1.3",
-                              "from": "domelementtype@~1.1.1"
+                              "from": "domelementtype@1.1.3",
+                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                             },
                             "entities": {
                               "version": "1.1.1",
-                              "from": "entities@~1.1.1"
+                              "from": "entities@1.1.1",
+                              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                             }
                           }
                         }
@@ -640,117 +763,143 @@
                     },
                     "domelementtype": {
                       "version": "1.3.0",
-                      "from": "domelementtype@1"
+                      "from": "domelementtype@1.3.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@1.1",
+                      "from": "readable-stream@1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0"
+                          "from": "core-util-is@1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1"
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x"
+                          "from": "string_decoder@0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1"
+                          "from": "inherits@2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "entities": {
                       "version": "1.0.0",
-                      "from": "entities@1.0"
+                      "from": "entities@1.0.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "1.0.0",
-                  "from": "minimatch@1.0.x",
+                  "from": "minimatch@1.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@2"
+                      "from": "lru-cache@2.6.5",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "shelljs": {
                   "version": "0.3.0",
-                  "from": "shelljs@0.3.x"
+                  "from": "shelljs@0.3.0",
+                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
                 },
                 "strip-json-comments": {
                   "version": "1.0.4",
-                  "from": "strip-json-comments@1.0.x"
+                  "from": "strip-json-comments@1.0.4",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                 },
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "underscore@1.6.x"
+                  "from": "underscore@1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 }
               }
             },
             "hooker": {
               "version": "0.2.3",
-              "from": "hooker@~0.2.3"
+              "from": "hooker@0.2.3",
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
             }
           }
         },
         "grunt": {
           "version": "0.4.5",
-          "from": "grunt@^0.4.5",
+          "from": "grunt@0.4.5",
+          "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
           "dependencies": {
             "async": {
               "version": "0.1.22",
-              "from": "async@~0.1.22"
+              "from": "async@0.1.22",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
             },
             "coffee-script": {
               "version": "1.3.3",
-              "from": "coffee-script@~1.3.3"
+              "from": "coffee-script@1.3.3",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
             },
             "colors": {
               "version": "0.6.2",
-              "from": "colors@~0.6.2"
+              "from": "colors@0.6.2",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
             },
             "dateformat": {
               "version": "1.0.2-1.2.3",
-              "from": "dateformat@1.0.2-1.2.3"
+              "from": "dateformat@1.0.2-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
             },
             "eventemitter2": {
               "version": "0.4.14",
-              "from": "eventemitter2@~0.4.13"
+              "from": "eventemitter2@0.4.14",
+              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
             },
             "findup-sync": {
               "version": "0.1.3",
-              "from": "findup-sync@~0.1.2",
+              "from": "findup-sync@0.1.3",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@~3.2.9",
+                  "from": "glob@3.2.11",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2"
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@0.3",
+                      "from": "minimatch@0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.6.5",
-                          "from": "lru-cache@2"
+                          "from": "lru-cache@2.6.5",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@~1.0.0"
+                          "from": "sigmund@1.0.1",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     }
@@ -758,123 +907,150 @@
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@~2.4.1"
+                  "from": "lodash@2.4.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.1.21",
-              "from": "glob@~3.1.21",
+              "from": "glob@3.1.21",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@~1.2.0"
+                  "from": "graceful-fs@1.2.3",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 },
                 "inherits": {
                   "version": "1.0.2",
-                  "from": "inherits@1"
+                  "from": "inherits@1.0.2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                 }
               }
             },
             "hooker": {
               "version": "0.2.3",
-              "from": "hooker@~0.2.3"
+              "from": "hooker@0.2.3",
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
             },
             "iconv-lite": {
               "version": "0.2.11",
-              "from": "iconv-lite@~0.2.11"
+              "from": "iconv-lite@0.2.11",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@~0.2.12",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@2"
+                  "from": "lru-cache@2.6.5",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@~1.0.0"
+                  "from": "sigmund@1.0.1",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "nopt": {
               "version": "1.0.10",
-              "from": "nopt@~1.0.10",
+              "from": "nopt@1.0.10",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@1"
+                  "from": "abbrev@1.0.7",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@~2.2.8"
+              "from": "rimraf@2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "lodash": {
               "version": "0.9.2",
-              "from": "lodash@~0.9.2"
+              "from": "lodash@0.9.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
             },
             "underscore.string": {
               "version": "2.2.1",
-              "from": "underscore.string@~2.2.1"
+              "from": "underscore.string@2.2.1",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
             },
             "which": {
               "version": "1.0.9",
-              "from": "which@~1.0.5"
+              "from": "which@1.0.9",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             },
             "js-yaml": {
               "version": "2.0.5",
-              "from": "js-yaml@~2.0.5",
+              "from": "js-yaml@2.0.5",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "0.1.16",
-                  "from": "argparse@~ 0.1.11",
+                  "from": "argparse@0.1.16",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.7.0",
-                      "from": "underscore@~1.7.0"
+                      "from": "underscore@1.7.0",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                     },
                     "underscore.string": {
                       "version": "2.4.0",
-                      "from": "underscore.string@~2.4.0"
+                      "from": "underscore.string@2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@~ 1.0.2"
+                  "from": "esprima@1.0.4",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@~0.1.1"
+              "from": "exit@0.1.2",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "getobject": {
               "version": "0.1.0",
-              "from": "getobject@~0.1.0"
+              "from": "getobject@0.1.0",
+              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
             },
             "grunt-legacy-util": {
               "version": "0.2.0",
-              "from": "grunt-legacy-util@~0.2.0"
+              "from": "grunt-legacy-util@0.2.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
             },
             "grunt-legacy-log": {
               "version": "0.1.2",
-              "from": "grunt-legacy-log@~0.1.0",
+              "from": "grunt-legacy-log@0.1.2",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
               "dependencies": {
                 "grunt-legacy-log-utils": {
                   "version": "0.1.1",
-                  "from": "grunt-legacy-log-utils@^0.1.1"
+                  "from": "grunt-legacy-log-utils@0.1.1",
+                  "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@~2.4.1"
+                  "from": "lodash@2.4.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@~2.3.3"
+                  "from": "underscore.string@2.3.3",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                 }
               }
             }
@@ -884,72 +1060,72 @@
     },
     "browserify": {
       "version": "9.0.3",
-      "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
+      "from": "browserify@9.0.3",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.10.0",
-          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+          "from": "JSONStream@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+              "from": "jsonparse@0.0.5",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
             },
             "through": {
-              "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+              "version": "2.3.6",
+              "from": "through@>=2.2.7 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "assert": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+          "from": "assert@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
-          "version": "4.0.4",
-          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
+          "version": "4.0.1",
+          "from": "browser-pack@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "version": "0.8.4",
+              "from": "JSONStream@>=0.8.4 <0.9.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
-                  "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+              "from": "combine-source-map@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                  "from": "inline-source-map@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                      "from": "source-map@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "dependencies": {
                         "amdefine": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
                     }
@@ -957,41 +1133,36 @@
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+                  "from": "convert-source-map@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.31 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 }
               }
             },
-            "defined": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-            },
             "through2": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "from": "through2@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -999,177 +1170,187 @@
               }
             },
             "umd": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
+              "version": "3.0.0",
+              "from": "umd@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
             }
           }
         },
         "browser-resolve": {
-          "version": "1.9.0",
-          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz"
+          "version": "1.8.2",
+          "from": "browser-resolve@>=1.7.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "from": "browserify-zlib@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
-              "version": "0.2.7",
-              "from": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+              "version": "0.2.6",
+              "from": "pako@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
             }
           }
         },
         "buffer": {
-          "version": "3.3.1",
-          "from": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz",
+          "version": "3.1.2",
+          "from": "buffer@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+              "from": "base64-js@0.0.8",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+              "version": "1.1.4",
+              "from": "ieee754@>=1.1.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
             },
             "is-array": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+              "from": "is-array@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+          "from": "builtins@>=0.0.3 <0.1.0",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+          "from": "commondir@0.0.1",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
-          "version": "1.4.10",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "version": "1.4.7",
+          "from": "concat-stream@>=1.4.1 <1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "from": "console-browserify@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "from": "date-now@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+          "from": "constants-browserify@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
-          "version": "3.9.14",
-          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
+          "version": "3.9.13",
+          "from": "crypto-browserify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
           "dependencies": {
             "browserify-aes": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz"
+              "version": "1.0.0",
+              "from": "browserify-aes@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
             },
             "browserify-sign": {
-              "version": "3.0.2",
-              "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
+              "version": "2.8.0",
+              "from": "browserify-sign@2.8.0",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                  "version": "1.3.0",
+                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
+                  "version": "1.1.1",
+                  "from": "browserify-rsa@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                 },
                 "elliptic": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "version": "1.0.1",
+                  "from": "elliptic@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                      "from": "brorand@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                      "version": "1.0.2",
+                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                     }
                   }
                 },
                 "parse-asn1": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "version": "2.0.0",
+                  "from": "parse-asn1@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                      "version": "1.0.3",
+                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
+                    },
+                    "asn1.js-rfc3280": {
+                      "version": "1.0.0",
+                      "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
+                    },
+                    "pemstrip": {
+                      "version": "0.0.1",
+                      "from": "pemstrip@0.0.1",
+                      "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "create-ecdh": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
+              "version": "2.0.0",
+              "from": "create-ecdh@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                  "version": "1.3.0",
+                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "elliptic": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "version": "1.0.1",
+                  "from": "elliptic@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                      "from": "brorand@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                      "version": "1.0.2",
+                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                     }
                   }
                 }
@@ -1177,83 +1358,83 @@
             },
             "create-hash": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
+              "from": "create-hash@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "dependencies": {
                 "ripemd160": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "ripemd160@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
                 },
                 "sha.js": {
-                  "version": "2.4.2",
-                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz"
+                  "version": "2.3.6",
+                  "from": "sha.js@>=2.3.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                 }
               }
             },
             "create-hmac": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
+              "from": "create-hmac@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
-              "version": "3.0.2",
-              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
+              "version": "3.0.1",
+              "from": "diffie-hellman@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                  "version": "1.3.0",
+                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "miller-rabin": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
+                  "version": "1.1.5",
+                  "from": "miller-rabin@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                      "from": "brorand@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     }
                   }
                 }
               }
             },
-            "pbkdf2": {
-              "version": "3.0.4",
-              "from": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
+            "pbkdf2-compat": {
+              "version": "3.0.2",
+              "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
             },
             "public-encrypt": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
+              "version": "2.0.0",
+              "from": "public-encrypt@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                  "version": "1.3.0",
+                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
+                  "version": "2.0.0",
+                  "from": "browserify-rsa@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                 },
                 "parse-asn1": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "version": "3.0.0",
+                  "from": "parse-asn1@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                      "version": "1.0.3",
+                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
@@ -1264,40 +1445,64 @@
             },
             "randombytes": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
+              "from": "randombytes@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             }
           }
         },
         "deep-equal": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
+          "from": "deep-equal@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
         },
         "defined": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+          "from": "defined@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
-          "version": "1.3.9",
-          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
-          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+          "version": "1.3.5",
+          "from": "deps-sort@>=1.3.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "version": "0.8.4",
+              "from": "JSONStream@>=0.8.4 <0.9.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
-                  "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
                 }
               }
             }
@@ -1305,54 +1510,54 @@
         },
         "domain-browser": {
           "version": "1.1.4",
-          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
+          "from": "domain-browser@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
         },
         "duplexer2": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "from": "duplexer2@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "events": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+          "from": "events@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
           "version": "4.5.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "from": "glob@>=4.0.5 <5.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.8",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -1360,13 +1565,13 @@
               }
             },
             "once": {
-              "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -1375,141 +1580,145 @@
         },
         "has": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/has/-/has-1.0.0.tgz",
+          "from": "has@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "from": "http-browserify@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+              "from": "Base64@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+          "from": "https-browserify@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
-          "version": "6.5.2",
-          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
+          "version": "6.2.1",
+          "from": "insert-module-globals@>=6.2.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "version": "0.7.4",
+              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 }
               }
             },
             "combine-source-map": {
-              "version": "0.6.1",
-              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+              "version": "0.3.0",
+              "from": "combine-source-map@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
-                "convert-source-map": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
-                },
                 "inline-source-map": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                  "version": "0.3.1",
+                  "from": "inline-source-map@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.3.0",
+                      "from": "source-map@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
-                "lodash.memoize": {
-                  "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+                "convert-source-map": {
+                  "version": "0.3.5",
+                  "from": "convert-source-map@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
-                  "version": "0.4.3",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.31 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 }
               }
             },
             "lexical-scope": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
+              "version": "1.1.0",
+              "from": "lexical-scope@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
               "dependencies": {
                 "astw": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                  "version": "1.1.0",
+                  "from": "astw@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                   "dependencies": {
-                    "acorn": {
-                      "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                    "esprima-fb": {
+                      "version": "3001.1.0-dev-harmony-fb",
+                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                     }
                   }
                 }
               }
             },
             "process": {
-              "version": "0.11.1",
-              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+              "version": "0.6.0",
+              "from": "process@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
             },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            "through": {
+              "version": "2.3.6",
+              "from": "through@>=2.3.4 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "from": "isarray@0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
-              "version": "1.3.2",
-              "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+              "version": "1.3.1",
+              "from": "stream-splicer@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "dependencies": {
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                  "from": "readable-wrap@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                  "from": "indexof@0.0.1",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
@@ -1517,108 +1726,103 @@
           }
         },
         "module-deps": {
-          "version": "3.8.1",
-          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
+          "version": "3.7.6",
+          "from": "module-deps@>=3.7.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.6.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "version": "0.7.4",
+              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
-                  "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
-            "defined": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-            },
             "detective": {
-              "version": "4.1.1",
-              "from": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
+              "version": "4.0.0",
+              "from": "detective@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                  "version": "0.9.0",
+                  "from": "acorn@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 },
                 "escodegen": {
                   "version": "1.6.1",
-                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "from": "escodegen@>=1.4.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "dependencies": {
                     "estraverse": {
                       "version": "1.9.3",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                      "from": "estraverse@>=1.9.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                     },
                     "esutils": {
                       "version": "1.1.6",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                      "from": "esutils@>=1.1.6 <2.0.0",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                     },
                     "esprima": {
                       "version": "1.2.5",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                      "from": "esprima@>=1.2.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                      "from": "optionator@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
                         "prelude-ls": {
-                          "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                          "version": "1.1.1",
+                          "from": "prelude-ls@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                         },
                         "deep-is": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                          "from": "deep-is@>=0.1.2 <0.2.0",
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
                         "wordwrap": {
-                          "version": "0.0.3",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                          "version": "0.0.2",
+                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         },
                         "type-check": {
                           "version": "0.3.1",
-                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                          "from": "type-check@>=0.3.1 <0.4.0",
                           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                         },
                         "levn": {
                           "version": "0.2.5",
-                          "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                          "from": "levn@>=0.2.5 <0.3.0",
                           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                         },
                         "fast-levenshtein": {
                           "version": "1.0.6",
-                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+                          "from": "fast-levenshtein@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                         }
                       }
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "from": "source-map@>=0.1.40 <0.2.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
                     }
@@ -1626,32 +1830,80 @@
                 }
               }
             },
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+            },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "from": "stream-combiner2@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "from": "through2@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "from": "readable-stream@>=1.0.17 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                      "from": "xtend@>=3.0.0 <3.1.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "subarg": {
+              "version": "0.0.1",
+              "from": "subarg@0.0.1",
+              "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.4.2",
+              "from": "through2@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "from": "xtend@>=2.1.1 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "dependencies": {
+                    "object-keys": {
+                      "version": "0.4.0",
+                      "from": "object-keys@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                     }
                   }
                 }
@@ -1659,221 +1911,214 @@
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+          "from": "os-browserify@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+          "from": "parents@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.11.15",
-              "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+              "from": "path-platform@>=0.11.15 <0.12.0",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+          "from": "path-browserify@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.10.1",
-          "from": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
+          "from": "process@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+          "from": "punycode@>=1.2.3 <1.3.0",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+          "from": "querystring-es3@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.13 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+          "from": "resolve@>=1.1.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+          "from": "shallow-copy@0.0.1",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+          "from": "shasum@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
             },
             "sha.js": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
+              "from": "sha.js@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
             }
           }
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+          "from": "shell-quote@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "from": "stream-browserify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "from": "subarg@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+              "from": "minimist@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
             }
           }
         },
         "syntax-error": {
-          "version": "1.1.4",
-          "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
+          "version": "1.1.2",
+          "from": "syntax-error@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
           "dependencies": {
             "acorn": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+              "version": "0.9.0",
+              "from": "acorn@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "from": "through2@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "timers-browserify": {
-          "version": "1.4.1",
-          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
-          "dependencies": {
-            "process": {
-              "version": "0.11.1",
-              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
-            }
-          }
+          "version": "1.4.0",
+          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+          "from": "tty-browserify@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "from": "url@>=0.10.1 <0.11.0",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "from": "punycode@1.3.2",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             },
             "querystring": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+              "from": "querystring@0.2.0",
               "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "from": "util@>=0.10.1 <0.11.0",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "from": "vm-browserify@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+              "from": "indexof@0.0.1",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "from": "xtend@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
     },
     "chai": {
       "version": "1.10.0",
-      "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+      "from": "chai@1.10.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
       "dependencies": {
         "assertion-error": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+          "from": "assertion-error@1.0.0",
           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
         },
         "deep-eql": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "from": "deep-eql@0.1.3",
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "from": "type-detect@0.1.1",
               "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
             }
           }
@@ -1882,57 +2127,57 @@
     },
     "d3": {
       "version": "3.5.5",
-      "from": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz",
+      "from": "d3@3.5.5",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz"
     },
     "font-awesome": {
       "version": "4.3.0",
-      "from": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz",
+      "from": "font-awesome@4.3.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz"
     },
     "iframe-phone": {
       "version": "1.1.3",
-      "from": "git://github.com/concord-consortium/iframe-phone#v1.1.3",
+      "from": "../../tmp/npm-5418-3f5d22c2/1441117736713-0.026042116107419133/200f47f43ee32d640868072c17de4a675e16d96a",
       "resolved": "git://github.com/concord-consortium/iframe-phone#200f47f43ee32d640868072c17de4a675e16d96a"
     },
     "jquery": {
       "version": "2.1.3",
-      "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz",
+      "from": "jquery@2.1.3",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz"
     },
     "jshint": {
       "version": "2.8.0",
-      "from": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
+      "from": "jshint@*",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.6",
-          "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+          "from": "cli@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -1943,49 +2188,49 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "from": "date-now@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.3",
-          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+              "from": "domhandler@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "from": "domutils@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "from": "domelementtype@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     },
                     "entities": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                      "from": "entities@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
@@ -1994,8 +2239,442 @@
             },
             "domelementtype": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "from": "minimatch@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+        },
+        "strip-json-comments": {
+          "version": "1.0.2",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "from": "lodash@>=3.7.0 <3.8.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+        }
+      }
+    },
+    "jstify": {
+      "version": "0.9.0",
+      "from": "jstify@0.9.0",
+      "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
+      "dependencies": {
+        "html-minifier": {
+          "version": "0.6.9",
+          "from": "html-minifier@>=0.6.8 <0.7.0",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
+          "dependencies": {
+            "change-case": {
+              "version": "2.1.6",
+              "from": "change-case@>=2.1.0 <2.2.0",
+              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
+              "dependencies": {
+                "camel-case": {
+                  "version": "1.1.1",
+                  "from": "camel-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz"
+                },
+                "constant-case": {
+                  "version": "1.1.0",
+                  "from": "constant-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz"
+                },
+                "dot-case": {
+                  "version": "1.1.1",
+                  "from": "dot-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
+                },
+                "is-lower-case": {
+                  "version": "1.1.1",
+                  "from": "is-lower-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
+                },
+                "is-upper-case": {
+                  "version": "1.1.1",
+                  "from": "is-upper-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
+                },
+                "lower-case": {
+                  "version": "1.1.2",
+                  "from": "lower-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
+                },
+                "param-case": {
+                  "version": "1.1.1",
+                  "from": "param-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
+                },
+                "pascal-case": {
+                  "version": "1.1.0",
+                  "from": "pascal-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz"
+                },
+                "path-case": {
+                  "version": "1.1.1",
+                  "from": "path-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
+                },
+                "sentence-case": {
+                  "version": "1.1.2",
+                  "from": "sentence-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
+                },
+                "snake-case": {
+                  "version": "1.1.1",
+                  "from": "snake-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
+                },
+                "swap-case": {
+                  "version": "1.1.0",
+                  "from": "swap-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz"
+                },
+                "title-case": {
+                  "version": "1.1.0",
+                  "from": "title-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz"
+                },
+                "upper-case": {
+                  "version": "1.1.2",
+                  "from": "upper-case@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
+                },
+                "upper-case-first": {
+                  "version": "1.1.1",
+                  "from": "upper-case-first@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz"
+                }
+              }
+            },
+            "clean-css": {
+              "version": "2.2.23",
+              "from": "clean-css@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "2.2.0",
+                  "from": "commander@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
+                }
+              }
+            },
+            "cli": {
+              "version": "0.6.6",
+              "from": "cli@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.2.1 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "exit": {
+                  "version": "0.1.2",
+                  "from": "exit@0.1.2",
+                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.19",
+              "from": "uglify-js@>=2.4.0 <2.5.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.19.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "from": "yargs@>=3.5.4 <3.6.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.0.2",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                }
+              }
+            },
+            "relateurl": {
+              "version": "0.2.6",
+              "from": "relateurl@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "lodash.escape": {
+          "version": "3.0.0",
+          "from": "lodash.escape@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+          "dependencies": {
+            "lodash._basetostring": {
+              "version": "3.0.0",
+              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "leaflet": {
+      "version": "0.7.3",
+      "from": "leaflet@0.7.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
+    },
+    "leaflet-draw": {
+      "version": "0.2.3",
+      "from": "../../tmp/npm-5418-3f5d22c2/1441117743516-0.3635168285109103/e753b7d0eb9d1de8864ca85d5dafbf9ac955759c",
+      "resolved": "git://github.com/michaelguild13/Leaflet.draw#e753b7d0eb9d1de8864ca85d5dafbf9ac955759c"
+    },
+    "leaflet-plugins": {
+      "version": "1.3.8",
+      "from": "../../tmp/npm-29202-ddabb07a/1437065466188-0.06710644904524088/1fb49a72c8f53cf95786064b1569dc91bfebae6c",
+      "resolved": "git://github.com/azavea/leaflet-plugins#1fb49a72c8f53cf95786064b1569dc91bfebae6c"
+    },
+    "leaflet.locatecontrol": {
+      "version": "0.43.0",
+      "from": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz",
+      "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz"
+    },
+    "livereload": {
+      "version": "0.3.7",
+      "from": "livereload@*",
+      "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.3.7.tgz",
+      "dependencies": {
+        "opts": {
+          "version": "1.2.2",
+          "from": "opts@>=1.2.0",
+          "resolved": "https://registry.npmjs.org/opts/-/opts-1.2.2.tgz"
+        },
+        "websocket.io": {
+          "version": "0.2.1",
+          "from": "websocket.io@>=0.1.0",
+          "resolved": "https://registry.npmjs.org/websocket.io/-/websocket.io-0.2.1.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@*",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "ws": {
+              "version": "0.4.20",
+              "from": "ws@0.4.20",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.20.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                },
+                "tinycolor": {
+                  "version": "0.0.1",
+                  "from": "tinycolor@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                },
+                "options": {
+                  "version": "0.0.6",
+                  "from": "options@latest",
+                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.6.0",
+      "from": "lodash@3.6.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+    },
+    "minifyify": {
+      "version": "7.0.0",
+      "from": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.4.8",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
@@ -2016,549 +2695,6 @@
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "entities": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "2.0.8",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "shelljs": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-        },
-        "lodash": {
-          "version": "3.7.0",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
-        }
-      }
-    },
-    "jstify": {
-      "version": "0.9.0",
-      "from": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
-      "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
-      "dependencies": {
-        "html-minifier": {
-          "version": "0.6.9",
-          "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
-          "dependencies": {
-            "change-case": {
-              "version": "2.1.6",
-              "from": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
-              "dependencies": {
-                "camel-case": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz"
-                },
-                "constant-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.1.tgz"
-                },
-                "dot-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
-                },
-                "is-lower-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
-                },
-                "is-upper-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
-                },
-                "lower-case": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
-                },
-                "param-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
-                },
-                "pascal-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz"
-                },
-                "path-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
-                },
-                "sentence-case": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
-                },
-                "snake-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
-                },
-                "swap-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.1.tgz"
-                },
-                "title-case": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.1.tgz"
-                },
-                "upper-case": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
-                },
-                "upper-case-first": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz"
-                }
-              }
-            },
-            "clean-css": {
-              "version": "2.2.23",
-              "from": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
-                }
-              }
-            },
-            "cli": {
-              "version": "0.6.6",
-              "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "3.2.11",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.6.5",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "exit": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.4.23",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "source-map": {
-                  "version": "0.1.34",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
-                    }
-                  }
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                },
-                "yargs": {
-                  "version": "3.5.4",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
-                    },
-                    "decamelize": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "relateurl": {
-              "version": "0.2.6",
-              "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz",
-              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        },
-        "lodash.escape": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
-          "dependencies": {
-            "lodash._basetostring": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "leaflet": {
-      "version": "0.7.3",
-      "from": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
-    },
-    "leaflet-draw": {
-      "version": "0.2.3",
-      "from": "git://github.com/michaelguild13/Leaflet.draw.git#e753b7d",
-      "resolved": "git://github.com/michaelguild13/Leaflet.draw#e753b7d0eb9d1de8864ca85d5dafbf9ac955759c"
-    },
-    "leaflet-plugins": {
-      "version": "1.3.8",
-      "from": "git://github.com/azavea/leaflet-plugins#feature/browserify",
-      "resolved": "git://github.com/azavea/leaflet-plugins#1fb49a72c8f53cf95786064b1569dc91bfebae6c"
-    },
-    "leaflet.locatecontrol": {
-      "version": "0.43.0",
-      "from": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz",
-      "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz"
-    },
-    "livereloadify": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/livereloadify/-/livereloadify-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/livereloadify/-/livereloadify-2.0.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "gaze": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-          "dependencies": {
-            "globule": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                },
-                "glob": {
-                  "version": "3.1.21",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
-        },
-        "tiny-lr-fork": {
-          "version": "0.0.5",
-          "from": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-          "dependencies": {
-            "qs": {
-              "version": "0.5.6",
-              "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
-            },
-            "faye-websocket": {
-              "version": "0.4.4",
-              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
-            },
-            "noptify": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            }
-          }
-        }
-      }
-    },
-    "lodash": {
-      "version": "3.6.0",
-      "from": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
-    },
-    "minifyify": {
-      "version": "7.0.0",
-      "from": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.5.0",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            },
-            "readable-stream": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
             }
@@ -2575,9 +2711,9 @@
           "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
           "dependencies": {
             "lodash._createwrapper": {
-              "version": "3.0.7",
-              "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
+              "version": "3.0.6",
+              "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.6.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
@@ -2585,9 +2721,9 @@
                   "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
                 },
                 "lodash._basecreate": {
-                  "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
+                  "version": "3.0.2",
+                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.2.tgz"
                 }
               }
             },
@@ -2604,9 +2740,9 @@
           }
         },
         "lodash.defaults": {
-          "version": "3.1.2",
-          "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "version": "3.1.1",
+          "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.1.tgz",
           "dependencies": {
             "lodash.assign": {
               "version": "3.2.0",
@@ -2643,24 +2779,24 @@
                   }
                 },
                 "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "3.9.1",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                      "version": "3.9.0",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
                     },
                     "lodash.isarguments": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                      "version": "3.0.3",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
                     },
                     "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                      "version": "3.0.3",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
                     }
                   }
                 }
@@ -2689,19 +2825,19 @@
               "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
               "dependencies": {
                 "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "3.9.1",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                      "version": "3.9.0",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
                     },
                     "lodash.isarguments": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                      "version": "3.0.3",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
                     }
                   }
                 }
@@ -2713,9 +2849,9 @@
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             },
             "lodash.isarray": {
-              "version": "3.0.4",
-              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
             }
           }
         },
@@ -2732,21 +2868,21 @@
           }
         },
         "source-map": {
-          "version": "0.4.3",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+          "version": "0.4.2",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
         },
         "through": {
-          "version": "2.3.8",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+          "version": "2.3.7",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         },
         "tmp": {
           "version": "0.0.25",
@@ -2824,9 +2960,9 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
@@ -2868,100 +3004,100 @@
     },
     "mocha": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
+      "from": "mocha@2.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "from": "commander@2.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "debug": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "from": "debug@2.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "diff": {
           "version": "1.0.8",
-          "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+          "from": "diff@1.0.8",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "from": "escape-string-regexp@1.0.2",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "from": "glob@3.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@>=0.2.11 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "growl": {
           "version": "1.8.1",
-          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "from": "growl@1.8.1",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
         },
         "jade": {
           "version": "0.26.3",
-          "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "from": "jade@0.26.3",
           "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "dependencies": {
             "commander": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "from": "commander@0.6.1",
               "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "from": "mkdirp@0.3.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
@@ -4098,81 +4234,81 @@
     },
     "nunjucks": {
       "version": "1.3.4",
-      "from": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.3.4.tgz",
+      "from": "nunjucks@*",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.3.4.tgz",
       "dependencies": {
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@*",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "chokidar": {
           "version": "0.12.6",
-          "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
+          "from": "chokidar@>=0.12.5 <0.13.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
           "dependencies": {
             "readdirp": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "from": "readdirp@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@>=0.2.12 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -4181,7 +4317,7 @@
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+              "from": "async-each@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             }
           }
@@ -4190,60 +4326,60 @@
     },
     "nunjucksify": {
       "version": "0.2.2",
-      "from": "https://registry.npmjs.org/nunjucksify/-/nunjucksify-0.2.2.tgz",
+      "from": "nunjucksify@*",
       "resolved": "https://registry.npmjs.org/nunjucksify/-/nunjucksify-0.2.2.tgz",
       "dependencies": {
         "through": {
-          "version": "2.3.8",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+          "version": "2.3.7",
+          "from": "through@>=2.3.4 <2.4.0",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         }
       }
     },
     "retina.js": {
       "version": "1.3.0",
-      "from": "retina.js@git://github.com/imulus/retinajs#1.3.0",
+      "from": "../../tmp/npm-8916-f2f507bf/1432309084662-0.8805534425191581/a70e73639817473bad7bbb33f866b8e060e5f5a7",
       "resolved": "git://github.com/imulus/retinajs#a70e73639817473bad7bbb33f866b8e060e5f5a7"
     },
     "sinon": {
       "version": "1.14.1",
-      "from": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
+      "from": "sinon@1.14.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+          "from": "formatio@1.1.1",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "dependencies": {
             "samsam": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+              "from": "samsam@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "from": "util@>=0.10.3 <1.0.0",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "lolex": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz",
+          "from": "lolex@1.1.0",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
         }
       }
     },
     "testem": {
       "version": "0.5.15",
-      "from": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
+      "from": "testem@0.5.15",
       "resolved": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
       "dependencies": {
         "express": {
@@ -4322,64 +4458,64 @@
         },
         "mustache": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz",
+          "from": "mustache@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz"
         },
         "socket.io": {
           "version": "0.9.17",
-          "from": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
+          "from": "socket.io@>=0.9.13 <0.10.0",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
-              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "from": "socket.io-client@0.9.16",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.5",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
+                  "from": "uglify-js@1.2.5",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+                  "from": "ws@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+                      "from": "commander@>=2.1.0 <2.2.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
+                      "from": "nan@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                      "from": "options@>=0.0.5",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     }
                   }
                 },
                 "xmlhttprequest": {
                   "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
+                  "from": "xmlhttprequest@1.4.2",
                   "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "from": "active-x-obfuscator@0.0.1",
                   "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
+                      "from": "zeparser@0.0.5",
                       "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
@@ -4388,59 +4524,59 @@
             },
             "policyfile": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
+              "from": "policyfile@0.0.4",
               "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
             },
             "base64id": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+              "from": "base64id@0.1.0",
               "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
-              "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
+              "from": "redis@0.7.3",
               "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
         "winston": {
           "version": "0.7.3",
-          "from": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
+          "from": "winston@>=0.7.1 <0.8.0",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "dependencies": {
             "cycle": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+              "from": "cycle@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "from": "eyes@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "pkginfo": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
+              "from": "pkginfo@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "request": {
               "version": "2.16.6",
-              "from": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
+              "from": "request@>=2.16.0 <2.17.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "dependencies": {
                 "form-data": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+                  "from": "form-data@>=0.0.3 <0.1.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                          "from": "delayed-stream@0.0.5",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
@@ -4449,175 +4585,175 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "from": "mime@>=1.2.7 <1.3.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "hawk": {
                   "version": "0.10.2",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+                  "from": "hawk@>=0.10.2 <0.11.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.7.6",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
+                      "from": "hoek@>=0.7.0 <0.8.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
                     },
                     "boom": {
                       "version": "0.3.8",
-                      "from": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
+                      "from": "boom@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
                     },
                     "cryptiles": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
+                      "from": "cryptiles@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
                     },
                     "sntp": {
                       "version": "0.1.4",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
+                      "from": "sntp@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
+                  "from": "cookie-jar@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
                 },
                 "aws-sign": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
+                  "from": "aws-sign@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
+                  "from": "oauth-sign@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
+                  "from": "forever-agent@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
+                  "from": "tunnel-agent@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
+                  "from": "json-stringify-safe@>=3.0.0 <3.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
                 },
                 "qs": {
                   "version": "0.5.6",
-                  "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+                  "from": "qs@>=0.5.4 <0.6.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
                 }
               }
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "from": "stack-trace@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
         },
         "charm": {
           "version": "0.0.8",
-          "from": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz",
+          "from": "charm@>=0.0.5 <0.1.0",
           "resolved": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
+          "from": "js-yaml@>=2.1.0 <2.2.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "tap": {
           "version": "0.4.13",
-          "from": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
+          "from": "tap@>=0.4.4 <0.5.0",
           "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
           "dependencies": {
             "buffer-equal": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+              "from": "buffer-equal@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
             },
             "deep-equal": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
+              "from": "deep-equal@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
             },
             "difflet": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+              "from": "difflet@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
               "dependencies": {
                 "traverse": {
                   "version": "0.6.6",
-                  "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+                  "from": "traverse@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
                 },
                 "charm": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+                  "from": "charm@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "from": "deep-is@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 }
@@ -4625,56 +4761,56 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@*",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "mkdirp": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nopt": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+              "from": "nopt@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                  "version": "1.0.5",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                 }
               }
             },
             "runforcover": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+              "from": "runforcover@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
               "dependencies": {
                 "bunker": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+                  "from": "bunker@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                   "dependencies": {
                     "burrito": {
                       "version": "0.2.12",
-                      "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                      "from": "burrito@>=0.2.5 <0.3.0",
                       "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.5.2",
-                          "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+                          "from": "traverse@>=0.5.1 <0.6.0",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                         },
                         "uglify-js": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+                          "from": "uglify-js@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                         }
                       }
@@ -4685,106 +4821,106 @@
             },
             "slide": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+              "from": "slide@*",
               "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
             },
             "yamlish": {
-              "version": "0.0.7",
-              "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz"
+              "version": "0.0.6",
+              "from": "yamlish@*",
+              "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
             }
           }
         },
         "commander": {
-          "version": "2.8.1",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "version": "2.7.1",
+          "from": "commander@*",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "from": "graceful-readlink@>=1.0.0",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@>=0.2.11 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@>=0.2.7 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "backbone": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz",
+          "from": "backbone@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz"
         },
         "styled_string": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz",
+          "from": "styled_string@*",
           "resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "fileset": {
-          "version": "0.1.8",
-          "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
-          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+          "version": "0.1.5",
+          "from": "fileset@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+              "from": "minimatch@>=0.0.0 <1.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             }
@@ -4792,38 +4928,38 @@
         },
         "growl": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+          "from": "growl@>=1.7.0 <1.8.0",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
         },
         "consolidate": {
           "version": "0.8.0",
-          "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz",
+          "from": "consolidate@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz"
         },
         "did_it_work": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz",
+          "from": "did_it_work@>=0.0.5 <0.1.0",
           "resolved": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz"
         },
         "fireworm": {
           "version": "0.4.4",
-          "from": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
+          "from": "fireworm@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@>=0.2.9 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             }
@@ -4852,12 +4988,12 @@
     },
     "turf-bbox-polygon": {
       "version": "1.0.1",
-      "from": "turf-bbox-polygon@*",
+      "from": "https://registry.npmjs.org/turf-bbox-polygon/-/turf-bbox-polygon-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/turf-bbox-polygon/-/turf-bbox-polygon-1.0.1.tgz",
       "dependencies": {
         "turf-polygon": {
           "version": "1.0.3",
-          "from": "turf-polygon@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz"
         }
       }
@@ -4903,17 +5039,17 @@
     },
     "turf-destination": {
       "version": "1.2.1",
-      "from": "turf-destination@*",
+      "from": "https://registry.npmjs.org/turf-destination/-/turf-destination-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/turf-destination/-/turf-destination-1.2.1.tgz",
       "dependencies": {
         "turf-point": {
           "version": "2.0.1",
-          "from": "turf-point@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/turf-point/-/turf-point-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/turf-point/-/turf-point-2.0.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "1.1.2",
-              "from": "minimist@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
             }
           }
@@ -4921,44 +5057,47 @@
       }
     },
     "turf-erase": {
-        "version": "1.3.2",
-        "from": "turf-erase@",
-        "dependencies": {
-            "jsts": {
-                "version": "0.15.0",
-                "from": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
-                "resolved": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
-                "dependencies": {
-                    "javascript.util": {
-                        "version": "0.12.5",
-                        "from": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz",
-                        "resolved": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz"
-                    }
-                }
-            },
-            "turf-featurecollection": {
-                "version": "1.0.1",
-                "from": "turf-featurecollection@1.0.1"
+      "version": "1.3.2",
+      "from": "turf-erase@1.3.2",
+      "resolved": "https://registry.npmjs.org/turf-erase/-/turf-erase-1.3.2.tgz",
+      "dependencies": {
+        "jsts": {
+          "version": "0.15.0",
+          "from": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
+          "dependencies": {
+            "javascript.util": {
+              "version": "0.12.5",
+              "from": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz",
+              "resolved": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz"
             }
+          }
+        },
+        "turf-featurecollection": {
+          "version": "1.0.1",
+          "from": "turf-featurecollection@1.0.1",
+          "resolved": "https://registry.npmjs.org/turf-featurecollection/-/turf-featurecollection-1.0.1.tgz"
         }
+      }
     },
     "turf-intersect": {
-        "version": "1.4.2",
-        "from": "turf-intersect@",
-        "dependencies": {
-            "jsts": {
-                "version": "0.15.0",
-                "from": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
-                "resolved": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
-                "dependencies": {
-                    "javascript.util": {
-                        "version": "0.12.5",
-                        "from": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz",
-                        "resolved": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz"
-                    }
-                }
+      "version": "1.4.2",
+      "from": "turf-intersect@1.4.2",
+      "resolved": "https://registry.npmjs.org/turf-intersect/-/turf-intersect-1.4.2.tgz",
+      "dependencies": {
+        "jsts": {
+          "version": "0.15.0",
+          "from": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
+          "dependencies": {
+            "javascript.util": {
+              "version": "0.12.5",
+              "from": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz",
+              "resolved": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz"
             }
+          }
         }
+      }
     },
     "turf-random": {
       "version": "1.0.2",
@@ -4974,74 +5113,74 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "from": "underscore@1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "watchify": {
       "version": "3.1.0",
-      "from": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
+      "from": "watchify@3.1.0",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
       "dependencies": {
         "chokidar": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
+          "version": "1.0.0-rc5",
+          "from": "chokidar@>=1.0.0-rc4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc5.tgz",
           "dependencies": {
             "anymatch": {
-              "version": "1.3.0",
-              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "version": "1.2.1",
+              "from": "anymatch@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.2.1.tgz",
               "dependencies": {
                 "micromatch": {
-                  "version": "2.1.6",
-                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                  "version": "2.1.5",
+                  "from": "micromatch@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.5.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                      "from": "arr-diff@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
-                          "version": "0.2.3",
-                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                          "version": "0.2.2",
+                          "from": "array-slice@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
                         }
                       }
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                      "from": "braces@>=1.8.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
-                              "version": "2.2.2",
-                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "version": "2.2.0",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.0.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
+                                  "from": "is-number@>=1.1.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.1.tgz"
+                                  "version": "0.2.0",
+                                  "from": "isobject@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
+                                  "from": "randomatic@>=1.1.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "from": "repeat-string@>=1.5.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -5050,103 +5189,433 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                          "from": "preserve@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
-                          "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                          "version": "1.1.0",
+                          "from": "repeat-element@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz"
                         }
                       }
                     },
                     "debug": {
-                      "version": "2.2.0",
-                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "version": "2.1.3",
+                      "from": "debug@>=2.1.3 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
                       "dependencies": {
                         "ms": {
-                          "version": "0.7.1",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                          "version": "0.7.0",
+                          "from": "ms@0.7.0",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz",
+                      "from": "expand-brackets@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                      "from": "kind-of@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                      "from": "object.omit@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "from": "for-own@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
+                              "from": "for-in@>=0.1.4 <0.2.0",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+                          "from": "isobject@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                         }
                       }
                     },
                     "parse-glob": {
-                      "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                      "version": "3.0.0",
+                      "from": "parse-glob@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.0.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
+                          "from": "glob-base@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
+                          "version": "1.0.0",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
-                      "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "version": "0.3.0",
+                      "from": "regex-cache@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.3.0.tgz",
                       "dependencies": {
-                        "is-equal-shallow": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                        "benchmarked": {
+                          "version": "0.1.4",
+                          "from": "benchmarked@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/benchmarked/-/benchmarked-0.1.4.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.3.0",
+                              "from": "ansi@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                            },
+                            "benchmark": {
+                              "version": "1.0.0",
+                              "from": "benchmark@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                            },
+                            "chalk": {
+                              "version": "1.0.0",
+                              "from": "chalk@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.0.1",
+                                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "1.0.3",
+                                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    },
+                                    "get-stdin": {
+                                      "version": "4.0.1",
+                                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "2.0.1",
+                                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "1.3.1",
+                                  "from": "supports-color@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                                }
+                              }
+                            },
+                            "extend-shallow": {
+                              "version": "1.1.2",
+                              "from": "extend-shallow@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
+                            },
+                            "file-reader": {
+                              "version": "1.0.0",
+                              "from": "file-reader@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/file-reader/-/file-reader-1.0.0.tgz",
+                              "dependencies": {
+                                "extend-shallow": {
+                                  "version": "0.2.0",
+                                  "from": "extend-shallow@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz",
+                                  "dependencies": {
+                                    "array-slice": {
+                                      "version": "0.2.2",
+                                      "from": "array-slice@>=0.2.2 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
+                                    }
+                                  }
+                                },
+                                "map-files": {
+                                  "version": "0.3.0",
+                                  "from": "map-files@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/map-files/-/map-files-0.3.0.tgz",
+                                  "dependencies": {
+                                    "globby": {
+                                      "version": "0.1.1",
+                                      "from": "globby@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/globby/-/globby-0.1.1.tgz",
+                                      "dependencies": {
+                                        "array-differ": {
+                                          "version": "0.1.0",
+                                          "from": "array-differ@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
+                                        },
+                                        "array-union": {
+                                          "version": "0.1.0",
+                                          "from": "array-union@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+                                          "dependencies": {
+                                            "array-uniq": {
+                                              "version": "0.1.1",
+                                              "from": "array-uniq@>=0.1.0 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "async": {
+                                          "version": "0.9.0",
+                                          "from": "async@>=0.9.0 <0.10.0",
+                                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                                        },
+                                        "glob": {
+                                          "version": "4.5.3",
+                                          "from": "glob@>=4.0.2 <5.0.0",
+                                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                                          "dependencies": {
+                                            "inflight": {
+                                              "version": "1.0.4",
+                                              "from": "inflight@>=1.0.4 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                              "dependencies": {
+                                                "wrappy": {
+                                                  "version": "1.0.1",
+                                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "inherits": {
+                                              "version": "2.0.1",
+                                              "from": "inherits@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                            },
+                                            "minimatch": {
+                                              "version": "2.0.4",
+                                              "from": "minimatch@>=2.0.1 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                                              "dependencies": {
+                                                "brace-expansion": {
+                                                  "version": "1.1.0",
+                                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                                  "dependencies": {
+                                                    "balanced-match": {
+                                                      "version": "0.2.0",
+                                                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                                    },
+                                                    "concat-map": {
+                                                      "version": "0.0.1",
+                                                      "from": "concat-map@0.0.1",
+                                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "once": {
+                                              "version": "1.3.1",
+                                              "from": "once@>=1.3.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                                              "dependencies": {
+                                                "wrappy": {
+                                                  "version": "1.0.1",
+                                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "relative": {
+                                      "version": "0.1.6",
+                                      "from": "relative@>=0.1.6 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/relative/-/relative-0.1.6.tgz",
+                                      "dependencies": {
+                                        "normalize-path": {
+                                          "version": "0.1.1",
+                                          "from": "normalize-path@>=0.1.1 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-0.1.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "read-yaml": {
+                                  "version": "1.0.0",
+                                  "from": "read-yaml@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.0.0.tgz",
+                                  "dependencies": {
+                                    "js-yaml": {
+                                      "version": "3.2.7",
+                                      "from": "js-yaml@>=3.2.3 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                                      "dependencies": {
+                                        "argparse": {
+                                          "version": "1.0.2",
+                                          "from": "argparse@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                                          "dependencies": {
+                                            "sprintf-js": {
+                                              "version": "1.0.2",
+                                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "esprima": {
+                                          "version": "2.0.0",
+                                          "from": "esprima@>=2.0.0 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "for-own": {
+                              "version": "0.1.3",
+                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "0.1.4",
+                                  "from": "for-in@>=0.1.4 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "has-values": {
+                              "version": "0.1.3",
+                              "from": "has-values@>=0.1.2 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
+                            }
+                          }
                         },
-                        "is-primitive": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                        "chalk": {
+                          "version": "0.5.1",
+                          "from": "chalk@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "1.1.0",
+                              "from": "ansi-styles@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.3",
+                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "0.1.0",
+                              "from": "has-ansi@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "0.3.0",
+                              "from": "strip-ansi@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "0.2.0",
+                              "from": "supports-color@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                            }
+                          }
+                        },
+                        "micromatch": {
+                          "version": "1.6.2",
+                          "from": "micromatch@>=1.2.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-1.6.2.tgz",
+                          "dependencies": {
+                            "extglob": {
+                              "version": "0.2.0",
+                              "from": "extglob@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.2.0.tgz"
+                            },
+                            "parse-glob": {
+                              "version": "2.1.1",
+                              "from": "parse-glob@>=2.1.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.1.1.tgz",
+                              "dependencies": {
+                                "glob-base": {
+                                  "version": "0.1.1",
+                                  "from": "glob-base@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.1.1.tgz"
+                                },
+                                "glob-path-regex": {
+                                  "version": "1.0.0",
+                                  "from": "glob-path-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "to-key": {
+                          "version": "1.0.0",
+                          "from": "to-key@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/to-key/-/to-key-1.0.0.tgz",
+                          "dependencies": {
+                            "arr-map": {
+                              "version": "1.0.0",
+                              "from": "arr-map@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-1.0.0.tgz"
+                            },
+                            "for-in": {
+                              "version": "0.1.4",
+                              "from": "for-in@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                            }
+                          }
                         }
                       }
                     }
@@ -5156,91 +5625,86 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
+              "from": "arrify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+              "from": "async-each@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
+              "from": "glob-parent@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "version": "1.0.0",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
               "dependencies": {
                 "binary-extensions": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
+                  "version": "1.3.0",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
+              "from": "is-glob@>=1.1.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "from": "readdirp@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@>=0.2.12 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -5251,37 +5715,37 @@
         },
         "defined": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+          "from": "defined@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "outpipe": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+          "version": "1.1.0",
+          "from": "outpipe@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.0.tgz",
           "dependencies": {
             "shell-quote": {
               "version": "1.4.3",
-              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+              "from": "shell-quote@>=1.4.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "array-filter": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+                  "from": "array-filter@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                 },
                 "array-reduce": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+                  "from": "array-reduce@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
                 },
                 "array-map": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+                  "from": "array-map@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                 }
               }
@@ -5289,33 +5753,33 @@
           }
         },
         "through2": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "version": "0.6.3",
+          "from": "through2@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -5324,7 +5788,7 @@
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+          "from": "xtend@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "test",
     "lint": "node_modules/.bin/jshint $(find js -name *.js)",
-    "livereload": "node_modules/.bin/livereloadify /var/www/mmw/static --glob '**/*.*'"
+    "livereload": "./node_modules/.bin/livereload /var/www/mmw/static/css/ -i 200"
   },
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "leaflet-draw": "git://github.com/michaelguild13/Leaflet.draw#e753b7d",
     "leaflet-plugins": "git://github.com/azavea/leaflet-plugins#feature/browserify",
     "leaflet.locatecontrol": "0.43.0",
-    "livereloadify": "2.0.0",
+    "livereload": "0.3.7",
     "lodash": "3.6.0",
     "minifyify": "7.0.0",
     "mocha": "2.0.1",


### PR DESCRIPTION
This project has much better documentation and supports injecting changes
live on the page without having to do a full page refresh.

Reprovision the app VM then run these commands:

`./scripts/bundle.sh --debug --watch`

`./scripts/npm.sh run livereload`

If you have the Chrome livereload extension, any changes to the SASS files should be injected on to the page in real time.