### PR TITLE
Disable 3D transforms in embed mode to fix screenshots

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -52,6 +52,13 @@
         </script>
         <script type="text/javascript">
             window.clientSettings = {{ client_settings | safe }};
+
+            if (window.clientSettings.itsi_embed) {
+                // Instruct Leaflet to not use CSS 3D transforms in embed mode
+                // since they are not supported by PhantomJS which is used for
+                // taking screenshots.
+                window.L_DISABLE_3D = true;
+            }
         </script>
         <script type="text/javascript" src="{% static 'js/vendor.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/main.js' %}"></script>


### PR DESCRIPTION
## Overview

PhantomJS used for taking screenshots doesn't support CSS 3D transforms, causing the map and drawn shapes to appear askew and displaced. The flag `L_DISABLE_3D` instructs Leaflet not to use 3D transforms, but we cannot abandon them entirely because of performance improvements they offer due to hardware acceleration.

By disabling 3D transforms only for cases when we know we are running in an embedded environment, we achieve a solution that helps in most cases.

## Testing Instructions

Checkout the branch and run [`ngrok http 8000`](https://ngrok.com/). Go to http://concord-consortium.github.io/lara-interactive-api/ and resize the iframe (using developer tools) to be `936px` wide and `702px` tall (these are the dimensions of an ITSI Activity Embed iframe). Then load the `ngrok` URL into the iframe (for example `https://12cdaec6.ngrok.io/?itsi_embed=true`), draw a shape and navigate to the Modeling view. Move the map around and take a snapshot using the "Snapshot" button:

![image](https://cloud.githubusercontent.com/assets/1430060/10671439/880c48ce-78b8-11e5-8336-fd493902a36b.png)

Ensure that the screenshot renders both the map tiles and any shapes on it correctly.

You can right click the tiny screenshot and open it in a new tab to see it in full size.

Test in Chrome and Firefox.

## Demo

**Actual**

![image](https://cloud.githubusercontent.com/assets/1430060/10671557/2f6a5cc8-78b9-11e5-86a4-8afe443c1bac.png)

**Screenshot: Before**

![image](https://cloud.githubusercontent.com/assets/1430060/10671484/d32f8f00-78b8-11e5-876e-794bad9f756d.png)

**Screenshot: After**

![image](https://cloud.githubusercontent.com/assets/1430060/10671495/d977a780-78b8-11e5-837b-1c3399d15344.png)

Connects #971 
Connects #854 
Connects #817 