### PR TITLE
Activate & deactivate layers on start without using location

### DIFF
--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -26,17 +26,20 @@ var utils = {
     // A function to enable/disable UI entries in response to zoom
     // level changes.
     zoomToggle: function(map, layerData, actOnUI, actOnLayer) {
-        map.on('zoomend', function(e) {
-            var zoom = e.target.getZoom();
-            _.forEach(layerData, function(layerDatum) {
-                if (zoom < (layerDatum.minZoom || 0)) {
-                    actOnUI(layerDatum, true);
-                    actOnLayer(layerDatum);
-                } else if (zoom >= (layerDatum.minZoom || 0)) {
-                    actOnUI(layerDatum, false);
-                }
-            });
-        });
+        var toggleActiveLayers = function(e) {
+                var zoom = e.target.getZoom();
+                _.forEach(layerData, function(layerDatum) {
+                    if (zoom < (layerDatum.minZoom || 0)) {
+                        actOnUI(layerDatum, true);
+                        actOnLayer(layerDatum);
+                    } else if (zoom >= (layerDatum.minZoom || 0)) {
+                        actOnUI(layerDatum, false);
+                    }
+                });
+            };
+
+        map.once('touchstart mouseover', toggleActiveLayers);
+        map.on('zoomend', toggleActiveLayers);
     },
 
     // A numeric comparator for strings.


### PR DESCRIPTION
PR changes the `zoomToggle` method to update the active and inactive layers on the first (and only the first) detected `touchstart` and `mouseover` events. This ensures the active & inactive layers will get set even the map doesn't initially zoom in on a user's location.

To test:

- block MMW from detecting your location via the browser
- refresh the site
- open the Layer Control window and select the overlays tab
- verify that all the Boundary layers are inactive -- since the default zoom level is below the minimum zoom level required for these layers.

<img width="997" alt="screen shot 2016-03-16 at 12 38 58 pm" src="https://cloud.githubusercontent.com/assets/4165523/13820581/645d6cf8-eb74-11e5-992c-cf62038a4025.png">


Connects #1189