### PR TITLE
Fix precipitation slider issues in IE

### DIFF
--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -187,8 +187,7 @@
         <div class="sidebar">
 
             <div class="row pad-sm bdr-bottom"> <!-- Precipitation Slider -->
-                <div class="pull-left"><p>Precipitation for 24-hour storm event</p></div>
-                <br>
+                <div><p>Precipitation for 24-hour storm event</p></div>
                 <div class="well-precip row">
                     <label class="col-xs-2">
                         <img src="{% static 'images/water_balance/slider_min.png' %}" alt="slider min">

--- a/src/mmw/js/src/main_water_balance.js
+++ b/src/mmw/js/src/main_water_balance.js
@@ -113,7 +113,12 @@ var initialize = function(model) {
     }
 
     // Wire up events
-    $precipSlider.on('input', recalculate);
+    var isIE = ("ActiveXObject" in window);
+    if (isIE) {
+        $precipSlider.on('change', recalculate);
+    } else {
+        $precipSlider.on('input', recalculate);
+    }
     $('a[data-toggle="tab"]').on('shown.bs.tab', recalculate);
 
     // Trigger the first time page loads


### PR DESCRIPTION
## Overview

Enables precipitation slider in IE by firing the `change` event, since IE does not support the `input` event. Also fixes the label wrapping issue which happened only when the vertical scrollbar was visible.

## Demo

![mmw-ie-precipitation-slider-fix](https://cloud.githubusercontent.com/assets/1430060/13717293/95bec716-e7ae-11e5-80e1-d0868bd400df.gif)

Connects #1185 