### PR TITLE
Fix analyze table header

### DIFF
--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -126,9 +126,9 @@ var utils = {
 
     magnitudeOfArea: function(value) {
         if (value >= M2_IN_KM2) {
-            return 'km2';
+            return 'km<sup>2</sup>';
         } else {
-            return 'm2';
+            return 'm<sup>2</sup>';
         }
     },
 
@@ -136,9 +136,9 @@ var utils = {
         var fromTo = (fromUnit + ':' + toUnit).toLowerCase();
 
         switch (fromTo) {
-            case 'm2:km2':
+            case 'm<sup>2</sup>:km<sup>2</sup>':
                  return value / M2_IN_KM2;
-            case 'm2:m2':
+            case 'm<sup>2</sup>:m<sup>2</sup>':
                  return value;
             default:
                  throw 'Conversion not implemented.';

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -42,7 +42,7 @@ function actOnLayer(datum) {
 }
 
 function validateShape(shape) {
-    var area = coreUtils.changeOfAreaUnits(turfArea(shape), 'm2', 'km2'),
+    var area = coreUtils.changeOfAreaUnits(turfArea(shape), 'm<sup>2</sup>', 'km<sup>2</sup>'),
         d = new $.Deferred();
 
     if (area > MAX_AREA) {

--- a/src/mmw/js/src/modeling/analyze/templates/table.html
+++ b/src/mmw/js/src/modeling/analyze/templates/table.html
@@ -7,7 +7,7 @@
     <thead>
         <tr>
             <th data-sortable="true">Type</th>
-            <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Area ({{ units }})</th>
+            <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Area ({{ headerUnits }})</th>
             <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Coverage (%)</th>
         </tr>
     </thead>

--- a/src/mmw/js/src/modeling/analyze/tests.js
+++ b/src/mmw/js/src/modeling/analyze/tests.js
@@ -81,7 +81,7 @@ function checkTable(data) {
 }
 
 function checkTableHeader(name) {
-    var expectedHeaderLabels = ['Type', 'Area (m2)', 'Coverage (%)'];
+    var expectedHeaderLabels = ['Type', 'Area (m<sup>2</sup>)', 'Coverage (%)'];
     var headerLabels = $('#' + name + ' table thead tr th').map(function() {
         return $(this).text();
     }).get();

--- a/src/mmw/js/src/modeling/analyze/views.js
+++ b/src/mmw/js/src/modeling/analyze/views.js
@@ -162,7 +162,6 @@ var TabContentView = Marionette.LayoutView.extend({
         this.tableRegion.show(new TableView({
             units: units,
             model: new coreModels.GeoModel({
-                units: (units === 'km2') ? 'km<sup>2</sup>' : 'm<sup>2</sup>',
                 place: App.map.get('areaOfInterestName'),
                 shape: App.map.get('areaOfInterest')
             }),
@@ -205,6 +204,11 @@ var TableView = Marionette.CompositeView.extend({
     childViewOptions: function() {
         return {
             units: this.options.units
+        };
+    },
+    templateHelpers: function() {
+        return {
+            headerUnits: this.options.units
         };
     },
     childViewContainer: 'tbody',

--- a/src/mmw/js/src/modeling/analyze/views.js
+++ b/src/mmw/js/src/modeling/analyze/views.js
@@ -194,7 +194,7 @@ var TableRowView = Marionette.ItemView.extend({
             // Convert coverage to percentage for display.
             coveragePct: (this.model.get('coverage') * 100),
             // Scale the area to display units.
-            scaledArea: utils.changeOfAreaUnits(area, 'm2', units)
+            scaledArea: utils.changeOfAreaUnits(area, 'm<sup>2</sup>', units)
         };
     }
 });


### PR DESCRIPTION
* In 2b39fe8, the AoI name and area were added to the analyze results.
Because this change set the shape attribute of the GeoModel for this
view, the model initialization logic overwrote the units
attribute. We manually calculated this value to match the units of
the analyze results.  When the table header was drawn, the units value
matched that of the AoI and not the result units. Here we send
along the manually calculated units as a separate variable to the
analyze table view. We also remove the line to manually set the units
of the GeoModel instance because the initialization logic will take
care of this for us.

**Testing instructions**
- Draw a small AoI (<= 1 km2), and verify that the analysis results table displays `m2` for the area units.
- Draw a large AoI (>= 100 km2), and verify that the analysis results table displays `km2` for the area units.

![screen shot 2016-02-02 at 9 19 20 pm](https://cloud.githubusercontent.com/assets/1042475/12771082/4706088c-c9f4-11e5-9844-7cc196a0a21a.png)
![screen shot 2016-02-02 at 9 20 23 pm](https://cloud.githubusercontent.com/assets/1042475/12771083/47173ff8-c9f4-11e5-8004-ce4f8fa8eaf0.png)


Connects to #1125