### PR TITLE
Fix Opacity Slider in IE and Firefox

### DIFF
--- a/src/mmw/js/src/core/opacityControl.js
+++ b/src/mmw/js/src/core/opacityControl.js
@@ -68,7 +68,7 @@ module.exports = L.Control.extend({
         });
 
         $(view).on('mouseup', function(e) {
-            var el = $(e.toElement),
+            var el = $(e.target),
                 slider_value = el.val();
             opacityLayer.setOpacity(slider_value / 100);
             el.attr('value', slider_value);


### PR DESCRIPTION
## Overview

`toElement` is not standard anymore (Chrome has it, IE used to have it, Firefox never had it). Switch to `target` which works across browsers.
See https://developer.mozilla.org/en-US/docs/Web/API/Event/target and http://stackoverflow.com/questions/8600174/event-toelement-in-ie8-and-firefox

## Testing Instructions

Test in Firefox and IE. Also test in Chrome to ensure it is still working there. Test in any other browsers you might have access to.

Connects #943