### PR TITLE
Remove timestamp from log4j; add multiline support

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.beaver/templates/spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.beaver/templates/spark-jobserver.conf.j2
@@ -1,3 +1,4 @@
 [/var/log/upstart/spark-jobserver.log]
+multiline_regex_before = ^\s+
 type: spark-jobserver
 tags: spark-jobserver,beaver

--- a/deployment/ansible/roles/model-my-watershed.logstash/templates/logstash.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.logstash/templates/logstash.conf.j2
@@ -21,16 +21,6 @@ filter {
       match => [ "timestamp", "E, dd MMM yyyy HH:mm:ss z" ]
     }
   }
-
-  if [type] == "spark-jobserver" {
-    grok {
-      match => { "message" => "%{TIMESTAMP_ISO8601:timestamp}" }
-    }
-
-    date {
-      match => [ "timestamp", "yyyy-MM-dd HH:mm:ss,SSS" ]
-    }
-  }
 }
 
 output {

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/log4j.properties.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/log4j.properties.j2
@@ -11,7 +11,7 @@ log4j.logger.com.amazonaws=WARN
 {% endif %}
 
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d [%t] %-5p %c -  %m%n
+log4j.appender.console.layout.ConversionPattern=[%t] %-5p %c - %m%n
 
 log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
 log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN


### PR DESCRIPTION
Gather up Java exceptions into one message vs. having them split by line. Also, remove the timestamp from the log4j output and instead depend on the timestamp provided by the Kibana UI:

<img width="1011" alt="discover_-_kibana_4" src="https://cloud.githubusercontent.com/assets/43639/13187865/ff750114-d71b-11e5-8645-d5774fa756dd.png">

---

**Testing**

Provision changes in this pull request and cause a geoprocessing exception. Then, take a look at the Kibana UI.

To cause a geoprocessing exception, introduce a typo into the SJS configuration file (`spark-jobserver.conf.j2`):

```scala
jobdao = spark.jobserver.io.JobSqlDAOjoker
```