### PR TITLE
Slim down bars and add tooltips to bar segments

### DIFF
--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -44,7 +44,7 @@ function getNumBars(data) {
     note that x corresponds to the vertical axis since this is a horizontal bar
     chart.
 
-    options includes: barClasses, margin, yAxisLabel, isPercentage,
+    options includes: barClasses, margin, yAxisLabel, isPercentage, maxBarHeight
     and abbreviateTicks
 */
 function renderHorizontalBarChart(chartEl, data, options) {
@@ -76,10 +76,25 @@ function renderHorizontalBarChart(chartEl, data, options) {
         });
     }
 
+    function setChartHeight() {
+        // Set chart height to ensure that bars (and their padding)
+        // are no taller than maxBarHeight.
+        var numBars = getNumBars(data),
+            maxHeight = options.margin.top + options.margin.bottom +
+                        numBars * options.maxBarHeight,
+            actualHeight = $(svg).height();
+
+        if (actualHeight > maxHeight) {
+            chart.height(maxHeight);
+        } else {
+            chart.height(actualHeight);
+        }
+    }
+
     function updateChart() {
-        // Throws error if updating a hidden svg.
         if($(svg).is(':visible')) {
-            chart.update();
+            setChartHeight();
+            chart.update(); // Throws error if updating a hidden svg.
             if (options.barClasses) {
                 addBarClasses();
             }
@@ -87,13 +102,18 @@ function renderHorizontalBarChart(chartEl, data, options) {
     }
 
     options = options || {};
+    _.defaults(options, {
+        margin: {top: 30, right: 30, bottom: 40, left: 200},
+        maxBarHeight: 150
+    });
 
     nv.addGraph(function() {
         chart.showLegend(false)
              .showControls(false)
              .duration(0)
-             .margin(options.margin || {top: 30, right: 30, bottom: 40, left: 200});
+             .margin(options.margin);
 
+        setChartHeight();
         chart.tooltip.enabled(false);
         chart.yAxis.ticks(5);
         handleCommonOptions(chart, options);

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -203,7 +203,7 @@ function renderVerticalBarChart(chartEl, data, options) {
         setChartWidth();
         // Throws error if this is not set to false for unknown reasons.
         chart.legend.rightAlign(false);
-        chart.tooltip.enabled(false);
+        chart.tooltip.enabled(true);
         chart.yAxis.ticks(5);
         if (options.seriesColors) {
             chart.color(options.seriesColors);

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -78,7 +78,7 @@ var ResultView = Marionette.ItemView.extend({
             chartOptions = {
                 seriesColors: ['#F8AA00', '#CF4300', '#C2D33C'],
                 yAxisLabel: 'Level',
-                margin: this.compareMode ? {top: 20, right: 0, bottom: 40, left: 60} : null
+                margin: this.compareMode ? {top: 20, right: 0, bottom: 40, left: 60} : undefined
             };
 
             chart.renderVerticalBarChart(chartEl, data, chartOptions);


### PR DESCRIPTION
This PR puts a maximum width on bars in vertical charts (and similar for horizontal charts). It also adds tooltips to vertical stacked bar charts so that it is easier to see the value of individual bar segments. 

Before and after screenshots. Note tooltip in second screenshot.
![screen shot 2015-11-18 at 11 18 53 am 2](https://cloud.githubusercontent.com/assets/1896461/11246606/584917fa-8de6-11e5-9c05-531507c93e1a.png)
![screen shot 2015-11-18 at 10 58 07 am 2](https://cloud.githubusercontent.com/assets/1896461/11246608/59c75e5c-8de6-11e5-93d6-5beade6a73f9.png)
![screen shot 2015-11-18 at 11 18 33 am 2](https://cloud.githubusercontent.com/assets/1896461/11246660/93f99e78-8de6-11e5-9043-997e301d1082.png)
![screen shot 2015-11-18 at 10 42 54 am 2](https://cloud.githubusercontent.com/assets/1896461/11246635/75128128-8de6-11e5-9010-cbfe3cae0534.png)

Connects #1011 
Connects #1019 