### PR TITLE
Compare view back button

### DIFF
--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -43,6 +43,9 @@ var CompareController = {
         // Switch back to the origProject so any changes are discarded.
         App.currentProject.off();
         App.currentProject = App.origProject;
+        if (!App.map.get('areaOfInterest')) {
+            App.map.set('areaOfInterest', App.currentProject.get('area_of_interest'));
+        }
 
         App.rootView.footerRegion.empty();
     }

--- a/src/mmw/js/src/compare/templates/compareWindow.html
+++ b/src/mmw/js/src/compare/templates/compareWindow.html
@@ -1,5 +1,8 @@
 <div id="compare-scenarios-region"></div>
 <div id="compare-footer">
+    <div class="back"> <!-- Back -->
+      <a data-url="/project" class="btn btn-md btn-icon"><i class="fa fa-arrow-left"></i></a>
+    </div> <!-- End Back -->
     <h3>Navigate Scenarios</h3>
     <div id="slide-controls">
         <div class="btn-group">

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -621,13 +621,22 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
         'click @ui.toggle': 'toggleResultsWindow'
     },
 
-    initialize: function() {
+    initialize: function(options) {
         var scenarios = this.model.get('scenarios');
         this.listenTo(scenarios, 'change:active', this.showDetailsRegion);
+        if (options.lock) {
+            this.lock = options.lock;
+        }
     },
 
     onShow: function() {
         this.showDetailsRegion();
+    },
+
+    onRender: function() {
+        if (this.lock) {
+            this.lock.resolve();
+        }
     },
 
     showDetailsRegion: function() {


### PR DESCRIPTION
This patch does two things:

   * **Allow use of back and forward buttons.**  This attempts to fix a bug that prevents navigation form the modeling page, to the analyze page, then back to the modeling page via the browser back and forward buttons.
   * **Add back button to compare view.**  (Of course, this will  not be the final place or appearance for this button.)


![screenshot from 2015-09-29 14 03 28](https://cloud.githubusercontent.com/assets/11281373/10173688/a4bddc2e-66b3-11e5-81b0-fabbacdb3760.png)
 
Connects #724
Connects #725

**To Test**
   * Navigate to the compare view.  Notice that there is now a left-arrow at the bottom-left of the page.  Pressing it should send you back to the modeling page.  It should also work if you go directly to the compare view without going through the modeling page.
   * Navigate around the site using the browser arrow buttons.  In particular, try moving between the analyze view and the modeling page view the browser arrow buttons.