### PR TITLE
Collapse sidebar

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -39,7 +39,7 @@
     </div>
 
     <div id="sidebar">
-        <button class="btn btn-primary tab-content-toggle" type="button">
+        <button class="btn btn-primary tab-content-toggle" type="button" title="Show/Hide results sidebar">
             <i class="fa fa-angle-right"></i>
         </button>
         <div id="sidebar-content"></div>

--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -39,6 +39,10 @@
     </div>
 
     <div id="sidebar">
+        <button class="btn btn-primary tab-content-toggle" type="button">
+            <i class="fa fa-angle-right"></i>
+        </button>
+        <div id="sidebar-content"></div>
     </div>
 
     <div id="footer">

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -35,7 +35,7 @@ var App = new Marionette.Application({
             App.currentProject.set('needs_reset', needs);
         });
 
-        this.rootView = new views.RootView();
+        this.rootView = new views.RootView({app: this});
         this.user = new userModels.UserModel({});
 
         this.header = new views.HeaderView({

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -26,6 +26,11 @@ require('leaflet-plugins/layer/tile/Google');
 
 var RootView = Marionette.LayoutView.extend({
     el: 'body',
+    ui: {
+        collapse: '.tab-content-toggle',
+        mapContainer: '.map-container',
+        sidebar: '#sidebar'
+    },
     regions: {
         mainRegion: '#container',
         geocodeSearchRegion: '#geocode-search-region',
@@ -33,9 +38,38 @@ var RootView = Marionette.LayoutView.extend({
         subHeaderRegion: '#sub-header',
         sidebarRegion: {
             regionClass: TransitionRegion,
-            selector: '#sidebar'
+            selector: '#sidebar-content'
         },
         footerRegion: '#footer'
+    },
+    events: {
+        'click @ui.collapse': 'collapseSidebar',
+        'transitionend @ui.mapContainer': 'onMapResized'
+    },
+
+    collapseSidebar: function() {
+        // Toggle appropriate classes to show and hide
+        // the sidebar / make the map full/partial width
+        this.$el.find(this.ui.sidebar).toggleClass('hidden-sidebar');
+        this.$el.find(this.ui.mapContainer).toggleClass('hidden-sidebar');
+    },
+
+    showCollapsable: function() {
+        $(this.ui.collapse).show();
+    },
+
+    hideCollapsable: function() {
+        $(this.ui.collapse).hide();
+    },
+
+    onMapResized: function(e) {
+        // Many `transitionend` events are fired, but you can filter
+        // on the property name of the real event to find the correct
+        // transition to follow
+        if (e.originalEvent.propertyName !== 'right') {
+            return;
+        }
+        this.options.app.getMapView().resetMapSize();
     }
 });
 
@@ -121,7 +155,7 @@ var HeaderView = Marionette.ItemView.extend({
 // Init the locate plugin button and add it to the map.
 function addLocateMeButton(map, maxZoom, maxAge) {
     var locateOptions = {
-        position: 'topright',
+        position: 'topleft',
         metric: false,
         drawCircle: false,
         showPopup: false,
@@ -216,7 +250,7 @@ var MapView = Marionette.ItemView.extend({
         }
 
         if (options.addZoomControl) {
-            map.addControl(new L.Control.Zoom({position: 'topright'}));
+            map.addControl(new L.Control.Zoom({position: 'topleft'}));
         }
 
         var maxGeolocationAge = 60000;
@@ -227,7 +261,7 @@ var MapView = Marionette.ItemView.extend({
         if (options.addLayerSelector) {
             var layerOptions = {
                 autoZIndex: false,
-                position: 'topright',
+                position: 'topleft',
                 collapsed: false
             };
 
@@ -241,7 +275,7 @@ var MapView = Marionette.ItemView.extend({
         if (options.addStreamControl) {
             this.layerControl = new StreamSliderControl({
                 autoZIndex: false,
-                position: 'topright',
+                position: 'topleft',
                 collapsed: false
             }).addTo(map);
         }
@@ -387,7 +421,7 @@ var MapView = Marionette.ItemView.extend({
                     minZoom: 0});
                 leafletLayer = new L.TileLayer(tileUrl, layer);
                 if (layer.has_opacity_slider) {
-                    var slider = new OpacityControl();
+                    var slider = new OpacityControl({position: 'topleft'});
 
                     slider.setOpacityLayer(leafletLayer);
                     leafletLayer.slider = slider;
@@ -633,6 +667,11 @@ var MapView = Marionette.ItemView.extend({
                 self.fitToAoi();
             }
         }, 300);
+    },
+
+    resetMapSize: function() {
+        this._leafletMap.invalidateSize();
+        this.fitToAoi();
     },
 
     fitToAoi: function() {

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -11,6 +11,7 @@ var $ = require('jquery'),
 
 var ModelingController = {
     projectPrepare: function(projectId) {
+        App.rootView.showCollapsable();
         if (!projectId && !App.map.get('areaOfInterest')) {
             router.navigate('', { trigger: true });
             return false;
@@ -185,6 +186,7 @@ var ModelingController = {
     },
 
     projectCleanUp: function() {
+        App.rootView.hideCollapsable();
         if (App.currentProject) {
             var scenarios = App.currentProject.get('scenarios');
 

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -128,7 +128,7 @@ var ChartView = Marionette.ItemView.extend({
                 disableToggle: true,
                 margin: this.compareMode ?
                     {top: 20, right: 0, bottom: 40, left: 60} :
-                    {top: 0, right: 0, bottom: 40, left: 200}
+                    {top: 0, right: 0, bottom: 40, left: 150}
             };
 
             chart.renderVerticalBarChart(chartEl, data, chartOptions);

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -35,6 +35,18 @@ a {
   margin: 0!important;
 }
 
+button.btn.tab-content-toggle {
+  position: absolute;
+  z-index: 1000;
+  top: 161px;
+  right: 10px;
+  display:none;
+
+  .hidden-sidebar & i {
+    transform: rotate(-180deg);
+  }
+}
+
 #footer {
 
   &.top-nav {

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -40,7 +40,7 @@
     top: $height-lg * 2 + $toolbar-height;
     right: $sidebar-width;
     @media(min-width: 1040px) {
-      right: 540px !important;
+      right: 485px !important;
     }
   }
   // Sets map to correct container size for sidebar.
@@ -48,6 +48,10 @@
     bottom: 0 !important;
   }
 
+  // Sets map to correct container size for no sidebar
+  &.hidden-sidebar {
+    right: 0 !important;
+  }
   .compare-scenarios-container & {
     top: 0;
   }
@@ -89,6 +93,10 @@
     float: right;
 }
 
+.leaflet-top {
+  top: 10px;
+}
+
 .leaflet-control-layers-expanded {
   padding: 0;
   background-color: transparent;
@@ -104,8 +112,8 @@
     margin-right: 50px;
     display: none;
     position: absolute;
-    top: 10px;
-    right: 0px;
+    top: 120px;
+    left: 60px;
     // Be as tall as the map container,
     // minus some space for the attribution
     height: 83%;

--- a/src/mmw/sass/base/_search-map.scss
+++ b/src/mmw/sass/base/_search-map.scss
@@ -1,5 +1,0 @@
-#search-map {
-    position: relative;
-    float: left;
-    padding: 1rem;
-}

--- a/src/mmw/sass/components/_buttons.scss
+++ b/src/mmw/sass/components/_buttons.scss
@@ -143,7 +143,7 @@
 .btn-compare {
   color: $paper;
   background-color: $ui-secondary;
-  font-size: 0.6rem;
+  font-size: 0.8rem;
   height: $height-lg;
   border-radius: 0!important;
   padding: 0.7rem;

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -6,12 +6,17 @@
   bottom: 0;
   width: $sidebar-width !important;
   @media(min-width: 1040px) {
-    width: 540px !important;
+    width: 485px !important;
   }
   min-height: 300px;
   height: auto !important;
   background-color: $paper;
   z-index: 100;
+  transform: translateX(0%);
+
+  .hidden-sidebar & {
+    transform: translateX(100%);
+  }
 
   .title-row {
     background-color: $ui-light;

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -2,7 +2,7 @@
 #search-map {
   position: absolute;
   top: 0;
-  left: 0;
+  left: 30px;
   z-index: 100;
   padding: 1rem;
 


### PR DESCRIPTION
* Add element to transition visibility of map and sidebar
* Reorient map controls to the left so they don't interfere with sidebar
* Make sidebar narrower
* Make "Compare" button more prominent

Connects #1136 
Connects #1141

Test:
* Make sure new arrow button is not visible on any page but a project
* Test that the button toggles the size of the map/sidebar and re-adjusts the extent and AoI fit in the map
* Make sure that if the sidebar is minimized, the page is transitioned (to draw/compare) and transitioned back - the collapse toggle still behaves correctly
* Test the map controls are still accessible and open controls correctly (Stream slider is moving soon, and is currently a little weird - not active for staging/production)
