### PR TITLE
Upgrade RWD to version 1.0.0

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -2,4 +2,4 @@
 rwd_data_path: "/opt/rwd-data"
 rwd_host: "localhost"
 rwd_port: 5000
-rwd_docker_image: "quay.io/wikiwatershed/rwd:0.3.0"
+rwd_docker_image: "quay.io/wikiwatershed/rwd:1.0.0"

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -63,7 +63,7 @@
             "ami_block_device_mappings": [
                 {
                     "device_name": "/dev/sdf",
-                    "snapshot_id": "snap-3d8f22ab",
+                    "snapshot_id": "snap-4a764b4a",
                     "volume_type": "gp2",
                     "delete_on_termination": true
                 }

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -29,7 +29,8 @@ def start_rwd_job(location, snapping):
     which raises an exception.
     """
     location = json.loads(location)
-    rwd_url = 'http://localhost:5000/rwd/%f/%f' % (location[1], location[0])
+    lat, lng = location
+    rwd_url = 'http://localhost:5000/rwd/%f/%f' % (lat, lng)
 
     # The Webserver defaults to enable snapping, uses 1 (true) 0 (false)
     if not snapping:


### PR DESCRIPTION
The RWD endpoint now expects `/rwd/<lat>/<lng>` instead of the other way
around.

Connects #1149