### PR TITLE
Remove model comparisons from output

### DIFF
--- a/src/mmw/js/src/modeling/analyze/templates/aoiHeader.html
+++ b/src/mmw/js/src/modeling/analyze/templates/aoiHeader.html
@@ -1,0 +1,5 @@
+<div>
+    <h2>{{ place }}</h2>
+    <strong>Total Area</strong> <span class="right">{{ area|round|toLocaleString }} {{ units }}</span>
+</div>
+

--- a/src/mmw/js/src/modeling/analyze/templates/tabContent.html
+++ b/src/mmw/js/src/modeling/analyze/templates/tabContent.html
@@ -1,4 +1,5 @@
 <div class="result-region">
-    <div class="analyze-table-region"></div>
+    <div class="analyze-aoi-region"></div>
     <div class="analyze-chart-region"></div>
+    <div class="analyze-table-region"></div>
 </div>

--- a/src/mmw/js/src/modeling/analyze/templates/table.html
+++ b/src/mmw/js/src/modeling/analyze/templates/table.html
@@ -1,8 +1,3 @@
-<div>
-    <h2>{{ place }}</h2>
-    <strong>Total Area</strong> <span class="right">{{ area|round|toLocaleString }} {{ units }}</span>
-</div>
-
 <table class="table custom-hover" data-toggle="table">
     <thead>
         <tr>

--- a/src/mmw/js/src/modeling/analyze/views.js
+++ b/src/mmw/js/src/modeling/analyze/views.js
@@ -11,6 +11,7 @@ var $ = require('jquery'),
     windowTmpl = require('./templates/window.html'),
     messageTmpl = require('./templates/message.html'),
     detailsTmpl = require('../templates/resultsDetails.html'),
+    aoiHeaderTmpl = require('./templates/aoiHeader.html'),
     tableTmpl = require('./templates/table.html'),
     tableRowTmpl = require('./templates/tableRow.html'),
     tabPanelTmpl = require('../templates/resultsTabPanel.html'),
