### PR TITLE
Remove Scenario.census

### DIFF
--- a/src/mmw/apps/modeling/migrations/0015_remove_scenario_census.py
+++ b/src/mmw/apps/modeling/migrations/0015_remove_scenario_census.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0014_auto_20151005_0945'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='scenario',
+            name='census',
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -69,9 +69,6 @@ class Scenario(models.Model):
         help_text='A hash of the values for modifications to ' +
                   'compare to the existing model results, to determine if ' +
                   'the persisted result apply to the current values')
-    census = models.TextField(
-        null=True,
-        help_text='Serialized JSON representation of geoprocessing results')
     aoi_census = models.TextField(
         null=True,
         help_text='Serialized JSON representation of AoI census ' +

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -27,7 +27,6 @@ class ScenarioSerializer(serializers.ModelSerializer):
 
     inputs = JsonField()
     modifications = JsonField()
-    census = JsonField(required=False, allow_null=True)
     aoi_census = JsonField(required=False, allow_null=True)
     modification_censuses = JsonField(required=False, allow_null=True)
     results = JsonField(required=False, allow_null=True)

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -473,7 +473,6 @@ var ScenarioModel = Backbone.Model.extend({
         active: false,
         job_id: null,
         results: null, // ResultCollection
-        census: null, // JSON blob
         aoi_census: null, // JSON blob
         modification_censuses: null, // JSON blob
         allow_save: true // Is allowed to save to the server - false in compare mode


### PR DESCRIPTION
* The second part of a migration to update the census related fields
for scenarios.

**Testing instructions**
- Run migrations: `scripty manage migrate`
- Verify that projects load, run models and produce no errors.
- Verify that censuses are still being cached. (See https://github.com/WikiWatershed/model-my-watershed/pull/553 for instructions).

Connects to #906