### PR TITLE
Remove disclaimer

### DIFF
--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -1,4 +1,3 @@
-<div class="disclaimer">Results are for demonstration purposes only.</div>
 <table class="table custom-hover" data-toggle="table">
     <thead>
         <tr>

--- a/src/mmw/js/src/core/templates/barChart.html
+++ b/src/mmw/js/src/core/templates/barChart.html
@@ -1,2 +1,1 @@
-<div class="disclaimer">Results are for demonstration purposes only.</div>
 <div class="bar-chart"></div>

--- a/src/mmw/js/src/modeling/tr55/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/table.html
@@ -1,4 +1,3 @@
-<div class="disclaimer">Results are for demonstration purposes only.</div>
 <table class="table custom-hover" data-toggle="table">
     <thead>
         <tr>

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -139,11 +139,3 @@ a {
   z-index: 1;
   opacity: 0.8;
 }
-
-.disclaimer {
-  font-style: italic;
-  color: rosybrown;
-  text-align: center;
-  font-size: 15px;
-  clear: both;
-}

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -125,10 +125,6 @@
                 height: 12%;
               }
 
-              .disclaimer {
-                font-size: 12px;
-              }
-
               .result-region {
                 height: 95%;
 


### PR DESCRIPTION
Remove disclaimer text since it is no longer accurate along with associated CSS. To test, check that it is removed from the Analyze, Model, and Compare views.

Connects #990 