### PR TITLE
Move to 30m Soil and NLCD tiles

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -101,13 +101,14 @@ def aoi_resolution(area_of_interest):
     average_lat = reduce(lambda total, p: total+p[1], pairs, 0) / len(pairs)
 
     max_lat = 48.7
-    max_lat_count = 10025
+    max_lat_count = 1116  # Number of pixels found in sq km at max lat
     min_lat = 25.2
-    min_lat_count = 9980
+    min_lat_count = 1112  # Number of pixels found in sq km at min lat
 
-    # Because the tile CRS is Conus Albers, the number of pixels per
-    # square kilometer is roughly (but no exactly) 10,000 everywhere
-    # in the CONUS.
+    # Because the tile CRS is Conus Albers @ 30m, the number of pixels per
+    # square kilometer is roughly (but no exactly) 1100 everywhere
+    # in the CONUS.  Iterpolate the number of cells at the current lat along
+    # the range defined above.
     x = (average_lat - min_lat) / (max_lat - min_lat)
     x = min(max(x, 0.0), 1.0)
     pixels_per_sq_kilometer = ((1 - x) * min_lat_count) + (x * max_lat_count)

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -21,7 +21,7 @@ var $ = require('jquery'),
     placeMarkerTmpl = require('./templates/placeMarker.html'),
     settings = require('../core/settings');
 
-var MAX_AREA = 2700; // 2,700 km^2
+var MAX_AREA = 112700; // About the size of a large state
 var codeToLayer = {}; // code to layer mapping
 
 function actOnUI(datum, bool) {

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -367,8 +367,8 @@ GEOP = {
             'geometry': None,
             'tileCRS': 'ConusAlbers',
             'polyCRS': 'LatLng',
-            'nlcdLayer': 'nlcd-10m-epsg5070',
-            'soilLayer': 'ssurgo-soil-groups-10m',
+            'nlcdLayer': 'nlcd-2011-30m-epsg5070',
+            'soilLayer': 'ssurgo-hydro-groups-30m-epsg5070',
             'zoom': 0
         }
     }


### PR DESCRIPTION
* Point application to the new 30m EPSG:5070 soil and nlcd tiles.
* Update pixel / sqkm calculation
* Update size of bounding area allowed

Test:
Restart your worker or `debugcelery` to get updated tasks and check that modeling analyze/modeling results are found
* Test that larger areas (HUC8) return results

The max area will probably have to be tweaked.  Our current office network issues are making it hard to tell what is an acceptable limit.  We may also want to dial back down the polling time, but I think we should play with it in dev before making that decision.

Connects #1032 
Connects https://github.com/WikiWatershed/mmw-geoprocessing/issues/17