### PR TITLE
Fix screenshots of compare view

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -105,13 +105,13 @@ function initializeShutterbug() {
     $(window)
         .on('shutterbug-saycheese', function() {
             // Set fixed width before screenshot to constrain width to viewport
-            $('#model-output-wrapper, .map-container').css({
+            $('#model-output-wrapper, body > .map-container').css({
                 'width': window.innerWidth
             });
         })
         .on('shutterbug-asyouwere', function() {
             // Reset after screenshot has been taken
-            $('#model-output-wrapper, .map-container').css({
+            $('#model-output-wrapper, body > .map-container').css({
                 'width': ''
             });
         });


### PR DESCRIPTION
## Overview

Because the CSS selector wasn't specific enough, it would set the width of each `.map-container` in the compare view to 100%. By specifically targeting the one immediately below the body, we ensure that the views render correctly.

## Testing Instructions

If you would like to test, follow the instructions in #809.

## Demo

![image](https://cloud.githubusercontent.com/assets/1430060/11228135/a3416d40-8d58-11e5-9a4e-689cff900e02.png)

Connects #1024