### PR TITLE
Fix model runs with no modifications.

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -180,9 +180,10 @@ def run_tr55(censuses, model_input, cached_aoi_census=None):
     aoi_census = cached_aoi_census if cached_aoi_census else censuses[0]
 
     modifications = []
-    if ((modification_pieces and not modification_censuses) or
-       (modification_censuses and not modification_pieces)):
-            raise Exception('Missing pieces or censuses for modifications')
+    if (modification_pieces and not modification_censuses):
+        raise Exception('Missing censuses for modifications')
+    elif (modification_censuses and not modification_pieces):
+        modification_censuses = []
 
     modifications = build_tr55_modification_input(modification_pieces,
                                                   modification_censuses)


### PR DESCRIPTION
* Model runs with no modifications that previously had modifications
were throwing exceptions, but this case should be supported. If there
are pieces but no censuses, we should throw an exception because the
model results will be incorrect. However, if there are no pieces
but a census, we can just delete the census and run the model.

**Testing instructions:**
- Create a new project.
- Add a modification to the "New Scenario". The model should run correctly.
- Remove the modification. The bar chart results should still appear, and the modified column should match the current conditions column.


Connects to #921 