### PR TITLE
Runoff chart display only 1 bar in compare mode

### DIFF
--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -51,6 +51,7 @@ var ResultView = Marionette.LayoutView.extend({
             this.chartRegion.show(new ChartView({
                 model: this.model,
                 scenario: this.scenario,
+                compareMode: this.compareMode
             }));
         }
     }
@@ -62,6 +63,7 @@ var ChartView = Marionette.ItemView.extend({
 
     initialize: function(options) {
         this.scenario = options.scenario;
+        this.compareMode = options.compareMode;
     },
 
     onAttach: function() {


### PR DESCRIPTION
A recent refactor removed a reference to the view mode (compare view or
not).  This passes the reference to the newly created chart view which
ultimately restricts the number of bars represented in the chart.

![screenshot from 2016-02-01 14 57 18](https://cloud.githubusercontent.com/assets/1014341/12729330/24090d94-c8f4-11e5-8e5d-ceb26ce6c60d.png)
