### PR TITLE
Upgrade TR55 module

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -9,4 +9,4 @@ django-registration-redux==1.2
 python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
-tr55==1.0.2
+tr55==1.0.3


### PR DESCRIPTION
Includes a number of bug fixes.  See
https://github.com/WikiWatershed/tr-55/blob/develop/CHANGELOG.md#103
for the list.

Connects #977 

Test:
Reprovision `app` and make sure version `1.0.3` is loaded.