### PR TITLE
Translate "Compound" Soil Types in Census

### DIFF
--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -150,6 +150,12 @@ def data_to_census(data):
         if nlcd in NLCD_MAPPING and soil in SOIL_MAPPING:
             nlcd_str = NLCD_MAPPING[nlcd][0]
             soil_str = SOIL_MAPPING[soil][0]
+            if soil_str == 'ad':
+                soil_str = 'c'
+            elif soil_str == 'bd':
+                soil_str = 'c'
+            elif soil_str == 'cd':
+                soil_str = 'd'
             key_str = '%s:%s' % (soil_str, nlcd_str)
             dist[key_str] = {'cell_count': count}
 


### PR DESCRIPTION
The "compound" soil types (A/D, B/D, and C/D) have been translated to C, C, and D, respectively, in the census.

Connects #980 

**Testing Instructions**
   * Check out this branch
   * Within this branch, follow the testing instructions for https://github.com/WikiWatershed/mmw-geoprocessing/pull/13 .  You should now be able to use the site as normal.