### PR TITLE
Revert "Use backported kernel to avoid recent AUFS bugs"

### DIFF
--- a/deployment/ansible/workers.yml
+++ b/deployment/ansible/workers.yml
@@ -6,14 +6,6 @@
     - name: Update APT cache
       apt: update_cache=yes cache_valid_time=3600
 
-    - name: Install backported kernel
-      apt: pkg={{ item }} state=present
-      with_items:
-        - linux-headers-3.19.0-39
-        - linux-headers-3.19.0-39-generic
-        - linux-image-3.19.0-39-generic
-        - linux-image-extra-3.19.0-39-generic
-
   roles:
     - { role: "model-my-watershed.geoprocessing" }
     - { role: "model-my-watershed.celery-worker" }


### PR DESCRIPTION
This reverts 6fb93e6bae9c71d339d660c421b5852438531df9. The kernel version that fixes the AUFS bug referenced in that commit is in the latest Ubuntu release AMI (3.13.0-79).

See also:

- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1533043
- https://bugzilla.kernel.org/show_bug.cgi?id=109971