### PR TITLE
Return 404s for invalid boundary layer requests.

### DIFF
--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -985,6 +985,12 @@ class APIAccessTestCase(TestCase):
 
         self.assertEqual(response.status_code, 403)
 
+    def test_boundary_layer_details_returns_404_with_bad_table_code(self):
+        """Table code should match an item in layer_settings code field"""
+        response = self.c.put('/api/boundary-layers/foo/1234', format='json')
+
+        self.assertEqual(response.status_code, 404)
+
     def create_public_project(self):
         self.project['is_private'] = False
         response = self.c.post('/api/modeling/projects/', self.project,

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -24,6 +24,6 @@ urlpatterns = patterns(
     url(r'start/analyze/$', views.start_analyze, name='start_analyze'),
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),
-    url(r'boundary-layers/((?P<table_code>\w+)/(?P<obj_id>[0-9]+)/|)$',
+    url(r'boundary-layers/(?P<table_code>\w+)/(?P<obj_id>[0-9]+)/$',
         views.boundary_layer_detail, name='boundary_layer_detail'),
 )

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -276,13 +276,17 @@ def _construct_tr55_job_chain(model_input, job_id):
 @decorators.api_view(['GET'])
 @decorators.permission_classes((AllowAny, ))
 def boundary_layer_detail(request, table_code, obj_id):
-    layers = [layer for layer in settings.LAYERS
-              if layer.get('code') == table_code]
-    table_name = layers[0]['table_name']
-    json_field = layers[0].get('json_field', 'geom')
+    try:
+        layers = [layer for layer in settings.LAYERS
+                  if layer.get('code') == table_code and
+                  layer.get('boundary')]
+        table_name = layers[0]['table_name']
+        json_field = layers[0].get('json_field', 'geom')
 
-    query = 'SELECT {field} FROM {table} WHERE id = %s'.format(
-            field=json_field, table=table_name)
+        query = 'SELECT {field} FROM {table} WHERE id = %s'.format(
+                field=json_field, table=table_name)
+    except (KeyError, IndexError):
+        return Response(status=status.HTTP_404_NOT_FOUND)
 
     with connection.cursor() as cursor:
         cursor.execute(query, [int(obj_id)])


### PR DESCRIPTION
* Previously a 500 error would be returned if an table name wasn't
provided or was invalid. A 404 error is more appropriate for these
cases.

I tested the site out on our Nexus table and my iPhone, and the boundary selection worked fine in both cases. I wasn't able to reproduce this error using the app. I had to visit the bad URL directly.

**Testing instructions**
- Visit http://localhost:8000/api/modeling/boundary-layers/
- A DRF 404 error page should be returned.
- Visiting the same URL or `develop`, production or staging should throw a 500.

Connects to  #899