### PR TITLE
Prevent Modal Double-Clicks

### DIFF
--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var _ = require('underscore'),
+    coreUtils = require('../utils.js'),
     Marionette = require('../../../shim/backbone.marionette'),
     ZeroClipboard = require('zeroclipboard'),
     models = require('./models'),
@@ -48,6 +49,17 @@ var ModalBaseView = Marionette.ItemView.extend({
         }
     },
 
+    getDisabledState: function($el) {
+        var model = this.model;
+
+        if (coreUtils.modalButtonDisabled(model, $el)) {
+            return true;
+        } else {
+            coreUtils.modalButtonToggle(model, $el, false);
+            return false;
+        }
+    },
+
     primaryAction: function() {
         // Not implemented.
     },
@@ -75,6 +87,10 @@ var ConfirmView = ModalBaseView.extend({
     }, ModalBaseView.prototype.events),
 
     primaryAction: function() {
+        if (this.getDisabledState(this.ui.confirmation)) {
+            return;
+        }
+
         this.triggerMethod('confirmation');
         this.hide();
     },
@@ -102,6 +118,10 @@ var InputView = ModalBaseView.extend({
     },
 
     primaryAction: function() {
+        if (this.getDisabledState(this.ui.save) === true) {
+            return;
+        }
+
         var val = this.ui.input.val().trim();
 
         if (val) {

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -6,6 +6,23 @@ var _ = require('underscore'),
 var M2_IN_KM2 = 1000000;
 
 var utils = {
+    // A function for enabling/disabling modal buttons.  In additiion
+    // to adding the disabled class, it is also important to somehow
+    // note the fact that the button is disabled becaue there is an
+    // "enter key" listener which ignores the CSS class.
+    modalButtonToggle: function(model, $el, enabled) {
+        $el.attr('disabled', !enabled);
+        if (enabled === true) {
+            $el.removeClass('disabled');
+        } else if (enabled === false) {
+            $el.addClass('disabled');
+        }
+    },
+
+    modalButtonDisabled: function(model, $el) {
+        return $el.attr('disabled') ? true : false;
+    },
+
     // A function to enable/disable UI entries in response to zoom
     // level changes.
     zoomToggle: function(map, layerData, actOnUI, actOnLayer) {

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -2,6 +2,7 @@
 
 var _ = require('underscore'),
     $ = require('jquery'),
+    coreUtils = require('../core/utils.js'),
     Backbone = require('../../shim/backbone'),
     Marionette = require('../../shim/backbone.marionette'),
     router = require('../router').router,
@@ -69,11 +70,27 @@ var ModalBaseView = Marionette.ItemView.extend({
         }
     },
 
+    getDisabledState: function($el) {
+        var model = this.model;
+
+        if (coreUtils.modalButtonDisabled(model, $el)) {
+            return true;
+        } else {
+            coreUtils.modalButtonToggle(model, $el, false);
+            return false;
+        }
+    },
+
     // Primary Action might be "log in" or "sign up" or "reset password".
     // By default this serializes all form data and POSTs to child's `url`.
     // Override if other behavior is required.
     primaryAction: function() {
+        if (this.getDisabledState(this.ui.primary_button) === true) {
+            return;
+        }
+
         var formData = this.$el.find('form').serialize();
+
         this.model
             .fetch({
                 method: 'POST',
@@ -162,6 +179,10 @@ var LoginModalView = ModalBaseView.extend({
 
     // Login
     primaryAction: function() {
+        if (this.getDisabledState(this.ui.primary_button) === true) {
+            return;
+        }
+
         this.app.user
             .login(this.model.attributes)
             .done(_.bind(this.handleSuccess, this))
@@ -219,6 +240,10 @@ var LoginModalView = ModalBaseView.extend({
 
     // Login with ITSI
     itsiLogin: function() {
+        if (this.getDisabledState(this.ui.itsiLogin) === true) {
+            return;
+        }
+
         var loginURL = '/user/itsi/login?next=/' + Backbone.history.getFragment();
         window.location.href = loginURL;
     }


### PR DESCRIPTION
The main buttons of various modals are now disabled after selection to prevent accidental double-clicking.

Connects #922

**To Test**
   * It should be possible to use the various modals as normal, in particular the "sign up" modal, the "sign in" modal, and the various modals that appear when you make choices on the "/projects" page.
   * It should no longer be possible to double-tap the main buttons on these modals such that they are activated more than once before the modal disappears.  (This is true using the mouse as well as the enter key).
   * By setting break points, for example at model-my-watershed/src/mmw/js/src/projects/views.js line 152, it should be possible to see that the buttons are now disabled after they are activated, preventing them from being double-clicked.

**Limitations**
   * Not all buttons have received this treatment.  I tried to limit it to buttons which I thought would cause a problem if double-activated.
   * I took on-board the suggestion that the modal should stay open in the event of failures, for example when deleting a project, but simply removing the calls to the `hide` method was not sufficient.  It may be the case that this behavior is coming from deeper within the framework.