### PR TITLE
Order analyze chart by NLCD class number

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -268,13 +268,12 @@ var ChartView = Marionette.ItemView.extend({
 
     addChart: function() {
         var chartEl = this.$el.find('.bar-chart').get(0),
-            chartData = this.collection.map(function(model) {
-                var attrs = model.attributes;
+            chartData = _.map(this.collection.toJSON(), function(model) {
                 return {
-                    area: attrs.area,
-                    coverage: attrs.coverage,
-                    type: attrs.type,
-                    className: attrs.nlcd ? 'nlcd-' + attrs.nlcd : null
+                    area: model.area,
+                    coverage: model.coverage,
+                    type: model.type,
+                    className: model.nlcd ? 'nlcd-' + model.nlcd : null
                 };
             }),
             chartOptions = {
@@ -287,6 +286,7 @@ var ChartView = Marionette.ItemView.extend({
         if (this.model.get('name') === 'land') {
             chartOptions.useHorizBars = true;
         }
+
         chart.makeBarChart(chartEl, chartData, indVar, depVars, chartOptions);
     }
 });

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -201,17 +201,17 @@ var TabContentView = Marionette.LayoutView.extend({
         var categories = this.model.get('categories'),
             largestArea = _.max(_.pluck(categories, 'area')),
             units = utils.magnitudeOfArea(largestArea),
-            dataCollection = new coreModels.DataCollection(categories);
+            census = new coreModels.LandUseCensusCollection(categories);
 
         this.tableRegion.show(new TableView({
             units: units,
             model: new coreModels.GeoModel({units: (units === 'km2') ? 'km<sup>2</sup>' : 'm<sup>2</sup>'}),
-            collection: dataCollection
+            collection: census
         }));
 
         this.chartRegion.show(new ChartView({
             model: this.model,
-            collection: dataCollection
+            collection: census
         }));
     }
 });

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -183,7 +183,9 @@ var TaskModel = Backbone.Model.extend({
 });
 
 // A collection of data points, useful for tables.
-var DataCollection = Backbone.Collection.extend({});
+var DataCollection = Backbone.Collection.extend({
+    comparator: 'nlcd'
+});
 
 var GeoModel = Backbone.Model.extend({
     M_IN_KM: 1000000,

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -183,7 +183,7 @@ var TaskModel = Backbone.Model.extend({
 });
 
 // A collection of data points, useful for tables.
-var DataCollection = Backbone.Collection.extend({
+var LandUseCensusCollection = Backbone.Collection.extend({
     comparator: 'nlcd'
 });
 
@@ -237,7 +237,7 @@ var AppStateModel = Backbone.Model.extend({
 module.exports = {
     MapModel: MapModel,
     TaskModel: TaskModel,
-    DataCollection: DataCollection,
+    LandUseCensusCollection: LandUseCensusCollection,
     GeoModel: GeoModel,
     AreaOfInterestModel: AreaOfInterestModel,
     AppStateModel: AppStateModel

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -1,8 +1,8 @@
 "use strict";
 
 var $ = require('jquery'),
+    Backbone = require('../../../../shim/backbone'),
     Marionette = require('../../../../shim/backbone.marionette'),
-    DataCollection = require('../../../core/models.js').DataCollection,
     chart = require('../../../core/chart.js'),
     barChartTmpl = require('../../../core/templates/barChart.html'),
     resultTmpl = require('./templates/result.html'),
@@ -44,7 +44,7 @@ var ResultView = Marionette.LayoutView.extend({
                     model: this.model
                 }));
             } else {
-                var dataCollection = new DataCollection(
+                var dataCollection = new Backbone.Collection(
                     this.model.get('result')
                 );
 


### PR DESCRIPTION
* In the bar chart on the analyze page, order the land uses categories
by NLCD class number. This puts the categories in an order that matches the
official order and legend (http://www.mrlc.gov/nlcd01_leg.php).

**Testing instructions:**
- Select an area.
- Verify that the order of the NLCD categories in the bar chart matches the order here: http://www.mrlc.gov/nlcd01_leg.php

<img width="650" alt="screen shot 2015-09-25 at 1 53 18 pm" src="https://cloud.githubusercontent.com/assets/1042475/10108070/d043b064-638c-11e5-80a9-efe3825b667b.png">

Connects to #836