### PR TITLE
Fix stray reference to latest tag of SJS image

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -38,6 +38,7 @@ docker_options: "--storage-driver=aufs"
 
 sjs_host: "localhost"
 sjs_port: 8090
+sjs_container_image: "quay.io/azavea/spark-jobserver:0.6.1"
 
 geop_version: "0.4.0"
 

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
@@ -37,7 +37,7 @@
     - Restart Nginx
 
 - name: Pull Spark Job Server container image
-  command: /usr/bin/docker pull quay.io/azavea/spark-jobserver:latest
+  command: /usr/bin/docker pull quay.io/azavea/spark-jobserver:0.6.1
 
 - name: Configure Spark Job Server service definition
   template: src=upstart-spark-jobserver.conf.j2

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
@@ -37,7 +37,7 @@
     - Restart Nginx
 
 - name: Pull Spark Job Server container image
-  command: /usr/bin/docker pull quay.io/azavea/spark-jobserver:0.6.1
+  command: "/usr/bin/docker pull {{ sjs_container_image }}"
 
 - name: Configure Spark Job Server service definition
   template: src=upstart-spark-jobserver.conf.j2

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
@@ -27,7 +27,7 @@ exec /usr/bin/docker run \
   --env {{ k }}={{ v }} \
   {% endfor -%}
   --log-driver syslog \
-  quay.io/azavea/spark-jobserver:0.6.1 --driver-memory {{ sjs_driver_memory }}
+  {{ sjs_container_image }} --driver-memory {{ sjs_driver_memory }}
 
 post-start script
   while ! nc -w0 {{ sjs_host }} {{ sjs_port }}; do sleep 1; done


### PR DESCRIPTION
Don't use the `latest` tag to pull down the initial version of the SJS container image. Instead, use a specific version (0.6.1).