### PR TITLE
Allow display of registration content

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -33,7 +33,8 @@
         {% endblock map %}
     </div>
 
-    <div class="container-fluid top-nav" style="display: none;">
+    <div class="container-fluid top-nav">
+        <!-- Used on registration/account pages, not on main app -->
         {% block content %}
         {% endblock content %}
     </div>

--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -31,10 +31,8 @@
     <div class="map-container">
         {% block map %}
         {% endblock map %}
-    </div>
 
-    <div class="container-fluid top-nav">
-        <!-- Used on registration/account pages, not on main app -->
+        {# Used on registration/account pages, not on main app #}
         {% block content %}
         {% endblock content %}
     </div>


### PR DESCRIPTION
The previous map container was hidden during the transition to the
sidebar layout (c392ed6c75), but the registration content was not
updated to target the new container.  This restores the visibility of
the previous container, which is now only used for the account pages and
is empty in the main map mode.

Connects #1178 
Connects #1179 

#### To test:
* sign up for an account and use the activation link emailed (to console)
* Request to reset your password, follow the link emailed 
* Quick test of the map and micro apps should not have any altered layout issues.

Both account pages should display content instead of appearing blank with a header.
