### PR TITLE
Share AoI Census

### DIFF
--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -234,11 +234,15 @@ def _construct_tr55_job_chain(model_input, job_id):
     aoi = model_input.get('area_of_interest')
     aoi_census = model_input.get('aoi_census')
     modification_censuses = model_input.get('modification_censuses')
+    # Non-overlapping polygons derived from the modifications
     pieces = model_input.get('modification_pieces', [])
+    # The hash of the current modifications
     current_hash = model_input.get('modification_hash')
-    census_hash = None
-    modification_census_items = []
 
+    # The hash of the modifications whose censuses we already have
+    census_hash = None
+    # The list of already-computed censuses of the modifications
+    modification_census_items = []
     if modification_censuses:
         census_hash = modification_censuses.get('modification_hash')
         modification_census_items = modification_censuses.get('censuses')

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -737,9 +737,10 @@ var ScenariosCollection = Backbone.Collection.extend({
         return this.setActiveScenario(this.get({ cid: cid }));
     },
 
-    createNewScenario: function() {
+    createNewScenario: function(aoi_census) {
         var scenario = new ScenarioModel({
-            name: this.makeNewScenarioName('New Scenario')
+            name: this.makeNewScenarioName('New Scenario'),
+            aoi_census: aoi_census
         });
 
         this.add(scenario);

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -286,7 +286,14 @@ var ScenariosView = Marionette.LayoutView.extend({
     },
 
     addScenario: function() {
-        this.collection.createNewScenario();
+        var first = this.collection.first();
+
+        if (first) {
+            var aoi_census = first.get('aoi_census');
+            this.collection.createNewScenario(aoi_census);
+        } else {
+            this.collection.createNewScenario();
+        }
     },
 
     onScenarioTabClicked: function(e) {


### PR DESCRIPTION
When a new scenario is created, the census of the Area of Interest (AoI) is automatically attached to the new scenario.  Since the AoI is the same for all scenarios in a project, this can be done.  Doing this reduces the load the Geoprocessing service.

Connects #897

**To Test**
   * Open up the developer tools so that you can see the network traffic generated by the application, and also watch the spark-jobserver logs.
   * Go to a project and create a new scenario.
   * There should be no polling for the AoI census with this patch applied, but without it there should be.
   * Caching works on the compare page, as well.

**Limitations**
When a new project is created, there will still be two separate queries: one for "current conditions" and one for the "new scenario".  Since the census of the AoI is not available at that point, this cannot be helped without delaying the creation of the "new scenario" scenario.