### PR TITLE
 Change Pixel Resolution Computation

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -39,4 +39,4 @@ docker_options: "--storage-driver=aufs"
 sjs_host: "localhost"
 sjs_port: 8090
 
-geop_version: "0.2.0"
+geop_version: "0.3.0"

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -21,7 +21,7 @@ var $ = require('jquery'),
     placeMarkerTmpl = require('./templates/placeMarker.html'),
     settings = require('../core/settings');
 
-var MAX_AREA = 10000; // 10,000 km^2
+var MAX_AREA = 1000; // 1,000 km^2
 var codeToLayer = {}; // code to layer mapping
 
 function actOnUI(datum, bool) {

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -365,11 +365,11 @@ GEOP = {
     'request': {
         'input': {
             'geometry': None,
-            'tileCRS': 'WebMercator',
+            'tileCRS': 'ConusAlbers',
             'polyCRS': 'LatLng',
-            'nlcdLayer': 'nlcd-wm-ext-tms',
-            'soilLayer': 'soil-fake',
-            'zoom': 11
+            'nlcdLayer': 'nlcd-10m-epsg5070',
+            'soilLayer': 'ssurgo-soil-groups-10m',
+            'zoom': 0
         }
     }
 }


### PR DESCRIPTION
**Changes**
   * The `mmw-geoprocessing` code has been upgraded to version 0.3.0.
   * The maximum AoI size has been reduced by a factor of 10.
   * The new soil and NLCD tiles are now being used.
   * The new tiles are in the Conus Albers CRS.  This projection is supposed to have the feature of having roughly the same number of meters/pixel everywhere in the Continental US (CONUS).  Because of that, the resolution calculation has been changed.

Connects #984

**Testing Instructions**
   * Verify that the maximum AoI size is now 1,000 square kilometers.
   * Verify that the sum of the areas is in the `/analyze` table is approximately accurate by using the one square meter selection tool and summing the areas in the table.