### PR TITLE
Switch to NVD3 graph library and increase responsiveness

### DIFF
--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -100,6 +100,7 @@ CONCAT_VENDOR_CSS_COMMAND="cat \
     ./node_modules/leaflet-draw/dist/leaflet.draw.css \
     ./node_modules/font-awesome/css/font-awesome.min.css \
     ./node_modules/bootstrap-table/dist/bootstrap-table.min.css \
+    ./node_modules/nvd3/build/nv.d3.min.css \
     > $VENDOR_CSS_FILE"
 
 JS_DEPS=(backbone
@@ -121,6 +122,7 @@ JS_DEPS=(backbone
          leaflet-plugins/layer/tile/Google
          lodash
          nunjucks
+         nvd3
          turf-area
          turf-bbox-polygon
          turf-buffer

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -10,28 +10,29 @@ var _ = require('lodash'),
     models = require('./models'),
     views = require('./views'),
     App = require('../app'),
-    testUtils = require('../core/testUtils'),
-    sandboxTemplate = require('../core/templates/sandbox.html');
+    testUtils = require('../core/testUtils');
 
-var sandboxHeight = '500',
-    sandboxWidth = '700',
-    displaySandboxId = 'display-sandbox',
-    displaySandboxSelector = '#' + displaySandboxId;
-
-var SandboxRegion = Marionette.Region.extend({
-    el: displaySandboxSelector
-});
+var sandboxId = 'sandbox',
+    sandboxSelector = '#' + sandboxId,
+    SandboxRegion = Marionette.Region.extend({
+        el: sandboxSelector
+    });
 
 describe('Analyze', function() {
+    before(function() {
+        if ($(sandboxSelector).length === 0) {
+            $('<div>', {id: sandboxId}).appendTo('body');
+        }
+    });
+
     beforeEach(function() {
-        $(displaySandboxSelector).remove();
-        // Use a special sandbox so that we can test responsiveness of chart.
-        $('body').append(sandboxTemplate.render({height: sandboxHeight, width: sandboxWidth}));
+
     });
 
     afterEach(function() {
+        $(sandboxSelector).remove();
+        $('<div>', {id: sandboxId}).appendTo('body');
         testUtils.resetApp(App);
-        $(displaySandboxSelector).remove();
     });
 
     describe('DetailsView', function() {
@@ -50,10 +51,6 @@ describe('Analyze', function() {
             var dataSet = analyzeDataSets[dataSetInd];
             it('renders tables that match the data when there are ' + dataSetInd + ' categories in the dataset', function(done) {
                 setupViewAndTest(dataSet, checkTable, done);
-            });
-
-            it('renders charts that match the data when there are ' + dataSetInd + ' categories in the dataset', function(done) {
-                setupViewAndTest(dataSet, checkChart, done);
             });
         }
 
@@ -116,22 +113,6 @@ function checkTableBody(subData) {
             return $(td).text();
         }).get();
         assert.deepEqual(expectedRowVals, rowVals);
-    });
-}
-
-// Check that bar chart has correct number of bars and correct
-// x-axis labels.
-function checkChart(data) {
-    _.each(data, function(subData) {
-        var expectedAxisLabels = _.pluck(subData.categories, 'type');
-        var axisLabels = $('#' + subData.name + ' .x.axis .tick text').map(function() {
-            return $(this).text();
-        }).get();
-        assert.deepEqual(expectedAxisLabels, axisLabels);
-
-        var expectedNumBars = subData.categories.length;
-        var numBars = $('#' + subData.name + ' .bar').length;
-        assert.equal(expectedNumBars, numBars);
     });
 }
 

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -127,7 +127,7 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
         var self = this;
 
         App.map.setDoubleHeaderSmallFooterSize(true);
-       
+
         this.$el.animate({ height: '0%' }, 200, function() {
             self.trigger('animateOut');
         });
@@ -257,6 +257,7 @@ var TableView = Marionette.CompositeView.extend({
     }
 });
 
+
 var ChartView = Marionette.ItemView.extend({
     template: barChartTmpl,
     id: function() {
@@ -270,26 +271,27 @@ var ChartView = Marionette.ItemView.extend({
 
     addChart: function() {
         var chartEl = this.$el.find('.bar-chart').get(0),
-            chartData = _.map(this.collection.toJSON(), function(model) {
+            data = _.map(this.collection.toJSON(), function(model) {
                 return {
-                    area: model.area,
-                    coverage: model.coverage,
-                    type: model.type,
-                    className: model.nlcd ? 'nlcd-' + model.nlcd : null
+                    x: model.type,
+                    y: model.coverage,
+                    class: model.nlcd ? 'nlcd-' + model.nlcd : null
                 };
             }),
-            chartOptions = {
-                isPercentage: true,
-                depAxisLabel: 'Coverage'
-            },
-            depVars = ['coverage'],
-            indVar = 'type';
+            chartOptions,
+            barClasses = null;
 
         if (this.model.get('name') === 'land') {
-            chartOptions.useHorizBars = true;
+            barClasses = _.pluck(data, 'class');
         }
 
-        chart.makeBarChart(chartEl, chartData, indVar, depVars, chartOptions);
+        chartOptions = {
+           yAxisLabel: 'Coverage',
+           isPercentage: true,
+           barClasses: barClasses
+       };
+
+        chart.renderHorizontalBarChart(chartEl, data, chartOptions);
     }
 });
 

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -1,372 +1,185 @@
-
 "use strict";
 
 var d3 = require('d3'),
+    nv = require('nvd3'),
     $ = require('jquery'),
     _ = require('lodash');
 
-// Somewhat based on the reusable chart pattern
-// by Mike Bostock http://bost.ocks.org/mike/chart/
-// and http://bl.ocks.org/mbostock/3885304
+function makeSvg(el) {
+    // For some reason, the chart will only render if the style is
+    // defined inline, even if it is blank.
+    var svg = $('<svg style=""></svg>').get(0);
+    $(el).empty();
+    $(svg).appendTo(el);
+    return svg;
+}
 
-// el is the DOM element where the chart should be inserted.
-// indVar and depVars represent the independent and dependent variables which are displayed
-// on the x or y axes depending on the orientation of the chart.
-// In general, an independent variable is one that is directly controlled by an experimenter
-// and is usually represented by the x-axis. A dependent variable is one that varies as
-// a function of the independent variable and is usually represented on the y-axis.
-// If depVars contains > 1 variable, then the function will create a stacked bar chart.
-// The optional parameter options has optional properties: horizMargin, vertMargin, useHorizBars,
-// height, width, numDepTicks, isPercentage, depAxisLabel, depDisplayNames, and barColors.
-// If height and/or width aren't specified, then they are responsive (ie. set automatically according to the
-// size of the el).
-// depDisplayNames is the human readable counterpart to depVars.
-// If barColors is supplied, a legend will be drawn using the colors.
-function makeBarChart(el, data, indVar, depVars, options) {
-    options = options || {};
-
-    var $el = $(el),
-        numDepTicks = options.numDepTicks || 10,
-        hiddenSize = 100,
-        horizMargin = options.horizMargin || {top: 20, right: 80, bottom: 40, left: 120},
-        vertMargin = options.vertMargin || {top: 20, right: 80, bottom: 30, left: 40},
-        useHorizBars = options.useHorizBars !== undefined ? options.useHorizBars : false,
-        maxDepSum,
-        containerWidth,
-        width,
-        containerHeight,
-        height,
-        x,
-        y,
-        color,
-        xAxis,
-        yAxis,
-        svg,
-        chartGroup,
-        xAxisGroup,
-        yAxisGroup,
-        yLabelText,
-        barGroups,
-        bars,
-        legend;
-
-    /**
-     * Drawing constants. AXIS_OFFSET provides a forced px value offset to
-     * prevent the charts from sitting on top of the axis labels.
-     * CHART_CONTAINER_PERCENTAGE sets the actual bar chart area width to a
-     * percentage of the overall svg width. This helps ensure the chart doesn't
-     * take over the whole container, leaving room for the legend.
-     */
-    var AXIS_OFFSET = 20,
-        CHART_CONTAINER_PERCENTAGE = 0.8;
-
-    // Set the upper and lower bounds of each bar chart element.
-    _.forEach(data, function(datum) {
-        var depLower = 0;
-        datum.depVals = _.map(depVars, function(depVar, depVarInd) {
-            return {
-                name: depVar,
-                displayName: options.depDisplayNames ? options.depDisplayNames[depVarInd] : depVar,
-                depLower: depLower,
-                depUpper: depLower += datum[depVar]
-            };
-        });
-    });
-
-    // The maximum sum of the dependent variables across data points.
-    maxDepSum = d3.max(_.map(data, function(datum) {
-        return d3.sum(_.map(depVars, function(depVar) {
-            return datum[depVar];
-        }));
-    }));
-
-    var computeSizes = function(margin) {
-        // containerWidth will be 0 if the chart is in a
-        // tab that is currently hidden.
-        containerWidth = options.width || el.offsetWidth;
-        width = containerWidth - margin.left - margin.right;
-        containerHeight = options.height || el.offsetHeight;
-        height = containerHeight - margin.top - margin.bottom;
-        // Set to legal dummy value if it's non-positive because
-        // the container is hidden and containerWidth == 0.
-        width = width > 0 ? width : hiddenSize;
-        height = height > 0 ? height : hiddenSize;
-    };
-
-    var renderLegend = function(isVertical) {
-        // The constants in this function were set by trial and error to make things
-        // look reasonable.
-        var topMargin = isVertical ? vertMargin.top : horizMargin.top;
-        legend = svg.selectAll('.legend')
-            // loop over data in reverse order to match the bar chart rendering but do not alter the original data.
-            .data(data[0].depVals.slice().reverse())
-            .enter().append('g')
-            .attr('class', 'legend')
-            .attr('transform', function(d, i) { return 'translate(0,' + (topMargin + i * 10) + ')'; });
-
-        legend.append('rect')
-            .attr('x', containerWidth - 10)
-            .attr('y', 1)
-            .attr('width', 8)
-            .attr('height', 8)
-            .style('fill', function(d) { return color(d.name); });
-
-        legend.append('text')
-            .attr('x', containerWidth - 15)
-            .attr('y', 6)
-            .attr('dy', '.2em')
-            .style('text-anchor', 'end')
-            .style('font-size', '9px')
-            .text(function(d) { return d.displayName; });
-    };
-
-    var resizeLegend = function() {
-        legend.selectAll('rect')
-            .attr('x', containerWidth - 10);
-        legend.selectAll('text')
-            .attr('x', containerWidth - 15);
-    };
-
-    var renderVertical = function() {
-        computeSizes(vertMargin);
-
-        x = d3.scale.ordinal()
-            .rangeRoundBands([0, width * CHART_CONTAINER_PERCENTAGE], 0.1);
-
-        y = d3.scale.linear()
-            .rangeRound([height, 0]);
-
-        xAxis = d3.svg.axis()
-            .scale(x)
-            .orient('bottom');
-
-        yAxis = d3.svg.axis()
-            .scale(y)
-            .orient('left');
-        if (options.isPercentage) {
-            yAxis.ticks(numDepTicks, '%');
-        } else {
-            yAxis.ticks(numDepTicks);
-        }
-
-        svg = d3.select(el).append('svg')
-            .attr('width', containerWidth)
-            .attr('height', containerHeight);
-
-        chartGroup = svg.append('g')
-            .attr('class', 'chart-group')
-            .attr('transform', 'translate(' + vertMargin.left + ',' + vertMargin.top + ')');
-
-        x.domain(data.map(function(d) { return d[indVar]; }));
-        y.domain([0.0, maxDepSum]);
-
-        xAxisGroup = chartGroup.append('g')
-            .attr('class', 'x axis')
-            .attr('transform', 'translate(' + AXIS_OFFSET + ',' + height + ')')
-            .call(xAxis);
-
-        yAxisGroup = chartGroup.append('g')
-            .attr('class', 'y axis')
-            .call(yAxis);
-
-        if (options.depAxisLabel) {
-            yLabelText = yAxisGroup.append('g')
-                .append('text')
-                .attr('transform', 'rotate(-90)')
-                .attr('y', 6)
-                .attr('dy', '.71em')
-                .style('text-anchor', 'end')
-                .text(options.depAxisLabel);
-        }
-
-        barGroups = chartGroup.selectAll('.bar')
-            .data(data)
-            .enter().append('g')
-            .classed({'g': true, 'bar-container': true })
-            .attr('transform', function(d) {
-                return 'translate(' + (AXIS_OFFSET + x(d[indVar])) + ',0)';
-            });
-
-        bars = barGroups.selectAll('rect')
-            .data(function(d) { return d.depVals; })
-            .enter().append('rect')
-            .classed('bar', true)
-            .attr('width', x.rangeBand())
-            .attr('y', function(d) { return y(d.depUpper); })
-            .attr('height', function(d) { return y(d.depLower) - y(d.depUpper); });
-
-        if (options.barColors) {
-            color = d3.scale.ordinal()
-                .domain(depVars)
-                .range(options.barColors);
-            bars.style('fill', function(d) { return color(d.name); });
-            renderLegend();
-        }
-    };
-
-    // Ideas for making d3 charts responsive from
-    // http://eyeseast.github.io/visible-data/2013/08/28/responsive-charts-with-d3/
-    var resizeVertical = function() {
-        if ($el.length > 0) {
-            computeSizes(vertMargin);
-
-            x.rangeRoundBands([0, width * CHART_CONTAINER_PERCENTAGE], 0.1);
-            xAxis.scale(x);
-            xAxisGroup.attr('transform', 'translate(' + AXIS_OFFSET + ',' + height + ')')
-                .call(xAxis);
-
-            y.range([height, 0]);
-            yAxis.scale(y);
-            yAxisGroup.call(yAxis);
-
-            barGroups.attr('transform', function(d) {
-                return 'translate(' + (AXIS_OFFSET + x(d[indVar])) + ',0)';
-            });
-
-            bars.attr('width', x.rangeBand())
-                .attr('y', function(d) { return y(d.depUpper); })
-                .attr('height', function(d) { return y(d.depLower) - y(d.depUpper); });
-
-            svg.attr('width', containerWidth)
-                .attr('height', containerHeight);
-
-            if (options.barColors) {
-                resizeLegend();
-            }
-        }
-    };
-
-    var renderHorizontal = function() {
-        computeSizes(horizMargin);
-
-        // x is still horizontal, but now represents the dependent variable
-        x = d3.scale.linear()
-            .range([0, width]);
-
-        y = d3.scale.ordinal()
-            .rangeRoundBands([0, height], 0.1);
-
-        color = d3.scale.ordinal()
-            .domain(depVars)
-            .range(options.barColors);
-
-        xAxis = d3.svg.axis()
-            .orient('bottom')
-            .scale(x);
-        if (options.isPercentage) {
-            xAxis.ticks(numDepTicks, '%');
-        } else {
-            xAxis.ticks(numDepTicks);
-        }
-
-        yAxis = d3.svg.axis()
-            .scale(y)
-            .orient('left');
-
-        svg = d3.select(el).append('svg')
-            .attr('width', containerWidth)
-            .attr('height', containerHeight);
-
-        chartGroup = svg.append('g')
-            .attr('transform', 'translate(' + horizMargin.left + ',' + horizMargin.top + ')');
-
-        x.domain([0.0, maxDepSum]);
-        y.domain(data.map(function(d) { return d[indVar]; }));
-
-        xAxisGroup = chartGroup.append('g')
-            .attr('class', 'y axis')
-            .attr('transform', 'translate(0,' + height + ')')
-            .call(xAxis);
-
-        yAxisGroup = chartGroup.append('g')
-            .attr('class', 'x axis')
-            .call(yAxis);
-
-        if (options.depAxisLabel) {
-            yLabelText = yAxisGroup.append('g')
-                .append('text')
-                .attr('x', (x.range()[0] + x.range()[1]) / 2)
-                .attr('y', height + 30)
-                .style('text-anchor', 'middle')
-                .text(options.depAxisLabel);
-        }
-
-        barGroups = chartGroup.selectAll('.bar')
-                .data(data)
-                .enter().append('g')
-                .attr('class', function(d) { 
-                    return d.className ? d.className : ''; 
-                })
-                .classed('g', true)
-                .attr('transform', function(d) {
-                    return 'translate(0,' + y(d[indVar]) + ')';
-                });
-
-        bars = barGroups.selectAll('rect')
-            .data(function(d) { return d.depVals; })
-            .enter().append('rect')
-            .classed('bar', true)
-            .attr('width', function(d) {
-                return x(d.depUpper) - x(d.depLower);
-            })
-            .attr('x', function(d) { return x(d.depLower); })
-            .attr('height', y.rangeBand());
-
-        if (options.barColors) {
-            bars.style('fill', function(d) { return color(d.name); });
-            renderLegend();
-        }
-    };
-
-    var resizeHorizontal = function() {
-        if ($el.length > 0) {
-            computeSizes(horizMargin);
-
-            x.range([0, width]);
-            xAxis.scale(x);
-            xAxisGroup.attr('transform', 'translate(0,' + height + ')')
-                .call(xAxis);
-
-            y.rangeRoundBands([0, height], 0.1);
-            yAxis.scale(y);
-            yAxisGroup.call(yAxis);
-
-            barGroups.attr('transform', function(d) {
-                return 'translate(0,' + y(d[indVar]) + ')';
-            });
-
-            bars.attr('height', y.rangeBand())
-                .attr('x', function(d) { return x(d.depLower); })
-                .attr('width', function(d) { return x(d.depUpper) - x(d.depLower); });
-
-            svg.attr('width', containerWidth)
-                .attr('height', containerHeight);
-
-            if (options.depAxisLabel) {
-                yLabelText.attr('x', (x.range()[0] + x.range()[1]) / 2)
-                    .attr('y', height + 30);
-            }
-
-            if (options.barColors) {
-                resizeLegend();
-            }
-        }
-    };
-
-    if (useHorizBars) {
-        renderHorizontal();
-        $(window).on('resize', resizeHorizontal);
-        // bar-chart-refresh events occur when a tab in the Analyze view is selected.
-        // We need to listen for them since the chart might have been hidden when the last
-        // resize occured, in which case the size would have been set to the default.
-        $el.on('bar-chart:refresh', resizeHorizontal);
-    } else {
-        renderVertical();
-        $(window).on('resize', resizeVertical);
-        $el.on('bar-chart:refresh', resizeVertical);
+function handleCommonOptions(chart, options) {
+    if (options.yAxisLabel) {
+        chart.yAxis.axisLabel(options.yAxisLabel);
+    }
+    if (options.isPercentage) {
+        chart.yAxis.tickFormat(d3.format('.0%'));
+    }
+    if (options.abbreviateTicks) {
+        chart.yAxis.tickFormat(d3.format('.2s'));
     }
 }
 
+/*
+    Renders a horizontal bar chart for a single series of data without a legend.
+
+    data is of the form
+    [
+        {
+            x: ...,
+            y: ...
+        },
+        ...
+    ]
+    note that x corresponds to the vertical axis since this is a horizontal bar
+    chart.
+
+    options includes: barClasses, margin, yAxisLabel, isPercentage,
+    and abbreviateTicks
+*/
+function renderHorizontalBarChart(chartEl, data, options) {
+    var chart = nv.models.multiBarHorizontalChart(),
+        svg = makeSvg(chartEl);
+
+    // Augment data so that it is part of a single series to match
+    // the format expected by NVD3.
+    data = [
+        {
+          key: 'Series 1',
+          values: data
+        }
+    ];
+
+
+    // The colors and barColors methods on chart do not
+    // support the behavior we want.
+    function addBarClasses() {
+        var bars = $(chartEl).find('.nv-bar'),
+            oldClass,
+            newClass;
+
+        _.each(bars, function(bar, i) {
+            // Can't use addClass on SVG elements.
+            oldClass = $(bar).attr('class');
+            newClass = oldClass + ' ' + options.barClasses[i];
+            $(bar).attr('class', newClass);
+        });
+    }
+
+    function updateChart() {
+        // Throws error if updating a hidden svg.
+        if($(svg).is(':visible')) {
+            chart.update();
+            if (options.barClasses) {
+                addBarClasses();
+            }
+        }
+    }
+
+    options = options || {};
+
+    nv.addGraph(function() {
+        chart.showLegend(false)
+             .showControls(false)
+             .duration(0)
+             .margin(options.margin || {top: 30, right: 30, bottom: 40, left: 200});
+
+        chart.tooltip.enabled(false);
+        chart.yAxis.ticks(5);
+        handleCommonOptions(chart, options);
+
+        d3.select(svg)
+            .datum(data)
+            .call(chart);
+
+        if (options.barClasses) {
+            addBarClasses();
+        }
+
+        nv.utils.windowResize(updateChart);
+        // The bar-chart:refresh event occurs when switching tabs which requires
+        // redrawing the chart.
+        $(chartEl).on('bar-chart:refresh', updateChart);
+
+        return chart;
+    });
+}
+
+/*
+    Renders a stacked vertical bar chart for multiple series of data
+    with a legend.
+
+    data is of the form
+    [
+        {
+            key: series-name,
+            values: [
+                {
+                    x: ...,
+                    y: ...
+                },
+                ...
+            ]
+        },
+        ...
+   ]
+   where a series corresponds to a group of data that will be displayed with
+   the same color/legend item. Eg. Runoff
+
+    options includes: margin, yAxisLabel, seriesColors, isPercentage,
+    and abbreviateTicks
+*/
+function renderVerticalBarChart(chartEl, data, options) {
+    var chart = nv.models.multiBarChart(),
+        svg = makeSvg(chartEl);
+
+    function updateChart() {
+        if($(svg).is(':visible')) {
+            // Throws error if updating a hidden svg.
+            chart.update();
+        }
+    }
+
+    options = options || {};
+
+    nv.addGraph(function() {
+        chart.showLegend(true)
+             .showControls(false)
+             .stacked(true)
+             .reduceXTicks(false)
+             .staggerLabels(true)
+             .duration(0)
+             .margin(options.margin || {top: 20, right: 30, bottom: 40, left: 60});
+
+        // Throws error if this is not set to false for unknown reasons.
+        chart.legend.rightAlign(false);
+        chart.tooltip.enabled(false);
+        chart.yAxis.ticks(5);
+        if (options.seriesColors) {
+            chart.color(options.seriesColors);
+        }
+        handleCommonOptions(chart, options);
+
+        d3.select(svg)
+            .datum(data)
+            .call(chart);
+
+        nv.utils.windowResize(updateChart);
+        // The bar-chart:refresh event occurs when switching tabs which requires
+        // redrawing the chart.
+        $(chartEl).on('bar-chart:refresh', updateChart);
+
+        return chart;
+    });
+}
+
 module.exports = {
-    makeBarChart: makeBarChart
+    renderHorizontalBarChart: renderHorizontalBarChart,
+    renderVerticalBarChart: renderVerticalBarChart
 };

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -13,10 +13,8 @@ var $ = require('jquery'),
     views = require('./views'),
     models = require('./models'),
     AppRouter = require('../router').AppRouter,
-    chart = require('./chart'),
     settings = require('./settings'),
-    testUtils = require('./testUtils'),
-    sandboxTemplate = require('./templates/sandbox.html');
+    testUtils = require('./testUtils');
 
 var TEST_SHAPE = {
     'type': 'Feature',
@@ -26,15 +24,7 @@ var TEST_SHAPE = {
     }
 };
 
-var chartData = [{x: 'a', y: 1},
-                {x: 'b', y: 2},
-                {x: 'c', y: 3}],
-    xValue = 'x',
-    yValue = 'y',
-    displaySandboxHeight = '500',
-    displaySandboxWidth = '700',
-    displaySandboxSelector = '#display-sandbox',
-    sandboxId = 'sandbox',
+var sandboxId = 'sandbox',
     sandboxSelector = '#' + sandboxId;
 
 describe('Core', function() {
@@ -45,19 +35,12 @@ describe('Core', function() {
     });
 
     beforeEach(function() {
-        $(displaySandboxSelector).remove();
-        // Use a special sandbox so that we can test responsiveness of chart.
-        $('body').append(sandboxTemplate.render({
-            height: displaySandboxHeight,
-            width: displaySandboxWidth
-        }));
-        this.el = $(displaySandboxSelector).get(0);
     });
 
     afterEach(function() {
         $(sandboxSelector).remove();
         $('<div>', {id: sandboxId}).appendTo('body');
-        $(displaySandboxSelector).remove();
+
         // App adds a LoginModalView to the body
         // so we need to remove it.
         $('.modal').remove();
@@ -68,52 +51,6 @@ describe('Core', function() {
 
     after(function() {
         $(sandboxSelector).remove();
-    });
-
-    describe('Chart', function() {
-        it('changes size when the browser is resized and height and width are not provided', function() {
-            chart.makeBarChart(this.el, chartData, xValue, yValue);
-            var $svg = $(displaySandboxSelector).children('svg');
-
-            var beforeHeight = $svg.attr('height');
-            var beforeWidth = $svg.attr('width');
-            assert.equal(displaySandboxHeight, beforeHeight);
-            assert.equal(displaySandboxWidth, beforeWidth);
-
-            var afterSandboxHeight = 300;
-            var afterSandboxWidth = 400;
-            $(displaySandboxSelector).css('height', afterSandboxHeight);
-            $(displaySandboxSelector).css('width', afterSandboxWidth);
-            $(window).trigger('resize');
-            var afterHeight = $svg.attr('height');
-            var afterWidth = $svg.attr('width');
-            assert.equal(afterSandboxHeight, afterHeight);
-            assert.equal(afterSandboxWidth, afterWidth);
-        });
-
-        it('stays the same size when the browser is resized and height and width are provided', function() {
-            var options = {
-                height: 400,
-                width: 600
-            };
-            chart.makeBarChart(this.el, chartData, xValue, yValue, options);
-            var $svg = $(displaySandboxSelector).children('svg');
-
-            var beforeHeight = $svg.attr('height');
-            var beforeWidth = $svg.attr('width');
-            assert.equal(options.height, beforeHeight);
-            assert.equal(options.width, beforeWidth);
-
-            var afterSandboxHeight = 300;
-            var afterSandboxWidth = 400;
-            $(displaySandboxSelector).css('height', afterSandboxHeight);
-            $(displaySandboxSelector).css('width', afterSandboxWidth);
-            $(window).trigger('resize');
-            var afterHeight = $svg.attr('height');
-            var afterWidth = $svg.attr('width');
-            assert.equal(options.height, afterHeight);
-            assert.equal(options.width, afterWidth);
-        });
     });
 
     describe('Views', function() {

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -43,9 +43,10 @@ describe('Modeling', function() {
     });
 
     afterEach(function() {
-        $(sandboxSelector).empty();
-        testUtils.resetApp(App);
+        $(sandboxSelector).remove();
+        $('<div>', {id: sandboxId}).appendTo('body');
 
+        testUtils.resetApp(App);
         _.debounce = this.origDebounce;
     });
 

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var $ = require('jquery'),
+    _ = require('underscore'),
     Backbone = require('../../../../shim/backbone'),
     Marionette = require('../../../../shim/backbone.marionette'),
     chart = require('../../../core/chart.js'),
@@ -90,19 +91,18 @@ var ChartView = Marionette.ItemView.extend({
 
     addChart: function() {
         var chartEl = this.$el.find('.bar-chart').get(0),
-            chartData = this.collection.map(function(model) {
-                return model.attributes;
+            data = this.collection.map(function(model) {
+                return {
+                    x: model.attributes.measure,
+                    y: model.attributes.load
+                };
             }),
             chartOptions = {
-                isPercentage: false,
-                depAxisLabel: 'Load (kg)',
-                useHorizBars: true,
-                horizMargin: {top: 20, right: 80, bottom: 40, left: 150}
-            },
-            depVars = ['load'],
-            indVar = 'measure';
+                yAxisLabel: 'Load (kg)',
+                abbreviateTicks: true
+            };
 
-        chart.makeBarChart(chartEl, chartData, indVar, depVars, chartOptions);
+        chart.renderHorizontalBarChart(chartEl, data, chartOptions);
     }
 });
 
@@ -124,32 +124,41 @@ var CompareChartView = Marionette.ItemView.extend({
     },
 
     addChart: function() {
-        function getBarData() {
-            return {
-                load: '',
-                oxygen: result[0].load,
-                solids: result[1].load,
-                nitrogen: result[2].load,
-                phosphorus: result[3].load
-            };
+        function getData(result, seriesDisplayNames) {
+            return _.map(seriesDisplayNames, function(seriesDisplayName, seriesInd) {
+                return {
+                    key: seriesDisplayName,
+                    values: [
+                        {
+                            x: '',
+                            y: result[seriesInd].load
+                        }
+                    ]
+                };
+            });
         }
 
         var chartEl = this.$el.find('.bar-chart').get(0),
-            result = this.model.get('result');
+            result = this.model.get('result'),
+            seriesDisplayNames = ['Oxygen Demand',
+                                  'Suspended Solids',
+                                  'Nitrogen',
+                                  'Phosphorus'],
+            data,
+            chartOptions;
+
         $(chartEl).empty();
+
         if (result) {
-            var indVar = 'load',
-                depVars = ['oxygen', 'solids', 'nitrogen', 'phosphorus'],
-                options = {
-                    barColors: ['#1589ff', '#4aeab3', '#4ebaea', '#329b9c'],
-                    depAxisLabel: 'Load',
-                    depDisplayNames: ['Oxygen Demand',
-                                      'Suspended Solids',
-                                      'Nitrogen',
-                                      'Phosphorus']
-                },
-                data = [getBarData()];
-            chart.makeBarChart(chartEl, data, indVar, depVars, options);
+            data = getData(result, seriesDisplayNames);
+            chartOptions = {
+                seriesColors: ['#1589ff', '#4aeab3', '#4ebaea', '#329b9c'],
+                yAxisLabel: 'Load (kg)',
+                margin: {top: 20, right: 0, bottom: 40, left: 60},
+                abbreviateTicks: true
+            };
+
+            chart.renderVerticalBarChart(chartEl, data, chartOptions);
         }
     }
 });

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var $ = require('jquery'),
+    _ = require('underscore'),
     Marionette = require('../../../../shim/backbone.marionette'),
     chart = require('../../../core/chart.js'),
     barChartTmpl = require('../../../core/templates/barChart.html');
@@ -24,28 +25,35 @@ var ResultView = Marionette.ItemView.extend({
     },
 
     addChart: function() {
-        function getBarData(displayName, name) {
-            return {
-                type: displayName,
-                inf: result[name]['inf'],
-                runoff: result[name]['runoff'],
-                et: result[name]['et']
-            };
+        function getData(result, seriesNames, seriesDisplayNames,
+                         labelNames, labelDisplayNames) {
+            return _.map(seriesNames, function(seriesName, seriesInd) {
+                var seriesDisplayName = seriesDisplayNames[seriesInd];
+                return {
+                    key: seriesDisplayName,
+                    values: _.map(labelNames, function(labelName, labelInd) {
+                        var labelDisplayName = labelDisplayNames[labelInd];
+                        return {
+                            x: labelDisplayName,
+                            y: result[labelName][seriesName]
+                        };
+                    })
+                };
+            });
         }
 
         var chartEl = this.$el.find('.bar-chart').get(0),
-            result = this.model.get('result');
-        $(chartEl).empty();
-        if (result) {
-            var indVar = 'type',
-                depVars = ['inf', 'runoff', 'et'],
-                data,
-                options = {
-                    barColors: ['#F8AA00', '#CF4300', '#C2D33C'],
-                    depAxisLabel: 'Level',
-                    depDisplayNames: ['Infiltration', 'Runoff', 'Evapotranspiration']
-                };
+            result = this.model.get('result'),
+            seriesNames = ['inf', 'runoff', 'et'],
+            seriesDisplayNames = ['Infiltration', 'Runoff', 'Evapotranspiration'],
+            labelNames,
+            labelDisplayNames,
+            data,
+            chartOptions;
 
+        $(chartEl).empty();
+
+        if (result) {
             if (this.compareMode) {
                 var target_result = 'modified';
                 if (this.scenario.get('is_current_conditions')) {
@@ -54,24 +62,26 @@ var ResultView = Marionette.ItemView.extend({
                 if (this.scenario.get('is_pre_columbian')) {
                     target_result = 'pc_unmodified';
                 }
-                data = [
-                    getBarData('', target_result)
-                ];
+                labelNames = [target_result];
+                labelDisplayNames = [''];
                 this.$el.addClass('current-conditions');
             } else if (this.scenario.get('is_current_conditions')) {
-                data = [
-                    getBarData('100% Forest', 'pc_unmodified'),
-                    getBarData('Current Conditions', 'unmodified')
-                ];
+                labelNames = ['pc_unmodified', 'unmodified'];
+                labelDisplayNames = ['100% Forest', 'Current Conditions'];
             } else {
-                // Show the unmodified results and the modified
-                // results.
-                data = [
-                    getBarData('Current Conditions', 'unmodified'),
-                    getBarData('Modified', 'modified')
-                ];
+                labelNames = ['unmodified', 'modified'];
+                labelDisplayNames = ['Current Conditions', 'Modified'];
             }
-            chart.makeBarChart(chartEl, data, indVar, depVars, options);
+
+            data = getData(result, seriesNames, seriesDisplayNames,
+                           labelNames, labelDisplayNames);
+            chartOptions = {
+                seriesColors: ['#F8AA00', '#CF4300', '#C2D33C'],
+                yAxisLabel: 'Level',
+                margin: this.compareMode ? {top: 20, right: 0, bottom: 40, left: 60} : null
+            };
+
+            chart.renderVerticalBarChart(chartEl, data, chartOptions);
         }
     }
 });

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -4,27 +4,27 @@
   "dependencies": {
     "backbone": {
       "version": "1.1.2",
-      "from": "backbone@1.1.2",
+      "from": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz"
     },
     "backbone.marionette": {
       "version": "2.4.1",
-      "from": "backbone.marionette@2.4.1",
+      "from": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.1.tgz",
       "dependencies": {
         "backbone.babysitter": {
-          "version": "0.1.6",
-          "from": "backbone.babysitter@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.6.tgz"
+          "version": "0.1.8",
+          "from": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz"
         },
         "backbone.wreqr": {
-          "version": "1.3.1",
-          "from": "backbone.wreqr@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.1.tgz"
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@>=1.4.4 <=1.6.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
@@ -36,12 +36,12 @@
     },
     "bootstrap": {
       "version": "3.3.4",
-      "from": "bootstrap@3.3.4",
+      "from": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz"
     },
     "bootstrap-select": {
       "version": "1.6.4",
-      "from": "../../tmp/npm-3496-25385efb/1430415914259-0.019491331884637475/f1755efa102a41e43fc367ba36ce905b8f2b90e1",
+      "from": "../../tmp/npm-31030-7f32f0c4/1436971651298-0.12548802117817104/f1755efa102a41e43fc367ba36ce905b8f2b90e1",
       "resolved": "git://github.com/azavea/bootstrap-select#f1755efa102a41e43fc367ba36ce905b8f2b90e1"
     },
     "bootstrap-table": {
@@ -1060,72 +1060,72 @@
     },
     "browserify": {
       "version": "9.0.3",
-      "from": "browserify@9.0.3",
+      "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.10.0",
-          "from": "JSONStream@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
-              "from": "jsonparse@0.0.5",
+              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
             },
             "through": {
-              "version": "2.3.6",
-              "from": "through@>=2.2.7 <3.0.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+              "version": "2.3.8",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "assert": {
           "version": "1.3.0",
-          "from": "assert@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
-          "version": "4.0.1",
-          "from": "browser-pack@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
+          "version": "4.0.4",
+          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.8.4",
-              "from": "JSONStream@>=0.8.4 <0.9.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "combine-source-map@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.1",
-                  "from": "inline-source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.3.0",
-                      "from": "source-map@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "dependencies": {
                         "amdefine": {
-                          "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                         }
                       }
                     }
@@ -1133,36 +1133,41 @@
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "convert-source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.31 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 }
               }
             },
+            "defined": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+            },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -1170,187 +1175,177 @@
               }
             },
             "umd": {
-              "version": "3.0.0",
-              "from": "umd@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
             }
           }
         },
         "browser-resolve": {
-          "version": "1.8.2",
-          "from": "browser-resolve@>=1.7.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
+          "version": "1.9.0",
+          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "browserify-zlib@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
-              "version": "0.2.6",
-              "from": "pako@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
+              "version": "0.2.7",
+              "from": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
             }
           }
         },
         "buffer": {
-          "version": "3.1.2",
-          "from": "buffer@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
+          "version": "3.3.1",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "base64-js@0.0.8",
+              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
-              "version": "1.1.4",
-              "from": "ieee754@>=1.1.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+              "version": "1.1.6",
+              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
             },
             "is-array": {
               "version": "1.0.1",
-              "from": "is-array@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "builtins@>=0.0.3 <0.1.0",
+          "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
           "version": "0.0.1",
-          "from": "commondir@0.0.1",
+          "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
-          "version": "1.4.7",
-          "from": "concat-stream@>=1.4.1 <1.5.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+          "version": "1.4.10",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "constants-browserify@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
-          "version": "3.9.13",
-          "from": "crypto-browserify@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+          "version": "3.9.14",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
           "dependencies": {
             "browserify-aes": {
-              "version": "1.0.0",
-              "from": "browserify-aes@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz"
             },
             "browserify-sign": {
-              "version": "2.8.0",
-              "from": "browserify-sign@2.8.0",
-              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+              "version": "3.0.2",
+              "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "1.1.1",
-                  "from": "browserify-rsa@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "elliptic": {
-                  "version": "1.0.1",
-                  "from": "elliptic@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
-                      "version": "1.0.2",
-                      "from": "hash.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                     }
                   }
                 },
                 "parse-asn1": {
-                  "version": "2.0.0",
-                  "from": "parse-asn1@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.3",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "version": "2.1.2",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
-                    },
-                    "asn1.js-rfc3280": {
-                      "version": "1.0.0",
-                      "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
-                    },
-                    "pemstrip": {
-                      "version": "0.0.1",
-                      "from": "pemstrip@0.0.1",
-                      "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "create-ecdh": {
-              "version": "2.0.0",
-              "from": "create-ecdh@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "elliptic": {
-                  "version": "1.0.1",
-                  "from": "elliptic@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
-                      "version": "1.0.2",
-                      "from": "hash.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                     }
                   }
                 }
@@ -1358,83 +1353,83 @@
             },
             "create-hash": {
               "version": "1.1.1",
-              "from": "create-hash@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "dependencies": {
                 "ripemd160": {
-                  "version": "1.0.0",
-                  "from": "ripemd160@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
                 },
                 "sha.js": {
-                  "version": "2.3.6",
-                  "from": "sha.js@>=2.3.6 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+                  "version": "2.4.2",
+                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz"
                 }
               }
             },
             "create-hmac": {
               "version": "1.1.3",
-              "from": "create-hmac@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
-              "version": "3.0.1",
-              "from": "diffie-hellman@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+              "version": "3.0.2",
+              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "miller-rabin": {
-                  "version": "1.1.5",
-                  "from": "miller-rabin@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     }
                   }
                 }
               }
             },
-            "pbkdf2-compat": {
-              "version": "3.0.2",
-              "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
+            "pbkdf2": {
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
             },
             "public-encrypt": {
-              "version": "2.0.0",
-              "from": "public-encrypt@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "2.0.0",
-                  "from": "browserify-rsa@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "parse-asn1": {
-                  "version": "3.0.0",
-                  "from": "parse-asn1@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.3",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "version": "2.1.2",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
@@ -1445,64 +1440,40 @@
             },
             "randombytes": {
               "version": "2.0.1",
-              "from": "randombytes@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             }
           }
         },
         "deep-equal": {
           "version": "1.0.0",
-          "from": "deep-equal@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
-          "version": "1.3.5",
-          "from": "deps-sort@>=1.3.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+          "version": "1.3.9",
+          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.8.4",
-              "from": "JSONStream@>=0.8.4 <0.9.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-                }
-              }
-            },
-            "minimist": {
-              "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-            },
-            "through2": {
-              "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             }
@@ -1510,54 +1481,54 @@
         },
         "domain-browser": {
           "version": "1.1.4",
-          "from": "domain-browser@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
         },
         "duplexer2": {
           "version": "0.0.2",
-          "from": "duplexer2@>=0.0.2 <0.1.0",
+          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "events": {
           "version": "1.0.2",
-          "from": "events@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
           "version": "4.5.3",
-          "from": "glob@>=4.0.5 <5.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.4",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "version": "2.0.8",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -1565,13 +1536,13 @@
               }
             },
             "once": {
-              "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -1580,145 +1551,141 @@
         },
         "has": {
           "version": "1.0.0",
-          "from": "has@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/has/-/has-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "http-browserify@>=1.4.0 <2.0.0",
+          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.1 <2.1.0",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
-          "version": "6.2.1",
-          "from": "insert-module-globals@>=6.2.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
+          "version": "6.5.2",
+          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.7.4",
-              "from": "JSONStream@>=0.7.1 <0.8.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "combine-source-map": {
-              "version": "0.3.0",
-              "from": "combine-source-map@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
               "dependencies": {
-                "inline-source-map": {
-                  "version": "0.3.1",
-                  "from": "inline-source-map@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-                  "dependencies": {
-                    "source-map": {
-                      "version": "0.3.0",
-                      "from": "source-map@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
                 "convert-source-map": {
-                  "version": "0.3.5",
-                  "from": "convert-source-map@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+                },
+                "inline-source-map": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                },
+                "lodash.memoize": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
                 },
                 "source-map": {
-                  "version": "0.1.43",
-                  "from": "source-map@>=0.1.31 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "version": "0.4.3",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 }
               }
             },
             "lexical-scope": {
-              "version": "1.1.0",
-              "from": "lexical-scope@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
               "dependencies": {
                 "astw": {
-                  "version": "1.1.0",
-                  "from": "astw@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                   "dependencies": {
-                    "esprima-fb": {
-                      "version": "3001.1.0-dev-harmony-fb",
-                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                    "acorn": {
+                      "version": "1.2.2",
+                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     }
                   }
                 }
               }
             },
             "process": {
-              "version": "0.6.0",
-              "from": "process@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
+              "version": "0.11.1",
+              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
             },
-            "through": {
-              "version": "2.3.6",
-              "from": "through@>=2.3.4 <2.4.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            "xtend": {
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
-          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
-              "version": "1.3.1",
-              "from": "stream-splicer@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
               "dependencies": {
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "readable-wrap@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
@@ -1726,103 +1693,108 @@
           }
         },
         "module-deps": {
-          "version": "3.7.6",
-          "from": "module-deps@>=3.7.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.6.tgz",
+          "version": "3.8.1",
+          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.7.4",
-              "from": "JSONStream@>=0.7.1 <0.8.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
+            "defined": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+            },
             "detective": {
-              "version": "4.0.0",
-              "from": "detective@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+              "version": "4.1.1",
+              "from": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "0.9.0",
-                  "from": "acorn@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                  "version": "1.2.2",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                 },
                 "escodegen": {
                   "version": "1.6.1",
-                  "from": "escodegen@>=1.4.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "dependencies": {
                     "estraverse": {
                       "version": "1.9.3",
-                      "from": "estraverse@>=1.9.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                     },
                     "esutils": {
                       "version": "1.1.6",
-                      "from": "esutils@>=1.1.6 <2.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                     },
                     "esprima": {
                       "version": "1.2.5",
-                      "from": "esprima@>=1.2.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
-                      "from": "optionator@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
                         "prelude-ls": {
-                          "version": "1.1.1",
-                          "from": "prelude-ls@>=1.1.1 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                         },
                         "deep-is": {
                           "version": "0.1.3",
-                          "from": "deep-is@>=0.1.2 <0.2.0",
+                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
                         "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "version": "0.0.3",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         },
                         "type-check": {
                           "version": "0.3.1",
-                          "from": "type-check@>=0.3.1 <0.4.0",
+                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                         },
                         "levn": {
                           "version": "0.2.5",
-                          "from": "levn@>=0.2.5 <0.3.0",
+                          "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                         },
                         "fast-levenshtein": {
                           "version": "1.0.6",
-                          "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                         }
                       }
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.40 <0.2.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
-                          "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                         }
                       }
                     }
@@ -1830,295 +1802,254 @@
                 }
               }
             },
-            "minimist": {
-              "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-            },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "stream-combiner2@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "3.0.0",
-                      "from": "xtend@>=3.0.0 <3.1.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                     }
                   }
                 }
               }
             },
-            "subarg": {
-              "version": "0.0.1",
-              "from": "subarg@0.0.1",
-              "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "from": "minimist@>=0.0.7 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                }
-              }
-            },
-            "through2": {
-              "version": "0.4.2",
-              "from": "through2@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "2.1.2",
-                  "from": "xtend@>=2.1.1 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-                  "dependencies": {
-                    "object-keys": {
-                      "version": "0.4.0",
-                      "from": "object-keys@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "os-browserify@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "1.0.1",
-          "from": "parents@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.11.15",
-              "from": "path-platform@>=0.11.15 <0.12.0",
+              "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "path-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.10.1",
-          "from": "process@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
           "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "punycode@>=1.2.3 <1.3.0",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.13 <2.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "1.1.6",
-          "from": "resolve@>=1.1.4 <2.0.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
-          "from": "shallow-copy@0.0.1",
+          "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
           "version": "1.0.1",
-          "from": "shasum@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
             },
             "sha.js": {
               "version": "2.3.6",
-              "from": "sha.js@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
             }
           }
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "shell-quote@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "subarg@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "1.1.1",
-              "from": "minimist@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
             }
           }
         },
         "syntax-error": {
-          "version": "1.1.2",
-          "from": "syntax-error@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+          "version": "1.1.4",
+          "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
           "dependencies": {
             "acorn": {
-              "version": "0.9.0",
-              "from": "acorn@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "through2@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "timers-browserify": {
-          "version": "1.4.0",
-          "from": "timers-browserify@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
+          "version": "1.4.1",
+          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
+          "dependencies": {
+            "process": {
+              "version": "0.11.1",
+              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+            }
+          }
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "tty-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
           "version": "0.10.3",
-          "from": "url@>=0.10.1 <0.11.0",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             },
             "querystring": {
               "version": "0.2.0",
-              "from": "querystring@0.2.0",
+              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.1 <0.11.0",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "vm-browserify@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "indexof@0.0.1",
+              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "xtend@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
     },
     "chai": {
       "version": "1.10.0",
-      "from": "chai@1.10.0",
+      "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
       "dependencies": {
         "assertion-error": {
           "version": "1.0.0",
-          "from": "assertion-error@1.0.0",
+          "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
         },
         "deep-eql": {
           "version": "0.1.3",
-          "from": "deep-eql@0.1.3",
+          "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
-              "from": "type-detect@0.1.1",
+              "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
             }
           }
@@ -2127,57 +2058,57 @@
     },
     "d3": {
       "version": "3.5.5",
-      "from": "d3@3.5.5",
+      "from": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz"
     },
     "font-awesome": {
       "version": "4.3.0",
-      "from": "font-awesome@4.3.0",
+      "from": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz"
     },
     "iframe-phone": {
       "version": "1.1.3",
-      "from": "../../tmp/npm-5418-3f5d22c2/1441117736713-0.026042116107419133/200f47f43ee32d640868072c17de4a675e16d96a",
+      "from": "../../tmp/npm-20250-abe6eb52/1438892615234-0.44843362690880895/200f47f43ee32d640868072c17de4a675e16d96a",
       "resolved": "git://github.com/concord-consortium/iframe-phone#200f47f43ee32d640868072c17de4a675e16d96a"
     },
     "jquery": {
       "version": "2.1.3",
-      "from": "jquery@2.1.3",
+      "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz"
     },
     "jshint": {
       "version": "2.8.0",
-      "from": "jshint@*",
+      "from": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.6",
-          "from": "cli@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -2188,49 +2119,49 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.3",
-          "from": "htmlparser2@>=3.8.0 <3.9.0",
+          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "domutils@>=1.5.0 <1.6.0",
+              "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "dom-serializer@>=0.0.0 <1.0.0",
+                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "domelementtype@>=1.1.1 <1.2.0",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     },
                     "entities": {
                       "version": "1.1.1",
-                      "from": "entities@>=1.1.1 <1.2.0",
+                      "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
@@ -2239,442 +2170,8 @@
             },
             "domelementtype": {
               "version": "1.3.0",
-              "from": "domelementtype@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "readable-stream@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "entities": {
-              "version": "1.0.0",
-              "from": "entities@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "2.0.8",
-          "from": "minimatch@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.0",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.2.0",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "shelljs": {
-          "version": "0.3.0",
-          "from": "shelljs@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.2",
-          "from": "strip-json-comments@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-        },
-        "lodash": {
-          "version": "3.7.0",
-          "from": "lodash@>=3.7.0 <3.8.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
-        }
-      }
-    },
-    "jstify": {
-      "version": "0.9.0",
-      "from": "jstify@0.9.0",
-      "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
-      "dependencies": {
-        "html-minifier": {
-          "version": "0.6.9",
-          "from": "html-minifier@>=0.6.8 <0.7.0",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
-          "dependencies": {
-            "change-case": {
-              "version": "2.1.6",
-              "from": "change-case@>=2.1.0 <2.2.0",
-              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
-              "dependencies": {
-                "camel-case": {
-                  "version": "1.1.1",
-                  "from": "camel-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz"
-                },
-                "constant-case": {
-                  "version": "1.1.0",
-                  "from": "constant-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz"
-                },
-                "dot-case": {
-                  "version": "1.1.1",
-                  "from": "dot-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
-                },
-                "is-lower-case": {
-                  "version": "1.1.1",
-                  "from": "is-lower-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
-                },
-                "is-upper-case": {
-                  "version": "1.1.1",
-                  "from": "is-upper-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
-                },
-                "lower-case": {
-                  "version": "1.1.2",
-                  "from": "lower-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
-                },
-                "param-case": {
-                  "version": "1.1.1",
-                  "from": "param-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
-                },
-                "pascal-case": {
-                  "version": "1.1.0",
-                  "from": "pascal-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz"
-                },
-                "path-case": {
-                  "version": "1.1.1",
-                  "from": "path-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
-                },
-                "sentence-case": {
-                  "version": "1.1.2",
-                  "from": "sentence-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
-                },
-                "snake-case": {
-                  "version": "1.1.1",
-                  "from": "snake-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
-                },
-                "swap-case": {
-                  "version": "1.1.0",
-                  "from": "swap-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz"
-                },
-                "title-case": {
-                  "version": "1.1.0",
-                  "from": "title-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz"
-                },
-                "upper-case": {
-                  "version": "1.1.2",
-                  "from": "upper-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
-                },
-                "upper-case-first": {
-                  "version": "1.1.1",
-                  "from": "upper-case-first@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz"
-                }
-              }
-            },
-            "clean-css": {
-              "version": "2.2.23",
-              "from": "clean-css@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.2.0",
-                  "from": "commander@>=2.2.0 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
-                }
-              }
-            },
-            "cli": {
-              "version": "0.6.6",
-              "from": "cli@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "3.2.11",
-                  "from": "glob@>=3.2.1 <3.3.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "exit": {
-                  "version": "0.1.2",
-                  "from": "exit@0.1.2",
-                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.4.19",
-              "from": "uglify-js@>=2.4.0 <2.5.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.19.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "source-map": {
-                  "version": "0.1.34",
-                  "from": "source-map@0.1.34",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                    }
-                  }
-                },
-                "yargs": {
-                  "version": "3.5.4",
-                  "from": "yargs@>=3.5.4 <3.6.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.0.2",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                    },
-                    "decamelize": {
-                      "version": "1.0.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "from": "window-size@0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                }
-              }
-            },
-            "relateurl": {
-              "version": "0.2.6",
-              "from": "relateurl@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.3",
-          "from": "through2@>=0.6.3 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        },
-        "lodash.escape": {
-          "version": "3.0.0",
-          "from": "lodash.escape@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
-          "dependencies": {
-            "lodash._basetostring": {
-              "version": "3.0.0",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "leaflet": {
-      "version": "0.7.3",
-      "from": "leaflet@0.7.3",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
-    },
-    "leaflet-draw": {
-      "version": "0.2.3",
-      "from": "../../tmp/npm-5418-3f5d22c2/1441117743516-0.3635168285109103/e753b7d0eb9d1de8864ca85d5dafbf9ac955759c",
-      "resolved": "git://github.com/michaelguild13/Leaflet.draw#e753b7d0eb9d1de8864ca85d5dafbf9ac955759c"
-    },
-    "leaflet-plugins": {
-      "version": "1.3.8",
-      "from": "../../tmp/npm-29202-ddabb07a/1437065466188-0.06710644904524088/1fb49a72c8f53cf95786064b1569dc91bfebae6c",
-      "resolved": "git://github.com/azavea/leaflet-plugins#1fb49a72c8f53cf95786064b1569dc91bfebae6c"
-    },
-    "leaflet.locatecontrol": {
-      "version": "0.43.0",
-      "from": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz",
-      "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz"
-    },
-    "livereload": {
-      "version": "0.3.7",
-      "from": "livereload@*",
-      "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.3.7.tgz",
-      "dependencies": {
-        "opts": {
-          "version": "1.2.2",
-          "from": "opts@>=1.2.0",
-          "resolved": "https://registry.npmjs.org/opts/-/opts-1.2.2.tgz"
-        },
-        "websocket.io": {
-          "version": "0.2.1",
-          "from": "websocket.io@>=0.1.0",
-          "resolved": "https://registry.npmjs.org/websocket.io/-/websocket.io-0.2.1.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@*",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                }
-              }
-            },
-            "ws": {
-              "version": "0.4.20",
-              "from": "ws@0.4.20",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.20.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "0.6.1",
-                  "from": "commander@>=0.6.1 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                },
-                "tinycolor": {
-                  "version": "0.0.1",
-                  "from": "tinycolor@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
-                },
-                "options": {
-                  "version": "0.0.6",
-                  "from": "options@latest",
-                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "lodash": {
-      "version": "3.6.0",
-      "from": "lodash@3.6.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
-    },
-    "minifyify": {
-      "version": "7.0.0",
-      "from": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.4.8",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
@@ -2695,6 +2192,450 @@
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+        },
+        "strip-json-comments": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+        }
+      }
+    },
+    "jstify": {
+      "version": "0.9.0",
+      "from": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
+      "dependencies": {
+        "html-minifier": {
+          "version": "0.6.9",
+          "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
+          "dependencies": {
+            "change-case": {
+              "version": "2.1.6",
+              "from": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
+              "dependencies": {
+                "camel-case": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz"
+                },
+                "constant-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.1.tgz"
+                },
+                "dot-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
+                },
+                "is-lower-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
+                },
+                "is-upper-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
+                },
+                "lower-case": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
+                },
+                "param-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
+                },
+                "pascal-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz"
+                },
+                "path-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
+                },
+                "sentence-case": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
+                },
+                "snake-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
+                },
+                "swap-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.1.tgz"
+                },
+                "title-case": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.1.tgz"
+                },
+                "upper-case": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
+                },
+                "upper-case-first": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz"
+                }
+              }
+            },
+            "clean-css": {
+              "version": "2.2.23",
+              "from": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
+                }
+              }
+            },
+            "cli": {
+              "version": "0.6.6",
+              "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.5",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "exit": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.23",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "relateurl": {
+              "version": "0.2.6",
+              "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "lodash.escape": {
+          "version": "3.0.0",
+          "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+          "dependencies": {
+            "lodash._basetostring": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "leaflet": {
+      "version": "0.7.3",
+      "from": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
+    },
+    "leaflet-draw": {
+      "version": "0.2.3",
+      "from": "../../tmp/npm-20250-abe6eb52/1438892615591-0.05360055458731949/e753b7d0eb9d1de8864ca85d5dafbf9ac955759c",
+      "resolved": "git://github.com/michaelguild13/Leaflet.draw#e753b7d0eb9d1de8864ca85d5dafbf9ac955759c"
+    },
+    "leaflet-plugins": {
+      "version": "1.3.8",
+      "from": "git://github.com/azavea/leaflet-plugins#feature/browserify",
+      "resolved": "git://github.com/azavea/leaflet-plugins#1fb49a72c8f53cf95786064b1569dc91bfebae6c"
+    },
+    "leaflet.locatecontrol": {
+      "version": "0.43.0",
+      "from": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz",
+      "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz"
+    },
+    "livereload": {
+      "version": "0.3.7",
+      "from": "https://registry.npmjs.org/livereload/-/livereload-0.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.3.7.tgz",
+      "dependencies": {
+        "opts": {
+          "version": "1.2.2",
+          "from": "https://registry.npmjs.org/opts/-/opts-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/opts/-/opts-1.2.2.tgz"
+        },
+        "websocket.io": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/websocket.io/-/websocket.io-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/websocket.io/-/websocket.io-0.2.1.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "ws": {
+              "version": "0.4.20",
+              "from": "https://registry.npmjs.org/ws/-/ws-0.4.20.tgz",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.20.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                },
+                "tinycolor": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                },
+                "options": {
+                  "version": "0.0.6",
+                  "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.6.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+    },
+    "minifyify": {
+      "version": "7.0.0",
+      "from": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.5.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
             }
@@ -2711,9 +2652,9 @@
           "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
           "dependencies": {
             "lodash._createwrapper": {
-              "version": "3.0.6",
-              "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.6.tgz",
+              "version": "3.0.7",
+              "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
@@ -2721,9 +2662,9 @@
                   "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
                 },
                 "lodash._basecreate": {
-                  "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.2.tgz"
+                  "version": "3.0.3",
+                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
                 }
               }
             },
@@ -2740,9 +2681,9 @@
           }
         },
         "lodash.defaults": {
-          "version": "3.1.1",
-          "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.1.tgz",
+          "version": "3.1.2",
+          "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
           "dependencies": {
             "lodash.assign": {
               "version": "3.2.0",
@@ -2779,24 +2720,24 @@
                   }
                 },
                 "lodash.keys": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+                  "version": "3.1.2",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "3.9.0",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                      "version": "3.9.1",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     },
                     "lodash.isarray": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
                 }
