### PR TITLE
Wire in RWD service to UI workflow

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
@@ -8,6 +8,7 @@ proxy_cache_path {{ nginx_cache_dir }} levels=1:2 keys_zone=OBSERVATION:10m max_
 server {
   listen *:80;
   server_name _;
+  client_max_body_size 5M;
 
   root {{ app_home }}/static;
 

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -22,6 +22,12 @@ CM_PER_INCH = 2.54
 
 @shared_task
 def start_rwd_job(location):
+    """
+    Calls the Rapid Watershed Delineation endpoint
+    that is running in the Docker container, and returns
+    the response unless there is an out-of-watershed error
+    which raises an exception.
+    """
     location = json.loads(location)
     rwd_url = 'http://localhost:5000/rwd/%f/%f' % (location[1], location[0])
     response_json = requests.get(rwd_url).json()

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import requests
 from celery import shared_task
 import json
 import logging
@@ -19,25 +20,15 @@ KG_PER_POUND = 0.453592
 CM_PER_INCH = 2.54
 
 
-def run_rwd(location):
-    # TODO Replace this stub with a call to the real RWD code.
-
-    # Draw a diamond shape around location.
-    offset = 0.0005
-    return [
-        [location[0] + offset, location[1]],
-        [location[0], location[1] + offset],
-        [location[0] - offset, location[1]],
-        [location[0], location[1] - offset]
-    ]
-
-
 @shared_task
 def start_rwd_job(location):
-    print(location)
     location = json.loads(location)
+    rwd_url = 'http://localhost:5000/rwd/%f/%f' % (location[1], location[0])
+    response_json = requests.get(rwd_url).json()
+    if 'error' in response_json:
+        raise Exception(response_json['error'])
 
-    return run_rwd(location)
+    return response_json
 
 
 @shared_task

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -158,6 +158,9 @@ def scenario(request, scen_id):
 @decorators.api_view(['POST'])
 @decorators.permission_classes((AllowAny, ))
 def start_rwd(request, format=None):
+    """
+    Starts a job to run Rapid Watershed Delineation on a point-based location.
+    """
     user = request.user if request.user.is_authenticated() else None
     created = now()
     location = request.POST['location']

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -146,7 +146,7 @@ var TaskModel = Backbone.Model.extend({
                         if (error && error.cancelledJob) {
                             console.log('Job ' + error.cancelledJob + ' was cancelled.');
                         } else {
-                            taskHelper.pollFailure();
+                            taskHelper.pollFailure(error);
                         }
                     })
                     .always(taskHelper.pollEnd);

--- a/src/mmw/js/src/draw/models.js
+++ b/src/mmw/js/src/draw/models.js
@@ -23,6 +23,7 @@ var ToolbarModel = Backbone.Model.extend({
     }
 });
 
