### PR TITLE
Add Observation layers to the layer control

### DIFF
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -126,7 +126,8 @@ def get_client_settings(request):
             'raster_layers': get_layer_config(['raster', 'overlay']),
             'draw_tools': settings.DRAW_TOOLS,
             'map_controls': settings.MAP_CONTROLS,
-            'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY
+            'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,
+            'vizer_layer_url': settings.VIZER_LAYER_URL
         })
     }
 

--- a/src/mmw/js/src/core/templates/layerControlList.html
+++ b/src/mmw/js/src/core/templates/layerControlList.html
@@ -5,10 +5,12 @@
 <ul class="nav nav-tabs" role="tablist">
     <li role="presentation" class="active"><a href="#basemap-layer-list" aria-controls="basemap" role="tab" data-toggle="tab">Basemap</a></li>
     <li role="presentation"><a href="#overlays-layer-list" aria-controls="overlays" role="tab" data-toggle="tab">Overlays</a></li>
+    <li role="presentation"><a href="#observations-layer-list" aria-controls="observations" role="tab" data-toggle="tab">Observations</a></li>
 </ul>
 <form class="leaflet-control-layers-list">
     <div class="tab-content">
         <div role="tabpanel" class="tab-pane active" id="basemap-layer-list"></div>
         <div role="tabpanel" class="tab-pane" id="overlays-layer-list"></div>
+        <div role="tabpanel" class="tab-pane" id="observations-layer-list"></div>
     </div>
 </form>

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -17,7 +17,9 @@ var L = require('leaflet'),
     settings = require('./settings'),
     LayerControl = require('./layerControl'),
     StreamSliderControl = require('./streamSliderControl'),
-    OpacityControl = require('./opacityControl');
+    OpacityControl = require('./opacityControl'),
+    VizerLayers = require('./vizerLayers');
+
 
 require('leaflet.locatecontrol');
 require('leaflet-plugins/layer/tile/Google');
@@ -187,11 +189,14 @@ var MapView = Marionette.ItemView.extend({
             interactiveMode: true // True if clicking on map does stuff
         });
 
-        var map = new L.Map(this.el, {
+        var self = this,
+            map = new L.Map(this.el, {
                 zoomControl: false,
                 attributionControl: options.showLayerAttribution
             }),
-            overlayLayers = this.prepareOverlayLayers();
+            overlayLayers = this.prepareOverlayLayers(),
+            vizer = new VizerLayers(settings.get('vizer_layer_url')),
+            layersReadyDeferred = vizer.getLayers();
 
         // Center the map on the U.S.
         map.fitBounds([
@@ -218,13 +223,15 @@ var MapView = Marionette.ItemView.extend({
             addLocateMeButton(map, maxGeolocationAge);
         }
 
-        if (options.addLayerSelector) {
-            this.layerControl = new LayerControl(this.baseLayers, this.overlayLayers, {
-                autoZIndex: false,
-                position: 'topright',
-                collapsed: false
-            }).addTo(map);
-        }
+        layersReadyDeferred.then(function(vizerLayers) {
+            if (options.addLayerSelector) {
+                self.layerControl = new LayerControl(self.baseLayers, self.overlayLayers, vizerLayers, {
+                    autoZIndex: false,
+                    position: 'topright',
+                    collapsed: false
+                }).addTo(map);
+            }
+        });
 
         if (options.addStreamControl) {
             this.layerControl = new StreamSliderControl({

--- a/src/mmw/js/src/core/vizerLayers.js
+++ b/src/mmw/js/src/core/vizerLayers.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var $ = require('jquery'),
+    _ = require('underscore'),
+    L = require('leaflet');
+
+// These are likely temporary until we develop custom icons for each type
+var platformIcons = {
+        'River Guage': '#F44336',
+        'Weather Station': '#2196F3',
+        'Fixed Shore Platform': '#4CAF50',
+        'Soil Pit': '#FFEB3B',
+        'Well': '#795548'
+    };
+
+function VizerLayers(layerUrl) {
+    var layersReady = $.Deferred();
+
+    this.getLayers = function() {
+        $.getJSON(layerUrl, function(assets) {
+            // A list of all assets (typically sensor devices) and the variables
+            // they manage, along with various meta data grouped by the data
+            // provider which acts as the "layer" which can be toggled on/off
+            var layerAssets = _.groupBy(assets.result, 'provider');
+            var layers = _.map(layerAssets, function(assets, provider) {
+
+                // Create a marker for each asset point in this layer and
+                // use the appropriate style for the platform type
+                var label = makeProviderLabel(provider, assets),
+                    markers = _.map(assets, function(asset) {
+                        var color = _.has(platformIcons, asset.platform_type) ?
+                                platformIcons[asset.platform_type] :
+                                '#607D8B';
+
+                        return L.circleMarker([asset.lat, asset.lon], {
+                            attributes: asset,
+                            fillColor: color,
+                            fillOpacity: 1.0
+                        });
+                    });
+
+                return [label, L.featureGroup(markers)];
+            });
+
+            // All layers are loaded have have markers created for all assets
+            layersReady.resolve(_.object(layers));
+        });
+
+        return layersReady;
+    };
+}
+
+function makeProviderLabel(provider, assets) {
+    // Create a label for the layer selector.
+    return provider + ' (' + assets.length + ')';
+}
+
+module.exports = VizerLayers;

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -12,7 +12,7 @@ from os import environ
 from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 
-from layer_settings import LAYERS  # NOQA
+from layer_settings import LAYERS, VIZER_LAYER_URL  # NOQA
 
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -181,3 +181,8 @@ LAYERS = [
         'basemap': True,
     }
 ]
+
+# Vizer observation meta data URL.  Happens to be proxied through a local app
+# server to avoid Cross Domain request errors
+VIZER_ROOT = '/observation/services/'
+VIZER_LAYER_URL = VIZER_ROOT + 'get_asset_info.php?opt=meta&asset_type=siso'


### PR DESCRIPTION
The existing Vizer implementation at http://wikiwatershed-vs.org is
providing an API to observation sensors in the DRB.  Show these systems
as layers than can be added to the map.  Layers are defined by parsing
the entire network by data provider and symbolizing the sensor by
platform type.

To test, open the layer selector and see a new Observations tab with 6 layers that add markers around the DRB.

Connects #1006 
Connects #1007 

**Note: I'm merging this into a long-running feature branch on upstream so that we won't deploy it until the full feature is complete.**