### PR TITLE
Cache censuses

### DIFF
--- a/src/mmw/apps/modeling/migrations/0014_auto_20151005_0945.py
+++ b/src/mmw/apps/modeling/migrations/0014_auto_20151005_0945.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0013_project_area_of_interest_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='scenario',
+            name='aoi_census',
+            field=models.TextField(help_text='Serialized JSON representation of AoI census geoprocessing results', null=True),
+        ),
+        migrations.AddField(
+            model_name='scenario',
+            name='modification_censuses',
+            field=models.TextField(help_text='Serialized JSON representation of modification censuses geoprocessing results, with modification_hash', null=True),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -72,6 +72,14 @@ class Scenario(models.Model):
     census = models.TextField(
         null=True,
         help_text='Serialized JSON representation of geoprocessing results')
+    aoi_census = models.TextField(
+        null=True,
+        help_text='Serialized JSON representation of AoI census ' +
+                  'geoprocessing results')
+    modification_censuses = models.TextField(
+        null=True,
+        help_text='Serialized JSON representation of modification censuses ' +
+                  'geoprocessing results, with modification_hash')
     results = models.TextField(
         null=True,
         help_text='Serialized JSON representation of the model results')

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -28,6 +28,8 @@ class ScenarioSerializer(serializers.ModelSerializer):
     inputs = JsonField()
     modifications = JsonField()
     census = JsonField(required=False, allow_null=True)
+    aoi_census = JsonField(required=False, allow_null=True)
+    modification_censuses = JsonField(required=False, allow_null=True)
     results = JsonField(required=False, allow_null=True)
 
 

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -18,10 +18,23 @@ from celery import chain, shared_task
 
 
 @shared_task
-def nothing_to_histogram():
+def get_test_histogram():
     return {
         'pixel_width': 33,
-        'histogram': [[[[24, 2], 268], [[24, 4], 279], [[21, 4], 5], [[22, 4], 16], [[23, 4], 322], [[22, 2], 35], [[22, 1], 55], [[23, 2], 339], [[21, 1], 22], [[24, 1], 537], [[21, 2], 1], [[23, 1], 773]]]  # noqa
+        'histogram': [[
+            [[24, 2], 268],
+            [[24, 4], 279],
+            [[21, 4], 5],
+            [[22, 4], 16],
+            [[23, 4], 322],
+            [[22, 2], 35],
+            [[22, 1], 55],
+            [[23, 2], 339],
+            [[21, 1], 22],
+            [[24, 1], 537],
+            [[21, 2], 1],
+            [[23, 1], 773]]
+        ]
     }
 
 
@@ -262,8 +275,26 @@ class TaskRunnerTestCase(TestCase):
                     'value': 1.2
                 }
             ],
-            'inputmod_hash': '9780bd0887ab5008620efd25bd2eec3f',
-            'modification_pieces': [],
+            "inputmod_hash": "f70f743cb92e67cff0eb8f8faa9c0eb6d"
+                             "751713988987e9331980363e24189ce",
+            'modification_pieces': [{
+                'name': 'conservation_practice',
+                'shape': {
+                    'type': 'Feature',
+                    'properties': {},
+                    'geometry': {
+                        'type': 'Polygon',
+                        'coordinates': [[
+                            [-75.09326934814453, 40.10092245173233],
+                            [-75.13343811035156, 40.060731050581396],
+                            [-75.0637435913086, 40.065460682065535],
+                            [-75.0692367553711, 40.095670021782404],
+                            [-75.09326934814453, 40.10092245173233]
+                        ]]
+                    },
+                    'value': 'rain_garden'
+                }
+            }],
             'modifications': [{
                 'name': 'conservation_practice',
                 'area': 15.683767964377065,
@@ -294,7 +325,9 @@ class TaskRunnerTestCase(TestCase):
                      [-75.06271362304688, 40.15893480687665]]
                 ]]
             },
-            'modification_hash': '39f488abec2de49f17652631ae843946'
+            'aoi_census': None,
+            'modification_censuses': None,
+            'modification_hash': '4c23321de9e52f12e1b37460afc28db2',
         }
 
         created = now()
@@ -305,6 +338,9 @@ class TaskRunnerTestCase(TestCase):
 
     @override_settings(CELERY_ALWAYS_EAGER=True)
     def test_tr55_job_runs_in_chain(self):
