### PR TITLE
Stub out Mapshed endpoint

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import time
 import requests
 from celery import shared_task
 import json
@@ -18,6 +19,20 @@ logger = logging.getLogger(__name__)
 
 KG_PER_POUND = 0.453592
 CM_PER_INCH = 2.54
+
+
+@shared_task
+def start_mapshed_job(input):
+    """
+    Runs a Mapshed job. For now, just wait 3s and return the input.
+    """
+    # TODO remove sleep and call actual mapshed code
+    time.sleep(3)
+    response_json = {
+        'input': input
+    }
+
+    return response_json
 
 
 @shared_task

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -25,6 +25,7 @@ urlpatterns = patterns(
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),
     url(r'start/rwd/$', views.start_rwd, name='start_rwd'),
+    url(r'start/mapshed/$', views.start_mapshed, name='start_mapshed'),
     url(r'boundary-layers/(?P<table_code>\w+)/(?P<obj_id>[0-9]+)/$',
         views.boundary_layer_detail, name='boundary_layer_detail'),
 )


### PR DESCRIPTION
This adds a stubbed out endpoint for starting Mapshed jobs, modeled after the one for RWD, since it isn't clear what the inputs from the UI are yet. To test, run `./debugcelery.sh` and `http -f POST http://localhost:8000/api/modeling/start/mapshed/ input=5`. Then run `http http://localhost:8000/api/modeling/jobs/<job_uuid>/` which should return results containing `{ input: 5 }`.

Connects #1201