### PR TITLE
Remove Chart Display Delay

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -571,7 +571,11 @@ var ScenarioModel = Backbone.Model.extend({
         delete response.inputs;
 
         if (!_.isEmpty(response.results)) {
-            this.get('results').reset(response.results);
+            if (this.get('waitToRefresh') === true) {
+                this.get('results').reset(response.results, {silent: true});
+            } else {
+                this.get('results').reset(response.results);
+            }
         }
 
         delete response.results;
@@ -652,6 +656,9 @@ var ScenarioModel = Backbone.Model.extend({
 
                 pollSuccess: function() {
                     self.setResults();
+                    if (self.get('waitToRefresh')) {
+                        self.get('results').trigger('reset');
+                    }
                 },
 
                 pollFailure: function() {
@@ -751,6 +758,7 @@ var ScenariosCollection = Backbone.Collection.extend({
             aoi_census: aoi_census
         });
 
+        scenario.set('waitToRefresh', true);
         this.add(scenario);
         this.setActiveScenarioByCid(scenario.cid);
     },


### PR DESCRIPTION
When the user clicked the little "+" button to create a new scenario, there was a slight delay between the time the spinners stop spinning and the chart was displayed.

That was caused by the fact that the `reset` method on the `ResultCollection` was firing a `reset` event which caused the spinner to stop spinning.  Now, that `reset` call is made with the `silent` option set to true so that the event is not fired, then it is later manually fired after the model results are obtained.

Connects #940

**To Test**
   * Go to a project and create a new scenario.
   * It should be possible to observe that there is no delay between the time the spinner stops spinning and the chart shows up.