### PR TITLE
Fix Squashed Labels on Horizontal Charts

### DIFF
--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -51,7 +51,8 @@ function getNumBars(data) {
 */
 function renderHorizontalBarChart(chartEl, data, options) {
     var chart = nv.models.multiBarHorizontalChart(),
-        svg = makeSvg(chartEl);
+        svg = makeSvg(chartEl),
+        $svg = $(svg);
 
     // Augment data so that it is part of a single series to match
     // the format expected by NVD3.
@@ -84,7 +85,7 @@ function renderHorizontalBarChart(chartEl, data, options) {
         var numBars = getNumBars(data),
             maxHeight = options.margin.top + options.margin.bottom +
                         numBars * options.maxBarHeight,
-            actualHeight = $(svg).height();
+            actualHeight = $svg.height();
 
         if (actualHeight > maxHeight) {
             chart.height(maxHeight);
@@ -94,8 +95,14 @@ function renderHorizontalBarChart(chartEl, data, options) {
     }
 
     function updateChart() {
-        if($(svg).is(':visible')) {
+        var width = $svg.width(),
+            availableWidth = width - (options.margin.left + options.margin.right),
+            minTickWidth = 60,
+            yticks = Math.floor(availableWidth / minTickWidth);
+
+        if($svg.is(':visible')) {
             setChartHeight();
+            chart.yAxis.ticks(Math.min(yticks, 5));
             chart.update(); // Throws error if updating a hidden svg.
             if (options.barClasses) {
                 addBarClasses();
@@ -214,7 +221,6 @@ function renderVerticalBarChart(chartEl, data, options) {
             .rightAlign(false);
         chart.tooltip.enabled(true);
         chart.yAxis.ticks(5);
-
         handleCommonOptions(chart, options);
 
         if (options.yAxisUnit) {


### PR DESCRIPTION
This is a fix for squashed labels which sometimes occur in horizontal charts.  The attempt is to make sure that each tick on the y-axis is given at least 60 pixels.

Connects #995

## Note ##

A much more obvious solution would have been something like:

```diff
diff --git a/src/mmw/js/src/core/chart.js b/src/mmw/js/src/core/chart.js
index 510b892..7f74108 100644
--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -117,7 +117,9 @@ function renderHorizontalBarChart(chartEl, data, options) {
 
         setChartHeight();
         chart.tooltip.enabled(false);
-        chart.yAxis.ticks(5);
+        chart.yAxis
+            .axisLabelDistance(90)
+            .ticks(5);
         handleCommonOptions(chart, options);
 
         d3.select(svg)
```

but unfortunately, that does not work.

## To Test ##

Load the application and find a horizontal bar chart.  Try stretching and compression the browser horizontally.  Previously, squashing of the labels on the horizontal axis could be observed.

![screenshot from 2015-12-02 15 46 23](https://cloud.githubusercontent.com/assets/11281373/11544258/ed8037c6-990e-11e5-93fa-7ac2021484d9.png)

![screenshot from 2015-12-02 15 46 32](https://cloud.githubusercontent.com/assets/11281373/11544262/f2c0fff4-990e-11e5-8fa6-22de846dc9de.png)

![screenshot from 2015-12-02 15 46 41](https://cloud.githubusercontent.com/assets/11281373/11544266/fb044cd4-990e-11e5-9251-a13f3cc9e661.png)

![screenshot from 2015-12-02 15 46 52](https://cloud.githubusercontent.com/assets/11281373/11544273/04ca2022-990f-11e5-8caf-e8ea5345b163.png)

![screenshot from 2015-12-02 15 47 01](https://cloud.githubusercontent.com/assets/11281373/11544278/09948e80-990f-11e5-8c68-a7d56bf961c0.png)

![screenshot from 2015-12-02 15 47 13](https://cloud.githubusercontent.com/assets/11281373/11544283/0eb6aa7e-990f-11e5-94ad-3d48538d83e4.png)