### PR TITLE
Client-side validation that user-selected point is within DRB

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -51,7 +51,8 @@ function validateRwdShape(result) {
             })
             .fail(d.reject);
     } else {
-        d.reject(result);
+        var message = 'Unable to delineate watershed at this location';
+        d.reject(message);
     }
     return d.promise();
 }
@@ -66,8 +67,7 @@ function validateShape(polygon) {
         message += Math.floor(area) + ' square km were selected, ';
         message += 'but the maximum supported size is currently ';
         message += MAX_AREA + ' square km.';
-        window.alert(message);
-        d.reject();
+        d.reject(message);
     } else {
         d.resolve(polygon);
     }
@@ -82,7 +82,8 @@ function validateClickedPointWithinDRB(latlng) {
     if (turfIntersect(point, drbPerimeter)) {
         d.resolve(latlng);
     } else {
-        d.reject(latlng);
+        var message = 'Selected point is outside the Delaware River Basin';
+        d.reject(message);
     }
     return d.promise();
 }
@@ -404,7 +405,9 @@ var WatershedDelineationView= Marionette.ItemView.extend({
                             polling: false
                         });
                         console.log(response.error);
-                        deferred.reject();
+                        var message = 'Unable to delineate watershed at ' +
+                                      'this location';
+                        deferred.reject(message);
                     },
 
                     pollEnd: function() {
@@ -416,7 +419,8 @@ var WatershedDelineationView= Marionette.ItemView.extend({
                             pollError: true,
                             polling: false
                         });
-                        deferred.reject();
+                        var message = 'Unable to delineate watershed';
+                        deferred.reject(message);
                     },
 
                     postData: {
@@ -456,9 +460,11 @@ var WatershedDelineationView= Marionette.ItemView.extend({
                 addLayer(result.watershed, itemName);
                 navigateToAnalyze();
             })
-            .fail(function() {
+            .fail(function(message) {
                 revertLayer();
-                window.alert('Unable to delineate watershed at this location');
+                if (message) {
+                    window.alert(message);
+                }
             })
             .always(function() {
                 self.model.enableTools();


### PR DESCRIPTION
This PR adds some client-side validation that the user-selected point for "Delineate Watershed" is within the Delaware River Basin. If the point's not in the DRB, the app will immediate show an alert message to explain the error without making a request to the server. This one depends on @lewfish PR #1204.

I also rewrote how the flow of "Delineate Watershed" handles displaying error message alerts: the general `.fail` case now accepts an optional `message` argument. If there's a message, it will get displayed as an alert; if not, the failure will pass by silently. I added error messages to each possible failure that should show them. For a "failure" like the one mentioned in #1181 where the user has hit Escape or clicked Reset to cancel selecting a point, everything will just reset silently.

**Testing Instructions**

- click Delineate Watershed > Stream Network, then select a point in What Cheer, Iowa (or, really, anywhere not in the DRB). You should see this alert, and you should *not* see a failure icon on the "Delineate Watershed" button:

<img width="680" alt="screen shot 2016-03-22 at 10 29 43 am" src="https://cloud.githubusercontent.com/assets/4165523/13954924/1ed0c21c-f019-11e5-8b4c-d27df0f0753d.png">

- click OK and everything should reset

- click Delineate Watershed > Stream Network and then hit Escape or click Reset. You shouldn't see an alert message and everything should reset.

- turn on Chrome's Network Link Conditioner to simulate being offline altogether, then try to select a point within the DRB. You should see something like:

<img width="509" alt="screen shot 2016-03-22 at 10 34 49 am" src="https://cloud.githubusercontent.com/assets/4165523/13955095/c263abd8-f019-11e5-9381-ed5c04f70bbf.png">

& everything should reset.

There are specific messages for a few additional possible failures, and a generic "Unable to delineate watershed at this location" message for others.

Connects #1181 
Connects #1160