### PR TITLE
Remove DRB streams in favor on NHDPlus Flowlines

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -68,7 +68,7 @@ fi
 
 if [ "$load_stream" = "true" ] ; then
     # Fetch stream network layer sql files
-    FILES=("drb_stream_network_20.sql.gz" "drb_stream_network_50.sql.gz" "drb_stream_network_100.sql.gz")
+    FILES=("nhdflowline.sql.gz")
 
     download_and_load $FILES
 fi


### PR DESCRIPTION
Updates the data loading script:
* Remove partial-DRB coverage of stream network
* Add national coverage of NHDPlus Flowlines

Connects #1194 

To test:

* Reload your services with more RAM (I used 5GB, but didn't try less)
* Load the stream network data via `$ ./scripts/setupdb.sh -s`
* Verify via pgsql or pgweb that the `nhdflowlines` table is created and loaded with `2993513` records and a spatial index on column "geom".

Once merged, I'll run this on our staging RDS instance prior to a PR that tiles this data so it can be tested.