### PR TITLE
Fix IE search bar.

### DIFF
--- a/src/mmw/sass/components/_inputs.scss
+++ b/src/mmw/sass/components/_inputs.scss
@@ -9,6 +9,7 @@
   box-shadow: 0 0 6px $black-74;
   font-size: 0.7rem;
   width: 300px;
+  height: 36px;
   padding: 0 1rem;
   color: $black-54;
   background-color: $paper;


### PR DESCRIPTION
IE will not respect the line height for search boxes to make the box larger.
Creating an explicit height fixes this.

Connects #915 

### To test
 * bundle and then view in IE.
 * search bar should look the same as other browsers.

![screenshot from 2015-10-12 18 47 19](https://cloud.githubusercontent.com/assets/903219/10440961/b3f109b0-7111-11e5-9c26-2ed848ea03bc.png)

