### PR TITLE
Fix libpq version

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -19,9 +19,9 @@ postgresql_password: mmw
 postgresql_database: mmw
 
 postgresql_version: "9.4"
-postgresql_package_version: "9.4.*-2.pgdg14.04+1"
+postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "9.5.*.pgdg14.04+2"
+postgresql_support_libpq_version: "9.5.*.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.6"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"


### PR DESCRIPTION
The main libpq version changed from 9.5.0 to 9.5.1. This reset the package build number back to 1.