### PR TITLE
Save Scenarios for new Projects

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -509,7 +509,8 @@ var ScenarioModel = Backbone.Model.extend({
         }
 
         // Save silently so server values don't trigger reload
-        this.save(null, { silent: true })
+        // except when this is a new scenario and there are no existing values
+        this.save(null, { silent: !this.isNew() })
             .fail(function() {
                 console.log('Failed to save scenario');
             });


### PR DESCRIPTION
## Overview

Previously, we would always use a "silent" save which would discard the server's response in favor of the one available in the client. This was useful since the client usually had newer values anyway, and autosaving served the purpose of updating the server on changes from the client.

However, new scenarios are on exception where the server's response has a newer value: the scenario's ID. In silent saves, we would discard the ID along with everything else, and thus the client would treat scenario as unsaved, causing new scenario generation on revisiting the project.

Thus, we switch to silently saving only pre-existing scenarios, and now save new scenarios the regular way, ensuring the UI is updated when the server's response is received.

## Testing Instructions

Create a new project, move to the Model view. Ensure that scenarios are saved upon entering the view. Ensure that any modifications or changes to inputs are retained when refreshing the full page.

Ensure that you can quickly change inputs and modifications, without those views being reset by saving of scenarios in the background.

Connects #849
Improves #739