@@ -148,6 +149,7 @@ var TabContentView = Marionette.LayoutView.extend({
         role: 'tabpanel'
     },
     regions: {
+        aoiRegion: '.analyze-aoi-region',
         tableRegion: '.analyze-table-region',
         chartRegion: '.analyze-chart-region'
     },
@@ -159,12 +161,15 @@ var TabContentView = Marionette.LayoutView.extend({
                 new coreModels.LandUseCensusCollection(categories) :
                 new coreModels.SoilCensusCollection(categories);
 
-        this.tableRegion.show(new TableView({
-            units: units,
+        this.aoiRegion.show(new AoiView({
             model: new coreModels.GeoModel({
                 place: App.map.get('areaOfInterestName'),
                 shape: App.map.get('areaOfInterest')
-            }),
+            })
+        }));
+
+        this.tableRegion.show(new TableView({
+            units: units,
             collection: census
         }));
 
@@ -181,6 +186,10 @@ var TabContentsView = Marionette.CollectionView.extend({
     onRender: function() {
         this.$el.find('.tab-pane:first').addClass('active');
     }
+});
+
+var AoiView = Marionette.ItemView.extend({
+    template: aoiHeaderTmpl
 });
 
 var TableRowView = Marionette.ItemView.extend({

--- a/src/mmw/js/src/modeling/tr55/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/result.html
@@ -1,2 +1,2 @@
-<div class="quality-table-region"></div>
 <div class="quality-chart-region"></div>
+<div class="quality-table-region"></div>

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
@@ -1,2 +1,2 @@
-<div class="runoff-table-region"></div>
 <div class="runoff-chart-region"></div>
+<div class="runoff-table-region"></div>

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
@@ -1,7 +1,6 @@
 <table class="table custom-hover" data-toggle="table">
     <thead>
         <tr>
-            <th data-sortable="true">Scenario</th>
             <th data-sortable="true">Runoff Partition</th>
             <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Water Depth (cm)</th>
             <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Water Volume (m<sup>3</sup>)</th>

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/tableRow.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/tableRow.html
@@ -1,4 +1,3 @@
-<td>{{ scenario }}</td>
 <td>{{ runoffType }}</td>
 <td class="strong text-left">{{ depth|round(3)|toLocaleString }}</td>
-<td class="strong ">{{ adjustedVolume|round(2)|toLocaleString }}</td>
+<td class="strong text-left">{{ adjustedVolume|round(2)|toLocaleString }}</td>

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -111,11 +111,11 @@ var ChartView = Marionette.ItemView.extend({
                 labelDisplayNames = [''];
                 this.$el.addClass('current-conditions');
             } else if (this.scenario.get('is_current_conditions')) {
-                labelNames = ['pc_unmodified', 'unmodified'];
-                labelDisplayNames = ['100% Forest', 'Current Conditions'];
+                labelNames = ['unmodified'];
+                labelDisplayNames = ['Current Conditions'];
             } else {
-                labelNames = ['unmodified', 'modified'];
-                labelDisplayNames = ['Current Conditions', 'Modified'];
+                labelNames = ['modified'];
+                labelDisplayNames = ['Modified'];
             }
 
             data = getData(result, seriesNames, seriesDisplayNames,

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -42,7 +42,6 @@ var ResultView = Marionette.LayoutView.extend({
 
             if (!this.compareMode) {
                 this.tableRegion.show(new TableView({
-                    scenario: this.scenario,
                     model: this.model,
                     aoiVolumeModel: aoiVolumeModel
                 }));
@@ -152,48 +151,33 @@ var TableView = Marionette.CompositeView.extend({
         { name: 'inf', display: 'Infiltration' }
     ],
 
-    initialize: function(options) {
+    initialize: function() {
         this.aoiVolumeModel = this.options.aoiVolumeModel;
         this.tr55Results = this.model.get('result');
 
-        this.collection = this.formatData(options.scenario);
+        this.collection = this.formatData();
     },
 
     onAttach: function() {
         $('[data-toggle="table"]').bootstrapTable();
     },
 
-    formatData: function(scenario) {
+    formatData: function() {
         // The TR55 results should be broken down into:
-        // Scenario | Runoff Partition | Depth | Volume
-        var collection = new Backbone.Collection(),
-            // If not Current Conditions, match the chart label by calling
-            // the scenario "modified"
-            label = 'Modified';
+        // Runoff Partition | Depth | Volume
+        var collection = new Backbone.Collection();
 
-        // Special cases:  100% Forest may exist as pc_unmodified if scenario
-        // is_current_conditions, otherwise we also want to include unmodified
-        // which is the value of `Current Conditions`.
-        if (scenario.get('is_current_conditions')) {
-            collection.add(this.makeRowsForScenario('pc_unmodified', '100% Forest'));
-            label = scenario.get('name');
-        } else {
-            collection.add(this.makeRowsForScenario('unmodified', 'Current Conditions'));
-        }
-
-        collection.add(this.makeRowsForScenario('modified', label));
+        collection.add(this.makeRowsForScenario('modified'));
 
         return collection;
     },
 
-    makeRowsForScenario: function(runoffKey, scenarioName) {
+    makeRowsForScenario: function(runoffKey) {
         var self = this,
             runoffPartition = this.tr55Results[runoffKey];
 
         return _.map(this.runoffTypes, function(runoffType) {
-            return _.extend(self.getRunoffTypeValue(runoffPartition, runoffType), {
-                scenario: scenarioName
-            });
+            return _.extend(self.getRunoffTypeValue(runoffPartition, runoffType));
         });
     },
 

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -126,7 +126,9 @@ var ChartView = Marionette.ItemView.extend({
                 yAxisUnit: 'cm',
                 reverseLegend: true,
                 disableToggle: true,
-                margin: this.compareMode ? {top: 20, right: 0, bottom: 40, left: 60} : undefined
+                margin: this.compareMode ?
+                    {top: 20, right: 0, bottom: 40, left: 60} :
+                    {top: 0, right: 0, bottom: 40, left: 200}
             };
 
             chart.renderVerticalBarChart(chartEl, data, chartOptions);

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -13,6 +13,7 @@
   height: 300px;
   vertical-align: baseline;
   vertical-align: bottom;
+  margin-bottom: 20px;
 
   .nv-bar {
     fill: $brand-primary;

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -5,7 +5,6 @@
 .chart-container {
   width: 100%;
   height: 100%;
-  margin-top: 30px;
 }
 
 .bar-chart {


### PR DESCRIPTION
Removes all inter-scenario comparisons in TR55 runoff output, including:

* Bar chart only describes current scenario
* Table only describes current scenario
* Compare mode should still include non-scenario "100% Forest" item.

Connects #1137 
Connects #1135 
Connects #1138 

![screenshot from 2016-02-04 13 26 28](https://cloud.githubusercontent.com/assets/1014341/12825168/e8d44648-cb42-11e5-9059-7cbd0be45f26.png)
