### PR TITLE
Add stream network to overlay layers

### DIFF
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -120,10 +120,11 @@ def get_client_settings(request):
         'client_settings': json.dumps({
             EMBED_FLAG: request.session.get(EMBED_FLAG, False),
             'base_layers': get_layer_config(['basemap']),
-            'stream_layers': get_layer_config(['stream']),
+            'stream_drb_layers': get_layer_config(['stream_drb']),
             'boundary_layers': get_layer_config(['boundary']),
             'vector_layers': get_layer_config(['vector', 'overlay']),
             'raster_layers': get_layer_config(['raster', 'overlay']),
+            'stream_layers': get_layer_config(['stream', 'overlay']),
             'draw_tools': settings.DRAW_TOOLS,
             'map_controls': settings.MAP_CONTROLS,
             'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,

--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -138,14 +138,22 @@ module.exports = L.Control.Layers.extend({
             input.checked = true;
         }
 
-        if (_.contains(['raster', 'vector'], obj.overlayType)) {
+        if (_.contains(['stream', 'raster', 'vector'], obj.overlayType)) {
              var subcontainer = document.getElementById('overlay-subclass-' + obj.overlayType);
              if (subcontainer === null) {
                  subcontainer = document.createElement('div');
                  subcontainer.id = 'overlay-subclass-' + obj.overlayType;
                  this._overlaysList.appendChild(subcontainer);
 
-                 var title = obj.overlayType === 'vector' ? 'Boundary' : 'Coverage';
+                 var title;
+                 if (obj.overlayType === 'vector') {
+                     title = 'Boundary';
+                 } else if (obj.overlayType === 'raster') {
+                     title = 'Coverage';
+                 } else if (obj.overlayType === 'stream') {
+                     title = 'Streams';
+                 }
+
                  var textNode = document.createElement('h4');
                  textNode.innerHTML = title;
                  subcontainer.appendChild(textNode);
@@ -174,7 +182,17 @@ module.exports = L.Control.Layers.extend({
         };
 
         if (tabType === 'overlay') {
-             this._layers[id].overlayType = layer.options.vector ? 'vector' : 'raster';
+            var overlayType;
+            if (layer.options.vector) {
+                overlayType = 'vector';
+            } else if (layer.options.raster) {
+                overlayType = 'raster';
+            } else if (layer.options.stream) {
+                overlayType = 'stream';
+            }
+
+            this._layers[id].overlayType = overlayType;
+
         } else if (tabType === 'observation') {
              this._layers[id].overlayType = tabType;
         }

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -4,6 +4,7 @@ var defaultSettings = {
     itsi_embed: false,
     base_layers: {},
     stream_layers: {},
+    stream_drb_layers: {},
     boundary_layers: {},
     draw_tools: [],
     map_controls: [],

--- a/src/mmw/js/src/core/streamSliderControl.js
+++ b/src/mmw/js/src/core/streamSliderControl.js
@@ -58,7 +58,7 @@ var StreamSliderView = Marionette.ItemView.extend({
 
     initialize: function(options) {
         this.streamFeatures = options.streamFeatures;
-        this.streamLayers = settings.get('stream_layers');
+        this.streamLayers = settings.get('stream_drb_layers');
     },
 
     onShow: function() {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -295,26 +295,23 @@ var MapView = Marionette.ItemView.extend({
     },
 
     prepareOverlayLayers: function() {
-        var nullVectorLayer = {
-                display: 'nullVector',
-                vector: true,
-                empty: true
-            },
-            nullRasterLayer = {
-                display: 'nullRaster',
-                raster: true,
-                empty: true
-            },
-            vectorOverlayLayers = settings.get('vector_layers'),
-            rasterOverlayLayers = settings.get('raster_layers');
+        // For each type of overlay, create an empty "layer" used for
+        // the "None" option and order the actual defined layer configs
+        // after it.
+        var overlayTypes = ['stream', 'vector', 'raster'],
+            overlayLayers = _.map(overlayTypes, function(type) {
+                var nullLayer =  {
+                    display: 'null' + type,
+                    empty: true
+                };
 
-        vectorOverlayLayers = !_.isEmpty(vectorOverlayLayers) ?
-                                [nullVectorLayer].concat(vectorOverlayLayers) : [];
+                nullLayer[type] = true;
 
-        rasterOverlayLayers = !_.isEmpty(rasterOverlayLayers) ?
-                                [nullRasterLayer].concat(rasterOverlayLayers) : [];
+                var layers = settings.get(type + '_layers');
+                return [nullLayer].concat(layers);
+            });
 
-        return vectorOverlayLayers.concat(rasterOverlayLayers);
+        return _.flatten(overlayLayers);
     },
 
     setupGeoLocation: function(maxAge) {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -307,8 +307,13 @@ var MapView = Marionette.ItemView.extend({
 
                 nullLayer[type] = true;
 
+                // Layers may be null in testing
                 var layers = settings.get(type + '_layers');
-                return [nullLayer].concat(layers);
+                if (!_.isEmpty(layers)) {
+                    return [nullLayer].concat(layers);
+                } else {
+                    return [nullLayer];
+                }
             });
 
         return _.flatten(overlayLayers);

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -110,6 +110,15 @@ LAYERS = [
         'minZoom': 9,
     },
     {
+        'code': 'stream',
+        'display': 'National Stream Network',
+        'table_name': 'nhdflowline',
+        'boundary': False,
+        'stream': True,
+        'overlay': True,
+        'minZoom': 10
+    },
+    {
         'display': 'National Land Cover Database',
         'short_display': 'NLCD',
         'helptext': 'National Land Cover Database defines'
@@ -144,19 +153,19 @@ LAYERS = [
         'code': 'stream-low',
         'display': 'Low-Res',
         'table_name': 'deldem4net100r',
-        'stream': True,
+        'stream_drb': True,
     },
     {
         'code': 'stream-medium',
         'display': 'Medium-Res',
         'table_name': 'deldem4net50r',
-        'stream': True,
+        'stream_drb': True,
     },
     {
         'code': 'stream-high',
         'display': 'High-Res',
         'table_name': 'deldem4net20r',
-        'stream': True,
+        'stream_drb': True,
     },
     {
         'type': 'mapbox',

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -35,7 +35,8 @@ var interactivity = {
         huc12: 'boundary_huc12',
         'stream-low': 'drb_stream_network_100',
         'stream-medium': 'drb_stream_network_50',
-        'stream-high': 'drb_stream_network_20'
+        'stream-high': 'drb_stream_network_20',
+        stream: 'nhdflowline'
     },
     shouldCacheRequest = function(req) {
         // Caching can happen if the bucket to write to is defined

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -20,13 +20,14 @@
   }
 }
 
-@zoomBase: 0.3;
+@zoomBase: 0.5;
 
 #drb_stream_network_20,
 #drb_stream_network_50,
-#drb_stream_network_100
+#drb_stream_network_100,
+#nhdflowline
 {
-  line-color: #78CAE6;
+  line-color: #1562A9;
   [zoom<=10] { line-width: 1.0 * @zoomBase; }
   [zoom=11] { line-width: 2.0 * @zoomBase; }
   [zoom=12] { line-width: 4.0 * @zoomBase; }


### PR DESCRIPTION
* Configure app & windshaft to serve and style nhdflowlines
* Consolidate generation of overlay list
* Renamed "stream slider" streams data to be DRB specific.  These may be removed/updated soon.
* Adds new category type to overlay layers

DRB Streams as-is will probably be removed in the near future as the feature
is deprecated.

Connects #1194 

To test, assumes you have `nhdflowlines` loaded (see #1196).

After bundling, on the Layer Selector Overlay panel, you should see a new category for Streams with an option to turn on National Stream Network

![screenshot from 2016-03-15 10 47 41](https://cloud.githubusercontent.com/assets/1014341/13781975/9b6861aa-ea9b-11e5-9d0d-cd603f6d5855.png)
