### PR TITLE
Fix Modeling view screenshots

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -51,7 +51,7 @@ var App = new Marionette.Application({
         this.currentProject = null;
 
         // Enable screenshot functionality
-        shutterbug.enable('body');
+        initializeShutterbug();
     },
 
     load: function(data) {
@@ -99,6 +99,24 @@ function RestAPI() {
             });
         }
     };
+}
+
+function initializeShutterbug() {
+    $(window)
+        .on('shutterbug-saycheese', function() {
+            // Set fixed width before screenshot to constrain width to viewport
+            $('#model-output-wrapper, .map-container').css({
+                'width': window.innerWidth
+            });
+        })
+        .on('shutterbug-asyouwere', function() {
+            // Reset after screenshot has been taken
+            $('#model-output-wrapper, .map-container').css({
+                'width': ''
+            });
+        });
+
+    shutterbug.enable('body');
 }
 
 module.exports = App;


### PR DESCRIPTION
## Overview

Because of the [5000px width set on `.scenario-tabs-wrapper`](https://github.com/WikiWatershed/model-my-watershed/blob/74485b4f67667d6e48288bea851400d9229c725f/src/mmw/sass/base/_header.scss#L149), and the way PhantomJS sees things, some elements which are positioned absolutely and have percent widths or `right: 0` would render way off screen.

We use the `shutterbug-saycheese` and `shutterbug-asyouwere` [events fired by Shutterbug](https://github.com/concord-consortium/shutterbug.js#shutterbug-jquery-custom-events) immediately before and after taking a screenshot to add a fixed width, equivalent to the viewport's width, to `#model-output-wrapper`, ensuring that all its contents are displayed within visible bounds.

## Testing Instructions

Checkout the branch and run [`ngrok http 8000`](https://ngrok.com/). Go to http://concord-consortium.github.io/lara-interactive-api/ and resize the iframe (using developer tools) to be `936px` wide and `702px` tall (these are the dimensions of an ITSI Activity Embed iframe). Then load the `ngrok` URL into the iframe, draw a shape and navigate to the Modeling view. Switch to the "Water Quality" tab in model results and take a snapshot using the "Snapshot" button:

![image](https://cloud.githubusercontent.com/assets/1430060/10619125/f4907b46-7741-11e5-80ea-1d12c9191113.png)

Ensure that the screenshot renders both the table and the graph in Water Quality, and that the Map Controls are rendered correctly.

You can right click the tiny screenshot and open it in a new tab to see it in full size.

## Demo

**Before**

![image](https://cloud.githubusercontent.com/assets/1430060/10619253/9844dc46-7742-11e5-9a58-f043f3edc7a8.png)

**After**

![image](https://cloud.githubusercontent.com/assets/1430060/10619183/359977dc-7742-11e5-8731-4580b4c6d278.png)

Connects #961 
Connects #969 