### PR TITLE
Celery Worker Affinity

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.celery-worker/templates/celeryd-defaults.j2
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/templates/celeryd-defaults.j2
@@ -1,5 +1,5 @@
 # Names of nodes to start
-CELERYD_NODES="{% for id in range(0,celery_number_of_workers) %}worker{{ id }} {% endfor %}"
+CELERYD_NODES="{% for id in range(0,celery_number_of_workers) %}$(cat /etc/mmw.d/env/MMW_STACK_COLOR)-worker{{ id }} {% endfor %}"
 
 # Absolute or relative path to the 'celery' command:
 CELERY_BIN="envdir /etc/mmw.d/env /usr/local/bin/celery"

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -29,6 +29,10 @@ from apps.modeling.serializers import (ProjectSerializer,
                                        ProjectUpdateSerializer,
                                        ScenarioSerializer)
 
+# When CELERY_WORKER_DIRECT = True, this exchange is automatically
+# created to allow direct communication with workers.
+MAGIC_EXCHANGE = 'C.dq'
+
 
 @decorators.api_view(['GET', 'POST'])
 @decorators.permission_classes((IsAuthenticated, ))
@@ -204,17 +208,15 @@ def choose_worker():
 
 
 def _initiate_analyze_job_chain(area_of_interest, job_id, testing=False):
-    exchange = 'C.dq'
+    exchange = MAGIC_EXCHANGE
     routing_key = choose_worker()
 
-    return chain(tasks.start_histogram_job.s(area_of_interest).set(
-                    exchange=exchange, routing_key=routing_key),
-                 tasks.get_histogram_job_results.s().set(
-                     exchange=exchange, routing_key=routing_key),
-                 tasks.histogram_to_survey.s().set(
-                     exchange=exchange, routing_key=routing_key),
-                 save_job_result.s(job_id, area_of_interest).set(
-                     exchange=exchange, routing_key=routing_key)) \
+    return chain(tasks.start_histogram_job.s(area_of_interest)
+                 .set(exchange=exchange, routing_key=routing_key),
+                 tasks.get_histogram_job_results.s()
+                 .set(exchange=exchange, routing_key=routing_key),
+                 tasks.histogram_to_survey.s(),
+                 save_job_result.s(job_id, area_of_interest)) \
         .apply_async(link_error=save_job_error.s(job_id))
 
 
@@ -244,7 +246,7 @@ def _initiate_tr55_job_chain(model_input, job_id):
 
 
 def _construct_tr55_job_chain(model_input, job_id):
-    exchange = 'C.dq'
+    exchange = MAGIC_EXCHANGE
     routing_key = choose_worker()
 
     job_chain = []
@@ -269,32 +271,28 @@ def _construct_tr55_job_chain(model_input, job_id):
        census_hash == current_hash) or not pieces)):
         censuses = [aoi_census] + modification_census_items
 
-        job_chain.append(tasks.run_tr55.s(censuses, model_input).set(
-            exchange=exchange, routing_key=routing_key))
+        job_chain.append(tasks.run_tr55.s(censuses, model_input))
     else:
-        job_chain.append(tasks.get_histogram_job_results.s().set(
-            exchange=exchange, routing_key=routing_key))
-        job_chain.append(tasks.histograms_to_censuses.s().set(
-            exchange=exchange, routing_key=routing_key))
+        job_chain.append(tasks.get_histogram_job_results.s()
+                         .set(exchange=exchange, routing_key=routing_key))
+        job_chain.append(tasks.histograms_to_censuses.s()
+                         .set(exchange=exchange, routing_key=routing_key))
 
         if aoi_census and pieces:
             polygons = [m['shape']['geometry'] for m in pieces]
 
-            job_chain.insert(0, tasks.start_histograms_job.s(polygons).set(
-                    exchange=exchange, routing_key=routing_key))
+            job_chain.insert(0, tasks.start_histograms_job.s(polygons)
+                             .set(exchange=exchange, routing_key=routing_key))
             job_chain.insert(len(job_chain), tasks.run_tr55.s(model_input,
-                             cached_aoi_census=aoi_census).set(
-                                 exchange=exchange, routing_key=routing_key))
+                             cached_aoi_census=aoi_census))
         else:
             polygons = [aoi] + [m['shape']['geometry'] for m in pieces]
 
