### PR TITLE
Spinners in sync with graphs

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -536,8 +536,7 @@ var ScenarioModel = Backbone.Model.extend({
         }
 
         // Save silently so server values don't trigger reload
-        // except when this is a new scenario and there are no existing values
-        this.save(null, { silent: !this.isNew() })
+        this.save(null, { silent: true })
             .fail(function() {
                 console.log('Failed to save scenario');
             });
@@ -559,6 +558,13 @@ var ScenarioModel = Backbone.Model.extend({
     },
 
     parse: function(response, options) {
+        // In case of new scenarios, update with new server fields,
+        // but keep the values of existing fields as they are.
+        if (this.isNew()) {
+            var newServerFields = _.omit(response, _.keys(this.attributes));
+            this.set(newServerFields);
+        }
+
         if (options.silent) {
             // Don't reload server values
             return this.attributes;


### PR DESCRIPTION
## Overview

This is a more correct implementation of #877. Previously, we updated the entire object with server values if it was new. This would cause a number of local changes, such as `results.polling` which controlled the spinners, to be overwritten by server defaults. Now we only update the local object with fields that were not present locally and are supplied by the server. Currently, these fields are `id`, `created_at`, and `modified_at`, but the expression which simply updates all fields not present locally will scale to include fields added in the future.

## Testing Instructions

Draw an AoI. Proceed to Model view. Ensure that the project and scenario are saved. Ensure that the spinners and graphs are in sync in all the following use cases:
 * Current Conditions gets values for the first time
 * Change precipitation slider value in Current Conditions
 * Add modifications to New Scenario
 * Add a new scenario to the project
 * Duplicate an existing scenario

## Reasoning

This is the diff between the values sent to the server and the values received from the server, when saving a new scenario:

```diff
diff -r  
2,3d0
<     "active": false,
<     "allow_save": true,
4a3,4
>     "created_at": "2015-10-19T15:44:21.073883Z",
>     "id": 368,
20d19
<     "job_id": null,
105a105
>     "modified_at": "2015-10-19T15:44:21.073902Z",
125,132c125
<     ],
<     "taskModel": {
<         "pollInterval": 500,
<         "taskName": "tr55",
<         "taskType": "modeling",
<         "timeout": 22000
<     },
<     "user_id": 1
---
>     ]
```

All other values are exactly what was sent to the server, mirrored back. In this case, the value of `results.polling` would be updated in the client _after_ we send a save request to the server (as part of calling `fetchResultsIfNeeded` which would set `polling` to `true`), so when the server sent back a reflected response with the addition of some new fields, it would have _stale_ values for some of those reflected fields. When we would replace all fields with those from the server, we would replace _new_ state with _old_ state. By refreshing only the fields that are present in the server response but not in the client state, we ensure that the final merged object has the latest state from all sources.

Connects #940
Connects #876