### PR TITLE
Add snapped and clicked outlet point

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -2,4 +2,4 @@
 rwd_data_path: "/opt/rwd-data"
 rwd_host: "localhost"
 rwd_port: 5000
-rwd_docker_image: "quay.io/wikiwatershed/rwd:0.2.2"
+rwd_docker_image: "quay.io/wikiwatershed/rwd:0.3.0"

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -585,6 +585,7 @@ var MapView = Marionette.ItemView.extend({
                     return drawUtils.polygonDefaults;
                 }});
             this._areaOfInterestLayer.addLayer(layer);
+            this.addAdditionalAoiShapes();
         }
     },
 
@@ -596,16 +597,37 @@ var MapView = Marionette.ItemView.extend({
 
         if (!areaOfInterest) {
             this._areaOfInterestLayer.clearLayers();
+            this.model.set('areaOfInterestAdditionals', null);
         } else {
             try {
                 var layer = new L.GeoJSON(areaOfInterest);
                 applyMask(this._areaOfInterestLayer, layer);
                 this.model.set('maskLayerApplied', true);
                 this._leafletMap.fitBounds(layer.getBounds(), { reset: true });
+                this.addAdditionalAoiShapes();
             } catch (ex) {
                 console.log('Error adding Leaflet layer (invalid GeoJSON object)');
             }
         }
+    },
+
+    addAdditionalAoiShapes: function() {
+        var self = this,
+            additionalShapes = this.model.get('areaOfInterestAdditionals');
+
+        if (additionalShapes) {
+            var pointsLayer = new L.GeoJSON(additionalShapes, {
+                onEachFeature: function(feature, layer) {
+                    var message = "Outlet point snapped to nearest stream";
+                    if (feature.properties && feature.properties.original) {
+                        message = "Original clicked outlet point";
+                    }
+
+                    layer.bindPopup(message);
+                }
+            });
+            self._areaOfInterestLayer.addLayer(pointsLayer);
+        };
     },
 
     // Add GeoJSON layer for each modification model in modificationsColl.

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -627,7 +627,7 @@ var MapView = Marionette.ItemView.extend({
                 }
             });
             self._areaOfInterestLayer.addLayer(pointsLayer);
-        };
+        }
     },
 
     // Add GeoJSON layer for each modification model in modificationsColl.

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -41,8 +41,11 @@ function actOnLayer(datum) {
     }
 }
 
-function validateShape(shape) {
-    var area = coreUtils.changeOfAreaUnits(turfArea(shape), 'm<sup>2</sup>', 'km<sup>2</sup>'),
+// Takes a GeoJSON shape, or if a key is specified, a dict
+// with a GeoJSON object found at shape[shapeKey]
+function validateShape(shape, shapeKey) {
+    var polygon = shapeKey ? shape[shapeKey] : shape,
+        area = coreUtils.changeOfAreaUnits(turfArea(shape), 'm<sup>2</sup>', 'km<sup>2</sup>'),
         d = new $.Deferred();
 
     if (area > MAX_AREA) {
@@ -363,7 +366,6 @@ var WatershedDelineationView= Marionette.ItemView.extend({
         utils.placeMarker(map)
              .then(function(latlng) {
                 var point = L.marker(latlng).toGeoJSON(),
-                    shape,
                     deferred = $.Deferred();
 
                 var taskHelper = {
@@ -372,9 +374,9 @@ var WatershedDelineationView= Marionette.ItemView.extend({
                     },
 
                     pollSuccess: function(response) {
-                        shape = JSON.parse(response.result).features[0];
                         self.model.set('polling', false);
-                        deferred.resolve(shape);
+                        var result = JSON.parse(response.result);
+                        deferred.resolve(result);
                     },
 
                     pollFailure: function(response) {
@@ -410,10 +412,32 @@ var WatershedDelineationView= Marionette.ItemView.extend({
                 self.rwdTaskModel.start(taskHelper);
                 return deferred;
             })
-            .done(validateShape)
-            .done(function(shape) {
-                addLayer(shape, itemName);
-                navigateToAnalyze();
+            .done(_.partialRight(validateShape, 'watershed'))
+            .done(function(result) {
+                if (result.watershed) {
+                    var inputPoints = result.input_pt;
+                    // add additional aoi points:w
+                    if (inputPoints) {
+                        var properties = inputPoints.features[0].properties;
+
+                        // If the point was snapped, there will be the original
+                        // point as attributes
+                        if (properties.Dist_moved) {
+                            inputPoints.features.push(
+                                makePointGeoJson([properties.Lon, properties.Lat], {
+                                    original: true
+                                })
+                            );
+                        }
+                        App.map.set({
+                            'areaOfInterestAdditionals': inputPoints
+                        });
+                    }
+
+                    // Add Watershed AoI layer
+                    addLayer(result.watershed, itemName);
+                    navigateToAnalyze();
+                }
             })
             .fail(function() {
                 revertLayer();
@@ -448,6 +472,17 @@ var ResetDrawView = Marionette.ItemView.extend({
         clearBoundaryLayer(this.model);
     }
 });
+
+function makePointGeoJson(coords, props) {
+    return {
+        geometry: {
+            coordinates: coords,
+            type: 'Point'
+        },
+        properties: props,
+        type: 'Feature'
+    }
+}
 
 function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {
     // The shapeId might not be available at the time of the click

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -57,7 +57,7 @@ function validateShape(shape, shapeKey) {
         window.alert(message);
         d.reject();
     } else {
-        d.resolve(shape);
+        d.resolve(polygon);
     }
     return d.promise();
 }
@@ -481,7 +481,7 @@ function makePointGeoJson(coords, props) {
         },
         properties: props,
         type: 'Feature'
-    }
+    };
 }
 
 function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {


### PR DESCRIPTION
Preserve the originally clicked location and the point which the RWD
service snapped to along with the AoI.

* Upgrade RWD service to that which supports returning outlet points
* Save click and snap points and display on map alongside AoI

Connects #1085 

##### Caveats
* Marker style, marker duration and popup language open to feedback, intending to release on staging for experiments

##### Test
* Provision worker
* Delineate a watershed using Stream Network
* See that there are two points, one at your original click location.
* See that the markers are visible while the AoI is visible, and are removed when the AoI is reset or redrawn.
