### PR TITLE
Embed SASS source maps

### DIFF
--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -71,8 +71,7 @@ fi
 
 if [ -n "$ENABLE_DEBUG" ]; then
     BROWSERIFY="$BROWSERIFY --debug"
-    NODE_SASS="$NODE_SASS --source-map ${STATIC_CSS_DIR}main.css.map \
-        --source-map-contents"
+    NODE_SASS="$NODE_SASS --source-map true --source-map-embed"
 fi
 
 if [ -n "$ENABLE_MINIFY" ]; then


### PR DESCRIPTION
The source map arguments changed in the latest version of node-sass.
This change should fix this error when running `./scripts/bundle.sh --debug`:

> Multi-file compilation: requires sourceMap to be a directory or "true".