### PR TITLE
Fix Micro Site Slider

### DIFF
--- a/src/mmw/sass/components/_slider-native.scss
+++ b/src/mmw/sass/components/_slider-native.scss
@@ -5,6 +5,10 @@
     margin: -7px 0;
     cursor: pointer;
 
+    &:focus {
+        outline: none;
+    }
+
     &.slider-leaflet {
         background: $black;
         width: 150px;
@@ -14,64 +18,61 @@
         border-radius: 4px;
         box-shadow: -1px 0 5px $black-65;
         cursor: pointer;
-    }
 
-    &:focus {
-        outline: none;
-    }
-    &::-webkit-slider-thumb {
-        background: $paper;
-        width: 12px;
-        height: 12px;
-        border: 2px solid $black-74;
-        border-radius: 4px;
-        box-shadow: -1px 0 1px $black-54;
-        -webkit-appearance: none;
-    }
-    &:focus::-webkit-slider-thumb {
-        background: $black;
-    }
+        &::-webkit-slider-thumb {
+            background: $paper;
+            width: 12px;
+            height: 12px;
+            border: 2px solid $black-74;
+            border-radius: 4px;
+            box-shadow: -1px 0 1px $black-54;
+            -webkit-appearance: none;
+        }
+        &:focus::-webkit-slider-thumb {
+            background: $black;
+        }
 
-    &::-moz-range-track {
-        background: $black;
-    }
-    &::-moz-range-thumb {
-        background: $paper;
-        width: 10px;
-        height: 10px;
-        border: 2px solid $black-74;
-        border-radius: 4px;
-        box-shadow: -1px 0 1px $black-54;
-    }
+        &::-moz-range-track {
+            background: $black;
+        }
+        &::-moz-range-thumb {
+            background: $paper;
+            width: 10px;
+            height: 10px;
+            border: 2px solid $black-74;
+            border-radius: 4px;
+            box-shadow: -1px 0 1px $black-54;
+        }
 
-    &::-ms-track {
-        background: transparent;
-        border-color: transparent;
-        color: transparent;
-    }
-    &::-ms-thumb {
-        background: $paper;
-        width: 14px;
-        height: 14px;
-        border: 2px solid $black-74;
-        border-radius: 4px;
-        box-shadow: -1px 0 1px $black-54;
-    }
-    &::-ms-fill-lower {
-        background:$paper;
-        border: $paper;
-    }
-    &::-ms-fill-upper {
-        background:$paper;
-        border: $paper;
-    }
-    &:focus::-ms-fill-lower {
-        background:$paper;
-        border: $paper;
-    }
-    &:focus::-ms-fill-upper {
-        background:$paper;
-        border: $paper;
+        &::-ms-track {
+            background: transparent;
+            border-color: transparent;
+            color: transparent;
+        }
+        &::-ms-thumb {
+            background: $paper;
+            width: 14px;
+            height: 14px;
+            border: 2px solid $black-74;
+            border-radius: 4px;
+            box-shadow: -1px 0 1px $black-54;
+        }
+        &::-ms-fill-lower {
+            background:$paper;
+            border: $paper;
+        }
+        &::-ms-fill-upper {
+            background:$paper;
+            border: $paper;
+        }
+        &:focus::-ms-fill-lower {
+            background:$paper;
+            border: $paper;
+        }
+        &:focus::-ms-fill-upper {
+            background:$paper;
+            border: $paper;
+        }
     }
 }
 

--- a/src/mmw/sass/components/_slider-native.scss
+++ b/src/mmw/sass/components/_slider-native.scss
@@ -2,7 +2,6 @@
 .slider {
     -webkit-appearance: none;
     width: 100%;
-    margin: -7px 0;
     cursor: pointer;
 
     &:focus {
@@ -74,8 +73,76 @@
             border: $paper;
         }
     }
+
+    &#precip-slider {
+        height: 24px;
+        padding: 0px;
+        background: transparent;
+
+        &::-webkit-slider-runnable-track {
+            width: 100%;
+            height: 4px;
+            background: #a4c9d7;
+        }
+        &::-webkit-slider-thumb {
+            border: 3px solid $paper;
+            height: 24px;
+            width: 24px;
+            border-radius: 15px;
+            background: $active;
+            -webkit-appearance: none;
+            margin-top: -10px;
+        }
+        &:focus::-webkit-slider-runnable-track {
+            background: #a4c9d7;
+        }
+
+        &::-moz-range-track {
+            width: 100%;
+            height: 4px;
+            background: #a4c9d7;
+        }
+        &::-moz-range-thumb {
+            border: 3px solid $paper;
+            height: 24px;
+            width: 24px;
+            border-radius: 15px;
+            background: $active;
+        }
+
+        &::-ms-track {
+            width: 100%;
+            height: 24px;
+            background: transparent;
+            border-color: transparent;
+            color: transparent;
+        }
+        &::-ms-fill-lower {
+            background: #a4c9d7;
+            border: 0px solid #000000;
+            border-radius: 24px;
+        }
+        &::-ms-fill-upper {
+            background: #a4c9d7;
+            border: 0px solid #000000;
+            border-radius: 24px;
+        }
+        &::-ms-thumb {
+            border: 3px solid $paper;
+            height: 18px;
+            width: 18px;
+            border-radius: 15px;
+            background: $active;
+        }
+        &:focus::-ms-fill-lower {
+            background: #a4c9d7;
+        }
+        &:focus::-ms-fill-upper {
+            background: #a4c9d7;
+        }
+    }
 }
 
 .opacity_slider_control {
-    transform: matrix(0,-1,1,0,-62,70);
+    transform: matrix(0,-1,1,0,-62,63);
 }

