### PR TITLE
Remove stream layers from boundary selection

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -122,7 +122,6 @@ LAYERS = [
         'code': 'stream',
         'display': 'National Stream Network',
         'table_name': 'nhdflowline',
-        'boundary': False,
         'stream': True,
         'overlay': True,
         'minZoom': 10
@@ -131,7 +130,6 @@ LAYERS = [
         'code': 'drb_streams',
         'display': 'DRB Stream Network',
         'table_name': 'drb_streams_50',
-        'boundary': False,
         'stream': True,
         'overlay': True,
         'minZoom': 11,


### PR DESCRIPTION
The code which filters layers based on layer attributes uses the
existance of the key, not the truthiness of it, to determine inclusion.
Remove the `boundary: False` value to remove from the app.

Connects #1217 

##### Test
Start the app and see that Streams and DRB Stream are *not* available in the "Select by Boundary" dropdown, but are still preserved in the Layer Selector Overlay panel.

![screenshot from 2016-03-31 13 10 35](https://cloud.githubusercontent.com/assets/1014341/14184320/9c7a5c48-f742-11e5-83d7-c6fbaf52a232.png)