+        # For the purposes of this test, there are no modifications
+        self.model_input['modification_pieces'] = []
+
         # Get the job chain
         job_chain = views._construct_tr55_job_chain(self.model_input,
                                                     self.job.id)
@@ -314,7 +350,7 @@ class TaskRunnerTestCase(TestCase):
         self.assertTrue('tasks.get_histogram_job_results' in str(job_chain[1]))
 
         # Modify the chain to prevent it from trying to talk to endpoint
-        job_chain = [nothing_to_histogram.s()] + job_chain[2:]
+        job_chain = [get_test_histogram.s()] + job_chain[2:]
         task_list = chain(job_chain).apply_async()
 
         found_job = Job.objects.get(uuid=task_list.id)
@@ -349,7 +385,7 @@ class TaskRunnerTestCase(TestCase):
                                                     self.job.id)
         self.assertTrue('tasks.start_histograms_job' in str(job_chain[0]))
         self.assertTrue('tasks.get_histogram_job_results' in str(job_chain[1]))
-        job_chain = [nothing_to_histogram.s()] + job_chain[2:]
+        job_chain = [get_test_histogram.s()] + job_chain[2:]
 
         with self.assertRaises(Exception) as context:
             chain(job_chain).apply_async()
@@ -358,70 +394,232 @@ class TaskRunnerTestCase(TestCase):
                          'No precipitation value defined',
                          'Unexpected exception occurred')
 
