### PR TITLE
Reorder and turn on additional layers.

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -59,7 +59,7 @@ LAYERS = [
     },
     {
         'code': 'county',
-        'display': 'US Counties',
+        'display': 'County Lines',
         'short_display': 'County',
         'table_name': 'boundary_county',
         'helptext': 'Counties in U.S. states are administrative divisions '

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -12,37 +12,6 @@ For basemaps, maxZoom must be defined.
 
 LAYERS = [
     {
-        'code': 'county',
-        'display': 'US Counties',
-        'short_display': 'County',
-        'table_name': 'boundary_county',
-        'helptext': 'Counties in U.S. states are administrative divisions '
-                    'of the state in which their boundaries are drawn. 3,144 '
-                    'counties and county equivalents carve up the United '
-                    'States, ranging in quantity from 3 for Delaware to 254 '
-                    'for Texas. Where they exist, they are the intermediate '
-                    'tier of state government, between the statewide tier '
-                    'and the immediately local government tier',
-        'boundary': False,
-        'vector': True,
-    },
-    {
-        'code': 'district',
-        'display': 'Congressional Districts',
-        'short_display': 'Congressional District',
-        'table_name': 'boundary_district',
-        'helptext': 'There are 435 congressional districts in the United '
-                    'States House of Representatives, with each one '
-                    'representing approximately 700,000 people. In addition '
-                    'to the 435 congressional districts, the five inhabited '
-                    'U.S. territories and the federal district of Washington, '
-                    'D.C. This tool will allow you to select the boundary of '
-                    'a congressional district on which to perform water '
-                    'quality analysis.',
-        'boundary': True,
-        'vector': True,
-    },
-    {
         'code': 'huc8',
         'display': 'USGS Subbasin unit (HUC-8)',
         'short_display': 'Subbasin',
@@ -89,11 +58,43 @@ LAYERS = [
         'vector': True,
     },
     {
+        'code': 'county',
+        'display': 'US Counties',
+        'short_display': 'County',
+        'table_name': 'boundary_county',
+        'helptext': 'Counties in U.S. states are administrative divisions '
+                    'of the state in which their boundaries are drawn. 3,144 '
+                    'counties and county equivalents carve up the United '
+                    'States, ranging in quantity from 3 for Delaware to 254 '
+                    'for Texas. Where they exist, they are the intermediate '
+                    'tier of state government, between the statewide tier '
+                    'and the immediately local government tier',
+        'boundary': True,
+        'vector': True,
+    },
+    {
+        'code': 'district',
+        'display': 'Congressional Districts',
+        'short_display': 'Congressional District',
+        'table_name': 'boundary_district',
+        'helptext': 'There are 435 congressional districts in the United '
+                    'States House of Representatives, with each one '
+                    'representing approximately 700,000 people. In addition '
+                    'to the 435 congressional districts, the five inhabited '
+                    'U.S. territories and the federal district of Washington, '
+                    'D.C. This tool will allow you to select the boundary of '
+                    'a congressional district on which to perform water '
+                    'quality analysis.',
+        'boundary': True,
+        'vector': True,
+    },
+    {
         'code': 'school',
         'display': 'School Districts',
         'short_display': 'School Districts',
         'table_name': 'boundary_school_district',
         'helptext': 'U.S. school district boundaries.',
+        'boundary': True,
         'vector': True,
     },
     {


### PR DESCRIPTION
* Reorder boundary and overlay layers according to layer order
preferred by Stroud.
* Turn on Schools and Counties as boundary layers.

**Testing instructions:**
- Verify that the layers boundary selector and the layers in the boundary section of the overlay control are in the same order.

<img width="916" alt="screen shot 2015-09-25 at 2 34 49 pm" src="https://cloud.githubusercontent.com/assets/1042475/10109281/0186aaee-6394-11e5-8bdf-ba2e2e0561e9.png">

Connects to #835