### PR TITLE
Soil chart and table updates

### DIFF
--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -213,12 +213,12 @@ def data_to_survey(data):
         if nlcd in NLCD_MAPPING:
             update_category(NLCD_MAPPING[nlcd], count, landCategories)
         else:
-            update_category(['?']*2, count, landCategories)
+            update_category([nlcd, nlcd], count, landCategories)
 
         if soil in SOIL_MAPPING:
             update_category(SOIL_MAPPING[soil], count, soilCategories)
         else:
-            update_category(['?']*2, count, soilCategories)
+            update_category([soil, soil], count, soilCategories)
 
     def after_rule(count, survey):
         nlcd_names = [v[1] for v in NLCD_MAPPING.values()]

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -186,13 +186,17 @@ def data_to_survey(data):
     """
     Turn raw data from Geotrellis into a survey.
     """
-    def update_category(string, count, categories):
-        if string in categories:
-            entry = categories[string]
+    def update_category(codeAndValue, count, categories):
+        code = codeAndValue[0]
+        value = codeAndValue[1]
+
+        if value in categories:
+            entry = categories[value]
             entry['area'] += count
         else:
-            categories[string] = {
-                'type': string,
+            categories[value] = {
+                'code': code,
+                'type': value,
                 'area': count,
                 'coverage': None
             }
@@ -207,14 +211,14 @@ def data_to_survey(data):
         soilCategories = survey[1]['categories']
 
         if nlcd in NLCD_MAPPING:
-            update_category(NLCD_MAPPING[nlcd][1], count, landCategories)
+            update_category(NLCD_MAPPING[nlcd], count, landCategories)
         else:
-            update_category('?', count, landCategories)
+            update_category(['?']*2, count, landCategories)
 
         if soil in SOIL_MAPPING:
-            update_category(SOIL_MAPPING[soil][1], count, soilCategories)
+            update_category(SOIL_MAPPING[soil], count, soilCategories)
         else:
-            update_category('?', count, soilCategories)
+            update_category(['?']*2, count, soilCategories)
 
     def after_rule(count, survey):
         nlcd_names = [v[1] for v in NLCD_MAPPING.values()]

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -144,24 +144,28 @@ class ExerciseGeoprocessing(TestCase):
                 "name": "land",
                 "categories": [
                     {
+                        "code": "woody_wetlands",
                         "nlcd": 90,
                         "type": "Woody Wetlands",
                         "coverage": 0.03213078618662748,
                         "area": 4373
                     },
                     {
+                        "code": "developed_med",
                         "nlcd": 23,
                         "type": "Developed, Medium Intensity",
                         "coverage": 0.057817781043350475,
                         "area": 7869
                     },
                     {
+                        "code": "barren_land",
                         "nlcd": 31,
                         "type": "Barren Land (Rock/Sand/Clay)",
                         "coverage": 0.0006024981631153563,
                         "area": 82
                     },
                     {
+                        "code": "developed_low",
                         "nlcd": 22,
                         "type": "Developed, Low Intensity",
                         "coverage": 0.19052902277736958,
@@ -174,18 +178,21 @@ class ExerciseGeoprocessing(TestCase):
                         'area': 0
                     },
                     {
+                        "code": "deciduous_forest",
                         "nlcd": 41,
                         "type": "Deciduous Forest",
                         "coverage": 0.20648052902277736,
                         "area": 28102
                     },
                     {
+                        "code": "open_water",
                         "nlcd": 11,
                         "type": "Open Water",
                         "coverage": 0.005349008082292432,
                         "area": 728
                     },
                     {
+                        "code": "mixed_forest",
                         "nlcd": 43,
                         "type": "Mixed Forest",
                         "coverage": 0.022299779573842764,
@@ -198,42 +205,49 @@ class ExerciseGeoprocessing(TestCase):
                         'area': 0
                     },
                     {
+                        "code": "developed_high",
                         "nlcd": 24,
                         "type": "Developed, High Intensity",
                         "coverage": 0.009639970609845701,
                         "area": 1312
                     },
                     {
+                        "code": "shrub",
                         "nlcd": 52,
                         "type": "Shrub/Scrub",
                         "coverage": 0.03096987509184423,
                         "area": 4215
                     },
                     {
+                        "code": "cultivated_crops",
                         "nlcd": 82,
                         "type": "Cultivated Crops",
                         "coverage": 0.005811903012490816,
                         "area": 791
                     },
                     {
+                        "code": "grassland",
                         "nlcd": 71,
                         "type": "Grassland/Herbaceous",
                         "coverage": 0.0014033798677443056,
                         "area": 191
                     },
                     {
+                        "code": "evergreen_forest",
                         "nlcd": 42,
                         "type": "Evergreen Forest",
                         "coverage": 0.020543717854518737,
                         "area": 2796
                     },
                     {
+                        "code": "developed_open",
                         "nlcd": 21,
                         "type": "Developed, Open Space",
                         "coverage": 0.3669654665686995,
                         "area": 49944
                     },
                     {
+                        "code": "pasture",
                         "nlcd": 81,
                         "type": "Pasture/Hay",
                         "coverage": 0.04945628214548126,
@@ -245,16 +259,19 @@ class ExerciseGeoprocessing(TestCase):
                 "name": "soil",
                 "categories": [
                     {
+                        "code": "b",
                         "type": "B - Moderate Infiltration",
                         "coverage": 0.25432770022042617,
                         "area": 34614
                     },
                     {
+                        "code": "a",
                         "type": "A - High Infiltration",
                         "coverage": 0.49510653930933135,
                         "area": 67384
                     },
                     {
+                        "code": "d",
                         "type": "D - Very Slow Infiltration",
                         "coverage": 0.2505657604702425,
                         "area": 34102

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -203,7 +203,9 @@ var TabContentView = Marionette.LayoutView.extend({
         var categories = this.model.get('categories'),
             largestArea = _.max(_.pluck(categories, 'area')),
             units = utils.magnitudeOfArea(largestArea),
-            census = new coreModels.LandUseCensusCollection(categories);
+            census = this.model.get('name') === 'land' ?
+                new coreModels.LandUseCensusCollection(categories) :
+                new coreModels.SoilCensusCollection(categories);
 
         this.tableRegion.show(new TableView({
             units: units,

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -269,27 +269,31 @@ var ChartView = Marionette.ItemView.extend({
         this.addChart();
     },
 
+    getBarClass: function(item) {
+        var name = this.model.get('name');
+        if (name === 'land') {
+            return 'nlcd-' + item.nlcd;
+        } else if (name === 'soil') {
+            return 'soil-' + item.code;
+        }
+    },
+
     addChart: function() {
-        var chartEl = this.$el.find('.bar-chart').get(0),
+        var self = this,
+            chartEl = this.$el.find('.bar-chart').get(0),
             data = _.map(this.collection.toJSON(), function(model) {
                 return {
                     x: model.type,
                     y: model.coverage,
-                    class: model.nlcd ? 'nlcd-' + model.nlcd : null
+                    class: self.getBarClass(model)
                 };
             }),
-            chartOptions,
-            barClasses = null;
 
-        if (this.model.get('name') === 'land') {
-            barClasses = _.pluck(data, 'class');
-        }
-
-        chartOptions = {
-           yAxisLabel: 'Coverage',
-           isPercentage: true,
-           barClasses: barClasses
-       };
+            chartOptions = {
+               yAxisLabel: 'Coverage',
+               isPercentage: true,
+               barClasses: _.pluck(data, 'class')
+           };
 
         chart.renderHorizontalBarChart(chartEl, data, chartOptions);
     }

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -209,6 +209,10 @@ var LandUseCensusCollection = Backbone.Collection.extend({
     comparator: 'nlcd'
 });
 
+var SoilCensusCollection = Backbone.Collection.extend({
+    comparator: 'code'
+});
+
 var GeoModel = Backbone.Model.extend({
     M_IN_KM: 1000000,
 
@@ -260,6 +264,7 @@ module.exports = {
     MapModel: MapModel,
     TaskModel: TaskModel,
     LandUseCensusCollection: LandUseCensusCollection,
+    SoilCensusCollection: SoilCensusCollection,
     GeoModel: GeoModel,
     AreaOfInterestModel: AreaOfInterestModel,
     AppStateModel: AppStateModel

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -33,6 +33,14 @@
   .nlcd-82 { fill: $nlcd-82; }
   .nlcd-90 { fill: $nlcd-90; }
 
+  .soil-a { fill: $soil-a; }
+  .soil-b { fill: $soil-b; }
+  .soil-c { fill: $soil-c; }
+  .soil-d { fill: $soil-d; }
+  .soil-ad { fill: $soil-ad; }
+  .soil-bd { fill: $soil-bd; }
+  .soil-cd { fill: $soil-cd; }
+
   svg {
     width: 100%;
     height: 100%;

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -50,6 +50,15 @@ $nlcd-81: #FBF65D;
 $nlcd-82: #CA9146;
 $nlcd-90: #C8E6F8;
 
+//Hydrologic Soil Groups
+$soil-a: #ffffd4;
+$soil-b: #fee391;
+$soil-c: #fec44f;
+$soil-d: #8c2d04;
+$soil-ad: #fe9929;
+$soil-bd: #ec7014;
+$soil-cd: #cc4c02;
+
 //Type
 $font-family: 'Roboto', helvetica, arial, sans-serif;
 $font-h1: 1.5rem;


### PR DESCRIPTION
* The analyze hydrologic soil chart will play double duty as a legend with
the colors of the rendered soil layer matching the bar values.
* Start the chart and table sorted alphabetically by group name

To Test:

* Select an area with many soil types and make sure the original teal color is replaced by the corresponding soil group color value (High Infl => Light; Low Infl => Dark)

![screenshot from 2016-01-26 21 18 17](https://cloud.githubusercontent.com/assets/1014341/12601854/8ce1d638-c472-11e5-895f-cbf1fb8b23fa.png)

* Check that the initial sort on both table and chart is alphabetic, and that the NLCD table/chart is still by NLCD code (Open Water is first).

Connects #1111 