### PR TITLE
Upgrade Geoprocessing to 0.3.2

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -39,7 +39,7 @@ docker_options: "--storage-driver=aufs"
 sjs_host: "localhost"
 sjs_port: 8090
 
-geop_version: "0.3.0"
+geop_version: "0.3.2"
 
 nginx_cache_dir: "/var/cache/nginx"
 observation_api_url: "http://www.wikiwatershed-vs.org/"


### PR DESCRIPTION
Includes https://github.com/WikiWatershed/mmw-geoprocessing/pull/18

Supersedes #1034, since we're now past targeting that release, so targeting `develop` instead. See testing results there.

Connects #1015