### PR TITLE
Move to OpenJDK version to 7u91

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -30,7 +30,7 @@ elasticsearch_cluster_name: "logstash"
 
 nodejs_npm_version: 2.1.17
 
-java_version: "7u85-*"
+java_version: "7u91-*"
 
 docker_version: "1.8.*"
 docker_py_version: "1.2.3"


### PR DESCRIPTION
The previous version, 7u85, seems to no longer be available.

### To Test ###

Reprovision on this branch.  It should succeed.
