### PR TITLE
Use SQL data access layer vs. file access layer

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 sjs_home: "/opt/spark-jobserver"
 sjs_driver_memory: "1G"
-sjs_jars_dir: "/opt/spark-jobserver/jars"
-sjs_filedao_dir: "/opt/spark-jobserver/filedao/data"
+sjs_data_dir: "/opt/spark-jobserver/data"

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
@@ -5,8 +5,7 @@
         state=directory
   with_items:
     - "{{ sjs_home }}"
-    - "{{ sjs_jars_dir }}"
-    - "{{ sjs_filedao_dir }}"
+    - "{{ sjs_data_dir }}"
 
 - name: Copy AWS Crendentials
   copy: src=~/.aws/ dest=/aws

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/spark-jobserver.conf.j2
@@ -4,8 +4,12 @@
 
 spark.jobserver {
   port = 8090
-  jar-store-rootdir = {{ sjs_jars_dir }}
-  filedao.rootdir = {{ sjs_filedao_dir }}
+  jobdao = spark.jobserver.io.JobSqlDAO
+
+  sqldao {
+    rootdir = {{ sjs_data_dir }}
+    jdbc.url = "jdbc:h2:file:/{{ sjs_data_dir }}/h2-db"
+  }
 }
 
 spark.contexts {

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
@@ -21,8 +21,7 @@ exec /usr/bin/docker run \
   {% endif -%}
   --volume {{ sjs_home }}/spark-jobserver.conf:{{ sjs_home }}/spark-jobserver.conf \
   --volume {{ sjs_home }}/log4j.properties:{{ sjs_home }}/log4j.properties \
-  --volume {{ sjs_jars_dir }}:{{ sjs_jars_dir }} \
-  --volume {{ sjs_filedao_dir }}:{{ sjs_filedao_dir }} \
+  --volume {{ sjs_data_dir }}:{{ sjs_data_dir }} \
   {% for k,v in app_config.items() -%}
   --env {{ k }}={{ v }} \
   {% endfor -%}


### PR DESCRIPTION
The Docker container image assembled by the SJS author makes use of `SqlDAO` and claims it is more robust when compared to the `FileDAO`. When testing the issues we've been seeing in staging with `FileDAO` enabled, I was unable to reproduce them.