### PR TITLE
Keep map sized in container

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -28,14 +28,19 @@
     {% block header %}
     {% endblock header %}
 
-    <div class="container-fluid top-nav">
+    <div class="map-container">
+        {% block map %}
+        {% endblock map %}
+    </div>
+
+    <div class="container-fluid top-nav" style="display: none;">
         {% block content %}
         {% endblock content %}
+    </div>
 
-        <div id="footer">
-            {% block footer %}
-            {% endblock footer %}
-        </div>
+    <div id="footer">
+        {% block footer %}
+        {% endblock footer %}
     </div>
 
     {% block modals %}

--- a/src/mmw/apps/home/templates/home/analyze.html
+++ b/src/mmw/apps/home/templates/home/analyze.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="container-fluid"> <!-- Container -->
 
-    <div class="map-half"><div id="map"></div></div> <!-- Leaflet Map -->
+    <div class="map-half"><div id="map" class="test-analyze"></div></div> <!-- Leaflet Map -->
 
     <div id="analyze-output-wrapper"> <!-- Analyze Data -->
 

--- a/src/mmw/apps/home/templates/home/home.html
+++ b/src/mmw/apps/home/templates/home/home.html
@@ -2,19 +2,17 @@
 
 {% block header %}
 <header></header>
+<div id="sub-header"></div>
 {% endblock header %}
 
