### PR TITLE
Upgrade SJS to 0.6.1; account for job status API change

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -39,7 +39,7 @@ docker_options: "--storage-driver=aufs"
 sjs_host: "localhost"
 sjs_port: 8090
 
-geop_version: "0.3.2"
+geop_version: "0.4.0"
 
 nginx_cache_dir: "/var/cache/nginx"
 observation_api_url: "http://www.wikiwatershed-vs.org/"

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
@@ -27,7 +27,7 @@ exec /usr/bin/docker run \
   --env {{ k }}={{ v }} \
   {% endfor -%}
   --log-driver syslog \
-  quay.io/azavea/spark-jobserver:latest --driver-memory {{ sjs_driver_memory }}
+  quay.io/azavea/spark-jobserver:0.6.1 --driver-memory {{ sjs_driver_memory }}
 
 post-start script
   while ! nc -w0 {{ sjs_host }} {{ sjs_port }}; do sleep 1; done

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -116,11 +116,8 @@ def histogram_finish(job_id, retry):
     else:
         raise Exception('Unable to communicate with SJS (bottom-half).')
 
-    if data['status'] == 'OK':
-        if delete(url):  # job complete, remove
-            return [dict_to_array(d) for d in data['result']]
-        else:
-            raise Exception('Job completed, unable to delete.')
+    if data['status'] == 'FINISHED':
+        return [dict_to_array(d) for d in data['result']]
     elif data['status'] == 'RUNNING':
         try:
             retry()


### PR DESCRIPTION
Make use of the Spark Job Server (SJS) 0.6.1 container image, and account for behavior changes on successful job competition. Before, when a job completed successfully, we removed it from the list of jobs as a maintenance task. Now, it appears that SJS takes care of this by itself. In addition, it changed the status field in the job status API call from `OK` to `FINISHED`.

Attempts to resolve #1079
Depends on https://github.com/WikiWatershed/mmw-geoprocessing/pull/21

---

**Testing**

First, build an assembly JAR from https://github.com/WikiWatershed/mmw-geoprocessing/pull/21 using Scala 2.10:

```bash
$ docker run --rm -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt \
    -v ${PWD}:/mmw-geoprocessing -w /mmw-geoprocessing \
    quay.io/azavea/scala:2.10.5 ./sbt assembly
```

Next, provision with `worker` virtual machine with this branch, then `scp` the assembly JAR:

```bash
$ scp ./summary/target/scala-2.10/mmw-geoprocessing-assembly-0.3.2.jar vagrant@33.33.34.20:
```

Then, SSH into the `worker` and overwrite the geoprocessing JAR:

```bash
$ vagrant ssh worker
vagrant@worker:~$ sudo mv mmw-geoprocessing-assembly-0.3.2.jar \
    /opt/geoprocessing/mmw-geoprocessing-0.3.2.jar 
```

Lastly, reload the `worker` virtual machine:

```bash
$ vagrant reload worker
```