### PR TITLE
Style RWD click-snap markers

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -19,7 +19,6 @@ var L = require('leaflet'),
     OpacityControl = require('./opacityControl'),
     VizerLayers = require('./vizerLayers');
 
-
 require('leaflet.locatecontrol');
 require('leaflet-plugins/layer/tile/Google');
 
@@ -610,17 +609,31 @@ var MapView = Marionette.ItemView.extend({
             additionalShapes = this.model.get('areaOfInterestAdditionals');
 
         if (additionalShapes) {
-            var pointsLayer = new L.GeoJSON(additionalShapes, {
-                onEachFeature: function(feature, layer) {
-                    var message = "Outlet point snapped to nearest stream";
-                    if (feature.properties && feature.properties.original) {
-                        message = "Original clicked outlet point";
-                    }
-
-                    layer.bindPopup(message);
+            _.each(additionalShapes.features, function(geoJSONpoint) {
+                function createMarkerIcon(iconName) {
+                    return L.divIcon({
+                        className: 'marker-rwd marker-rwd-' + iconName,
+                        iconSize: [16,16]
+                    });
                 }
+
+                var newLayer = L.geoJson(geoJSONpoint, {
+                    pointToLayer: function(feature, latLngForPoint) {
+                        var customIcon = feature.properties.original ?
+                            createMarkerIcon('original-point') :
+                            createMarkerIcon('nearest-stream-point');
+                        return L.marker(latLngForPoint, { icon: customIcon });
+                    },
+                    onEachFeature: function(feature, layer) {
+                        var popupMessage = feature.properties.original ?
+                            "Original clicked outlet point" :
+                            "Outlet point snapped to nearest stream";
+                        layer.bindPopup(popupMessage);
+                    }
+                });
+
+                self._areaOfInterestLayer.addLayer(newLayer);
             });
-            self._areaOfInterestLayer.addLayer(pointsLayer);
         }
     },
 

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -175,3 +175,31 @@
 .leaflet-popup {
   font-family: $font-family !important;
 }
+
+// style markers for 'Delineate Watershed'
+
+.marker-rwd {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 100%;
+  border: 1px solid #fff;
+  &:after {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    top: 2px;
+    left: 2px;
+    background-color: #fff;
+    content: "";
+    border-radius: 100%;
+  }
+}
+
+.marker-rwd-original-point {
+  background-color: #8e44ad;
+}
+
+.marker-rwd-nearest-stream-point {
+  background-color: #3498db;
+}


### PR DESCRIPTION
This commit creates some custom marker icons to be used in the "Delineate Watershed" tool. 

#1164 had a request to use different marker colors and icons to represent the point a student originally clicked and the point snapped to the nearest stream. I tweaked the colors a bit from Jeff's original design in order to make the difference between the points more stark. The method that creates the icon's now set up to make it easier to alter them using CSS rules.

I ended up *not* doing anything to change the appearance of the marker used when selecting a point. If we should change that, too, let's handle it in a different issue.

I tested this on OS X with Safari, Chrome, and Firefox.

**Testing**
- open the "Delineate Watershed" dropdown
- select "Stream Network"
- place the marker somewhere on the map for which we've got data (Philly proper seems to work). 

The result should look something like ...

<img width="773" alt="screen shot 2016-03-18 at 4 46 34 pm" src="https://cloud.githubusercontent.com/assets/4165523/13891689/05c8a386-ed29-11e5-8eb8-dba72199c66d.png">

- Click the purple-ringed dot to verify that you see a pop-up reading "Original clicked outlet point"
- Click the blue-ringed dot to verify that you see a pop-up reading "Outlet point snapped to nearest stream"
- Click the Back button in the Analyze pane to verify that it returns you to a map with tool options enabled and the markers still placed and clickable:

<img width="988" alt="screen shot 2016-03-18 at 4 50 26 pm" src="https://cloud.githubusercontent.com/assets/4165523/13891777/8b55afe4-ed29-11e5-951f-671fa3359b3f.png">

Connects #1164 