### PR TITLE
Setup cached proxy for Vizer endpoint

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -40,3 +40,6 @@ sjs_host: "localhost"
 sjs_port: 8090
 
 geop_version: "0.3.0"
+
+nginx_cache_dir: "/var/cache/nginx"
+observation_api_url: "http://www.wikiwatershed-vs.org/"

--- a/deployment/ansible/roles/model-my-watershed.app/tasks/reverse-proxy.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/reverse-proxy.yml
@@ -1,4 +1,13 @@
 ---
+- name: Ensure Nginx cache directory exists
+  file: path="{{ nginx_cache_dir }}"
+        state=directory
+        owner="{{ ansible_ssh_user }}"
+        group=mmw
+        mode=0775
+  notify:
+    - Restart Nginx
+
 - name: Configure Nginx site
   template: src=nginx-app.conf.j2
             dest=/etc/nginx/sites-available/mmw-app.conf

--- a/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
@@ -1,3 +1,10 @@
+# Protects against scenarios where DNS records for the
+# site being proxied change.
+resolver 8.8.8.8 valid=300s;
+resolver_timeout 10s;
+
+proxy_cache_path {{ nginx_cache_dir }} levels=1:2 keys_zone=OBSERVATION:10m max_size=100m;
+
 server {
   listen *:80;
   server_name _;
@@ -57,4 +64,48 @@ server {
 
     proxy_pass http://127.0.0.1:8000;
   }
+
+  location /observation/ {
+
+    # Prevent us from reverse proxying anything other
+    # than GETs.
+    limit_except GET {
+      deny all;
+    }
+
+    proxy_cache OBSERVATION;
+
+    # Queues multiple requests for same resource until
+    # it exists in the cache.
+    proxy_cache_lock on;
+    proxy_redirect off;
+    proxy_cache_valid 200 24h;
+    proxy_cache_valid 403 15m;
+
+    # Ignore all of these headers coming back from the
+    # origin server that prevent us from caching.
+    proxy_ignore_headers "X-Accel-Redirect";
+    proxy_ignore_headers "X-Accel-Limit-Rate";
+    proxy_ignore_headers "X-Accel-Buffering";
+    proxy_ignore_headers "X-Accel-Charset";
+    proxy_ignore_headers "Expires";
+    proxy_ignore_headers "Cache-Control";
+    proxy_ignore_headers "Set-Cookie";
+    proxy_ignore_headers "Vary";
+
+    # Hide these headers from our clients.
+    proxy_hide_header "X-Powered-By";
+    proxy_hide_header "Pragma";
+    proxy_hide_header "Set-Cookie";
+
+    # Set header that allow us to determine a request's
+    # cached status.
+    add_header X-Proxy-Cache $upstream_cache_status;
+
+    # Set some caching headers for our clients.
+    expires 30m;
+
+    proxy_pass {{ observation_api_url }};
+  }
+
 }


### PR DESCRIPTION
The Vizer webservices at http://www.wikiwatershed-vs.org/ are not CORS
enabled and the meta (asset) request was asked to be cached.

* Proxy through the app server so client can make ajax requests
* Cache the response for a period of time, the details of which may need
  to be worked out further.

To Test:
* Reprovision `app`
* Request http://localhost:8000/observation/services/get_asset_info.php?opt=meta&asset_type=siso and see that X-Proxy-Cache is `MISS`
* Refresh that request, see that X-Proxy-Cache is `HIT`

The endpoint is being proxied and cached.

Connects #992 

Big h/t to @hectcastro for help.