### PR TITLE
Fill empty space when selecting Draw tools

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -332,7 +332,6 @@ var ResetDrawView = Marionette.ItemView.extend({
         utils.cancelDrawing(App.getLeafletMap());
         clearAoiLayer();
         clearBoundaryLayer(this.model);
-        App.map.setDrawSize(true);
     }
 });
 
@@ -398,6 +397,7 @@ function clearAoiLayer() {
 
     App.map.set('areaOfInterest', null);
     App.projectNumber = undefined;
+    App.map.setDrawSize(false);
 
     return function revertLayer() {
         var previousShape = App.map.previous('areaOfInterest');


### PR DESCRIPTION
## Overview

Previously, if there was a location bar left over from the Analyze view, and the user reset the AoI or selected a new draw tool, the location bar would disappear but leave an empty white space.

2e57f36 tried to fix this but made the mistake of resetting the map only after the user clicked "Reset", and not when the user simply selected a different draw tool. By moving the call to `setDrawSize` within `clearAoILayer`, we ensure that the map is always resized whenever the AoI is cleared.

We switch from `setDrawSize(true)` to `setDrawSize(false)` because there is no AoI to fit to, thus we don't attempt fitting, making the resize transition slightly smoother.

## Testing Instructions

 1. Draw a shape. Click the back arrow in the Analyze view to return to Draw view.
 2. Click "Reset". Ensure that when the black bar disappears the map is resized to occupy all space and there is no left over whitespace.
 3. Draw another shape. Click the back arrow in the Analyze view to return to Draw view.
 4. Click any draw tool. Ensure that when the black bar disappears the map is resized to occupy all space and there is no left over whitespace.

Connects #893