### PR TITLE
Project Deletion Flow

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -159,7 +159,17 @@ var ProjectMenuView = Marionette.ItemView.extend({
                     confirmLabel: 'Delete',
                     cancelLabel: 'Cancel'
                 })
-            });
+            }),
+            navigateAfterDelete = function() {
+                App.currentProject = null;
+                App.projectNumber = undefined;
+                App.map.set({
+                    'areaOfInterest': null,
+                    'areaOfInterestName': null
+                });
+
+                router.navigate('projects/', { trigger: true });
+            };
 
         del.render();
 
@@ -169,14 +179,12 @@ var ProjectMenuView = Marionette.ItemView.extend({
             // which point this could get consolidated without a conditional.
             var xhr = self.model.destroy({wait: true});
             if (xhr) {
-                xhr.done(function() {
-                        router.navigate('/', {trigger: true});
-                    })
+                xhr.done(navigateAfterDelete)
                     .fail(function() {
                         window.alert('Could not delete this project.');
                     });
             } else {
-                router.navigate('/', {trigger: true});
+                navigateAfterDelete();
             }
         });
     },


### PR DESCRIPTION
## Overview

Previously we would navigate to the Draw view after deleting a project, but we weren't clearing the `currentProject` or the Area of Interest correctly. Now, we clear those elements and navigate to the My Projects view instead. This view is always available for logged in users, and only logged in users can have saved projects, thus only logged in users can delete projects.

## Testing Instructions

Log in and draw an area. Proceed to the Modeling view. Delete the project. You should be redirected to My Projects list. Ensure that you can create a new project, and proceed to the Draw view, and create a new project all the way to the Modeling view. Also try launching an existing project from the My Projects view and ensure it works correctly.

## Notes

I tried to consolidate the project clearing functionality in one place (see https://github.com/WikiWatershed/model-my-watershed/compare/13f1904...rajadain:e5f2e93), specifically in https://github.com/rajadain/model-my-watershed/commit/8608671cc3f428ee9957b18b50931c0a2b77e714. But that ended up breaking #756. I've added a comment to #762 which I think would be a good fit for doing together.

Connects #965 