### PR TITLE
Fix sliders in Internet Explorer

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -212,6 +212,12 @@ var PrecipitationView = ControlView.extend({
                 value: imperialValue
             });
 
+        // Update values for IE which doesn't trigger onSliderDragged. Will
+        // effectively noop on other browsers, since the same values were
+        // already set by onSliderDragged.
+        this.ui.slider.attr('value', value);
+        this.ui.displayValue.text(this.getDisplayValue(value));
+
         PrecipitationSynchronizer.syncTo(this);
 
         this.addOrReplaceInput(modification);

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -214,7 +214,9 @@ header {
         // Undo bootstrap input[type="range"] syling
         input {
           display: inline-block;
-          width: auto;
+          width: 120px;
+          margin: 0 0.7rem;
+          padding: 0;
           vertical-align: bottom;
         }
       }

--- a/src/mmw/sass/components/_inputs.scss
+++ b/src/mmw/sass/components/_inputs.scss
@@ -145,5 +145,5 @@ input[type=range][orient=vertical]
     -webkit-appearance: slider-vertical; /* WebKit */
     width: 8px;
     height: 175px;
-    padding: 0 5px;
+    padding: 0;
 }

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -147,6 +147,7 @@
                       z-index: 10;
                       padding: 0;
                       margin-top: 10px;
+                      width: 100%;
 
                       label {
                         display: table;


### PR DESCRIPTION
## Overview

The invisibility of the sliders in Internet Explorer was caused by its inability to automatically determine their width. By giving them, or their containers, explicit widths, we ensure that the sliders are always visible.

In addition, their behavior was different because IE doesn't trigger `input` event when the slider is being dragged, but instead triggers `change` continuously. This is different from Firefox, Chrome and Safari, which trigger `input` when dragging the slider, and `change` when the user stops dragging.

Previously we would only update the UI on the `input` event to preview the value selected by the user. Unfortunately, since IE never fires it, the UI would not update even when the user stopped dragging. This edit ensures that the UI is updated with the final value.

The actual fetching of the results is debounced, so even though we are firing a lot more `change` events than were originally expected, there are no more network requests and performance is quite consistent.

## Testing Instructions

Create a project, and proceed to the Model view. Test the sliders. Go to the Compare view. Test the sliders.

Test in IE, but also in other browsers to ensure that the expected behavior hasn't changed.

## Demo

Chrome 45 on Mac:

![image](https://cloud.githubusercontent.com/assets/1430060/10436654/d3d3c3d8-70f5-11e5-98bd-6233c812ff68.png)

Safari 9 on Mac:

![image](https://cloud.githubusercontent.com/assets/1430060/10436672/e42526e6-70f5-11e5-89a8-6a4edd7d2e3f.png)

Firefox 41 on Mac:

![image](https://cloud.githubusercontent.com/assets/1430060/10436689/00812ad8-70f6-11e5-8cda-fe12730a1885.png)

IE 11 on Windows:

![image](https://cloud.githubusercontent.com/assets/1430060/10436698/10ea9de6-70f6-11e5-9e8b-03376ea582c5.png)

Firefox 41 on Windows:

![image](https://cloud.githubusercontent.com/assets/1430060/10436743/46dbba98-70f6-11e5-8495-70dccfcb8ee0.png)

## Notes

I can't get the opacity slider to actually change the opacity of the coverage layer in either IE or Firefox. These observations should probably be made into a new issue.

Connects #913 