-            job_chain.insert(0, tasks.start_histograms_job.s(polygons).set(
-                exchange=exchange, routing_key=routing_key))
-            job_chain.insert(len(job_chain), tasks.run_tr55.s(model_input).set(
-                exchange=exchange, routing_key=routing_key))
+            job_chain.insert(0, tasks.start_histograms_job.s(polygons)
+                             .set(exchange=exchange, routing_key=routing_key))
+            job_chain.insert(len(job_chain), tasks.run_tr55.s(model_input))
 
-    job_chain.append(save_job_result.s(job_id, model_input).set(
-        exchange=exchange, routing_key=routing_key))
+    job_chain.append(save_job_result.s(job_id, model_input))
 
     return job_chain
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -121,6 +121,8 @@ STATSD_CELERY_SIGNALS = True
 CELERY_DEFAULT_QUEUE = environ.get('MMW_STACK_COLOR', 'Black').lower()
 CELERY_DEFAULT_ROUTING_KEY = ('task.%s' %
                               environ.get('MMW_STACK_COLOR', 'Black').lower())
+CELERY_WORKER_DIRECT = True
+CELERY_CREATE_MISSING_QUEUES = True
 # END CELERY CONFIGURATION
 
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -65,6 +65,9 @@ STATSD_PREFIX = 'django'
 STATSD_HOST = environ.get('MMW_STATSD_HOST', 'localhost')
 # END STATSD CONFIGURATION
 
+# STACK COLOR CONFIGURATION
+STACK_COLOR = environ.get('MMW_STACK_COLOR', 'Black')
+# END STACK COLOR CONFIGURATION
 
 # CACHE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
@@ -118,9 +121,6 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 STATSD_CELERY_SIGNALS = True
-CELERY_DEFAULT_QUEUE = environ.get('MMW_STACK_COLOR', 'Black').lower()
-CELERY_DEFAULT_ROUTING_KEY = ('task.%s' %
-                              environ.get('MMW_STACK_COLOR', 'Black').lower())
 CELERY_WORKER_DIRECT = True
 CELERY_CREATE_MISSING_QUEUES = True
 # END CELERY CONFIGURATION


### PR DESCRIPTION
The parts of the the job chain which must remain on the same worker, namely the top- and bottom-halves of the SJS submission/polling functionality, are forced to remain on the same worker.  This is done so that the polling task is not scheduled on another worker which does not have access to the spark-jobserver on which the geoprocessing query has been submitted.

Connects #886

It might be helpful to install the `vagrant-cachier` plugin, if you have not done so already.

**Test with two workers**
   * Halt the `worker` VM.
   * Pull down the following branch https://github.com/jamesmcclain/model-my-watershed/tree/affinity-testing, and switch to it.  This branch is identical to the pull request branch except for the last commit which adds workers.  This last commit should not be merged, and I also don't want to put it into the P/R branch for fear of messing up Jenkins.
   * Type `vagrant up worker1 worker2` to create the two VMs.
   * Reload the `app` VM.
   * Use the site as normal.  Hopefully everything works, and you will be able to verify that jobs are being executed on both VMs by looking at the Celery logs (`/var/log/celery/Black-worker[01].log` on both `worker1` and `worker2` [that is the purpose of SSHing into the VMs]).
   * Run tests: `./scripts/test.sh`.
   * After testing, halt or destroy the two worker VMs.

**Test with one worker**
   * Now switch to the P/R branch https://github.com/jamesmcclain/model-my-watershed/tree/feature/celery-worker-affinity
   * Reprovision the worker VM: `vagrant provision worker`
   * Reload the `app` VM.
   * Conform that the site works as normal with one worker.
   * Run tests: `./scripts/test.sh`.