### PR TITLE
Catch TR55 key errors.

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -195,12 +195,23 @@ def run_tr55(censuses, model_input, cached_aoi_census=None):
 
     # Run the model under both current conditions and Pre-Columbian
     # conditions.
-    model_output = simulate_day(aoi_census, precip, cell_res=resolution)
-    precolumbian_output = simulate_day(aoi_census, precip,
-                                       cell_res=resolution, precolumbian=True)
+    try:
+        model_output = simulate_day(aoi_census, precip, cell_res=resolution)
+        precolumbian_output = simulate_day(aoi_census,
+                                           precip,
+                                           cell_res=resolution,
+                                           precolumbian=True)
+        model_output['pc_unmodified'] = precolumbian_output['unmodified']
+        model_output['pc_modified'] = precolumbian_output['modified']
+        runoff = format_runoff(model_output)
+        quality = format_quality(model_output)
 
-    model_output['pc_unmodified'] = precolumbian_output['unmodified']
-    model_output['pc_modified'] = precolumbian_output['modified']
+    except KeyError as e:
+        model_output = None
+        precolumbian_output = None
+        runoff = {}
+        quality = []
+        logger.error('Bad input data to TR55: %s' % e)
 
     # Modifications were added to aoi_census for TR-55, but we do
     # not want to persist it since we have it stored seperately
@@ -214,8 +225,8 @@ def run_tr55(censuses, model_input, cached_aoi_census=None):
         'modification_hash': model_input['modification_hash'],
         'aoi_census': aoi_census,
         'modification_censuses': modification_censuses,
-        'runoff': format_runoff(model_output),
-        'quality': format_quality(model_output)
+        'runoff': runoff,
+        'quality': quality
     }
 
 

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -9,4 +9,4 @@ django-registration-redux==1.2
 python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
-tr55==1.0.3
+tr55==1.0.5


### PR DESCRIPTION
Connects #976

The new version of TR55 raises KeyError when there it receives simulation data
with unsupported types. This updates our worker to catch such errors and
gracefully fallback to avoid crashes.

### To test:
 - Reprovision worker to get new TR55.
 - Start celery debug script and watch logs.
 - Supply junk data to TR55 (Try the attached patch to let the UI do it for you.)
 - Ensure that we log the exception and do not crash.