### PR TITLE
Load vizer layers asyncronously

### DIFF
--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -11,7 +11,9 @@ module.exports = L.Control.Layers.extend({
 
     // Copied from  https://github.com/Leaflet/Leaflet/blob/master/src/control/Control.Layers.js
     // with modifications for allowing a third layer type (observations)
-    initialize: function (baseLayers, overlays, observationLayers, options) {
+    initialize: function (baseLayers, overlays, observationsDeferred, options) {
+        var self = this;
+
         L.setOptions(this, options);
 
         this._layers = {};
@@ -26,9 +28,18 @@ module.exports = L.Control.Layers.extend({
             this._addLayer(overlays[i], i, 'overlay');
         }
 
-        for (i in observationLayers) {
-            this._addLayer(observationLayers[i], i, 'observation');
-        }
+        observationsDeferred
+            .done(function(observationLayers) {
+                for (i in observationLayers) {
+                    self._addLayer(observationLayers[i], i, 'observation');
+                }
+
+                // Redraw the UI with the new layers
+                self._update();
+            })
+            .fail(function(reason) {
+                $('#observations-layer-list').text(reason);
+            });
     },
 
     // Somewhat copied from https://github.com/Leaflet/Leaflet/blob/master/src/control/Control.Layers.js,

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -196,7 +196,7 @@ var MapView = Marionette.ItemView.extend({
             }),
             overlayLayers = this.prepareOverlayLayers(),
             vizer = new VizerLayers(),
-            layersReadyDeferred = vizer.getLayers();
+            observationsDeferred = vizer.getLayers();
 
         // Center the map on the U.S.
         map.fitBounds([
@@ -223,15 +223,19 @@ var MapView = Marionette.ItemView.extend({
             addLocateMeButton(map, maxGeolocationAge);
         }
 
-        layersReadyDeferred.then(function(vizerLayers) {
-            if (options.addLayerSelector) {
-                self.layerControl = new LayerControl(self.baseLayers, self.overlayLayers, vizerLayers, {
-                    autoZIndex: false,
-                    position: 'topright',
-                    collapsed: false
-                }).addTo(map);
-            }
-        });
+        if (options.addLayerSelector) {
+            var layerOptions = {
+                autoZIndex: false,
+                position: 'topright',
+                collapsed: false
+            };
+
+            self.layerControl = new LayerControl(
+                self.baseLayers, self.overlayLayers, observationsDeferred, layerOptions
+            );
+
+            self.layerControl.addTo(map);
+        }
 
         if (options.addStreamControl) {
             this.layerControl = new StreamSliderControl({


### PR DESCRIPTION
Vizer Observation layers were requested async, but the layer control was
not rendered until their successful return.  This caused the control to
disappear when the Vizer API was down.  This commit updates the layer
control with vizer layers as they are returned, without waiting on them
to render.  If there are failures in loading the UI will report a
message on the observation tab.

Connects #1108 

To test:
* First make sure that the observation overlays are showing and loading to the map (if the API is up, it is at the time of this writing)
* Alter the `$.getJSON(vizerUrls.layers)` line in VizerLayers.js to cause an error (appending a random string to the request will work: `$.getJSON(vizerUrls.layers + 'foo')`.  
* Rebundle and reload the page.  The layer control should exist and there should be a basic error message in the observation panel.
