### PR TITLE
Fix ITSI Screenshots between sessions

### DIFF
--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -245,6 +245,9 @@ var LoginModalView = ModalBaseView.extend({
         }
 
         var loginURL = '/user/itsi/login?next=/' + Backbone.history.getFragment();
+        if (window.clientSettings.itsi_embed) {
+            loginURL = '/?itsi_embed=true&next=/' + Backbone.history.getFragment();
+        }
         window.location.href = loginURL;
     }
 });


### PR DESCRIPTION
## Overview

The approach taken in #978 relies on the presence of `itsi_embed: true` in the `window.clientSettings` hash, which is populated from the session variable `itsi_embed`, which is populated from the URL query string `?itsi_embed=true`. In most cases it worked correctly since an ITSI embed session would always be initialized with `?itsi_embed=true`. However, there are two cases where it didn't work:

 1. New users being registered for the first time. While we did save `itsi_embed` to the session for these users, as soon as we logged them in they would get a new session id, one that did not have these old variables.
 2. Existing users logging out, and then logging with ITSI via the UI. This would redirect them to new page without the `?itsi_embed=true` URL, thus this new logged in session would not have it correctly set.

By saving the session value before logging a new user in, and restoring it after they are logged in, we address 1.
By simulating an initialization with `?itsi_embed=true` when in embed mode, instead of sending them to the classical ITSI login URL, we address 2.

See commit messages for details.

## Testing Instructions

This PR can be indirectly tested by ensuring that `window.clientSettings.itsi_embed` is set in all the correct cases, and not in all the incorrect ones. You can test its current value by typing it into the JavaScript console

    window.clientSettings.itsi_embed

Test Case | Description | `window.clientSettings.itsi_embed`
----------|-------------|-----------------------------------
 1 | Go to home page [http://localhost:8000/](http://localhost:8000/) | `false`
 2 | Log in as ITSI | `false`
 3 | Go to home page in embed mode [http://localhost:8000/?itsi_embed=true](http://localhost:8000/?itsi_embed=true) | `true`
 4 | Log out | `true`
 5 | Log in as ITSI | `true`
 6 | Log out and refresh the page | `false`
 7 | Log out of ITSI, and log in with an account that does not have a corresponding MMW account (or, delete the MMW account corresponding to your ITSI login). Then go to home page in embed mode [http://localhost:8000/?itsi_embed=true](http://localhost:8000/?itsi_embed=true). | `true`

To test this within the ITSI embed environment and the actual screenshots, more preparation is required. Come see me, and I'll set it up.

Connects #1099 