### PR TITLE
Remove Incompatible Results from Scenarios

### DIFF
--- a/src/mmw/apps/modeling/migrations/0016_old_scenarios.py
+++ b/src/mmw/apps/modeling/migrations/0016_old_scenarios.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def clear_old_scenario_results(apps, schema_editor):
+    Scenario = apps.get_model('modeling', 'Scenario')
+    for scenario in Scenario.objects.all():
+        if 'pc_modified' not in scenario.results or 'pc_unmodified' not in scenario.results:
+            scenario.results = "[]"
+            scenario.modification_hash = ""
+            scenario.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0015_remove_scenario_census'),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_old_scenario_results)
+    ]


### PR DESCRIPTION
This patch provides a data migratin which removes incompatible results from scenarios created prior to https://github.com/WikiWatershed/model-my-watershed/pull/716.

Connects #935

**To Test**
   * For testing purposes, you may want to take a snapshot of your services VM (halt the services VM, open up the Virtual Box GUI, click on the services VM [in the list on the left], click on snapshots [in the upper-right of the window], click on the "take snapshot" icon).
   * Run the new migration `./scripts/manage migrate`
   * Try to open an old scenario in the MMW application.  It should be possible now, whereas it was not before.