### PR TITLE
Ensure that micro site numbers are always on top

### DIFF
--- a/src/mmw/sass/pages/_water-balance.scss
+++ b/src/mmw/sass/pages/_water-balance.scss
@@ -164,6 +164,7 @@
     bottom: 30px;
     padding-bottom: 48px;
     white-space: normal;
+    z-index: 200;
 
     .column {
       position: relative;
@@ -251,6 +252,7 @@
     background-color: $paper;
     border-radius: 0.3rem;
     padding: 16px;
+    z-index: 300;
 
     label {
       padding-top: 4px;


### PR DESCRIPTION
## Overview

Previously the micro site numbers would be obscured on small screens. This change ensures that they are on top of the effect arrows as well as the water column.

## Testing Instructions

Open the micro site and make the browser window really small.

## Demo

![mmw-small-micro-site](https://cloud.githubusercontent.com/assets/1430060/11853541/a4b7c834-a40c-11e5-81da-a9918dd5aabe.gif)

Connects #998 