### PR TITLE
Re-enable NLCD overlay layer

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -111,6 +111,7 @@ LAYERS = [
         'url': 'https://s3.amazonaws.com/com.azavea.datahub.tms/'
                'nlcd/{z}/{x}/{y}.png',
         'raster': True,
+        'overlay': True,
         'maxNativeZoom': 13,
         'maxZoom': 18,
         'opacity': 0.618,


### PR DESCRIPTION
We need to add this flag as of #868 

because NLCD Overlays are not available without them:

![image](https://cloud.githubusercontent.com/assets/1430060/10182976/9a55cc84-66f8-11e5-8952-376f5c6fff9c.png)

but are with them:

![image](https://cloud.githubusercontent.com/assets/1430060/10182977/a33238ec-66f8-11e5-814c-fc48d94c8fae.png)
