### PR TITLE
Fix postgres package build version.

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -19,7 +19,7 @@ postgresql_password: mmw
 postgresql_database: mmw
 
 postgresql_version: "9.4"
-postgresql_package_version: "9.4.*-1.pgdg14.04+1"
+postgresql_package_version: "9.4.*-2.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
 postgresql_support_libpq_version: "9.5.*.pgdg14.04+2"
 postgresql_support_psycopg2_version: "2.6"


### PR DESCRIPTION
The specified version was no longer available.

You would get the following error with the old version:

```
TASK: [azavea.postgresql | Install PostgreSQL] ********************************
failed: [services] => (item=postgresql-9.4=9.4.*-1.pgdg14.04+1,postgresql-server-dev-9.4=9.4.*-1.pgdg14.04+1) => {"failed": true, "item": "postgresql-9.4=9.4.*-1.pgdg14.04+1,postgresql-server-dev-9.4=9.4.*-1.pgdg14.04+1"}
stderr: E: Version '9.4.*-1.pgdg14.04+1' for 'postgresql-9.4' was not found
E: Version '9.4.*-1.pgdg14.04+1' for 'postgresql-server-dev-9.4' was not found

stdout: Reading package lists...
Building dependency tree...
Reading state information...

msg: '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"   install 'postgresql-9.4=9.4.*-1.pgdg14.04+1' 'postgresql-server-dev-9.4=9.4.*-1.pgdg14.04+1'' failed: E: Version '9.4.*-1.pgdg14.04+1' for 'postgresql-9.4' was not found
E: Version '9.4.*-1.pgdg14.04+1' for 'postgresql-server-dev-9.4' was not found


FATAL: all hosts have already failed -- aborting
```

**Testing instructions**
- Reprovision the services VM and ensure postgresql can be installed.

Thanks @hectcastro for the fix.