### PR TITLE
Use NLCD color for popover and highlight for micro site

### DIFF
--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -209,85 +209,85 @@
                 <ul id="thumbs-land" class="nav" role="tablist"> <!-- Landcover Thumbs -->
 
                     <li id="thumb-open_water">
-                        <a href="#land-open_water" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="" style="background-color: gray;" alt="Open Water" data-container="body" data-toggle="popover" data-placement="left" data-title="Open Water" data-content="Areas of open water, generally with less than 25% cover of vegetation or soil.">
+                        <a href="#land-open_water" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-11">
+                            <img src="" style="background-color: gray;" alt="Open Water" data-container="body" data-toggle="popover" data-placement="left" data-title="Open Water" data-content="Areas of open water, generally with less than 25% cover of vegetation or soil." data-nlcd="nlcd-11">
                         </a>
                         <label>Water</label>
                     </li>
 
                     <li id="thumb-developed_open">
-                        <a href="#land-developed_open" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_turfGrass.png' %}" alt="Developed, Open Space" data-container="body" data-toggle="popover" data-placement="left" data-title="Developed, Open Space" data-content="Areas with a mixture of some constructed materials, but mostly vegetation in the form of lawn grasses. Impervious surfaces account for less than 20% of total cover. These areas most commonly include large-lot single-family housing units, parks, golf courses, and vegetation planted in developed settings for recreation, erosion control, or aesthetic purposes.">
+                        <a href="#land-developed_open" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-21">
+                            <img src="{% static 'images/water_balance/thumb_turfGrass.png' %}" alt="Developed, Open Space" data-container="body" data-toggle="popover" data-placement="left" data-title="Developed, Open Space" data-content="Areas with a mixture of some constructed materials, but mostly vegetation in the form of lawn grasses. Impervious surfaces account for less than 20% of total cover. These areas most commonly include large-lot single-family housing units, parks, golf courses, and vegetation planted in developed settings for recreation, erosion control, or aesthetic purposes." data-nlcd="nlcd-21">
                         </a>
                         <label>Developed, Open Space</label>
                     </li>
 
                     <li id="thumb-developed_low" class="active">
-                        <a href="#land-developed_low" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_lir.png' %}" alt="Developed, Low Intensity" data-container="body" data-toggle="popover" data-placement="left" data-title="Developed, Low Intensity" data-content="Areas with a mixture of constructed materials and vegetation. Impervious surfaces account for 20% to 49% percent of total cover. These areas most commonly include single-family housing units.">
+                        <a href="#land-developed_low" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-22">
+                            <img src="{% static 'images/water_balance/thumb_lir.png' %}" alt="Developed, Low Intensity" data-container="body" data-toggle="popover" data-placement="left" data-title="Developed, Low Intensity" data-content="Areas with a mixture of constructed materials and vegetation. Impervious surfaces account for 20% to 49% percent of total cover. These areas most commonly include single-family housing units." data-nlcd="nlcd-22">
                         </a>
                         <label>Developed-Low</label>
                     </li>
 
                     <li id="thumb-developed_med">
-                        <a href="#land-developed_med" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_hir.png' %}" alt="Developed, Medium Intensity" data-container="body" data-toggle="popover" data-placement="left" data-title="Developed, Medium Intensity" data-content="Areas with a mixture of constructed materials and vegetation. Impervious surfaces account for 50% to 79% of the total cover. These areas most commonly include single-family housing units.">
+                        <a href="#land-developed_med" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-23">
+                            <img src="{% static 'images/water_balance/thumb_hir.png' %}" alt="Developed, Medium Intensity" data-container="body" data-toggle="popover" data-placement="left" data-title="Developed, Medium Intensity" data-content="Areas with a mixture of constructed materials and vegetation. Impervious surfaces account for 50% to 79% of the total cover. These areas most commonly include single-family housing units." data-nlcd="nlcd-23">
                         </a>
                         <label>Developed-Med</label>
                     </li>
 
                     <li id="thumb-developed_high">
