### PR TITLE
Fix overlay layer zIndex setting.

### DIFF
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -72,16 +72,16 @@ def project_clone(request, proj_id=None):
     return redirect('/project/{0}'.format(project.id))
 
 
-def get_layer_config(layerKey):
+def get_layer_config(layerKeys):
     """ Retrieves the configuration for the provided
-    layer type. layerKey is a string that should be a
-    key and set to True for each layer that should
-    be returned.
+    layer types. layerKeys is an array of strings that
+    contains keys. Layers with these keys set to True
+    will be returned.
     """
     selected_layers = []
 
     for layer in settings.LAYERS:
-        if layerKey in layer and layer[layerKey]:
+        if all(key in layer for key in layerKeys):
             # Populate the layer url for layers that we host
             if 'url' not in layer and 'table_name' in layer:
                 layer['url'] = get_layer_url(layer)
@@ -112,11 +112,11 @@ def get_client_settings(request):
     client_settings = {
         'client_settings': json.dumps({
             EMBED_FLAG: request.session.get(EMBED_FLAG, False),
-            'base_layers': get_layer_config('basemap'),
-            'stream_layers': get_layer_config('stream'),
-            'boundary_layers': get_layer_config('boundary'),
-            'vector_layers': get_layer_config('vector'),
-            'raster_layers': get_layer_config('raster'),
+            'base_layers': get_layer_config(['basemap']),
+            'stream_layers': get_layer_config(['stream']),
+            'boundary_layers': get_layer_config(['boundary']),
+            'vector_layers': get_layer_config(['vector', 'overlay']),
+            'raster_layers': get_layer_config(['raster', 'overlay']),
             'draw_tools': settings.DRAW_TOOLS,
             'map_controls': settings.MAP_CONTROLS,
             'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -25,6 +25,7 @@ LAYERS = [
                     'HUC-8 to analyze.',
         'boundary': True,
         'vector': True,
+        'overlay': True,
     },
     {
         'code': 'huc10',
@@ -40,6 +41,7 @@ LAYERS = [
                     'HUC-10 to analyze.',
         'boundary': True,
         'vector': True,
+        'overlay': True,
     },
     {
         'code': 'huc12',
@@ -56,6 +58,7 @@ LAYERS = [
                     'HUC-12 to analyze.',
         'boundary': True,
         'vector': True,
+        'overlay': True,
     },
     {
         'code': 'county',
@@ -71,6 +74,7 @@ LAYERS = [
                     'and the immediately local government tier',
         'boundary': True,
         'vector': True,
+        'overlay': True,
     },
     {
         'code': 'district',
@@ -87,6 +91,7 @@ LAYERS = [
                     'quality analysis.',
         'boundary': True,
         'vector': True,
+        'overlay': True,
     },
     {
         'code': 'school',
@@ -96,6 +101,7 @@ LAYERS = [
         'helptext': 'U.S. school district boundaries.',
         'boundary': True,
         'vector': True,
+        'overlay': True,
     },
     {
         'display': 'National Land Cover Database',


### PR DESCRIPTION
* Bring back overlay key in layer config for layers that are used
as overlays.
* Support multiple layer keys when retrieving layers from layer config.

**Testing instructions:**
- Turn on any overlay layer.
- Switch to satellite basemap. 
- Switch back to streets basemap.
- The overlay layer should still be visible.
- Try with other layers and ensure that the overlay layers are always on top of the basemap.

Connects to #842