### PR TITLE
Add RWD service to worker

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,6 +93,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     worker.vm.synced_folder ".", "/vagrant", disabled: true
     worker.vm.synced_folder "src/mmw", "/opt/app/"
 
+    if ENV["VAGRANT_ENV"].nil? || ENV["VAGRANT_ENV"] != "TEST"
+      worker.vm.synced_folder "/opt/rwd-data", "/opt/rwd-data"
+    end
+
     # Docker
     worker.vm.network "forwarded_port", {
       guest: 2375,

--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+rwd_data_path: "/opt/rwd-data"
+rwd_host: "localhost"
+rwd_port: 5000
+rwd_docker_image: "quay.io/wikiwatershed/rwd:0.2.0"

--- a/deployment/ansible/roles/model-my-watershed.rwd/handlers/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart mmw-rwd
+  service: name=mmw-rwd state=restarted

--- a/deployment/ansible/roles/model-my-watershed.rwd/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "model-my-watershed.docker" }

--- a/deployment/ansible/roles/model-my-watershed.rwd/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Pull docker container image
+  command: /usr/bin/docker pull {{ rwd_docker_image }}
+
+- name: Configure upstart service
+  template: src=upstart-mmw-rwd.conf.j2
+            dest=/etc/init/mmw-rwd.conf
+  notify:
+    - Restart mmw-rwd
+
+- name: Ensure service is running
+  service: name=mmw-rwd state=started

--- a/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
@@ -1,0 +1,32 @@
+description "Rapid Watershed Delineation"
+
+{% if ['development', 'test'] | some_are_in(group_names) -%}
+start on (vagrant-mounted)
+{% else %}
+start on (filesystem and started docker)
+{% endif %}
+stop on stopping docker
+
+kill timeout 20
+kill signal CONT
+respawn
+
+pre-start script
+  /usr/bin/docker kill rwd || true
+  /usr/bin/docker rm rwd || true
+end script
+
+exec /usr/bin/docker run \
+  --name rwd \
+  --publish {{ rwd_port }}:5000 \
+  --volume {{ rwd_data_path }}:{{ rwd_data_path }} \
+  {{ rwd_docker_image }}
+
+post-start script
+  while ! nc -w0 {{ rwd_host }} {{ rwd_port }}; do sleep 1; done
+end script
+
+post-stop script
+  /usr/bin/docker kill rwd
+  /usr/bin/docker rm rwd
+end script

--- a/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
@@ -19,7 +19,7 @@ end script
 exec /usr/bin/docker run \
   --name rwd \
   --publish {{ rwd_port }}:5000 \
-  --volume {{ rwd_data_path }}:{{ rwd_data_path }} \
+  --volume {{ rwd_data_path }}:{{ rwd_data_path }}:ro \
   {{ rwd_docker_image }}
 
 post-start script

--- a/deployment/ansible/workers.yml
+++ b/deployment/ansible/workers.yml
@@ -9,3 +9,4 @@
   roles:
     - { role: "model-my-watershed.geoprocessing" }
     - { role: "model-my-watershed.celery-worker" }
+    - { role: "model-my-watershed.rwd" }


### PR DESCRIPTION
To test:
 * Ensure you have the RWD shapefiles mounted at `/opt/rwd-data`.

 * Reload & reprovision worker VM.

```vagrant reload worker --provision```

 * SSH to the worker VM and verify the service returns results.

```curl http://localhost:5000/rwd/-75.276639/39.892986```

Connects #1070