@@ -2825,19 +2766,19 @@
               "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
               "dependencies": {
                 "lodash.keys": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+                  "version": "3.1.2",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "3.9.0",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                      "version": "3.9.1",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     }
                   }
                 }
@@ -2849,9 +2790,9 @@
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             },
             "lodash.isarray": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
             }
           }
         },
@@ -2868,21 +2809,21 @@
           }
         },
         "source-map": {
-          "version": "0.4.2",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+          "version": "0.4.3",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
             }
           }
         },
         "through": {
-          "version": "2.3.7",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+          "version": "2.3.8",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "tmp": {
           "version": "0.0.25",
@@ -2960,9 +2901,9 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                 }
               }
             },
@@ -3004,100 +2945,100 @@
     },
     "mocha": {
       "version": "2.0.1",
-      "from": "mocha@2.0.1",
+      "from": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "from": "commander@2.3.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "debug": {
           "version": "2.0.0",
-          "from": "debug@2.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "diff": {
           "version": "1.0.8",
-          "from": "diff@1.0.8",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "from": "escape-string-regexp@1.0.2",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.3",
-          "from": "glob@3.2.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "growl": {
           "version": "1.8.1",
-          "from": "growl@1.8.1",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
         },
         "jade": {
           "version": "0.26.3",
-          "from": "jade@0.26.3",
+          "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "dependencies": {
             "commander": {
               "version": "0.6.1",
-              "from": "commander@0.6.1",
+              "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
@@ -3106,105 +3047,105 @@
     },
     "node-sass": {
       "version": "3.3.2",
-      "from": "node-sass@3.3.2",
+      "from": "https://registry.npmjs.org/node-sass/-/node-sass-3.3.2.tgz",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.3.2.tgz",
       "dependencies": {
         "async-foreach": {
           "version": "0.1.3",
-          "from": "async-foreach@>=0.1.3 <0.2.0",
+          "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "gaze": {
           "version": "0.5.1",
-          "from": "gaze@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "globule@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.2",
-                  "from": "lodash@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "glob@>=3.1.21 <3.2.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "graceful-fs@>=1.2.0 <1.3.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
                       "version": "1.0.2",
-                      "from": "inherits@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -3215,49 +3156,49 @@
         },
         "get-stdin": {
           "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         },
         "glob": {
           "version": "5.0.14",
-          "from": "glob@>=5.0.14 <6.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3266,63 +3207,63 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "meow": {
           "version": "3.3.0",
-          "from": "meow@>=3.3.0 <4.0.0",
+          "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "1.0.0",
-              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "map-obj@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 }
               }
             },
             "indent-string": {
               "version": "1.2.2",
-              "from": "indent-string@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
               "dependencies": {
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -3333,165 +3274,165 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "object-assign": {
               "version": "3.0.0",
-              "from": "object-assign@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nan": {
           "version": "2.0.9",
-          "from": "nan@>=2.0.8 <3.0.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
         },
         "npmconf": {
           "version": "2.1.2",
-          "from": "npmconf@>=2.1.2 <3.0.0",
+          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.9",
-              "from": "config-chain@>=1.1.8 <1.2.0",
+              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
               "version": "1.3.4",
-              "from": "ini@>=1.2.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "nopt": {
               "version": "3.0.4",
-              "from": "nopt@>=3.0.1 <3.1.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "uid-number": {
               "version": "0.0.5",
-              "from": "uid-number@0.0.5",
+              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
             }
           }
         },
         "pangyp": {
           "version": "2.3.2",
-          "from": "pangyp@>=2.3.0 <3.0.0",
+          "from": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.2.tgz",
           "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.2.tgz",
           "dependencies": {
             "fstream": {
               "version": "1.0.8",
-              "from": "fstream@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "glob": {
               "version": "4.3.5",
-              "from": "glob@>=4.3.5 <4.4.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -3500,27 +3441,27 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.5 <3.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3529,59 +3470,59 @@
             },
             "nopt": {
               "version": "3.0.4",
-              "from": "nopt@>=3.0.1 <3.1.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "npmlog": {
               "version": "1.0.0",
-              "from": "npmlog@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
-                  "from": "ansi@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                 },
                 "are-we-there-yet": {
                   "version": "1.0.4",
-                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                   "dependencies": {
                     "delegates": {
                       "version": "0.1.0",
-                      "from": "delegates@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.13 <2.0.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -3590,12 +3531,12 @@
                 },
                 "gauge": {
                   "version": "1.0.2",
-                  "from": "gauge@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                   "dependencies": {
                     "has-unicode": {
                       "version": "1.0.0",
-                      "from": "has-unicode@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
                     }
                   }
@@ -3604,54 +3545,54 @@
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@>=0.0.0 <1.0.0",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
             "request": {
               "version": "2.51.0",
-              "from": "request@>=2.51.0 <2.52.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -3660,32 +3601,32 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "caseless@>=0.8.0 <0.9.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -3694,106 +3635,106 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@>=2.3.1 <2.4.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.0.0",
-                  "from": "tough-cookie@>=0.12.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "ctype@0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "oauth-sign@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "hawk@1.1.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -3802,81 +3743,81 @@
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@>=2.2.8 <2.3.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.3.6 <4.4.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "tar": {
               "version": "1.0.3",
-              "from": "tar@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.8",
-                  "from": "block-stream@*",
+                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "which": {
               "version": "1.0.9",
-              "from": "which@>=1.0.8 <1.1.0",
+              "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             }
           }
         },
         "request": {
           "version": "2.62.0",
-          "from": "request@>=2.61.0 <3.0.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.62.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.62.0.tgz",
           "dependencies": {
             "bl": {
               "version": "1.0.0",
-              "from": "bl@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.2",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.3",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.1",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
@@ -3885,201 +3826,201 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "form-data@>=1.0.0-rc1 <1.1.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.4.2",
-                  "from": "async@>=1.4.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.6",
-              "from": "mime-types@>=2.1.2 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.6.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.6.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.18.0",
-                  "from": "mime-db@>=1.18.0 <1.19.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.18.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
               "version": "5.1.0",
-              "from": "qs@>=5.1.0 <5.2.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.1",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
               "version": "2.0.0",
-              "from": "tough-cookie@>=0.12.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "http-signature@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.0",
-              "from": "oauth-sign@>=0.8.0 <0.9.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "hawk": {
               "version": "3.1.0",
-              "from": "hawk@>=3.1.0 <3.2.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.16.2",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.2.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.2.tgz"
                 },
                 "boom": {
                   "version": "2.8.0",
-                  "from": "boom@>=2.8.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "1.8.0",
-              "from": "har-validator@>=1.6.1 <2.0.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
                   "version": "2.10.0",
-                  "from": "bluebird@>=2.9.30 <3.0.0",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.0.tgz"
                 },
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@>=2.8.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.2",
-                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -4090,59 +4031,59 @@
         },
         "sass-graph": {
           "version": "2.0.1",
-          "from": "sass-graph@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.8.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "yargs": {
               "version": "3.25.0",
-              "from": "yargs@>=3.8.0 <4.0.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.25.0.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.25.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.1",
-                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.0.2",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -4151,34 +4092,34 @@
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.0.2",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -4187,29 +4128,29 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "os-locale": {
                   "version": "1.4.0",
-                  "from": "os-locale@>=1.3.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                   "dependencies": {
                     "lcid": {
                       "version": "1.0.0",
-                      "from": "lcid@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                       "dependencies": {
                         "invert-kv": {
                           "version": "1.0.0",
-                          "from": "invert-kv@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                         }
                       }
@@ -4218,12 +4159,12 @@
                 },
                 "window-size": {
                   "version": "0.1.2",
-                  "from": "window-size@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
                 },
                 "y18n": {
                   "version": "3.1.0",
-                  "from": "y18n@>=3.1.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/y18n/-/y18n-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.1.0.tgz"
                 }
               }
@@ -4234,81 +4175,81 @@
     },
     "nunjucks": {
       "version": "1.3.4",
-      "from": "nunjucks@*",
+      "from": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.3.4.tgz",
       "dependencies": {
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@*",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "chokidar": {
           "version": "0.12.6",
-          "from": "chokidar@>=0.12.5 <0.13.0",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
           "dependencies": {
             "readdirp": {
               "version": "1.3.0",
-              "from": "readdirp@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.12 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -4317,7 +4258,7 @@
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             }
           }
@@ -4326,60 +4267,65 @@
     },
     "nunjucksify": {
       "version": "0.2.2",
-      "from": "nunjucksify@*",
+      "from": "https://registry.npmjs.org/nunjucksify/-/nunjucksify-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/nunjucksify/-/nunjucksify-0.2.2.tgz",
       "dependencies": {
         "through": {
-          "version": "2.3.7",
-          "from": "through@>=2.3.4 <2.4.0",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+          "version": "2.3.8",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         }
       }
     },
+    "nvd3": {
+      "version": "1.8.1",
+      "from": "nvd3@*",
+      "resolved": "https://registry.npmjs.org/nvd3/-/nvd3-1.8.1.tgz"
+    },
     "retina.js": {
       "version": "1.3.0",
-      "from": "../../tmp/npm-8916-f2f507bf/1432309084662-0.8805534425191581/a70e73639817473bad7bbb33f866b8e060e5f5a7",
+      "from": "../../tmp/npm-31030-7f32f0c4/1436971651112-0.5243154705967754/a70e73639817473bad7bbb33f866b8e060e5f5a7",
       "resolved": "git://github.com/imulus/retinajs#a70e73639817473bad7bbb33f866b8e060e5f5a7"
     },
     "sinon": {
       "version": "1.14.1",
-      "from": "sinon@1.14.1",
+      "from": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
-          "from": "formatio@1.1.1",
+          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "dependencies": {
             "samsam": {
               "version": "1.1.2",
-              "from": "samsam@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.3 <1.0.0",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "lolex": {
           "version": "1.1.0",
-          "from": "lolex@1.1.0",
+          "from": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
         }
       }
     },
     "testem": {
       "version": "0.5.15",
-      "from": "testem@0.5.15",
+      "from": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
       "resolved": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
       "dependencies": {
         "express": {
@@ -4458,64 +4404,64 @@
         },
         "mustache": {
           "version": "0.4.0",
-          "from": "mustache@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz"
         },
         "socket.io": {
           "version": "0.9.17",
-          "from": "socket.io@>=0.9.13 <0.10.0",
+          "from": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
-              "from": "socket.io-client@0.9.16",
+              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.5",
-                  "from": "uglify-js@1.2.5",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "ws@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "commander@>=2.1.0 <2.2.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "nan@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
+                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     }
                   }
                 },
                 "xmlhttprequest": {
                   "version": "1.4.2",
-                  "from": "xmlhttprequest@1.4.2",
+                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
-                  "from": "active-x-obfuscator@0.0.1",
+                  "from": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
-                      "from": "zeparser@0.0.5",
+                      "from": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
@@ -4524,59 +4470,59 @@
             },
             "policyfile": {
               "version": "0.0.4",
-              "from": "policyfile@0.0.4",
+              "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
             },
             "base64id": {
               "version": "0.1.0",
-              "from": "base64id@0.1.0",
+              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
-              "from": "redis@0.7.3",
+              "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
               "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
         "winston": {
           "version": "0.7.3",
-          "from": "winston@>=0.7.1 <0.8.0",
+          "from": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "dependencies": {
             "cycle": {
               "version": "1.0.3",
-              "from": "cycle@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "pkginfo": {
               "version": "0.3.0",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "request": {
               "version": "2.16.6",
-              "from": "request@>=2.16.0 <2.17.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "dependencies": {
                 "form-data": {
                   "version": "0.0.10",
-                  "from": "form-data@>=0.0.3 <0.1.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
@@ -4585,175 +4531,175 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.7 <1.3.0",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "hawk": {
                   "version": "0.10.2",
-                  "from": "hawk@>=0.10.2 <0.11.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.7.6",
-                      "from": "hoek@>=0.7.0 <0.8.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
                     },
                     "boom": {
                       "version": "0.3.8",
-                      "from": "boom@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
                     },
                     "cryptiles": {
                       "version": "0.1.3",
-                      "from": "cryptiles@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
                     },
                     "sntp": {
                       "version": "0.1.4",
-                      "from": "sntp@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.2.0",
-                  "from": "cookie-jar@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
                 },
                 "aws-sign": {
                   "version": "0.2.0",
-                  "from": "aws-sign@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.2.0",
-                  "from": "oauth-sign@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.2.0",
-                  "from": "forever-agent@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.2.0",
-                  "from": "tunnel-agent@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "3.0.0",
-                  "from": "json-stringify-safe@>=3.0.0 <3.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
                 },
                 "qs": {
                   "version": "0.5.6",
-                  "from": "qs@>=0.5.4 <0.6.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
                 }
               }
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
         },
         "charm": {
           "version": "0.0.8",
-          "from": "charm@>=0.0.5 <0.1.0",
+          "from": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "js-yaml@>=2.1.0 <2.2.0",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "tap": {
           "version": "0.4.13",
-          "from": "tap@>=0.4.4 <0.5.0",
+          "from": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
           "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
           "dependencies": {
             "buffer-equal": {
               "version": "0.0.1",
-              "from": "buffer-equal@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
             },
             "deep-equal": {
               "version": "0.0.0",
-              "from": "deep-equal@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
             },
             "difflet": {
               "version": "0.2.6",
-              "from": "difflet@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
               "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
               "dependencies": {
                 "traverse": {
                   "version": "0.6.6",
-                  "from": "traverse@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
                   "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
                 },
                 "charm": {
                   "version": "0.1.2",
-                  "from": "charm@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
@@ -4761,56 +4707,56 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@*",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "mkdirp": {
-              "version": "0.5.0",
-              "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nopt": {
               "version": "2.2.1",
-              "from": "nopt@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.5",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "runforcover": {
               "version": "0.0.2",
-              "from": "runforcover@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
               "dependencies": {
                 "bunker": {
                   "version": "0.1.2",
-                  "from": "bunker@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                   "dependencies": {
                     "burrito": {
                       "version": "0.2.12",
-                      "from": "burrito@>=0.2.5 <0.3.0",
+                      "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                       "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.5.2",
-                          "from": "traverse@>=0.5.1 <0.6.0",
+                          "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                         },
                         "uglify-js": {
                           "version": "1.1.1",
-                          "from": "uglify-js@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                         }
                       }
@@ -4821,106 +4767,106 @@
             },
             "slide": {
               "version": "1.1.6",
-              "from": "slide@*",
+              "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
             },
             "yamlish": {
-              "version": "0.0.6",
-              "from": "yamlish@*",
-              "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
+              "version": "0.0.7",
+              "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz"
             }
           }
         },
         "commander": {
-          "version": "2.7.1",
-          "from": "commander@*",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+          "version": "2.8.1",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
+              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "backbone": {
           "version": "1.0.0",
-          "from": "backbone@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz"
         },
         "styled_string": {
           "version": "0.0.1",
-          "from": "styled_string@*",
+          "from": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "fileset": {
-          "version": "0.1.5",
-          "from": "fileset@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+          "version": "0.1.8",
+          "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.4.0",
-              "from": "minimatch@>=0.0.0 <1.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             }
@@ -4928,38 +4874,38 @@
         },
         "growl": {
           "version": "1.7.0",
-          "from": "growl@>=1.7.0 <1.8.0",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
         },
         "consolidate": {
           "version": "0.8.0",
-          "from": "consolidate@>=0.8.0 <0.9.0",
+          "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz",
           "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz"
         },
         "did_it_work": {
           "version": "0.0.6",
-          "from": "did_it_work@>=0.0.5 <0.1.0",
+          "from": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz"
         },
         "fireworm": {
           "version": "0.4.4",
-          "from": "fireworm@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.9 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             }
@@ -5113,74 +5059,74 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "underscore@1.8.3",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "watchify": {
       "version": "3.1.0",
-      "from": "watchify@3.1.0",
+      "from": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
       "dependencies": {
         "chokidar": {
-          "version": "1.0.0-rc5",
-          "from": "chokidar@>=1.0.0-rc4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc5.tgz",
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
           "dependencies": {
             "anymatch": {
-              "version": "1.2.1",
-              "from": "anymatch@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.2.1.tgz",
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
-                  "version": "2.1.5",
-                  "from": "micromatch@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.5.tgz",
+                  "version": "2.1.6",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
-                          "version": "0.2.2",
-                          "from": "array-slice@>=0.2.2 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
+                          "version": "0.2.3",
+                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@>=1.8.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
-                              "version": "2.2.0",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.0.tgz",
+                              "version": "2.2.2",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "is-number@>=1.1.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
-                                  "version": "0.2.0",
-                                  "from": "isobject@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.1.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "randomatic@>=1.1.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -5189,433 +5135,103 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
-                          "version": "1.1.0",
-                          "from": "repeat-element@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz"
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "debug": {
-                      "version": "2.1.3",
-                      "from": "debug@>=2.1.3 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                      "version": "2.2.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
-                          "version": "0.7.0",
-                          "from": "ms@0.7.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                          "version": "0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.1",
-                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "kind-of@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "0.2.1",
-                      "from": "object.omit@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "0.2.0",
-                          "from": "isobject@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                         }
                       }
                     },
                     "parse-glob": {
-                      "version": "3.0.0",
-                      "from": "parse-glob@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.0.tgz",
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "glob-base@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
-                          "version": "1.0.0",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
-                      "version": "0.3.0",
-                      "from": "regex-cache@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.3.0.tgz",
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
-                        "benchmarked": {
-                          "version": "0.1.4",
-                          "from": "benchmarked@>=0.1.3 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/benchmarked/-/benchmarked-0.1.4.tgz",
-                          "dependencies": {
-                            "ansi": {
-                              "version": "0.3.0",
-                              "from": "ansi@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-                            },
-                            "benchmark": {
-                              "version": "1.0.0",
-                              "from": "benchmark@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
-                            },
-                            "chalk": {
-                              "version": "1.0.0",
-                              "from": "chalk@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.0.1",
-                                  "from": "ansi-styles@>=2.0.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.3",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "1.0.3",
-                                  "from": "has-ansi@>=1.0.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "1.1.1",
-                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                                    },
-                                    "get-stdin": {
-                                      "version": "4.0.1",
-                                      "from": "get-stdin@>=4.0.1 <5.0.0",
-                                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "2.0.1",
-                                  "from": "strip-ansi@>=2.0.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "1.1.1",
-                                      "from": "ansi-regex@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "1.3.1",
-                                  "from": "supports-color@>=1.3.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
-                                }
-                              }
-                            },
-                            "extend-shallow": {
-                              "version": "1.1.2",
-                              "from": "extend-shallow@>=1.1.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
-                            },
-                            "file-reader": {
-                              "version": "1.0.0",
-                              "from": "file-reader@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/file-reader/-/file-reader-1.0.0.tgz",
-                              "dependencies": {
-                                "extend-shallow": {
-                                  "version": "0.2.0",
-                                  "from": "extend-shallow@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz",
-                                  "dependencies": {
-                                    "array-slice": {
-                                      "version": "0.2.2",
-                                      "from": "array-slice@>=0.2.2 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
-                                    }
-                                  }
-                                },
-                                "map-files": {
-                                  "version": "0.3.0",
-                                  "from": "map-files@>=0.3.0 <0.4.0",
-                                  "resolved": "https://registry.npmjs.org/map-files/-/map-files-0.3.0.tgz",
-                                  "dependencies": {
-                                    "globby": {
-                                      "version": "0.1.1",
-                                      "from": "globby@>=0.1.1 <0.2.0",
-                                      "resolved": "https://registry.npmjs.org/globby/-/globby-0.1.1.tgz",
-                                      "dependencies": {
-                                        "array-differ": {
-                                          "version": "0.1.0",
-                                          "from": "array-differ@>=0.1.0 <0.2.0",
-                                          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
-                                        },
-                                        "array-union": {
-                                          "version": "0.1.0",
-                                          "from": "array-union@>=0.1.0 <0.2.0",
-                                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
-                                          "dependencies": {
-                                            "array-uniq": {
-                                              "version": "0.1.1",
-                                              "from": "array-uniq@>=0.1.0 <0.2.0",
-                                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
-                                            }
-                                          }
-                                        },
-                                        "async": {
-                                          "version": "0.9.0",
-                                          "from": "async@>=0.9.0 <0.10.0",
-                                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                                        },
-                                        "glob": {
-                                          "version": "4.5.3",
-                                          "from": "glob@>=4.0.2 <5.0.0",
-                                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                                          "dependencies": {
-                                            "inflight": {
-                                              "version": "1.0.4",
-                                              "from": "inflight@>=1.0.4 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                                              "dependencies": {
-                                                "wrappy": {
-                                                  "version": "1.0.1",
-                                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                                }
-                                              }
-                                            },
-                                            "inherits": {
-                                              "version": "2.0.1",
-                                              "from": "inherits@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                            },
-                                            "minimatch": {
-                                              "version": "2.0.4",
-                                              "from": "minimatch@>=2.0.1 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                                              "dependencies": {
-                                                "brace-expansion": {
-                                                  "version": "1.1.0",
-                                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                                                  "dependencies": {
-                                                    "balanced-match": {
-                                                      "version": "0.2.0",
-                                                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                                                    },
-                                                    "concat-map": {
-                                                      "version": "0.0.1",
-                                                      "from": "concat-map@0.0.1",
-                                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                                    }
-                                                  }
-                                                }
-                                              }
-                                            },
-                                            "once": {
-                                              "version": "1.3.1",
-                                              "from": "once@>=1.3.0 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                                              "dependencies": {
-                                                "wrappy": {
-                                                  "version": "1.0.1",
-                                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "relative": {
-                                      "version": "0.1.6",
-                                      "from": "relative@>=0.1.6 <0.2.0",
-                                      "resolved": "https://registry.npmjs.org/relative/-/relative-0.1.6.tgz",
-                                      "dependencies": {
-                                        "normalize-path": {
-                                          "version": "0.1.1",
-                                          "from": "normalize-path@>=0.1.1 <0.2.0",
-                                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-0.1.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "read-yaml": {
-                                  "version": "1.0.0",
-                                  "from": "read-yaml@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.0.0.tgz",
-                                  "dependencies": {
-                                    "js-yaml": {
-                                      "version": "3.2.7",
-                                      "from": "js-yaml@>=3.2.3 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-                                      "dependencies": {
-                                        "argparse": {
-                                          "version": "1.0.2",
-                                          "from": "argparse@>=1.0.0 <1.1.0",
-                                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
-                                          "dependencies": {
-                                            "sprintf-js": {
-                                              "version": "1.0.2",
-                                              "from": "sprintf-js@>=1.0.2 <1.1.0",
-                                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
-                                            }
-                                          }
-                                        },
-                                        "esprima": {
-                                          "version": "2.0.0",
-                                          "from": "esprima@>=2.0.0 <2.1.0",
-                                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "for-own": {
-                              "version": "0.1.3",
-                              "from": "for-own@>=0.1.3 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                              "dependencies": {
-                                "for-in": {
-                                  "version": "0.1.4",
-                                  "from": "for-in@>=0.1.4 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
-                                }
-                              }
-                            },
-                            "has-values": {
-                              "version": "0.1.3",
-                              "from": "has-values@>=0.1.2 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
-                            }
-                          }
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
-                        "chalk": {
-                          "version": "0.5.1",
-                          "from": "chalk@>=0.5.1 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "1.1.0",
-                              "from": "ansi-styles@>=1.1.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.3",
-                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "0.1.0",
-                              "from": "has-ansi@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "0.2.1",
-                                  "from": "ansi-regex@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "0.3.0",
-                              "from": "strip-ansi@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "0.2.1",
-                                  "from": "ansi-regex@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "0.2.0",
-                              "from": "supports-color@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-                            }
-                          }
-                        },
-                        "micromatch": {
-                          "version": "1.6.2",
-                          "from": "micromatch@>=1.2.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-1.6.2.tgz",
-                          "dependencies": {
-                            "extglob": {
-                              "version": "0.2.0",
-                              "from": "extglob@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.2.0.tgz"
-                            },
-                            "parse-glob": {
-                              "version": "2.1.1",
-                              "from": "parse-glob@>=2.1.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.1.1.tgz",
-                              "dependencies": {
-                                "glob-base": {
-                                  "version": "0.1.1",
-                                  "from": "glob-base@>=0.1.0 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.1.1.tgz"
-                                },
-                                "glob-path-regex": {
-                                  "version": "1.0.0",
-                                  "from": "glob-path-regex@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "to-key": {
-                          "version": "1.0.0",
-                          "from": "to-key@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-key/-/to-key-1.0.0.tgz",
-                          "dependencies": {
-                            "arr-map": {
-                              "version": "1.0.0",
-                              "from": "arr-map@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-1.0.0.tgz"
-                            },
-                            "for-in": {
-                              "version": "0.1.4",
-                              "from": "for-in@>=0.1.3 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
-                            }
-                          }
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
                     }
@@ -5625,86 +5241,91 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "glob-parent@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
-              "version": "1.0.0",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
-                  "version": "1.3.0",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "is-glob@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "1.3.0",
-              "from": "readdirp@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.12 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -5715,37 +5336,37 @@
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "outpipe": {
-          "version": "1.1.0",
-          "from": "outpipe@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.0.tgz",
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
           "dependencies": {
             "shell-quote": {
               "version": "1.4.3",
-              "from": "shell-quote@>=1.4.2 <2.0.0",
+              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "array-filter": {
                   "version": "0.0.1",
-                  "from": "array-filter@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                 },
                 "array-reduce": {
                   "version": "0.0.0",
-                  "from": "array-reduce@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
                 },
                 "array-map": {
                   "version": "0.0.0",
-                  "from": "array-map@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                 }
               }
@@ -5753,33 +5374,33 @@
           }
         },
         "through2": {
-          "version": "0.6.3",
-          "from": "through2@>=0.6.3 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -5788,7 +5409,7 @@
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "xtend@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -43,6 +43,7 @@
     "node-sass": "3.3.2",
     "nunjucks": "1.3.4",
     "nunjucksify": "0.2.2",
+    "nvd3": "1.8.1",
     "retina.js": "git://github.com/imulus/retinajs#1.3.0",
     "sinon": "1.14.1",
     "testem": "0.5.15",

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -11,53 +11,30 @@
   width: 100%;
   display: block;
   height: 100%;
-  min-height: 200px;
+  min-height: 300px;
   vertical-align: baseline;
   vertical-align: bottom;
 
-  .bar {
-    margin: 0 2%;
-    display: inline-block;
+  .nv-bar {
     fill: $brand-primary;
-    border-radius: $radius-sm!important;
-    vertical-align: bottom;
-
-    &:hover {
-      fill: lighten($brand-primary, 10%);
-    }
   }
 
-  .axis {
-    color: $black-54;
-    font-size: 0.5rem;
-    white-space: normal;
+  // Official NLCD legend colors for classes selected for display
+  .nlcd-11 { fill: $nlcd-11; }
+  .nlcd-21 { fill: $nlcd-21; }
+  .nlcd-22 { fill: $nlcd-22; }
+  .nlcd-23 { fill: $nlcd-23; }
+  .nlcd-24 { fill: $nlcd-24; }
+  .nlcd-31 { fill: $nlcd-31; }
+  .nlcd-41 { fill: $nlcd-41; }
+  .nlcd-52 { fill: $nlcd-52; }
+  .nlcd-71 { fill: $nlcd-71; }
+  .nlcd-81 { fill: $nlcd-81; }
+  .nlcd-82 { fill: $nlcd-82; }
+  .nlcd-90 { fill: $nlcd-90; }
 
-    line, path {
-      fill: none;
-      stroke: $black-12;
-      shape-rendering: crispEdges;
-    }
-
-    text {
-      color: $black-54;
-    }
-  }
-
-  .x.axis line, .x.axis path {
-    display: none;
+  svg {
+    width: 100%;
+    height: 100%;
   }
 }
-
-// Official NLCD legend colors for classes selected for display
-.nlcd-11 .bar { fill: $nlcd-11; }
-.nlcd-21 .bar { fill: $nlcd-21; }
-.nlcd-22 .bar { fill: $nlcd-22; }
-.nlcd-23 .bar { fill: $nlcd-23; }
-.nlcd-24 .bar { fill: $nlcd-24; }
-.nlcd-31 .bar { fill: $nlcd-31; }
-.nlcd-41 .bar { fill: $nlcd-41; }
-.nlcd-52 .bar { fill: $nlcd-52; }
-.nlcd-71 .bar { fill: $nlcd-71; }
-.nlcd-81 .bar { fill: $nlcd-81; }
-.nlcd-82 .bar { fill: $nlcd-82; }
-.nlcd-90 .bar { fill: $nlcd-90; }


### PR DESCRIPTION
This PR switches from a hand-rolled graphing library to the open source (Apache 2.0 license) NVD3 library and in doing so, adds more responsiveness to the graphs to better support a variety of screen sizes. In particular, changes in the container size trigger changes in the number of ticks, the staggering of the ticks, and the layout of the legend. In addition, the numbers in the quality graphs in the compare view are now formatted to take up less space.

To test, run `npm install` and `bundle.sh --vendor`. Make sure all charts look similar to the originals  and that things don't  start overlapping or get cut off when the height and/or width of the screen gets small.

##### Known Issues
* ~~There is an error message that shows up in Chrome (but not Firefox) when showing vertical charts despite things rendering properly. I'm having a hard time figuring this out.~~ Fixed by https://github.com/lewfish/model-my-watershed/commit/f0344f744d7f38d01dfc6a0aa3a68621a403c629
<img width="720" alt="screen shot 2015-11-12 at 9 55 50 am" src="https://cloud.githubusercontent.com/assets/1896461/11121558/95e55234-8924-11e5-8a51-27a645ca90e9.png">
* The NVD3 library doesn't currently support ordering the legend using the same order as the bar segments. It also doesn't let you put the legend to the right, so this looks different than before. I think we can patch NVD3 in a separate PR.
![screen shot 2015-11-12 at 9 56 09 am 2](https://cloud.githubusercontent.com/assets/1896461/11121616/e51b6c30-8924-11e5-8ee0-0d00a65bc850.png)
![screen shot 2015-11-12 at 9 55 37 am 2](https://cloud.githubusercontent.com/assets/1896461/11121617/e684c382-8924-11e5-9a9e-010b061daa2e.png)


Connects #857 
Connects #994 
Connects #853 