-    def test_tr55_chain_skips_census_if_census_is_up_to_date(self):
-        # Census with current modification_hash
-        self.model_input['census'] = {
-            'cell_count': 100,
-            'distribution': {
-                'c:developed_high': {
-                    'cell_count': 70
-                },
-                'a:deciduous_forest': {
-                    'cell_count': 30
-                }
+    def test_tr55_chain_doesnt_generate_censuses_if_they_exist(self):
+        """If the AoI census and modifications exist in the model input,
+        and the modification censuses are up-to-date (meaning the hash
+        stored with the census matches the model input hash, neither census
+        is generated and the censuses are passed directly to the model.
+        """
+        self.model_input['aoi_census'] = {
+            "distribution": {
+                "b:developed_med": {"cell_count": 155},
+                "a:developed_high": {"cell_count": 1044},
+                "b:developed_high": {"cell_count": 543},
+                "d:developed_high": {"cell_count": 503},
+                "d:developed_med": {"cell_count": 164},
+                "a:developed_med": {"cell_count": 295}
             },
-            'modification_hash': '39f488abec2de49f17652631ae843946',
-            'modifications': [{
-                'bmp': 'no_till',
-                'cell_count': 1,
-                'distribution': {
-                    'a:deciduous_forest': {'cell_count': 1},
+            "cell_count": 2704
+        }
+        self.model_input['modification_censuses'] = {
+            "modification_hash": "4c23321de9e52f12e1b37460afc28db2",
+            "censuses": [
+                {
+                    "distribution": {
+                        "b:developed_med": {"cell_count": 5},
+                        "a:developed_high": {"cell_count": 10},
+                        "b:developed_high": {"cell_count": 4},
+                        "d:developed_high": {"cell_count": 5},
+                        "d:developed_med": {"cell_count": 2},
+                        "a:developed_med": {"cell_count": 2}
+                    },
+                    "cell_count": 28,
+                    "change": ":deciduous_forest:"
                 }
-            }]
+            ]
         }
 
         job_chain = views._construct_tr55_job_chain(self.model_input,
                                                     self.job.id)
 
-        self.assertFalse('tasks.prepare_census' in str(job_chain),
-                         'Census preparation should be skipped')
+        skipped_tasks = [
+            'start_histograms_job',
+            'get_histogram_job_results',
+            'histograms_to_censuses'
+        ]
+
+        needed_tasks = [
+            'run_tr55'
+        ]
+
+        self.assertFalse(all([True if t in str(job_chain)
+                             else False for t in skipped_tasks]),
+                         'unnecessary job in chain')
+
+        self.assertTrue(all([True if t in str(job_chain)
+                            else False for t in needed_tasks]),
+                        'missing necessary job in chain')
+
+    def test_tr55_chain_doesnt_generate_aoi_census_if_it_exists_and_mods(self):
+        """If the AoI census exists in the model input, and there are modifications,
+        it should be provided to TR-55 and not generated.
+        """
+        self.model_input['aoi_census'] = {
+            "distribution": {
+                "b:developed_med": {"cell_count": 155},
+                "a:developed_high": {"cell_count": 1044},
+                "b:developed_high": {"cell_count": 543},
+                "d:developed_high": {"cell_count": 503},
+                "d:developed_med": {"cell_count": 164},
+                "a:developed_med": {"cell_count": 295}
+            },
+            "cell_count": 2704
+        }
+
+        skipped_tasks = []
+
+        # Job chain is the same as if no census exists because
+        # we still need to generate modification censuses
+        needed_tasks = [
+            'start_histograms_job',
+            'get_histogram_job_results',
+            'histograms_to_censuses',
+            'run_tr55'
+        ]
+
+        job_chain = views._construct_tr55_job_chain(self.model_input,
+                                                    self.job.id)
+
+        cached_argument = ("cached_aoi_census={u'distribution': "
+                           "{u'b:developed_med'"
+                           ": {u'cell_count': 155}, u'a:developed_high': "
+                           "{u'cell_count': 1044}, u'b:developed_high': "
+                           "{u'cell_count': 543}, u'd:developed_high': "
+                           "{u'cell_count': 503}, u'd:developed_med': "
+                           "{u'cell_count': 164}, u'a:developed_med': "
+                           "{u'cell_count': 295}}, u'cell_count': 2704})")
+
+        self.assertTrue(all([True if t in str(job_chain)
+                             else False for t in skipped_tasks]),
+                        'unnecessary job in chain')
+
+        self.assertTrue(all([True if t in str(job_chain)
+                            else False for t in needed_tasks]),
+                        'missing necessary job in chain')
+
+        self.assertTrue(cached_argument in str(job_chain[3]))
+
+    def test_tr55_chain_doesnt_generate_aoi_census_if_it_exists_and_no_mods(self):  # noqa
+        """If the AoI census exists in the model input, and there are no modifications,
+        it should be provided to TR-55 and not generated.
+        """
+        self.model_input['aoi_census'] = {
+            "distribution": {
+                "b:developed_med": {"cell_count": 155},
+                "a:developed_high": {"cell_count": 1044},
+                "b:developed_high": {"cell_count": 543},
+                "d:developed_high": {"cell_count": 503},
+                "d:developed_med": {"cell_count": 164},
+                "a:developed_med": {"cell_count": 295}
+            },
+            "cell_count": 2704
+        }
+        self.model_input['modification_censuses'] = None
+        self.model_input['modification_pieces'] = []
+
+        skipped_tasks = [
+            'start_histograms_job',
+            'get_histogram_job_results',
+            'histograms_to_censuses',
+        ]
+
+        needed_tasks = [
+            'run_tr55'
+        ]
+
+        job_chain = views._construct_tr55_job_chain(self.model_input,
+                                                    self.job.id)
+
+        self.assertFalse(all([True if t in str(job_chain)
+                             else False for t in skipped_tasks]),
+                         'unnecessary job in chain')
+
+        self.assertTrue(all([True if t in str(job_chain)
+                            else False for t in needed_tasks]),
+                        'missing necessary job in chain')
 
     @override_settings(CELERY_ALWAYS_EAGER=True)
-    def test_tr55_chain_generates_census_if_census_is_stale(self):
-        # Census with stale modification_hash
-        self.model_input['census'] = {
-            'cell_count': 100,
-            'distribution': {
-                'c:developed_high': {
-                    'cell_count': 70
-                },
-                'a:deciduous_forest': {
-                    'cell_count': 30
-                }
+    def test_tr55_chain_generates_modification_censuses_if_they_are_old(self):
+        """If they modification censuses exist in the model input, but the
+        hash stored with the censuses does not match the hash passed in
+        with the model input, the modification censuses are regenerated.
+        """
+        self.model_input['aoi_census'] = {
+            "distribution": {
+                "b:developed_med": {"cell_count": 155},
+                "a:developed_high": {"cell_count": 1044},
+                "b:developed_high": {"cell_count": 543},
+                "d:developed_high": {"cell_count": 503},
+                "d:developed_med": {"cell_count": 164},
+                "a:developed_med": {"cell_count": 295}
             },
-            'modification_hash': 'j3jk3jk3jn3knm3nmn39usd',
-            'modifications': [{
-                'bmp': 'no_till',
-                'cell_count': 1,
-                'distribution': {
-                    'a:deciduous_forest': {'cell_count': 1},
+            "cell_count": 2704
+        }
+        self.model_input['modification_censuses'] = {
+            "modification_hash": "out-of-date-3jk34n9j3knk3kv",
+            "censuses": [
+                {
+                    "distribution": {
+                        "b:developed_med": {"cell_count": 5},
+                        "a:developed_high": {"cell_count": 10},
+                        "b:developed_high": {"cell_count": 4},
+                        "d:developed_high": {"cell_count": 5},
+                        "d:developed_med": {"cell_count": 2},
+                        "a:developed_med": {"cell_count": 2}
+                    },
+                    "cell_count": 28,
+                    "change": ":deciduous_forest:"
                 }
-            }]
+            ]
         }
 
         job_chain = views._construct_tr55_job_chain(self.model_input,
                                                     self.job.id)
 
-        self.assertTrue('tasks.histograms_to_censuses' in str(job_chain),
-                        'Census preparation should not be skipped')
+        skipped_tasks = []
+
+        needed_tasks = [
+            'start_histograms_job',
+            'get_histogram_job_results',
+            'histograms_to_censuses',
+            'run_tr55'
+        ]
+
+        self.assertTrue(all([True if t in str(job_chain)
+                             else False for t in skipped_tasks]),
+                        'unnecessary job in chain')
+
+        self.assertTrue(all([True if t in str(job_chain)
+                            else False for t in needed_tasks]),
+                        'missing necessary job in chain')
 
     @override_settings(CELERY_ALWAYS_EAGER=True)
-    def test_tr55_chain_generates_census_if_census_does_not_exist(self):
+    def test_tr55_chain_generates_both_censuses_if_they_are_missing(self):
+        """If neither the AoI censuses or the modification censuses exist,
+        they are both generated.
+        """
+        self.model_input['aoi_census'] = None
+        self.model_input['modification_censuses'] = None
+
         job_chain = views._construct_tr55_job_chain(self.model_input,
                                                     self.job.id)
 
-        self.assertTrue('tasks.histograms_to_censuses' in str(job_chain),
-                        'Census preparation should not be skipped')
+        skipped_tasks = []
+
+        needed_tasks = [
+            'start_histograms_job',
+            'get_histogram_job_results',
+            'histograms_to_censuses',
+            'run_tr55'
+        ]
+
+        self.assertTrue(all([True if t in str(job_chain)
+                             else False for t in skipped_tasks]),
+                        'unnecessary job in chain')
+
+        self.assertTrue(all([True if t in str(job_chain)
+                            else False for t in needed_tasks]),
+                        'missing necessary job in chain')
 
 
 class APIAccessTestCase(TestCase):

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -75,132 +75,48 @@ class ExerciseGeoprocessing(TestCase):
     def test_census(self):
         expected = {
             "distribution": {
-                "a:barren_land": {
-                    "cell_count": 37
-                },
-                "b:deciduous_forest": {
-                    "cell_count": 7140
-                },
-                "a:shrub": {
-                    "cell_count": 2103
-                },
-                "b:mixed_forest": {
-                    "cell_count": 800
-                },
-                "a:developed_open": {
-                    "cell_count": 24709
-                },
-                "b:grassland": {
-                    "cell_count": 54
-                },
-                "b:open_water": {
-                    "cell_count": 162
-                },
-                "d:open_water": {
-                    "cell_count": 132
-                },
-                "a:deciduous_forest": {
-                    "cell_count": 13731
-                },
-                "a:developed_high": {
-                    "cell_count": 640
-                },
-                "b:evergreen_forest": {
-                    "cell_count": 715
-                },
-                "d:developed_open": {
-                    "cell_count": 12472
-                },
-                "a:developed_low": {
-                    "cell_count": 12977
-                },
-                "a:cultivated_crops": {
-                    "cell_count": 392
-                },
-                "d:developed_high": {
-                    "cell_count": 320
-                },
-                "b:woody_wetlands": {
-                    "cell_count": 1090
-                },
-                "b:developed_med": {
-                    "cell_count": 2026
-                },
-                "d:grassland": {
-                    "cell_count": 46
-                },
-                "d:developed_low": {
-                    "cell_count": 6470
-                },
-                "d:cultivated_crops": {
-                    "cell_count": 202
-                },
-                "b:pasture": {
-                    "cell_count": 1716
-                },
-                "a:evergreen_forest": {
-                    "cell_count": 1406
-                },
-                "d:pasture": {
-                    "cell_count": 1717
-                },
-                "a:open_water": {
-                    "cell_count": 434
-                },
-                "b:cultivated_crops": {
-                    "cell_count": 197
-                },
-                "a:mixed_forest": {
-                    "cell_count": 1490
-                },
-                "d:barren_land": {
-                    "cell_count": 20
-                },
-                "d:woody_wetlands": {
-                    "cell_count": 1093
-                },
-                "b:barren_land": {
-                    "cell_count": 25
-                },
-                "d:shrub": {
-                    "cell_count": 1022
-                },
-                "b:developed_open": {
-                    "cell_count": 12763
-                },
-                "b:developed_low": {
-                    "cell_count": 6484
-                },
-                "d:mixed_forest": {
-                    "cell_count": 745
-                },
-                "a:developed_med": {
-                    "cell_count": 3886
-                },
-                "d:developed_med": {
-                    "cell_count": 1957
-                },
-                "d:deciduous_forest": {
-                    "cell_count": 7231
-                },
-                "a:pasture": {
-                    "cell_count": 3298
-                },
-                "b:developed_high": {
-                    "cell_count": 352
-                },
-                "a:grassland": {
-                    "cell_count": 91
-                },
-                "a:woody_wetlands": {
-                    "cell_count": 2190
-                },
-                "b:shrub": {
-                    "cell_count": 1090
-                },
-                "d:evergreen_forest": {
-                    "cell_count": 675
-                }
+                "a:barren_land": {"cell_count": 37},
+                "b:deciduous_forest": {"cell_count": 7140},
+                "a:shrub": {"cell_count": 2103},
+                "b:mixed_forest": {"cell_count": 800},
+                "a:developed_open": {"cell_count": 24709},
+                "b:grassland": {"cell_count": 54},
+                "b:open_water": {"cell_count": 162},
+                "d:open_water": {"cell_count": 132},
+                "a:deciduous_forest": {"cell_count": 13731},
+                "a:developed_high": {"cell_count": 640},
+                "b:evergreen_forest": {"cell_count": 715},
+                "d:developed_open": {"cell_count": 12472},
+                "a:developed_low": {"cell_count": 12977},
+                "a:cultivated_crops": {"cell_count": 392},
+                "d:developed_high": {"cell_count": 320},
+                "b:woody_wetlands": {"cell_count": 1090},
+                "b:developed_med": {"cell_count": 2026},
+                "d:grassland": {"cell_count": 46},
+                "d:developed_low": {"cell_count": 6470},
+                "d:cultivated_crops": {"cell_count": 202},
+                "b:pasture": {"cell_count": 1716},
+                "a:evergreen_forest": {"cell_count": 1406},
+                "d:pasture": {"cell_count": 1717},
+                "a:open_water": {"cell_count": 434},
+                "b:cultivated_crops": {"cell_count": 197},
+                "a:mixed_forest": {"cell_count": 1490},
+                "d:barren_land": {"cell_count": 20},
+                "d:woody_wetlands": {"cell_count": 1093},
+                "b:barren_land": {"cell_count": 25},
+                "d:shrub": {"cell_count": 1022},
+                "b:developed_open": {"cell_count": 12763},
+                "b:developed_low": {"cell_count": 6484},
+                "d:mixed_forest": {"cell_count": 745},
+                "a:developed_med": {"cell_count": 3886},
+                "d:developed_med": {"cell_count": 1957},
+                "d:deciduous_forest": {"cell_count": 7231},
+                "a:pasture": {"cell_count": 3298},
+                "b:developed_high": {"cell_count": 352},
+                "a:grassland": {"cell_count": 91},
+                "a:woody_wetlands": {"cell_count": 2190},
+                "b:shrub": {"cell_count": 1090},
+                "d:evergreen_forest": {"cell_count": 675}
             },
             "cell_count": 136100
         }

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -394,8 +394,8 @@ class TaskRunnerTestCase(TestCase):
                                                     self.job.id)
 
         # Make sure the chain is well-formed
-        self.assertTrue('tasks.polygons_to_id' in str(job_chain[0]))
-        self.assertTrue('tasks.id_to_histogram' in str(job_chain[1]))
+        self.assertTrue('tasks.start_histograms_job' in str(job_chain[0]))
+        self.assertTrue('tasks.get_histogram_job_results' in str(job_chain[1]))
 
         # Modify the chain to prevent it from trying to talk to endpoint
         job_chain = [nothing_to_histogram.s()] + job_chain[2:]
@@ -431,8 +431,8 @@ class TaskRunnerTestCase(TestCase):
 
         job_chain = views._construct_tr55_job_chain(model_input,
                                                     self.job.id)
-        self.assertTrue('tasks.polygons_to_id' in str(job_chain[0]))
-        self.assertTrue('tasks.id_to_histogram' in str(job_chain[1]))
+        self.assertTrue('tasks.start_histograms_job' in str(job_chain[0]))
+        self.assertTrue('tasks.get_histogram_job_results' in str(job_chain[1]))
         job_chain = [nothing_to_histogram.s()] + job_chain[2:]
 
         with self.assertRaises(Exception) as context:

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -218,16 +218,38 @@ def _initiate_tr55_job_chain(model_input, job_id):
 def _construct_tr55_job_chain(model_input, job_id):
     job_chain = []
 
-    # TODO put this into an if/else block and only do it if the
-    # censuses are not already cached.
-
     aoi = model_input.get('area_of_interest')
-    pieces = model_input.get('modification_pieces')
-    polygons = [aoi] + [m['shape']['geometry'] for m in pieces]
-    job_chain.append(tasks.start_histograms_job.s(polygons))
-    job_chain.append(tasks.get_histogram_job_results.s())
-    job_chain.append(tasks.histograms_to_censuses.s())
-    job_chain.append(tasks.run_tr55.s(model_input))
+    aoi_census = model_input.get('aoi_census')
+    modification_censuses = model_input.get('modification_censuses')
+    pieces = model_input.get('modification_pieces', [])
+    current_hash = model_input.get('modification_hash')
+    census_hash = None
+    modification_census_items = []
+
+    if modification_censuses:
+        census_hash = modification_censuses.get('modification_hash')
+        modification_census_items = modification_censuses.get('censuses')
+
+    if (aoi_census and ((modification_census_items and
+       census_hash == current_hash) or not pieces)):
+        censuses = [aoi_census] + modification_census_items
+
+        job_chain.append(tasks.run_tr55.s(censuses, model_input))
+    else:
+        job_chain.append(tasks.get_histogram_job_results.s())
+        job_chain.append(tasks.histograms_to_censuses.s())
+
+        if aoi_census and pieces:
+            polygons = [m['shape']['geometry'] for m in pieces]
+
+            job_chain.insert(0, tasks.start_histograms_job.s(polygons))
+            job_chain.insert(len(job_chain), tasks.run_tr55.s(model_input,
+                             cached_aoi_census=aoi_census))
+        else:
+            polygons = [aoi] + [m['shape']['geometry'] for m in pieces]
+
+            job_chain.insert(0, tasks.start_histograms_job.s(polygons))
+            job_chain.insert(len(job_chain), tasks.run_tr55.s(model_input))
 
     job_chain.append(save_job_result.s(job_id, model_input))
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -454,6 +454,8 @@ var ScenarioModel = Backbone.Model.extend({
         job_id: null,
         results: null, // ResultCollection
         census: null, // JSON blob
+        aoi_census: null, // JSON blob
+        modification_censuses: null, // JSON blob
         allow_save: true // Is allowed to save to the server - false in compare mode
     },
 
@@ -586,7 +588,11 @@ var ScenarioModel = Backbone.Model.extend({
                 }
             });
 
-            this.set('census', serverResults.aoi_census);
+            this.set('aoi_census', serverResults.aoi_census);
+            this.set('modification_censuses', {
+                modification_hash: serverResults.modification_hash,
+                censuses: serverResults.modification_censuses
+            });
         }
     },
 
@@ -605,7 +611,8 @@ var ScenarioModel = Backbone.Model.extend({
                         inputs: self.get('inputs').toJSON(),
                         modification_pieces: alterModifications(self.get('modifications'), self.get('modification_hash')),
                         area_of_interest: App.currentProject.get('area_of_interest'),
-                        census: self.get('census'),
+                        aoi_census: self.get('aoi_census'),
+                        modification_censuses: self.get('modification_censuses'),
                         inputmod_hash: self.get('inputmod_hash'),
                         modification_hash: self.get('modification_hash')
                     })

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -279,7 +279,7 @@ var ProjectModel = Backbone.Model.extend({
 });
 
 /**
- * A predicate for a filter function used in the _modifyModifications.
+ * A predicate for a filter function used in the _alterModifications.
  * Returns true if piece has a valid shape with non-zero area, and
  * false otherwise.
  */
@@ -293,7 +293,7 @@ function validShape(piece) {
  * point on the map is covered by more than one 'BMP' or more than one
  * 'reclassification'.
  */
-function _modifyModifications(rawModifications) {
+function _alterModifications(rawModifications) {
     var pieces = [],
         reclass = 'landcover',
         bmp = 'conservation_practice',
@@ -395,7 +395,7 @@ function _modifyModifications(rawModifications) {
     return pieces;
 }
 
-var modifyModifications = _.memoize(_modifyModifications, function(_, hash) {return hash;});
+var alterModifications = _.memoize(_alterModifications, function(_, hash) {return hash;});
 
 var ModificationModel = coreModels.GeoModel.extend({
     defaults: _.extend({
@@ -586,7 +586,7 @@ var ScenarioModel = Backbone.Model.extend({
                 }
             });
 
-            this.set('census', serverResults.census);
+            this.set('census', serverResults.aoi_census);
         }
     },
 
@@ -603,8 +603,7 @@ var ScenarioModel = Backbone.Model.extend({
                 postData: {
                     model_input: JSON.stringify({
                         inputs: self.get('inputs').toJSON(),
-                        modifications: self.get('modifications').toJSON(),
-                        modification_pieces: modifyModifications(self.get('modifications'), self.get('modification_hash')),
+                        modification_pieces: alterModifications(self.get('modifications'), self.get('modification_hash')),
                         area_of_interest: App.currentProject.get('area_of_interest'),
                         census: self.get('census'),
                         inputmod_hash: self.get('inputmod_hash'),


### PR DESCRIPTION
Cache AoI and modification censuses.
* If a AoI census or modification censuses have already been generated
and are still valid, skip the geoprocessing tasks and run TR55 directly.
* If only the AoI census is available, generate the modification
censuses and provide the cached AoI census to TR-55.
* Modify the structure of the Scenario.census to contain the
modification hash from when the censuses were generated, as well
as both the AoI census and the modification censuses in the structure
expected in the geoprocessing tasks.
* Update and add tests to test caching logic.

Connects to #870

**Testing instructions:**
- Start a new project with a fairly large AoI so that it's easy to see the difference in computation time.

![screen shot 2015-10-02 at 12 04 56 pm](https://cloud.githubusercontent.com/assets/1042475/10251311/d26c5ece-68fd-11e5-9636-3ebca69294d6.png)

- Switch to the "New Scenario"
- The initial model run should take a few seconds.
- Change just the precipitation slider.
- The model run should be faster than the previous run.
- Add a modification. The model run should be slower than the last run, and maybe a bit slower than the first run (more modifications means a longer model run time).
- Change just the precipitation slider again.
- The model run should be fast again.
- Repeat until you are confident there is some caching going on.
- Run the tests.

@jamesmcclain had a good idea that I didn't take on in this card because I spent a lot of time upfront reading through and rewriting things, and it's a discrete task. When a new scenario is added, we should pass along the AoI census from the previous or first scenario if the AoI census exists. Issue here: https://github.com/WikiWatershed/model-my-watershed/issues/897

Looking for input from @jamesmcclain re: new function and variable names, and function comments.