### PR TITLE
Ensure that search results are on top

### DIFF
--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -70,6 +70,7 @@
     background-color: $paper;
     margin-top: 6px;
     min-width: 300px;
+    z-index: 10;
     & > li {
       cursor: pointer;
       padding: 0.5rem 1rem;


### PR DESCRIPTION
## Overview

Previously they would be obscured by Draw Tools on small screens. This ensures that when they are visible they are on top of all other items.

## Demo

See here: https://1cfc461b.ngrok.io

![image](https://cloud.githubusercontent.com/assets/1430060/10374929/cdf18110-6dc3-11e5-9747-4c67f445d3f9.png)

Connects #917 