### PR TITLE
Show 100% Forest Cover scenario in Compare View

### DIFF
--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -16,6 +16,7 @@ var CompareController = {
     compare: function(projectId) {
         if (App.currentProject) {
             setupProjectCopy();
+            addForestCoverScenario();
             showCompareWindow();
         } else if (projectId) {
             App.currentProject = new modelingModels.ProjectModel({
@@ -25,6 +26,7 @@ var CompareController = {
                 .fetch()
                 .done(function() {
                     setupProjectCopy();
+                    addForestCoverScenario();
                     showCompareWindow();
                 });
         }
@@ -94,6 +96,27 @@ function copyProject(project) {
         scenarios: scenariosCopy,
         allow_save: false
     });
+}
+
+// Adds special 100% Forest Cover Scenario for the Compare View
+function addForestCoverScenario() {
+    var project = App.currentProject,
+        forestCoverScenario = new modelingModels.ScenarioModel({}),
+        currentConditions = project.get('scenarios').findWhere({ is_current_conditions: true });
+
+    forestCoverScenario.set({
+        name: '100% Forest Cover',
+        is_current_conditions: false,
+        is_pre_columbian: true,
+        modifications: currentConditions.get('modifications'),
+        modification_hash: currentConditions.get('modification_hash'),
+        results: new modelingModels.ResultCollection(currentConditions.get('results').toJSON()),
+        inputs: new modelingModels.ModificationsCollection(currentConditions.get('inputs').toJSON()),
+        inputmod_hash: currentConditions.get('inputmod_hash'),
+        allow_save: false
+    });
+    forestCoverScenario.get('inputs').on('add', _.debounce(_.bind(forestCoverScenario.fetchResults, forestCoverScenario), 500));
+    project.get('scenarios').add(forestCoverScenario, { at: 1 });
 }
 
 function saveAfterLogin(user, guest) {

--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -116,7 +116,7 @@ function addForestCoverScenario() {
         allow_save: false
     });
     forestCoverScenario.get('inputs').on('add', _.debounce(_.bind(forestCoverScenario.fetchResults, forestCoverScenario), 500));
-    project.get('scenarios').add(forestCoverScenario, { at: 1 });
+    project.get('scenarios').add(forestCoverScenario, { at: 0 });
 }
 
 function saveAfterLogin(user, guest) {

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -59,11 +59,9 @@ var ResultView = Marionette.ItemView.extend({
                 ];
                 this.$el.addClass('current-conditions');
             } else if (this.scenario.get('is_current_conditions')) {
-                // Show the unmodified results and the unmodified
-                // Pre-Columbian (a.k.a. "100% Forest") results.
                 data = [
-                    getBarData('Current Conditions', 'unmodified'),
-                    getBarData('100% Forest', 'pc_unmodified')
+                    getBarData('100% Forest', 'pc_unmodified'),
+                    getBarData('Current Conditions', 'unmodified')
                 ];
             } else {
                 // Show the unmodified results and the modified

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -47,11 +47,15 @@ var ResultView = Marionette.ItemView.extend({
                 };
 
             if (this.compareMode) {
-                // Use the modified results since they are the same as the unmodified results
-                // in Current Conditions, and they are the results we want to show
-                // in compareMode for other scenarios.
+                var target_result = 'modified';
+                if (this.scenario.get('is_current_conditions')) {
+                    target_result = 'unmodified';
+                }
+                if (this.scenario.get('is_pre_columbian')) {
+                    target_result = 'pc_unmodified';
+                }
                 data = [
-                    getBarData('', 'modified')
+                    getBarData('', target_result)
                 ];
                 this.$el.addClass('current-conditions');
             } else if (this.scenario.get('is_current_conditions')) {


### PR DESCRIPTION
## Overview

Since the Compare View needs scenarios, and 100% Forest Cover data is contained inside the Current Conditions scenario, we make a copy of it with `is_current_conditions` set to `false` and `is_pre_columbian` set to `true` before passing it to the Compare View.

When rendering TR55 Runoff views, we check if the current scenario is Current Conditions, Pre Columbian, or a regular one in Compare View. We use `unmodified`, `pc_unmodified`, or `modified` results respectively.

## Testing Instructions

Take any project to the Compare View. Update sliders, charts. Ensure that the view works as it should. Come back to Model View. Ensure that there is no new 100% Forest Cover scenario here.

## Demo

![image](https://cloud.githubusercontent.com/assets/1430060/10111483/5e12aeb2-63a2-11e5-839f-7bc2cc097dbc.png)

Connects #834 