### PR TITLE
Open new tab for observation links

### DIFF
--- a/src/mmw/js/src/core/templates/observationPopup.html
+++ b/src/mmw/js/src/core/templates/observationPopup.html
@@ -6,9 +6,9 @@
 {% endif %}
 <div class="measurements-region"></div>
 
-<div>Data from <a href="{{ provider_url }}">{{ provider }}</a></div>
+<div>Data from <a href="{{ provider_url }}" target="_blank">{{ provider }}</a></div>
 {% if url %}
-    <a href="{{ url }}">Original source data</a>
+    <a href="{{ url }}" target="_blank">Original source data</a>
 {% endif %}
 
 {% if measurements.length > 0 %}


### PR DESCRIPTION
Clicking one of the links in the observation popups should open a new tab.

Connects #1043 