### PR TITLE
Use backported kernel to avoid recent AUFS bugs

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -32,7 +32,7 @@ nodejs_npm_version: 2.1.17
 
 java_version: "7u91-*"
 
-docker_version: "1.8.*"
+docker_version: "1.9.*"
 docker_py_version: "1.2.3"
 docker_options: "--storage-driver=aufs"
 

--- a/deployment/ansible/roles/model-my-watershed.rwd/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
-- name: Pull docker container image
+- name: Create RWD data directory
+  file: path="{{ rwd_data_path }}"
+        state=directory
+
+- name: Pull RWD docker container image
   command: /usr/bin/docker pull {{ rwd_docker_image }}
 
-- name: Configure upstart service
+- name: Configure RWD service definition
   template: src=upstart-mmw-rwd.conf.j2
             dest=/etc/init/mmw-rwd.conf
   notify:

--- a/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
@@ -1,7 +1,7 @@
 description "Rapid Watershed Delineation"
 
 {% if ['development', 'test'] | some_are_in(group_names) -%}
-start on (vagrant-mounted)
+start on (vagrant-mounted and started docker)
 {% else %}
 start on (filesystem and started docker)
 {% endif %}

--- a/deployment/ansible/workers.yml
+++ b/deployment/ansible/workers.yml
@@ -6,6 +6,14 @@
     - name: Update APT cache
       apt: update_cache=yes cache_valid_time=3600
 
+    - name: Install backported kernel
+      apt: pkg={{ item }} state=present
+      with_items:
+        - linux-headers-3.19.0-39
+        - linux-headers-3.19.0-39-generic
+        - linux-image-3.19.0-39-generic
+        - linux-image-extra-3.19.0-39-generic
+
   roles:
     - { role: "model-my-watershed.geoprocessing" }
     - { role: "model-my-watershed.celery-worker" }


### PR DESCRIPTION
Bugs in a recent version of AUFS (included in the kernel) can produce zombie processes that consume 100% CPU utilization. Using a backported kernel allows things to continue to function as they did prior to the bug. We'll remove this workaround once the fix is included in another kernel update.

See also:

- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1533043
- https://bugzilla.kernel.org/show_bug.cgi?id=109971

---

**Testing**

First, provision the `worker` virtual machine:

```bash
$ vagrant provision worker
```

Then, ensure that you reload the `worker` so that the backported kernel can be used:

```bash
$ vagrant reload worker
```

Next, SSH into the worker and attempt to restart the SJS service:

```bash
$ vagrant ssh worker
vagrant@worker:~$ sudo restart spark-jobserver
```

Lastly, confirm that SJS/Spark is a child process of the Docker daemon, and that SJS is not associated with a defunct JVM:

```bash
vagrant@worker:~$ ps axf
...
  908 ?        Ssl    0:00 /usr/bin/docker daemon -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock --storage-driver=aufs
 1945 ?        Sl     0:00  \_ docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 5000 -container-ip 172.17.0.3 -container-port 5000
 1982 ?        Ss     0:00  \_ /usr/local/bin/python2 /usr/local/bin/gunicorn -w 4 --log-syslog --bind 0.0.0.0:5000 main:app
 2186 ?        S      0:00  |   \_ /usr/local/bin/python2 /usr/local/bin/gunicorn -w 4 --log-syslog --bind 0.0.0.0:5000 main:app
 2190 ?        S      0:00  |   \_ /usr/local/bin/python2 /usr/local/bin/gunicorn -w 4 --log-syslog --bind 0.0.0.0:5000 main:app
 2196 ?        S      0:00  |   \_ /usr/local/bin/python2 /usr/local/bin/gunicorn -w 4 --log-syslog --bind 0.0.0.0:5000 main:app
 2199 ?        S      0:00  |   \_ /usr/local/bin/python2 /usr/local/bin/gunicorn -w 4 --log-syslog --bind 0.0.0.0:5000 main:app
 3448 ?        Sl     0:00  \_ docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8090 -container-ip 172.17.0.2 -container-port 8090
 3460 ?        Ssl    0:11  \_ /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java -cp /opt/spark/conf/:/opt/spark/lib/spark-assembly-1.5.2-hadoop2.6.0.jar:...
...
```