### PR TITLE
Use retires with exponential backoff when choosing workers

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -12,3 +12,4 @@ djangorestframework-gis==0.8.2
 tr55==1.1.3
 requests==2.9.1
 rollbar>=0.11.0,<=0.12.0
+retry==0.9.1


### PR DESCRIPTION
When the call to ping available workers is made, if no workers come back and the string of calls results in an `AttributeError`, retry the call for workers again.

The current parameters should retry after:

- 0.5s
- 1s (2 x 0.5)
- 2s (2 x 1), and then fail

Attempts to resolve #1080