### PR TITLE
Add Hydrologic Soil Group layer

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -124,6 +124,23 @@ LAYERS = [
         'has_opacity_slider': True
     },
     {
+        'display': 'Hydrologic Soil Groups',
+        'short_display': 'SSURGO',
+        'helptext': 'Soils are classified by the Natural Resource Conservation '
+                    'Service into four Hydrologic Soil Groups based on the '
+                    'soil\'s runoff potential. The four Hydrologic Soils Groups'
+                    'are A, B, C and D. Where A\'s generally have the smallest '
+                    'runoff potential and D\'s the greatest.',
+        'url': 'https://s3.amazonaws.com/com.azavea.datahub.tms/'
+               'ssurgo-hydro-group-30m/{z}/{x}/{y}.png',
+        'raster': True,
+        'overlay': True,
+        'maxNativeZoom': 13,
+        'maxZoom': 18,
+        'opacity': 0.618,
+        'has_opacity_slider': True
+    },
+    {
         'code': 'stream-low',
         'display': 'Low-Res',
         'table_name': 'deldem4net100r',

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -99,7 +99,7 @@
     // Be as tall as the map container,
     // minus some space for the attribution
     height: 83%;
-    max-height: 340px;
+    max-height: 365px;
 
     h4 {
       font-size: 15px;


### PR DESCRIPTION
This adds the Hydrologic Soil Group layer to the layer selector which references the tiles generated in https://github.com/azavea/azavea-data-hub/pull/21

![screen shot 2016-01-12 at 10 28 13 am 2](https://cloud.githubusercontent.com/assets/1896461/12267673/3c99829a-b917-11e5-9701-9d99b275968a.png)
