### PR TITLE
Update Java version.

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -30,7 +30,7 @@ elasticsearch_cluster_name: "logstash"
 
 nodejs_npm_version: 2.1.17
 
-java_version: "7u79-*"
+java_version: "7u85-*"
 
 docker_version: "1.8.*"
 docker_py_version: "1.2.3"


### PR DESCRIPTION
OpenJDK had a security update and version 7u79 is no longer available. This was
causing the stack to not properly provision.

### To test:
Destroy one of the VMs that requires Java and then reprovision it.