### PR TITLE
Limit Overlay Zoom Levels

### DIFF
--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -78,6 +78,9 @@ module.exports = L.Control.Layers.extend({
         }
 
         input.layerId = L.stamp(obj.layer);
+        if (obj.overlay && obj.layer && obj.layer.options && obj.layer.options.code) {
+            $(input).attr('id', obj.layer.options.code);
+        }
 
         L.DomEvent.on(input, 'click', this._onInputClick, this);
 

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -6,6 +6,22 @@ var _ = require('underscore'),
 var M2_IN_KM2 = 1000000;
 
 var utils = {
+    // A function to enable/disable UI entries in response to zoom
+    // level changes.
+    zoomToggle: function(map, layerData, actOnUI, actOnLayer) {
+        map.on('zoomend', function(e) {
+            var zoom = e.target.getZoom();
+            _.forEach(layerData, function(layerDatum) {
+                if (zoom < (layerDatum.minZoom || 0)) {
+                    actOnUI(layerDatum, true);
+                    actOnLayer(layerDatum);
+                } else if (zoom >= (layerDatum.minZoom || 0)) {
+                    actOnUI(layerDatum, false);
+                }
+            });
+        });
+    },
+
     // A numeric comparator for strings.
     numericSort: function(_x, _y) {
         var x = parseFloat(_x.toString().replace(/[^0-9.]/g, '')),

--- a/src/mmw/js/src/draw/templates/selectType.html
+++ b/src/mmw/js/src/draw/templates/selectType.html
@@ -10,7 +10,8 @@
         <a role="menuitem" tabindex="-1" href="#"
            data-tile-url="{{ item.url }}"
            data-layer-code="{{ item.code }}"
-           data-short-display="{{ item.short_display }}">
+           data-short-display="{{ item.short_display }}"
+           data-min-zoom="{{ item.minZoom }}">
           <span>{{ item.display }}</span> <i class="split fa fa-question-circle"
                                              data-content="{{ item.helptext }}"></i>
         </a>

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -26,6 +26,7 @@ LAYERS = [
         'boundary': True,
         'vector': True,
         'overlay': True,
+        'minZoom': 7,
     },
     {
         'code': 'huc10',
@@ -42,6 +43,7 @@ LAYERS = [
         'boundary': True,
         'vector': True,
         'overlay': True,
+        'minZoom': 8,
     },
     {
         'code': 'huc12',
@@ -59,6 +61,7 @@ LAYERS = [
         'boundary': True,
         'vector': True,
         'overlay': True,
+        'minZoom': 9,
     },
     {
         'code': 'county',
@@ -75,6 +78,7 @@ LAYERS = [
         'boundary': True,
         'vector': True,
         'overlay': True,
+        'minZoom': 9,
     },
     {
         'code': 'district',
@@ -92,6 +96,7 @@ LAYERS = [
         'boundary': True,
         'vector': True,
         'overlay': True,
+        'minZoom': 6,
     },
     {
         'code': 'school',
@@ -102,6 +107,7 @@ LAYERS = [
         'boundary': True,
         'vector': True,
         'overlay': True,
+        'minZoom': 9,
     },
     {
         'display': 'National Land Cover Database',

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -54,6 +54,10 @@
   height: 100%;
 }
 
+#overlay-subclass-vector .disabled {
+  color: $black-54;
+}
+
 // Override default location of Leaflet spritesheet images.
 .leaflet-draw-toolbar a {
   background-image: url('../images/spritesheet.png');

--- a/src/mmw/sass/bootstrap/_dropdowns.scss
+++ b/src/mmw/sass/bootstrap/_dropdowns.scss
@@ -74,8 +74,8 @@
 
 // Hover/Focus state
 .dropdown-menu > li > a {
-  &:hover,
-  &:focus {
+  &:hover:not(.disabled),
+  &:focus:not(.disabled) {
     text-decoration: none;
     color: $dropdown-link-hover-color;
     background-color: $dropdown-link-hover-bg;

--- a/src/mmw/sass/components/_dropdowns.scss
+++ b/src/mmw/sass/components/_dropdowns.scss
@@ -27,13 +27,21 @@
         color: $black-74;
         line-height: $height-md;
         padding: 0 0.5rem;
-        cursor: pointer!important;
         font-size: 0.7rem;
         text-transform: capitalize!important;
 
-        &:hover, &:focus {
-          color: $black-74;
-          background-color: $ui-light;
+        &:not(.disabled) {
+          cursor: pointer;
+
+          &:hover, &:focus {
+            color: $black-74;
+            background-color: $ui-light;
+          }
+        }
+
+        &.disabled {
+            cursor: default!important;
+            color: $black-54;
         }
 
         i {


### PR DESCRIPTION
This pull request includes the following changes:
   * When the zoom level is sufficiently low (zoomed-out) it
      * prevents unavailable overlay layers from being displayed,
      * makes sure that no unwanted after-image is displayed, and
      * makes sure that unavailable overlay layers cannot be activated with the radio buttons
   * Does something similar to the predefined shape overlays that are available from the "Select By Boundary" dropdown.

The minimum zoom levels (`layer_settings.py`) -- except for the two given in the issue -- are best-guesses based on my testing.  If they do not meet everyone's needs, they can be changed.

**Issues**
   * Clicking a disabled entry in the "Select By Boundary" dropdown still causes the dropdown to close.
   * Zooming in very far with google layers enabled causes the overlay tiles to disappear.  This has been observed on staging, so was not caused by this PR.

**To Test**
   * Active the overlay layers menu (as in the first picture below).
   * Zoom in and out.  If you zoom far enough out, some of the selections will be disabled.
   * If you zoom too far out with an overlay active, it will disappear until you zoom in far enough to see it again.
   * Try the same thing with the predefined shape overlays from the "Select By Boundary" menu.

![screenshot from 2015-10-13 15 38 09](https://cloud.githubusercontent.com/assets/11281373/10466466/6c578906-71c2-11e5-8771-0b1a025f1e9e.png)

![screenshot from 2015-10-13 15 38 13](https://cloud.githubusercontent.com/assets/11281373/10466470/71389db6-71c2-11e5-931f-fb467229a4ed.png)

![screenshot from 2015-10-13 15 40 21](https://cloud.githubusercontent.com/assets/11281373/10466473/75b0f712-71c2-11e5-911d-4dc489e34c6e.png)

![screenshot from 2015-10-13 15 40 30](https://cloud.githubusercontent.com/assets/11281373/10466479/7ac5e06e-71c2-11e5-94ca-d3979610f264.png)

Connects #918