-                        <a href="#land-developed_high" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_commercial.png' %}" alt="Developed High Intensity" data-container="body" data-toggle="popover" data-placement="left" data-title="Developed High Intensity" data-content="Highly developed areas where people reside or work in high numbers. Examples include apartment complexes, row houses and commercial/industrial. Impervious surfaces account for 80% to 100% of the total cover.">
+                        <a href="#land-developed_high" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-24">
+                            <img src="{% static 'images/water_balance/thumb_commercial.png' %}" alt="Developed High Intensity" data-container="body" data-toggle="popover" data-placement="left" data-title="Developed High Intensity" data-content="Highly developed areas where people reside or work in high numbers. Examples include apartment complexes, row houses and commercial/industrial. Impervious surfaces account for 80% to 100% of the total cover." data-nlcd="nlcd-24">
                         </a>
                         <label>Developed-High</label>
                     </li>
 
                     <li id="thumb-barren_land">
-                        <a href="#land-barren_land" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_desert.png' %}" alt="Barren Land (Rock/Sand/Clay)" data-container="body" data-toggle="popover" data-placement="left" data-title="Barren Land (Rock/Sand/Clay)" data-content="(Including desert). Areas of bedrock, desert pavement, scarps, talus, slides, volcanic material, glacial debris, sand dunes, strip mines, gravel pits and other accumulations of earthen material. Generally, vegetation accounts for less than 15% of total cover.">
+                        <a href="#land-barren_land" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-31">
+                            <img src="{% static 'images/water_balance/thumb_desert.png' %}" alt="Barren Land (Rock/Sand/Clay)" data-container="body" data-toggle="popover" data-placement="left" data-title="Barren Land (Rock/Sand/Clay)" data-content="(Including desert). Areas of bedrock, desert pavement, scarps, talus, slides, volcanic material, glacial debris, sand dunes, strip mines, gravel pits and other accumulations of earthen material. Generally, vegetation accounts for less than 15% of total cover." data-nlcd="nlcd-31">
                         </a>
                         <label>Barren Land</label>
                     </li>
 
                     <li id="thumb-deciduous_forest">
-                        <a href="#land-deciduous_forest" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_forest.png' %}" alt="Forest" data-container="body" data-toggle="popover" data-placement="left" data-title="Forest" data-content="(Including deciduous, evergreen and mixed forest). Areas dominated by trees generally greater than 5 meters tall, and greater than 20% of total vegetation cover. Neither deciduous nor evergreen species are greater than 75% of total tree cover.">
+                        <a href="#land-deciduous_forest" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-41">
+                            <img src="{% static 'images/water_balance/thumb_forest.png' %}" alt="Forest" data-container="body" data-toggle="popover" data-placement="left" data-title="Forest" data-content="(Including deciduous, evergreen and mixed forest). Areas dominated by trees generally greater than 5 meters tall, and greater than 20% of total vegetation cover. Neither deciduous nor evergreen species are greater than 75% of total tree cover." data-nlcd="nlcd-41">
                         </a>
                         <label>Forest</label>
                     </li>
 
                     <li id="thumb-shrub">
-                        <a href="#land-shrub" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_chaparral.png' %}" alt="Shrub/Scrub" data-container="body" data-toggle="popover" data-placement="left" data-title="Shrub/Scrub" data-content="(Including chaparral). Areas dominated by shrubs; less than 5 meters tall with shrub canopy typically greater than 20% of total vegetation. This class includes true shrubs, young trees in an early successional stage or trees stunted from environmental conditions.">
+                        <a href="#land-shrub" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-52">
+                            <img src="{% static 'images/water_balance/thumb_chaparral.png' %}" alt="Shrub/Scrub" data-container="body" data-toggle="popover" data-placement="left" data-title="Shrub/Scrub" data-content="(Including chaparral). Areas dominated by shrubs; less than 5 meters tall with shrub canopy typically greater than 20% of total vegetation. This class includes true shrubs, young trees in an early successional stage or trees stunted from environmental conditions." data-nlcd="nlcd-52">
                         </a>
                         <label>Shrub/Scrub</label>
                     </li>
 
                     <li id="thumb-grassland">
