### PR TITLE
Turn of RWD in production

### DIFF
--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -95,7 +95,7 @@ PRIVATE_AWS_STORAGE_URL_PROTOCOL = 'https:'
 DRAW_TOOLS = [
     'SelectArea',   # Boundary Selector
     'Draw',         # Custom Area or 1 Sq Km stamp
-    'PlaceMarker',  # Delineate Watershed
+    #'PlaceMarker',  # Delineate Watershed
     'ResetDraw',
 ]
 


### PR DESCRIPTION
The RWD feature is disabled as it's not been approved for release.  This
commit is likely followed up with a commit to re-enable it so that it is
available for additional testing in staging.

Testing:  This will only remove RWD in production/staging environments.