### PR TITLE
Increase Spark context creation timeout

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/spark-jobserver.conf.j2
@@ -14,6 +14,8 @@ spark.jobserver {
   job-jar-paths {
     "geoprocessing-{{ geop_version }}" = {{ geop_home }}/mmw-geoprocessing-{{ geop_version }}.jar
   }
+
+  context-creation-timeout = 30 s
 }
 
 spark.contexts {


### PR DESCRIPTION
The default context creation timeout is 15 seconds, and we have been bumping up against it because of our current JAR size (~73MB). The context creation timeout is now 30 seconds.

See also: https://github.com/spark-jobserver/spark-jobserver/issues/381

---

**Testing**

I set `context-creation-timeout` to `1 s` and then attempted to restart the service:

```
2016-02-04 19:30:28,349 [JobServer-akka.actor.default-dispatcher-5] INFO  spark.jobserver.LocalContextSupervisorActor -  Starting actor spark.jobserver.LocalContextSupervisorActo
r
2016-02-04 19:30:28,357 [main] INFO  spark.jobserver.JobServer$ -  Adding initial job jars: {
    # spark-jobserver.conf: 15
    "geoprocessing-0.4.0" : "/opt/geoprocessing/mmw-geoprocessing-0.4.0.jar"
}

2016-02-04 19:30:28,367 [JobServer-akka.actor.default-dispatcher-4] INFO  spark.jobserver.JobInfoActor -  Starting actor spark.jobserver.JobInfoActor
2016-02-04 19:30:28,543 [JobServer-akka.actor.default-dispatcher-2] INFO  spark.jobserver.JobResultActor -  Starting actor spark.jobserver.JobResultActor
2016-02-04 19:30:28,710 [JobServer-akka.actor.default-dispatcher-3] INFO  spark.jobserver.JarManager -  Storing jar for app geoprocessing-0.4.0, 76188573 bytes
2016-02-04 19:30:29,379 [main] ERROR spark.jobserver.JobServer$ -  Unable to start Spark JobServer: 
java.util.concurrent.TimeoutException: Futures timed out after [1 second]
        at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:219)
        at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:223)
        at scala.concurrent.Await$$anonfun$result$1.apply(package.scala:107)
        at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:53)
        at scala.concurrent.Await$.result(package.scala:107)
        at spark.jobserver.JobServer$.storeInitialJars(JobServer.scala:113)
        at spark.jobserver.JobServer$.start(JobServer.scala:68)
        at spark.jobserver.JobServer$.main(JobServer.scala:121)
        at spark.jobserver.JobServer.main(JobServer.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:674)
```