### PR TITLE
Fix libpq version reference

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -21,7 +21,7 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*-1.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "9.4.*.pgdg14.04+1"
+postgresql_support_libpq_version: "9.5.*.pgdg14.04+2"
 postgresql_support_psycopg2_version: "2.6"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"


### PR DESCRIPTION
The PostgreSQL APT repositories are preparing to release PostgreSQL 9.5, which is shifting several base packages in and out of the main repository channel.