### PR TITLE
Send BMP area totals to TR55

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -326,7 +326,8 @@ function _alterModifications(rawModifications) {
             newPiece = {
                 name: rawModification.get('name'),
                 shape: rawModification.get('effectiveShape') || rawModification.get('shape'),
-                value: rawModification.get('value')
+                value: rawModification.get('value'),
+                area: 0
             };
 
         for (var j = 0; (j < pieces.length) && (newPiece.shape !== undefined) && (j < n2); ++j) {
@@ -407,7 +408,7 @@ function _alterModifications(rawModifications) {
                 }
             }
         }
-
+        newPiece.area = turfArea(newPiece.shape);
         pieces.push(newPiece);
         pieces = _.filter(pieces, validShape);
     }

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -9,5 +9,5 @@ django-registration-redux==1.2
 python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
-tr55==1.0.6
+tr55==1.1.1
 requests==2.9.1


### PR DESCRIPTION
Updates to TR55 require conservation practices to be passed in as sums
of thier effective area so that infiltration is added across the AoI and
not from a specific location of them.

Connects https://github.com/WikiWatershed/tr-55/issues/59

To test:
* Reprovision `worker` with this branch
* Restart celery to get latest task
* Model an AoI and draw a rain garden, porous paver, veg basin or green roof
* Notice a larger than usual decrease in runoff and a commensurate increase in infiltration
  * Precipitation below 2.5cm may produce *no* runoff when a BMP is applied, try increasing the value
![screenshot from 2016-01-25 18 04 42](https://cloud.githubusercontent.com/assets/1014341/12567826/82902e8e-c38f-11e5-8108-07a2cc18087e.png)
* Draw a very small rain garden and see that it decreases runoff (until the new table is merged in, you may not see a different due to rounding precision).
![screenshot from 2016-01-25 18 14 37](https://cloud.githubusercontent.com/assets/1014341/12567846/9c15f0fa-c38f-11e5-8a01-86f22e80def6.png)
