### PR TITLE
Add historic weather data to setup script

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -79,7 +79,7 @@ fi
 
 if [ "$load_mapshed" = "true" ] ; then
     # Fetch map shed specific vector features
-    FILES=("ms_weather_station.sql.gz" "ms_pointsource.sql.gz" "ms_county_animals.sql.gz")
+    FILES=("ms_weather.sql.gz" "ms_weather_station.sql.gz" "ms_pointsource.sql.gz" "ms_county_animals.sql.gz")
 
     download_and_load $FILES
 fi


### PR DESCRIPTION
Running mapshed data loading option will now import historical weather
data that relates to the existing ms_weather_station feature class.

Connects #1193 

To test

* Data sets are small, no need to tweak VM resources
* Copy this branch version of setupdb to a place accessible to psql (app VM is good)
* Run ./setupdb.sh -m to load vector & weather datasets:

```
mmw=# select count(*) from ms_weather;
 count  
--------
 253440
(1 row)
```