### PR TITLE
TR55 Table Output Columns

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -146,7 +146,8 @@ def format_quality(model_output):
         measure, code = input
         return {
             'measure': measure,
-            'load': model_output['modified'][code] * KG_PER_POUND
+            'load': model_output['modified'][code] * KG_PER_POUND,
+            'runoff': model_output['modified']['runoff']  # Already CM
         }
 
     return map(fn, zip(measures, codes))

--- a/src/mmw/js/src/modeling/tr55/models.js
+++ b/src/mmw/js/src/modeling/tr55/models.js
@@ -1,0 +1,36 @@
+"use strict";
+
+var Backbone = require('backbone'),
+    turfArea = require('turf-area');
+
+var AoiVolumeModel = Backbone.Model.extend({
+    defaults: {
+        areaOfInterest: null,
+        aoiArea: 0
+    },
+
+    initialize: function() {
+        if (this.canSetArea) {
+            this.setArea();
+        }
+
+        this.on('change:areaOfInterest', this.setArea);
+    },
+
+    canSetArea: function() {
+        return this.get('areaOfInterest') && !this.get('aoiArea');
+    },
+
+    setArea: function() {
+        this.set('aoiArea', turfArea(this.get('areaOfInterest')));
+    },
+
+    adjust: function(depth) {
+        // Adjusted runoff is depth (cm) -> meters * the AoI area (m2)
+        return (depth / 100) * this.get('aoiArea');
+    }
+});
+
+module.exports = {
+    AoiVolumeModel: AoiVolumeModel
+};

--- a/src/mmw/js/src/modeling/tr55/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/table.html
@@ -3,6 +3,7 @@
         <tr>
             <th data-sortable="true">Quality Measure</th>
             <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Load (kg)</th>
+            <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Average Concentration (g/L)</th>
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/modeling/tr55/quality/templates/tableRow.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/tableRow.html
@@ -1,2 +1,3 @@
 <td>{{ measure }}</td>
 <td class="strong text-left">{{ load|round(3)|toLocaleString }}</td>
+<td class="strong text-left">{{ concentration|round(3)|toLocaleString }}</td>

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -4,6 +4,7 @@ var $ = require('jquery'),
     _ = require('underscore'),
     Backbone = require('../../../../shim/backbone'),
     Marionette = require('../../../../shim/backbone.marionette'),
+    AoiVolumeModel = require('../models').AoiVolumeModel,
     chart = require('../../../core/chart.js'),
     barChartTmpl = require('../../../core/templates/barChart.html'),
     resultTmpl = require('./templates/result.html'),
