### PR TITLE
Fix draw popovers

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -105,7 +105,7 @@ var SelectAreaView = Marionette.ItemView.extend({
     onRender: function() {
         this.ui.helptextIcon.popover({
             trigger: 'hover',
-            viewport: '.container-fluid.top-nav'
+            viewport: '.map-container'
         });
     },
 
@@ -220,7 +220,7 @@ var DrawView = Marionette.ItemView.extend({
     onShow: function() {
         this.ui.helptextIcon.popover({
             trigger: 'hover',
-            viewport: '.container-fluid.top-nav'
+            viewport: '.map-container'
         });
     },
 
@@ -280,7 +280,7 @@ var PlaceMarkerView = Marionette.ItemView.extend({
     onShow: function() {
         this.ui.helptextIcon.popover({
             trigger: 'hover',
-            viewport: '.container-fluid.top-nav'
+            viewport: '.map-container'
         });
     },
 


### PR DESCRIPTION
## Overview

Since we now use the [`map`](https://github.com/WikiWatershed/model-my-watershed/blob/c392ed6c7548ef4b6cf34984606aecfda0e22a40/src/mmw/apps/core/templates/base.html#L31-L34) block rather than the [`content`](https://github.com/WikiWatershed/model-my-watershed/blob/c392ed6c7548ef4b6cf34984606aecfda0e22a40/src/mmw/apps/core/templates/base.html#L36-L39) block in [`base.html`](https://github.com/WikiWatershed/model-my-watershed/blob/c392ed6c7548ef4b6cf34984606aecfda0e22a40/src/mmw/apps/core/templates/base.html), which is wrapped in `.map-container` rather than `.container-fluid`, we have to adjust the target viewport in the given popovers.

## Testing Instructions

Hover over the help icons in entries in the Select by Boundary, Draw Area, and Delineate Watershed draw tools, and ensure that the popovers are shown correctly. Test in different browsers.

## Demo

![image](https://cloud.githubusercontent.com/assets/1430060/10400198/577d1b58-6e85-11e5-868c-043993360e44.png)

Connects #930