### PR TITLE
Stub out RWD

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -19,6 +19,27 @@ KG_PER_POUND = 0.453592
 CM_PER_INCH = 2.54
 
 
+def run_rwd(location):
+    # TODO Replace this stub with a call to the real RWD code.
+
+    # Draw a diamond shape around location.
+    offset = 0.0005
+    return [
+        [location[0] + offset, location[1]],
+        [location[0], location[1] + offset],
+        [location[0] - offset, location[1]],
+        [location[0], location[1] - offset]
+    ]
+
+
+@shared_task
+def start_rwd_job(location):
+    print(location)
+    location = json.loads(location)
+
+    return run_rwd(location)
+
+
 @shared_task
 def start_histogram_job(json_polygon):
     """ Calls the histogram_start function to

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -24,6 +24,7 @@ urlpatterns = patterns(
     url(r'start/analyze/$', views.start_analyze, name='start_analyze'),
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),
+    url(r'start/rwd/$', views.start_rwd, name='start_rwd'),
     url(r'boundary-layers/(?P<table_code>\w+)/(?P<obj_id>[0-9]+)/$',
         views.boundary_layer_detail, name='boundary_layer_detail'),
 )

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -157,6 +157,28 @@ def scenario(request, scen_id):
 
 @decorators.api_view(['POST'])
 @decorators.permission_classes((AllowAny, ))
+def start_rwd(request, format=None):
+    user = request.user if request.user.is_authenticated() else None
+    created = now()
+    location = request.POST['location']
+    job = Job.objects.create(created_at=created, result='', error='',
+                             traceback='', user=user, status='started')
+
+    task_list = _initiate_rwd_job_chain(location, job.id)
+
+    job.uuid = task_list.id
+    job.save()
+
+    return Response(
+        {
+            'job': task_list.id,
+            'status': 'started',
+        }
+    )
+
+
+@decorators.api_view(['POST'])
+@decorators.permission_classes((AllowAny, ))
 def start_analyze(request, format=None):
     user = request.user if request.user.is_authenticated() else None
     created = now()
@@ -220,6 +242,16 @@ def _initiate_analyze_job_chain(area_of_interest, job_id, testing=False):
                  .set(exchange=exchange, routing_key=routing_key),
                  tasks.histogram_to_survey.s(),
                  save_job_result.s(job_id, area_of_interest)) \
+        .apply_async(link_error=save_job_error.s(job_id))
+
+
+def _initiate_rwd_job_chain(location, job_id, testing=False):
+    exchange = MAGIC_EXCHANGE
+    routing_key = choose_worker()
+
+    return chain(tasks.start_rwd_job.s(location)
+                 .set(exchange=exchange, routing_key=routing_key),
+                 save_job_result.s(job_id, location)) \
         .apply_async(link_error=save_job_error.s(job_id))
 
 

--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -127,11 +127,9 @@ JS_DEPS=(backbone
          nunjucks
          turf-area
          turf-bbox-polygon
-         turf-buffer
          turf-destination
          turf-erase
          turf-intersect
-         turf-random
          underscore
          zeroclipboard)
 

--- a/src/mmw/js/src/draw/models.js
+++ b/src/mmw/js/src/draw/models.js
@@ -1,13 +1,17 @@
 "use strict";
 
-var Backbone = require('../../shim/backbone');
+var Backbone = require('../../shim/backbone'),
+    _ = require('jquery'),
+    coreModels = require('../core/models');
 
 var ToolbarModel = Backbone.Model.extend({
     defaults: {
         toolsEnabled: true,
         // Array of { endpoint, tableId, display } objects.
         predefinedShapeTypes: null,
-        outlineFeatureGroup: null
+        outlineFeatureGroup: null,
+        polling: false,
+        pollError: false
     },
 
     enableTools: function() {
@@ -19,6 +23,15 @@ var ToolbarModel = Backbone.Model.extend({
     }
 });
 
+var RwdTaskModel = coreModels.TaskModel.extend({
+    defaults: _.extend( {
+            taskName: 'rwd',
+            taskType: 'modeling'
+        }, coreModels.TaskModel.prototype.defaults
+    )
+});
+
 module.exports = {
-    ToolbarModel: ToolbarModel
+    ToolbarModel: ToolbarModel,
+    RwdTaskModel: RwdTaskModel
 };

--- a/src/mmw/js/src/draw/templates/placeMarker.html
+++ b/src/mmw/js/src/draw/templates/placeMarker.html
@@ -1,6 +1,12 @@
 <div id="delineate-shape" class="dropdown menu-left">
   <button class="btn btn-md btn-search-tool dropdown-toggle {{ 'disabled' if not toolsEnabled }}"
       type="button" data-toggle="dropdown" aria-expanded="true">
+    {% if polling %}
+        <i class="fa fa-circle-o-notch fa-spin"></i>
+    {% endif %}
+    {% if pollError %}
+        <i class="fa fa-exclamation-triangle"></i>
+    {% endif %}
     Delineate Watershed
     <span class="caret"></span>
   </button>
@@ -13,7 +19,7 @@
     </li>
     <li role="presentation">
       <a role="menuitem" tabindex="-1" href="#" data-shape-type="slope">
-        <span>Hill Slope</span> <i class="split fa fa-question-circle" 
+        <span>Hill Slope</span> <i class="split fa fa-question-circle"
           data-content="This selects the area contributing water to the exact point selected, regardless of whether the selected point is within a stream channel."></i>
       </a>
     </li>

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -6,7 +6,6 @@ var $ = require('jquery'),
     Marionette = require('../../shim/backbone.marionette'),
     turfArea = require('turf-area'),
     turfBboxPolygon = require('turf-bbox-polygon'),
-    turfBuffer = require('turf-buffer'),
     turfDestination = require('turf-destination'),
     router = require('../router').router,
     App = require('../app'),
@@ -351,7 +350,6 @@ var PlaceMarkerView = Marionette.ItemView.extend({
         var self = this,
             map = App.getLeafletMap(),
             itemName = $(e.currentTarget).text(),
-            itemType = $(e.currentTarget).data('shape-type'),
             revertLayer = clearAoiLayer();
 
         this.model.set('pollError', false);
@@ -360,8 +358,6 @@ var PlaceMarkerView = Marionette.ItemView.extend({
         utils.placeMarker(map)
             .then(function(latlng) {
                 var point = L.marker(latlng).toGeoJSON(),
-                    buffered = turfBuffer(point, 5000, 'meters'),
-                    bounds = L.geoJson(buffered).getBounds(),
                     shape,
                     deferred = $.Deferred();
 

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -4282,11 +4282,6 @@
         }
       }
     },
-    "nvd3": {
-      "version": "1.8.1",
-      "from": "nvd3@*",
-      "resolved": "https://registry.npmjs.org/nvd3/-/nvd3-1.8.1.tgz"
-    },
     "retina.js": {
       "version": "1.3.0",
       "from": "../../tmp/npm-31030-7f32f0c4/1436971651112-0.5243154705967754/a70e73639817473bad7bbb33f866b8e060e5f5a7",
@@ -4949,45 +4944,6 @@
         }
       }
     },
-    "turf-buffer": {
-      "version": "1.0.4",
-      "from": "https://registry.npmjs.org/turf-buffer/-/turf-buffer-1.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/turf-buffer/-/turf-buffer-1.0.4.tgz",
-      "dependencies": {
-        "geojson-normalize": {
-          "version": "0.0.0",
-          "from": "https://registry.npmjs.org/geojson-normalize/-/geojson-normalize-0.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/geojson-normalize/-/geojson-normalize-0.0.0.tgz"
-        },
-        "jsts": {
-          "version": "0.15.0",
-          "from": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
-          "resolved": "https://registry.npmjs.org/jsts/-/jsts-0.15.0.tgz",
-          "dependencies": {
-            "javascript.util": {
-              "version": "0.12.5",
-              "from": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz",
-              "resolved": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz"
-            }
-          }
-        },
-        "turf-combine": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/turf-combine/-/turf-combine-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/turf-combine/-/turf-combine-1.0.2.tgz"
-        },
-        "turf-featurecollection": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/turf-featurecollection/-/turf-featurecollection-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/turf-featurecollection/-/turf-featurecollection-1.0.1.tgz"
-        },
-        "turf-polygon": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz"
-        }
-      }
-    },
     "turf-destination": {
       "version": "1.2.1",
       "from": "https://registry.npmjs.org/turf-destination/-/turf-destination-1.2.1.tgz",
@@ -5047,18 +5003,6 @@
               "resolved": "https://registry.npmjs.org/javascript.util/-/javascript.util-0.12.5.tgz"
             }
           }
-        }
-      }
-    },
-    "turf-random": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/turf-random/-/turf-random-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/turf-random/-/turf-random-1.0.2.tgz",
-      "dependencies": {
-        "geojson-random": {
-          "version": "0.2.2",
-          "from": "https://registry.npmjs.org/geojson-random/-/geojson-random-0.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/geojson-random/-/geojson-random-0.2.2.tgz"
         }
       }
     },

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -49,11 +49,9 @@
     "testem": "0.5.15",
     "turf-area": "1.1.1",
     "turf-bbox-polygon": "1.0.1",
-    "turf-buffer": "1.0.4",
     "turf-destination": "1.2.1",
     "turf-erase": "1.3.2",
     "turf-intersect": "1.4.2",
-    "turf-random": "1.0.2",
     "underscore": "1.8.3",
     "watchify": "3.1.0",
     "zeroclipboard": "2.2.0"


### PR DESCRIPTION
This PR stubs out RWD. To test, click on 'Hill Slope' in the 'Delineate Watershed' dropdown and then click a point on the map. This will make a spinner visible next to 'Hill Slope', and will poll the backend, which should return a diamond shaped polygon. The other menu items should work as before (creating random polygons on the frontend). If you disable your network connection before clicking 'Hill Slope', you should see an error icon instead of a spinner, which will be removed if you make another selection from the dropdown. 

I'm not sure how to display the actual error message. We could associate a tooltip with the error icon, but that might not be obvious enough to the user.

Connects #1058 