--- a/src/mmw/sass/components/_slider-native.scss
+++ b/src/mmw/sass/components/_slider-native.scss
@@ -6,75 +6,75 @@
     cursor: pointer;
 
     &.slider-leaflet {
-      background: $black;
-      width: 150px;
-      height: 26px;
-      padding: 1px;
-      border: 11px solid $paper;
-      border-radius: 4px;
-      box-shadow: -1px 0 5px $black-65;
-      cursor: pointer;
+        background: $black;
+        width: 150px;
+        height: 26px;
+        padding: 1px;
+        border: 11px solid $paper;
+        border-radius: 4px;
+        box-shadow: -1px 0 5px $black-65;
+        cursor: pointer;
     }
 
     &:focus {
-      outline: none;
+        outline: none;
     }
     &::-webkit-slider-thumb {
-      background: $paper;
-      width: 12px;
-      height: 12px;
-      border: 2px solid $black-74;
-      border-radius: 4px;
-      box-shadow: -1px 0 1px $black-54;
-      -webkit-appearance: none;
+        background: $paper;
+        width: 12px;
+        height: 12px;
+        border: 2px solid $black-74;
+        border-radius: 4px;
+        box-shadow: -1px 0 1px $black-54;
+        -webkit-appearance: none;
     }
     &:focus::-webkit-slider-thumb {
-      background: $black;
+        background: $black;
     }
 
     &::-moz-range-track {
-      background: $black;
+        background: $black;
     }
     &::-moz-range-thumb {
-      background: $paper;
-      width: 10px;
-      height: 10px;
-      border: 2px solid $black-74;
-      border-radius: 4px;
-      box-shadow: -1px 0 1px $black-54;
+        background: $paper;
+        width: 10px;
+        height: 10px;
+        border: 2px solid $black-74;
+        border-radius: 4px;
+        box-shadow: -1px 0 1px $black-54;
     }
 
     &::-ms-track {
-      background: transparent;
-      border-color: transparent;
-      color: transparent;
+        background: transparent;
+        border-color: transparent;
+        color: transparent;
     }
     &::-ms-thumb {
-      background: $paper;
-      width: 14px;
-      height: 14px;
-      border: 2px solid $black-74;
-      border-radius: 4px;
-      box-shadow: -1px 0 1px $black-54;
+        background: $paper;
+        width: 14px;
+        height: 14px;
+        border: 2px solid $black-74;
+        border-radius: 4px;
+        box-shadow: -1px 0 1px $black-54;
     }
     &::-ms-fill-lower {
-      background:$paper;
-      border: $paper;
+        background:$paper;
+        border: $paper;
     }
     &::-ms-fill-upper {
-      background:$paper;
-      border: $paper;
+        background:$paper;
+        border: $paper;
     }
     &:focus::-ms-fill-lower {
-      background:$paper;
-      border: $paper;
+        background:$paper;
+        border: $paper;
     }
     &:focus::-ms-fill-upper {
-      background:$paper;
-      border: $paper;
+        background:$paper;
+        border: $paper;
     }
 }
 
 .opacity_slider_control {
-  transform: matrix(0,-1,1,0,-62,70);
+    transform: matrix(0,-1,1,0,-62,70);
 }


### PR DESCRIPTION
## Overview

The micro site's styling had been broken since we updated the opacity slider styling without caring for its specificity. By making the opacity slider styling more specific, and adding back lost micro site styling, we fix the precipitation slider in the micro site.

## Demo

Chrome:

![image](https://cloud.githubusercontent.com/assets/1430060/13683101/ed02c73e-e6d2-11e5-99ee-06466c179580.png)

Safari:

![image](https://cloud.githubusercontent.com/assets/1430060/13683114/ff55a046-e6d2-11e5-8023-9231c726e214.png)

Firefox:

![image](https://cloud.githubusercontent.com/assets/1430060/13683126/130ae5ba-e6d3-11e5-8af7-f81b019c8d67.png)

Internet Explorer:

![image](https://cloud.githubusercontent.com/assets/1430060/13683139/25d3a65a-e6d3-11e5-869e-005e19cb81c6.png)

## Testing Instructions

Test both opacity and precipitation sliders in multiple browsers.

Connects #1177 