-                        <a href="#land-grassland" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_grassland.png' %}" alt="Grassland/Herbaceous" data-container="body" data-toggle="popover" data-placement="left" data-title="Grassland/Herbaceous" data-content="Areas dominated by gramanoid or herbaceous vegetation, generally greater than 80% of total vegetation. These areas are not subject to intensive management such as tilling, but can be utilized for grazing.">
+                        <a href="#land-grassland" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-71">
+                            <img src="{% static 'images/water_balance/thumb_grassland.png' %}" alt="Grassland/Herbaceous" data-container="body" data-toggle="popover" data-placement="left" data-title="Grassland/Herbaceous" data-content="Areas dominated by gramanoid or herbaceous vegetation, generally greater than 80% of total vegetation. These areas are not subject to intensive management such as tilling, but can be utilized for grazing." data-nlcd="nlcd-71">
                         </a>
                         <label>Grassland</label>
                     </li>
 
                     <li id="thumb-pasture">
-                        <a href="#land-pasture" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_pasture.png' %}" alt="Pasture/Hay" data-container="body" data-toggle="popover" data-placement="left" data-title="Pasture/Hay" data-content="Areas of grasses, legumes, or grass-legume mixtures planted for livestock grazing or the production of seed or hay crops, typically on a perennial cycle. Pasture/hay vegetation accounts for greater than 20% of total vegetation.">
+                        <a href="#land-pasture" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-81">
+                            <img src="{% static 'images/water_balance/thumb_pasture.png' %}" alt="Pasture/Hay" data-container="body" data-toggle="popover" data-placement="left" data-title="Pasture/Hay" data-content="Areas of grasses, legumes, or grass-legume mixtures planted for livestock grazing or the production of seed or hay crops, typically on a perennial cycle. Pasture/hay vegetation accounts for greater than 20% of total vegetation." data-nlcd="nlcd-81">
                         </a>
                         <label>Pasture/Hay</label>
                     </li>
 
                     <li id="thumb-cultivated_crops">
-                        <a href="#land-cultivated_crops" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_rowCrops.png' %}" alt="Cultivated Crops" data-container="body" data-toggle="popover" data-placement="left" data-title="Cultivated Crops" data-content="Areas used for the production of annual crops, such as corn, soybeans, vegetables, tobacco, and cotton, and also perennial woody crops such as orchards and vineyards. Crop vegetation accounts for greater than 20% of total vegetation. This class also includes all land being actively tilled.">
+                        <a href="#land-cultivated_crops" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-82">
+                            <img src="{% static 'images/water_balance/thumb_rowCrops.png' %}" alt="Cultivated Crops" data-container="body" data-toggle="popover" data-placement="left" data-title="Cultivated Crops" data-content="Areas used for the production of annual crops, such as corn, soybeans, vegetables, tobacco, and cotton, and also perennial woody crops such as orchards and vineyards. Crop vegetation accounts for greater than 20% of total vegetation. This class also includes all land being actively tilled." data-nlcd="nlcd-82">
                         </a>
                         <label>Crops</label>
                     </li>
 
                     <li id="thumb-woody_wetlands">
-                        <a href="#land-woody_wetlands" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="" style="background-color: gray;" alt="Wetlands" data-container="body" data-toggle="popover" data-placement="left" data-title="Wetlands" data-content="(Including wooded wetland, herbaceous wetland, marsh, bog). Areas where forest or shrubland vegetation accounts for greater than 20% of vegetative cover and the soil or substrate is periodically saturated with or covered with water.">
+                        <a href="#land-woody_wetlands" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-90">
+                            <img src="" style="background-color: gray;" alt="Wetlands" data-container="body" data-toggle="popover" data-placement="left" data-title="Wetlands" data-content="(Including wooded wetland, herbaceous wetland, marsh, bog). Areas where forest or shrubland vegetation accounts for greater than 20% of vegetative cover and the soil or substrate is periodically saturated with or covered with water." data-nlcd="nlcd-90">
                         </a>
                         <label>Wetlands</label>
                     </li>
@@ -340,16 +340,4 @@
 {% block javascript %}
     <script type="text/javascript" src="{% static 'js/vendor_water_balance.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/main_water_balance.js' %}"></script>
