### PR TITLE
Lengthen Geoprocessing Timeout

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -56,7 +56,7 @@ def start_histograms_job(polygons):
     }
 
 
-@shared_task(bind=True, default_retry_delay=1, max_retries=20)
+@shared_task(bind=True, default_retry_delay=1, max_retries=42)
 def get_histogram_job_results(self, incoming):
     """ Calls a function that polls SJS for the results
     of the given Job. Self here is Celery.

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -89,7 +89,13 @@ var MapModel = Backbone.Model.extend({
 var TaskModel = Backbone.Model.extend({
     defaults: {
         pollInterval: 500,
-        timeout: 22000
+        /* The timeout is set to 45 seconds here, while in the
+           src/mmw/apps/modeling/tasks.py file it is set to 42
+           seconds.  That was done because the countdown starts in the
+           front-end before it does in the back-end and the we would
+           like them to finish at approximately the same time (with the
+           back-end finishing earlier if they are not synced). */
+        timeout: 45000
     },
 
     url: function() {

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -21,7 +21,7 @@ var $ = require('jquery'),
     placeMarkerTmpl = require('./templates/placeMarker.html'),
     settings = require('../core/settings');
 
-var MAX_AREA = 1000; // 1,000 km^2
+var MAX_AREA = 2700; // 2,700 km^2
 var codeToLayer = {}; // code to layer mapping
 
 function actOnUI(datum, bool) {


### PR DESCRIPTION
The geoprocessing timeout has been lengthened from ~20 seconds to ~40 seconds.  The maximum supported AoI size has been increased from 1,000 square kilometers to 2,700.

Connects #1000

The time limit exists in two places: the `TaskModel` model in the front-end and the combination of the polling interval and maximum number of retries in the back-end.

**To Test**
   * Confirm that the maximum AoI size is now 2,700 square kilometers.
   * Confirm analysis can now take more than 20 seconds -- possibly as many as 40 (do that by providing an AoI that is close to the size limit).

**Note**.  You may need to wait for the internet connection problem to be resolved before testing this.
