### PR TITLE
Adjust CSS related to header dropdown.

### DIFF
--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -50,6 +50,10 @@ header {
           right: 0px;
           a {
             color: $ui-secondary;
+
+            &:hover, &:active {
+              color: $ui-secondary;
+            }
           }
         }
 

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -4,7 +4,6 @@ header {
   width: 100%;
   position: relative;
   top: 0;
-  z-index: 500;
 }
 
 //Standard Header
@@ -46,8 +45,12 @@ header {
         display: inline-block;
         float: left;
 
-        .dropdown-menu a {
-          color: $ui-secondary;
+        .dropdown-menu {
+          left: auto;
+          right: 0px;
+          a {
+            color: $ui-secondary;
+          }
         }
 
         a {


### PR DESCRIPTION
Connects #910 
Connects #912 

Because of the absolute positioning, our dropdown for the user menu in the top
left was being pushed off the screen. Likewise, because the secondary menu bar
had an unnecessary z-index it was sitting on top of the open dropdown.

### To Test
 * Log in
 * Use user dropdown in top right
 * Ensure text is readable
 * Go to modeling page
 * Use user dropdown in top right
 * Ensure text is readable