-{% block content %}
-    <div id="sub-header"></div>
-    <div id="search-map">
-        <div id="geocode-search-region"></div>
-        <div id="draw-tools-region"></div>
-    </div>
-
-    <div id="map"></div>
-    <div id="boundary-label"></div>
-
-{% endblock content %}
+{% block map %}
+<div id="search-map">
+    <div id="geocode-search-region"></div>
+    <div id="draw-tools-region"></div>
+</div>
+<div id="map"></div>
+<div id="boundary-label"></div>
+{% endblock map %}
 
 {% block footer %}
 {% endblock footer %}

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -113,9 +113,10 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
     animateIn: function() {
         var self = this;
 
+        App.map.setAnalyzeSize(true);
+
         this.$el.animate({ height: '55%' }, 200, function() {
             self.trigger('animateIn');
-            App.map.setHalfSize(true);
         });
         if (this.lock !== undefined) {
             this.lock.resolve();
@@ -125,7 +126,8 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
     animateOut: function() {
         var self = this;
 
-        App.map.setFullSize(true);
+        App.map.setDoubleHeaderSmallFooterSize(true);
+       
         this.$el.animate({ height: '0%' }, 200, function() {
             self.trigger('animateOut');
         });

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -60,13 +60,25 @@ var MapModel = Backbone.Model.extend({
         this.set('areaOfInterest', _.clone(this.get('previousAreaOfInterest')));
     },
 
-    setHalfSize: function(fit) {
-        this.set('size', { half: true, fit: !!fit });
+    setDoubleHeaderSmallFooterSize: function(fit) {
+        this._setSizeOptions({ double: true  }, { small: true }, fit);
     },
 
-    setFullSize: function(fit) {
-        this.set('size', { half: false, fit: !!fit });
+    setDoubleHeaderHalfFooterSize: function(fit) {
+        this._setSizeOptions({ double: true  }, { large: true }, fit);
     },
+
+    setDrawWithBarSize: function(fit) {
+        this._setSizeOptions({ single: true  }, { med: true }, fit);
+    },
+
+    setAnalyzeSize: function(fit) {
+        this._setSizeOptions({ single: true  }, { large: true }, fit);
+    },
+
+    _setSizeOptions: function(top, bottom, fit) {
+        this.set('size', { top: top, bottom: bottom, fit: !!fit });
+    }
 
 });
 

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -185,28 +185,32 @@ describe('Core', function() {
                 view.destroy();
             });
 
-            it('adds the class "half" to the map view when the map model attribute halfSize is set to true', function(){
+            it('adds the map-container top & bottom classes to the map container for DoubleHeader and Small Footer', function(){
                 var model = new models.MapModel(),
                     view = new views.MapView({
                         model: model,
                         el: sandboxSelector
-                    });
+                    }),
+                    $container = $(sandboxSelector).parent();
 
-                model.setHalfSize();
-                assert.isTrue($(sandboxSelector).hasClass('half'));
+                model.setDoubleHeaderSmallFooterSize();
+                assert.isTrue($container.hasClass('map-container-top-2'));
+                assert.isTrue($container.hasClass('map-container-bottom-2'));
 
                 view.destroy();
             });
 
-            it('removes the class "half" to the map view when the map model attribute halfSize is set to false', function(){
+            it('adds the map-container top & bottom classes to the map container for Draw screen with AoI bar', function(){
                 var model = new models.MapModel(),
                     view = new views.MapView({
                         model: model,
                         el: sandboxSelector
-                    });
+                    }),
+                    $container = $(sandboxSelector).parent();
 
-                model.setFullSize();
-                assert.isFalse($(sandboxSelector).hasClass('half'));
+                model.setDrawWithBarSize();
+                assert.isTrue($container.hasClass('map-container-top-1'));
+                assert.isTrue($container.hasClass('map-container-bottom-3'));
 
                 view.destroy();
             });

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -563,19 +563,26 @@ var MapView = Marionette.ItemView.extend({
     },
 
     toggleMapSize: function() {
-        var size = this.model.get('size');
+        var self = this,
+            size = this.model.get('size'),
+            $container = this.$el.parent();
 
-        if (size.half) {
-            this.$el.addClass('half');
-        } else {
-            this.$el.removeClass('half');
-        }
+        $container.toggleClass('map-container-top-1', !!size.top.single);
+        $container.toggleClass('map-container-top-2', !!size.top.double);
 
-        this._leafletMap.invalidateSize();
+        $container.toggleClass('map-container-bottom-1', !!size.bottom.min);
+        $container.toggleClass('map-container-bottom-2', !!size.bottom.small);
+        $container.toggleClass('map-container-bottom-3', !!size.bottom.med);
+        $container.toggleClass('map-container-bottom-4', !!size.bottom.large);
 
-        if (size.fit) {
-            this.fitToAoi();
-        }
+
+        _.delay(function() {
+            self._leafletMap.invalidateSize();
+
+            if (size.fit) {
+                self.fitToAoi();
+            }
+        }, 300);
     },
 
     fitToAoi: function() {

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -43,6 +43,7 @@ var DrawController = {
             });
 
             App.rootView.footerRegion.show(aoiView);
+            App.map.setDrawWithBarSize(true);
         }
 
         App.state.set('current_page_title', 'Choose Area of Interest');

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -646,12 +646,13 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
         height: '0%'
     },
 
-    animateIn: function() {
-        var self = this;
+    animateIn: function(fitToBounds) {
+        var self = this,
+            fit = _.isUndefined(fitToBounds) ? true : fitToBounds;
 
         this.$el.animate({ height: '55%', 'min-height': '300px' }, 200, function() {
+            App.map.setDoubleHeaderHalfFooterSize(fit);
             self.trigger('animateIn');
-            App.map.setHalfSize(false);
             $(self.ui.toggle.selector).blur()
                 .find('i')
                     .removeClass('fa-angle-up')
@@ -666,7 +667,7 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
 
         // Change map to full size first so there isn't empty space when
         // results window animates out
-        App.map.setFullSize(fit);
+        App.map.setDoubleHeaderSmallFooterSize(fit);
 
         this.$el.animate({ height: '0%', 'min-height': '50px' }, 200, function() {
             self.trigger('animateOut');
@@ -679,7 +680,7 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
 
     toggleResultsWindow: function() {
         if (this.$el.css('height') === '50px') {
-            this.animateIn();
+            this.animateIn(false);
         } else {
             this.animateOut(false);
         }

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -33,16 +33,7 @@ a {
   margin: 0!important;
 }
 
-.container-fluid {
-  margin: 0!important;
-  padding: 0!important;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right:0;
-  overflow: hidden;
-  z-index: 1;
+#footer {
 
   &.top-nav {
     margin-top: 44px!important;
@@ -109,6 +100,7 @@ a {
   &.title-row {
     background-color: $ui-primary;
     height: 68px;
+    padding: 0.7rem;
 
     .title {
       display: inline-block;

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -71,7 +71,7 @@ header {
     right: 0;
     padding: 0.7rem;
     background-color: $paper;
-    height: 60px;
+    height: $toolbar-height;
 
     #modification-btn-wrapper {
       float: right;
@@ -180,7 +180,7 @@ header {
     right: 0;
     padding: 0.7rem;
     background-color: $paper;
-    height: 60px;
+    height: $toolbar-height;
 
     #modification-btn-wrapper {
       float: right;

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -1,24 +1,58 @@
-#map {
-  background-color: $black-12;
-  z-index: 1;
-  height: 100%;
-
-  &.full {
-    width: 100%;
-    height: 100%;
-    z-index: 1;
+.map-container {
+  position: absolute;
+  top: $height-lg;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  transition: all 200ms;
+  // Set top of map to height of initial header.
+  // Needs a more descriptive name.
+  &.map-container-top-1 {
+    top: $height-lg;
+  }
+  // Set top of map to combined height of initial header and toolbar.
+  // Needs a more descriptive name.
+  &.map-container-top-2 {
+    top: $height-lg + $toolbar-height;
+  }
+  // Set bottom of map to height of default view, which is 0px.
+  // Needs a more descriptive name.
+  &.map-container-bottom-1 {
+    bottom: 0;
+  }
+  // Set bottom of map to height of output toolbar.
+  // Needs a more descriptive name.
+  &.map-container-bottom-2 {
+    bottom: $output-height;
+  }
+  // Set bottom of map to location description toolbar.
+  // Needs a more descriptive name.
+  &.map-container-bottom-3 {
+    bottom: $location-description-height;
   }
 
-  &.half {
-    position: absolute;
+  // Set bottom of map to full standard footer height.
+  // Needs a more descriptive name.
+  &.map-container-bottom-4 {
+    bottom: $footer-height;
+  }
+
+
+  .compare-scenarios-container & {
     top: 0;
-    left: 0;
-    right: 0;
-    height: 45%;
-    z-index: 1;
   }
 }
 
+#map {
+  background-color: $black-12;
+  z-index: 1;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  height: 100%;
+}
 
 // Override default location of Leaflet spritesheet images.
 .leaflet-draw-toolbar a {

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -5,7 +5,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  height: 55%;
+  height: $footer-height;
   background-color: $paper;
   z-index: 100;
   width: 100%;

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -1,7 +1,7 @@
 .compare-scenarios-container {
   overflow: hidden;
   position: absolute;
-  top: 0;
+  top: $height-lg;
   left: 0;
   right: 0;
   bottom: 50px;

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -5,7 +5,7 @@
   right: 0;
   bottom: 0;
   min-height: 300px;
-  height: 55%;
+  height: $footer-height;
   background-color: $paper;
   z-index: 100;
   box-shadow: 0 0 4px $black-54;
@@ -53,7 +53,6 @@
     position: absolute;
     margin: 0.5rem;
     right: 0.5rem;
-
     outline: none;
   }
 }

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -9,6 +9,8 @@ $paper-54: rgba(255,255,255,.54);
 $paper-74: rgba(255,255,255,.74);
 $paper: #ffffff;
 
+
+
 //Custom Colors
 $ui-primary: #273238; /*Dark Grey*/
 $ui-secondary: #394750; /*Medium Grey*/
@@ -24,6 +26,10 @@ $i: #f8aa00; /*Infiltration*/
 $r: #cf4300; /*Runoff*/
 
 //Heights
+$footer-height: 55%;
+$location-description-height: 68px;
+$toolbar-height: 60px;
+$output-height: 50px;
 $height-lg: 44px;
 $height-md: 36px;
 $height-sm: 28px;


### PR DESCRIPTION
* New classes for specifying `top` and `bottom` positions for a new map container
* Add more size setting methods than just half and full

This is more or less temporary until we move to a sidebar design, which has been approved.  The new version will remove the map size transitions altogether.

Connects #742 
Connects #497 