+// Used for running Rapid Watershed Delineation tasks.
 var RwdTaskModel = coreModels.TaskModel.extend({
     defaults: _.extend( {
             taskName: 'rwd',

--- a/src/mmw/js/src/draw/templates/placeMarker.html
+++ b/src/mmw/js/src/draw/templates/placeMarker.html
@@ -23,11 +23,5 @@
           data-content="This selects the area contributing water to the exact point selected, regardless of whether the selected point is within a stream channel."></i>
       </a>
     </li>
-    <li role="presentation">
-      <a role="menuitem" tabindex="-1" href="#" data-shape-type="flow">
-        <span>Trace Flow Down</span> <i class="split fa fa-question-circle"
-          data-content="The does not select an area, but rather draws a line from the selected point along its whole flow path to the ocean."></i>
-      </a>
-    </li>
   </ul>
 </div>

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -20,7 +20,7 @@ var $ = require('jquery'),
     placeMarkerTmpl = require('./templates/placeMarker.html'),
     settings = require('../core/settings');
 
-var MAX_AREA = 112700; // About the size of a large state
+var MAX_AREA = 112700; // About the size of a large state (in km^2)
 var codeToLayer = {}; // code to layer mapping
 
 function actOnUI(datum, bool) {
@@ -356,7 +356,7 @@ var PlaceMarkerView = Marionette.ItemView.extend({
 
         this.model.disableTools();
         utils.placeMarker(map)
-            .then(function(latlng) {
+             .then(function(latlng) {
                 var point = L.marker(latlng).toGeoJSON(),
                     shape,
                     deferred = $.Deferred();
@@ -366,20 +366,18 @@ var PlaceMarkerView = Marionette.ItemView.extend({
                         self.model.set('polling', true);
                     },
 
-                    pollSuccess: function(results) {
-                        var latlngs = _.map(JSON.parse(results.result), function(latLng) {
-                            return L.latLng(latLng[0], latLng[1]);
-                        });
-                        shape = L.polygon(latlngs).toGeoJSON();
+                    pollSuccess: function(response) {
+                        shape = JSON.parse(response.result).features[0];
                         self.model.set('polling', false);
                         deferred.resolve(shape);
                     },
 
-                    pollFailure: function() {
+                    pollFailure: function(response) {
                         self.model.set({
                             pollError: true,
                             polling: false
                         });
+                        console.log(response.error);                        
                         deferred.reject();
                     },
 
@@ -411,7 +409,8 @@ var PlaceMarkerView = Marionette.ItemView.extend({
             })
             .fail(function() {
                 revertLayer();
-            }).always(function() {
+            })
+            .always(function() {
                 self.model.enableTools();
             });
     }

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -82,6 +82,7 @@ var ToolbarView = Marionette.LayoutView.extend({
         this.model.set('streamFeatureGroup', sfg);
         map.addLayer(ofg);
         map.addLayer(sfg);
+        this.rwdTaskModel = new models.RwdTaskModel();
     },
 
     onDestroy: function() {
@@ -108,12 +109,14 @@ var ToolbarView = Marionette.LayoutView.extend({
         }
         if (_.contains(draw_tools, 'PlaceMarker')) {
             this.placeMarkerRegion.show(new PlaceMarkerView({
-                model: this.model
+                model: this.model,
+                rwdTaskModel: this.rwdTaskModel
             }));
         }
         if (_.contains(draw_tools, 'ResetDraw')) {
             this.resetRegion.show(new ResetDrawView({
-                model: this.model
+                model: this.model,
+                rwdTaskModel: this.rwdTaskModel
             }));
         }
     }
@@ -342,8 +345,8 @@ var PlaceMarkerView = Marionette.ItemView.extend({
         'change:pollError': 'render'
     },
 
-    initialize: function() {
-        this.rwdTaskModel = new models.RwdTaskModel();
+    initialize: function(options) {
+        this.rwdTaskModel = options.rwdTaskModel;
     },
 
     onItemClicked: function(e) {
@@ -423,7 +426,18 @@ var ResetDrawView = Marionette.ItemView.extend({
 
     events: { 'click @ui.reset': 'resetDrawingState' },
 
+    initialize: function(options) {
+        this.rwdTaskModel = options.rwdTaskModel;
+    },
+
     resetDrawingState: function() {
+        this.rwdTaskModel.reset();
+        this.model.set({
+            polling: false,
+            pollError: false
+        });
+        this.model.enableTools();
+
         utils.cancelDrawing(App.getLeafletMap());
         clearAoiLayer();
         clearBoundaryLayer(this.model);

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -10,3 +10,4 @@ python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
 tr55==1.0.6
+requests==2.9.1


### PR DESCRIPTION
This enables the RWD REST API to be called by the RWD Celery task, and the results to be visualized in the UI.

##### Testing
* Run `./scripts/debugcelery.sh` to make sure the worker is running the latest worker code.
* In the Delineate Watershed menu, click either of the options (they do the same thing for now).
* Click a point near the Delaware River. After polling, it should set the AOI to the computed watershed.
* Reset and then click a point outside the Delaware River Basin. It should result in an error icon and message printed to the console.
* Clicking Reset should work at the following points in time. The original functionality for the other parts of the ToolbarView should be preserved.
 * after clicking the menu item, but before clicking a point on the map
 * after a polling failure
 * while polling (it will cancel the job)
 * after the results are shown on the map

##### Known Issues
* We should probably display the error message to the user when there's a polling failure. Maybe show a popup on the map? Currently, we show an alert box when the user draws an AOI that is too big, which seems kind of clunky. \cc @mmcfarland 

Connects #1071 

Here is the watershed computed for a point in Philly.
![screen shot 2016-01-07 at 1 05 03 pm 2](https://cloud.githubusercontent.com/assets/1896461/12178436/73a39298-b53f-11e5-96aa-8508148329ae.png)
![screen shot 2016-01-07 at 1 05 16 pm 2](https://cloud.githubusercontent.com/assets/1896461/12178451/853d4f62-b53f-11e5-922f-26fbfecf9c7d.png)

