### PR TITLE
Change owner of nginx cache directory

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/tasks/reverse-proxy.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/reverse-proxy.yml
@@ -2,9 +2,8 @@
 - name: Ensure Nginx cache directory exists
   file: path="{{ nginx_cache_dir }}"
         state=directory
-        owner="{{ ansible_ssh_user }}"
-        group=mmw
-        mode=0775
+        owner=www-data
+        group=www-data
   notify:
     - Restart Nginx
 


### PR DESCRIPTION
`www-data` is the more appropriate owner of this dir.

After provisioning `app`:

http://localhost:8000/observation/services/get_asset_info.php?opt=meta&asset_type=siso

should still work and produce a cache hit on the second request.