-    <script type="text/javascript">
-        if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
-                $('[data-toggle="popover"]').popover({triggger:'click'});
-                $('[data-toggle="popover"]').click(function(){
-                    $('[data-toggle="popover"]').not(this).popover('hide'); //all but this
-                });
-            } else {
-                $(function () {
-            $('[data-toggle="popover"]').popover({trigger:'hover'});
-        })
-            }
-    </script>
 {% endblock javascript %}

--- a/src/mmw/js/src/main_water_balance.js
+++ b/src/mmw/js/src/main_water_balance.js
@@ -116,9 +116,37 @@ var initialize = function(model) {
     recalculate();
 };
 
+var initBootstrap = function() {
+    $('[data-toggle="tooltip"]').tooltip();
+
+    $('[data-toggle="popover"]').each(function(i, popover) {
+        var nlcd = $(popover).data('nlcd') || 'default',
+            template = '<div class="popover" role="tooltip">' +
+                '<div class="arrow"></div>' +
+                '<h3 class="popover-title ' + ' ' + nlcd + '"></h3>' +
+                '<div class="popover-content"></div></div>';
+
+        if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+            $(popover).popover({
+                triggger:'click',
+                template: template
+            });
+
+            $(popover).click(function() {
+                $('[data-toggle="popover"]').not(this).popover('hide'); //all but this
+            });
+        } else {
+            $(popover).popover({
+                trigger: 'hover',
+                template: template
+            });
+        }
+    });
+};
+
 $(function() {
     R.Retina.init(window);
-    $('[data-toggle="tooltip"]').tooltip();
+    initBootstrap();
 
     $.ajax({
         type: 'GET',

--- a/src/mmw/js/src/main_water_balance.js
+++ b/src/mmw/js/src/main_water_balance.js
@@ -15,24 +15,24 @@ var initialize = function(model) {
     var precipKey = ['0.5', '1.0', '2.0', '3.2', '8.0'];
 
     // Cache references to DOM elements so as not to query them each time
-    var $etColumn = $('#column-et');
-    var $rColumn  = $('#column-r');
-    var $iColumn  = $('#column-i');
+    var $etColumn = $('#column-et'),
+        $rColumn  = $('#column-r'),
+        $iColumn  = $('#column-i'),
 
-    var $etArrow = $('#effect-evapo svg');
-    var $rArrow = $('#effect-runoff svg');
-    var $iArrow = $('#effect-infiltration svg');
+        $etArrow = $('#effect-evapo svg'),
+        $rArrow = $('#effect-runoff svg'),
+        $iArrow = $('#effect-infiltration svg'),
 
-    var $thumbsLand = $('#thumbs-land');
-    var $thumbsSoil = $('#thumbs-soil');
-    var $precipSlider = $('#precip-slider');
+        $thumbsLand = $('#thumbs-land'),
+        $thumbsSoil = $('#thumbs-soil'),
+        $precipSlider = $('#precip-slider'),
 
-    var $precipText = $('#well-precip > h1');
-    var $etText = $('#well-evapo > h1');
-    var $rText = $('#well-runoff > h1');
-    var $iText = $('#well-infil > h1');
+        $precipText = $('#well-precip > h1'),
+        $etText = $('#well-evapo > h1'),
+        $rText = $('#well-runoff > h1'),
+        $iText = $('#well-infil > h1'),
 
-    var $runOffAlert = $('#alert');
+        $runOffAlert = $('#alert');
 
     var getType = function($el) {
         // Return thumb type, after the 'thumb-' part of id
@@ -66,11 +66,10 @@ var initialize = function(model) {
     var recalculate = function() {
         hideRunoffAlert();
 
-        var soil = getType($thumbsSoil.children('.active'));
-        var land = getType($thumbsLand.children('.active'));
-        var precip = precipKey[$precipSlider.val()];
-
-        var result = model[soil][land][precip];
+        var soil = getType($thumbsSoil.children('.active')),
+            land = getType($thumbsLand.children('.active')),
+            precip = precipKey[$precipSlider.val()],
+            result = model[soil][land][precip];
 
         $precipText.text(convertToMetric(precip) + ' cm');
         $etText.text(convertToMetric(result.et) + ' cm');
@@ -89,8 +88,8 @@ var initialize = function(model) {
         // Set border radius for middle Runoff div
         // which has rounded borders whenever it is on the edge
         // but not when it is in the middle
-        var topRadius = (parseFloat(result.et) === 0) ? '0.3rem' : '0';
-        var bottomRadius = (parseFloat(result.i) === 0) ? '0.3rem' : '0';
+        var topRadius = (parseFloat(result.et) === 0) ? '0.3rem' : '0',
+            bottomRadius = (parseFloat(result.i) === 0) ? '0.3rem' : '0';
 
         if(result.r >= 2) {
             showRunoffAlert();

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -49,15 +49,15 @@
 }
 
 // Official NLCD legend colors for classes selected for display
-.nlcd-11 .bar { fill: #5475A8; }
-.nlcd-21 .bar { fill: #E8D1D1; }
-.nlcd-22 .bar { fill: #E29E8C; }
-.nlcd-23 .bar { fill: #ff0000; }
-.nlcd-24 .bar { fill: #B50000; }
-.nlcd-31 .bar { fill: #D2CDC0; }
-.nlcd-41 .bar { fill: #85C77E; }
-.nlcd-52 .bar { fill: #DCCA8F; }
-.nlcd-71 .bar { fill: #FDE9AA; }
-.nlcd-81 .bar { fill: #FBF65D; }
-.nlcd-82 .bar { fill: #CA9146; }
-.nlcd-90 .bar { fill: #C8E6F8; }
+.nlcd-11 .bar { fill: $nlcd-11; }
+.nlcd-21 .bar { fill: $nlcd-21; }
+.nlcd-22 .bar { fill: $nlcd-22; }
+.nlcd-23 .bar { fill: $nlcd-23; }
+.nlcd-24 .bar { fill: $nlcd-24; }
+.nlcd-31 .bar { fill: $nlcd-31; }
+.nlcd-41 .bar { fill: $nlcd-41; }
+.nlcd-52 .bar { fill: $nlcd-52; }
+.nlcd-71 .bar { fill: $nlcd-71; }
+.nlcd-81 .bar { fill: $nlcd-81; }
+.nlcd-82 .bar { fill: $nlcd-82; }
+.nlcd-90 .bar { fill: $nlcd-90; }

--- a/src/mmw/sass/pages/_water-balance.scss
+++ b/src/mmw/sass/pages/_water-balance.scss
@@ -337,6 +337,102 @@
             border-radius: 12px;
             text-align: center;
           }
+
+          &.nlcd-11 {
+            border-color: $nlcd-11;
+
+            &:after {
+              background-color: $nlcd-11;
+            }
+          }
+
+          &.nlcd-21 {
+            border-color: $nlcd-21;
+
+            &:after {
+              background-color: $nlcd-21;
+            }
+          }
+
+          &.nlcd-22 {
+            border-color: $nlcd-22;
+
+            &:after {
+              background-color: $nlcd-22;
+            }
+          }
+
+          &.nlcd-23 {
+            border-color: $nlcd-23;
+
+            &:after {
+              background-color: $nlcd-23;
+            }
+          }
+
+          &.nlcd-24 {
+            border-color: $nlcd-24;
+
+            &:after {
+              background-color: $nlcd-24;
+            }
+          }
+
+          &.nlcd-31 {
+            border-color: $nlcd-31;
+
+            &:after {
+              background-color: $nlcd-31;
+            }
+          }
+
+          &.nlcd-41 {
+            border-color: $nlcd-41;
+
+            &:after {
+              background-color: $nlcd-41;
+            }
+          }
+
+          &.nlcd-52 {
+            border-color: $nlcd-52;
+
+            &:after {
+              background-color: $nlcd-52;
+            }
+          }
+
+          &.nlcd-71 {
+            border-color: $nlcd-71;
+
+            &:after {
+              background-color: $nlcd-71;
+            }
+          }
+
+          &.nlcd-81 {
+            border-color: $nlcd-81;
+
+            &:after {
+              background-color: $nlcd-81;
+            }
+          }
+
+          &.nlcd-82 {
+            border-color: $nlcd-82;
+
+            &:after {
+              background-color: $nlcd-82;
+            }
+          }
+
+          &.nlcd-90 {
+            border-color: $nlcd-90;
+
+            &:after {
+              background-color: $nlcd-90;
+            }
+          }
         }
       }
     }
@@ -379,6 +475,57 @@
   border: 0;
   background-color: $brand-primary;
   border-radius: 0;
+
+  &.nlcd-11 {
+    background-color: $nlcd-11;
+  }
+
+  &.nlcd-21 {
+    background-color: $nlcd-21;
+  }
+
+  &.nlcd-22 {
+    background-color: $nlcd-22;
+  }
+
+  &.nlcd-23 {
+    background-color: $nlcd-23;
+  }
+
+  &.nlcd-24 {
+    background-color: $nlcd-24;
+  }
+
+  &.nlcd-31 {
+    background-color: $nlcd-31;
+  }
+
+  &.nlcd-41 {
+    background-color: $nlcd-41;
+  }
+
+  &.nlcd-52 {
+    background-color: $nlcd-52;
+  }
+
+  &.nlcd-71 {
+    background-color: $nlcd-71;
+    color: #333;
+  }
+
+  &.nlcd-81 {
+    background-color: $nlcd-81;
+    color: #333;
+  }
+
+  &.nlcd-82 {
+    background-color: $nlcd-82;
+  }
+
+  &.nlcd-90 {
+    background-color: $nlcd-90;
+    color: #333;
+  }
 }
 
 .popover-content {
@@ -432,4 +579,3 @@
     transform: scale(0.9);
   }
 }
-

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -31,3 +31,17 @@ $height-xs: 18px;
 
 //Border-radius
 $radius-sm: 2px;
+
+//NLCD
+$nlcd-11: #5475A8;
+$nlcd-21: #E8D1D1;
+$nlcd-22: #E29E8C;
+$nlcd-23: #ff0000;
+$nlcd-24: #B50000;
+$nlcd-31: #D2CDC0;
+$nlcd-41: #85C77E;
+$nlcd-52: #DCCA8F;
+$nlcd-71: #FDE9AA;
+$nlcd-81: #FBF65D;
+$nlcd-82: #CA9146;
+$nlcd-90: #C8E6F8;


### PR DESCRIPTION
Use NLCD color for popover and highlight
* Set popover to use a custom template that has a dynamic
class for each land use.
* Move popover init code to app JS file.
* Add NLCD color SASS variables.

**Testing Instructions:**
- Visit the micro app.
- Verify that for each land use, the popover header and highlight color match, and that they are the correct NLCD color.
- Verify that the soil choices still use the default color.

<img width="569" alt="screen shot 2015-09-28 at 11 03 59 am" src="https://cloud.githubusercontent.com/assets/1042475/10139391/a8bcf0fa-65d0-11e5-8555-66bd109544e0.png">

I also updated the text color of the "Grassland" and "Pasture/Hay" popovers because it was hard to read with the new background colors:

<img width="471" alt="screen shot 2015-09-28 at 11 08 43 am" src="https://cloud.githubusercontent.com/assets/1042475/10139590/860defe0-65d1-11e5-8cee-4dba11a25b53.png">

<img width="394" alt="screen shot 2015-09-28 at 11 10 31 am" src="https://cloud.githubusercontent.com/assets/1042475/10139604/91456bae-65d1-11e5-9f18-aa05a0a1584d.png">



Also, I created SASS variables for the NLCD colors and updated the analysis chart to use these variables. Verify that the analysis chart still uses NLCD colors:

<img width="420" alt="screen shot 2015-09-28 at 11 03 34 am" src="https://cloud.githubusercontent.com/assets/1042475/10139381/960a3e4a-65d0-11e5-83f0-0d1f775692ed.png">

Is the extra gray space between the image and the highlight a known issue? I assumed it was caused by the missing images.

<img width="103" alt="screen shot 2015-09-28 at 11 04 31 am" src="https://cloud.githubusercontent.com/assets/1042475/10139422/c9c1e24c-65d0-11e5-855b-ccb4b1614b56.png">

Connects to #840