@@ -34,6 +35,9 @@ var ResultView = Marionette.LayoutView.extend({
 
     initialize: function(options) {
         this.compareMode = options.compareMode;
+        this.aoiVolumeModel = new AoiVolumeModel({
+            areaOfInterest: this.options.areaOfInterest
+        });
     },
 
     onShow: function() {
@@ -50,6 +54,7 @@ var ResultView = Marionette.LayoutView.extend({
                 );
 
                 this.tableRegion.show(new TableView({
+                    aoiVolumeModel: this.aoiVolumeModel,
                     collection: dataCollection
                 }));
 
@@ -64,12 +69,28 @@ var ResultView = Marionette.LayoutView.extend({
 
 var TableRowView = Marionette.ItemView.extend({
     tagName: 'tr',
-    template: tableRowTmpl
+    template: tableRowTmpl,
+
+    templateHelpers: function() {
+        var load = this.model.get('load'),
+            runoff = this.model.get('runoff'),
+            adjustedRunoff = this.options.aoiVolumeModel.adjust(runoff);
+
+        return {
+            concentration: load / adjustedRunoff
+        };
+    }
 });
 
 var TableView = Marionette.CompositeView.extend({
     childView: TableRowView,
     childViewContainer: 'tbody',
+    childViewOptions: function() {
+        return {
+            aoiVolumeModel: this.options.aoiVolumeModel
+        };
+    },
+
     template: tableTmpl,
 
     onAttach: function() {

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
@@ -1,0 +1,2 @@
+<div class="left runoff-table-region"></div>
+<div class="right ui-light runoff-chart-region"></div>

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
@@ -2,8 +2,9 @@
     <thead>
         <tr>
             <th data-sortable="true">Scenario</th>
-            <th data-sortable="true">Runoff Type</th>
-            <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Depth (cm)</th>
+            <th data-sortable="true">Runoff Partition</th>
+            <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Water Depth (cm)</th>
+            <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Water Volume (m<sup>3</sup>)</th>
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
@@ -1,0 +1,11 @@
+<table class="table custom-hover" data-toggle="table">
+    <thead>
+        <tr>
+            <th data-sortable="true">Scenario</th>
+            <th data-sortable="true">Runoff Type</th>
+            <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Depth (cm)</th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/tableRow.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/tableRow.html
@@ -1,0 +1,3 @@
+<td>{{ scenario }}</td>
+<td>{{ runoffType }}</td>
+<td class="strong text-left">{{ depth|round(3)|toLocaleString }}</td>

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/tableRow.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/tableRow.html
@@ -1,3 +1,4 @@
 <td>{{ scenario }}</td>
 <td>{{ runoffType }}</td>
 <td class="strong text-left">{{ depth|round(3)|toLocaleString }}</td>
+<td class="strong ">{{ adjustedVolume|round(2)|toLocaleString }}</td>

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -2,21 +2,58 @@
 
 var $ = require('jquery'),
     _ = require('underscore'),
+    Backbone = require('backbone'),
     Marionette = require('../../../../shim/backbone.marionette'),
     chart = require('../../../core/chart.js'),
-    barChartTmpl = require('../../../core/templates/barChart.html');
+    barChartTmpl = require('../../../core/templates/barChart.html'),
+    resultTmpl = require('./templates/result.html'),
+    tableRowTmpl = require('./templates/tableRow.html'),
+    tableTmpl = require('./templates/table.html');
 
-var ResultView = Marionette.ItemView.extend({
-    template: barChartTmpl,
+var ResultView = Marionette.LayoutView.extend({
+    template: resultTmpl,
 
-    className: 'chart-container runoff-chart-container',
+    regions: {
+        tableRegion: '.runoff-table-region',
+        chartRegion: '.runoff-chart-region'
+    },
 
     modelEvents: {
-        'change': 'addChart'
+        'change': 'onShow'
     },
 
     initialize: function(options) {
-        this.compareMode = options.compareMode;
+        this.scenario = options.scenario;
+    },
+
+    onShow: function() {
+        this.tableRegion.reset();
+        this.chartRegion.reset();
+
+        if (this.model.get('result')) {
+            var dataCollection = new Backbone.Collection(
+                this.model.get('result')
+            );
+
+            this.tableRegion.show(new TableView({
+                scenario: this.scenario,
+                data: dataCollection
+            }));
+
+            this.chartRegion.show(new ChartView({
+                model: this.model,
+                scenario: this.scenario,
+                collection: dataCollection
+            }));
+        }
+    }
+});
+
+var ChartView = Marionette.ItemView.extend({
+    template: barChartTmpl,
+    className: 'chart-container runoff-chart-container',
+
+    initialize: function(options) {
         this.scenario = options.scenario;
     },
 
@@ -86,6 +123,74 @@ var ResultView = Marionette.ItemView.extend({
 
             chart.renderVerticalBarChart(chartEl, data, chartOptions);
         }
+    }
+
+});
+
+var TableRowView = Marionette.ItemView.extend({
+    tagName: 'tr',
+    template: tableRowTmpl
+});
+
+var TableView = Marionette.CompositeView.extend({
+    childView: TableRowView,
+    childViewContainer: 'tbody',
+    template: tableTmpl,
+
+    runoffTypes: [
+        { name: 'runoff', display: 'Runoff' },
+        { name: 'et', display: 'Evapotranspiration' },
+        { name: 'inf', display: 'Infiltration' }
+    ],
+
+    initialize: function(options) {
+        this.collection = this.formatData(options.data, options.scenario);
+    },
+
+    onAttach: function() {
+        $('[data-toggle="table"]').bootstrapTable();
+    },
+
+    formatData: function(data, scenario) {
+        // The TR55 results should be broken down into:
+        // Scenario | Runoff Type | Depth
+        var tr55Results = data.first().attributes,
+            collection = new Backbone.Collection(),
+            // If not Current Conditions, match the graph by calling
+            // the scenario "modified"
+            label = 'Modified';
+
+        // Special cases:  100% Forest may exist as pc_unmodified if scenario
+        // is_current_conditions, otherwise we also want to include unmodified
+        // which is the value of `Current Conditions`.
+        if (scenario.get('is_current_conditions')) {
+            collection.add(this.makeRowsForScenario(tr55Results.pc_unmodified,
+                '100% Forest'));
+            label = scenario.get('name');
+        } else {
+            collection.add(this.makeRowsForScenario(tr55Results.unmodified,
+                'Current Conditions'));
+        }
+
+        collection.add(this.makeRowsForScenario(tr55Results.modified, label));
+
+        return collection;
+    },
+
+    makeRowsForScenario: function(tr55Results, scenarioName) {
+        var self = this;
+        return _.map(this.runoffTypes, function(runoffType) {
+            return _.extend(self.getRunoffTypeValue(tr55Results, runoffType), {
+                scenario: scenarioName
+            });
+        });
+    },
+
+    getRunoffTypeValue: function(tr55ResultRow, runoffType) {
+        return {
+            runoffType: runoffType.display,
+            depth: tr55ResultRow[runoffType.name]
+        };
     }
 });
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -663,6 +663,7 @@ var ModelingResultsWindow = Marionette.LayoutView.extend({
 
         if (scenario) {
             this.detailsRegion.show(new ResultsDetailsView({
+                areaOfInterest: this.model.get('area_of_interest'),
                 collection: scenario.get('results'),
                 scenario: scenario
             }));
@@ -736,7 +737,8 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
 
         this.contentRegion.show(new ResultsTabContentsView({
             collection: this.collection,
-            scenario: this.scenario
+            scenario: this.scenario,
+            areaOfInterest: this.options.areaOfInterest
         }));
     }
 });
@@ -808,6 +810,7 @@ var ResultsTabContentView = Marionette.LayoutView.extend({
 
         this.resultRegion.show(new ResultView({
             model: this.model,
+            areaOfInterest: this.options.areaOfInterest,
             scenario: this.scenario
         }));
     }
@@ -820,7 +823,10 @@ var ResultsTabContentsView = Marionette.CollectionView.extend({
     className: 'tab-content',
     childView: ResultsTabContentView,
     childViewOptions: function() {
-        return {scenario: this.scenario};
+        return {
+            scenario: this.scenario,
+            areaOfInterest: this.options.areaOfInterest
+        };
     },
     initialize: function(options) {
         this.scenario = options.scenario;


### PR DESCRIPTION
* Represent the data in the water depth chart also in table form, including
the additional non-modifed column (either 100% Forest or Current
conditions depending on the scenario).
* Include a new column in the runoff table for the volume adjusted to the
AoI size and the Water Quality table for load adjusted by adjusted
runoff volume.

##### To Test
1. Create an AoI and note it's size (`471907` in my screenshots below)
2. Go to the model page and notice a new table for runoff.
  * Check that the values for water depth are consistent with the chart
  * Check that the values for volume are consistent with the formula: `(depth/100) * aoiArea`
3. Go to the water quality tab
  * Check that the new column, Concentration, has values consistent with the formula `load / modified runoff volume (from above)`

![screenshot from 2016-01-22 11 36 55](https://cloud.githubusercontent.com/assets/1014341/12516795/7990251c-c0fd-11e5-968e-96e1187af156.png)

![screenshot from 2016-01-22 11 37 11](https://cloud.githubusercontent.com/assets/1014341/12516799/7e96069e-c0fd-11e5-9def-4fe470edb0b3.png)

Connects #1091 
Connects #1092 