### PR TITLE
Select GWLF-E in UI

### DIFF
--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -12,6 +12,7 @@ urlpatterns = patterns(
     url(r'^$', home_page, name='home_page'),
     url(r'^projects/$', projects, name='projects'),
     url(r'^project/$', project, name='project'),
+    url(r'^project/new/', project, name='project'),
     url(r'^project/(?P<proj_id>[0-9]+)/$', project, name='project'),
     url(r'^project/(?P<proj_id>[0-9]+)/clone/?$',
         project_clone, name='project_clone'),

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -113,6 +113,13 @@ def get_layer_url(layer):
     return urljoin(tiler_base, layer['code'] + tiler_postfix)
 
 
+def get_model_packages():
+    for model_package in settings.MODEL_PACKAGES:
+        if model_package['name'] in settings.DISABLED_MODEL_PACKAGES:
+            model_package['disabled'] = True
+    return settings.MODEL_PACKAGES
+
+
 def get_client_settings(request):
     EMBED_FLAG = settings.ITSI['embed_flag']
 
@@ -127,7 +134,8 @@ def get_client_settings(request):
             'draw_tools': settings.DRAW_TOOLS,
             'map_controls': settings.MAP_CONTROLS,
             'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,
-            'vizer_urls': settings.VIZER_URLS
+            'vizer_urls': settings.VIZER_URLS,
+            'model_packages': get_model_packages(),
         })
     }
 

--- a/src/mmw/apps/modeling/migrations/0017_add_gwlfe.py
+++ b/src/mmw/apps/modeling/migrations/0017_add_gwlfe.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0016_old_scenarios'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='model_package',
+            field=models.CharField(help_text='Which model pack was chosen for this project', max_length=255, choices=[('tr-55', 'Site Storm Model'), ('gwlfe', 'Watershed Multi-Year Model')]),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -9,7 +9,11 @@ from django.contrib.auth.models import User
 
 class Project(models.Model):
     TR55 = 'tr-55'
-    MODEL_PACKAGES = ((TR55, 'Simple Model'),)
+    GWLFE = 'gwlfe'
+    MODEL_PACKAGES = (
+        (TR55, 'Site Storm Model'),
+        (GWLFE, 'Watershed Multi-Year Model'),
+    )
 
     user = models.ForeignKey(User)
     name = models.CharField(

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -22,14 +22,13 @@ CM_PER_INCH = 2.54
 
 
 @shared_task
-def start_mapshed_job(input):
+def start_gwlfe_job(model_input):
     """
-    Runs a Mapshed job. For now, just wait 3s and return the input.
+    Runs a GWLFE job. For now, just wait 3s and return the input.
     """
-    # TODO remove sleep and call actual mapshed code
+    # TODO remove sleep and call actual GWLFE code
     time.sleep(3)
     response_json = {
-        'input': input
     }
 
     return response_json

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -25,7 +25,7 @@ urlpatterns = patterns(
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),
     url(r'start/rwd/$', views.start_rwd, name='start_rwd'),
-    url(r'start/mapshed/$', views.start_mapshed, name='start_mapshed'),
+    url(r'start/gwlfe/$', views.start_gwlfe, name='start_gwlfe'),
     url(r'boundary-layers/(?P<table_code>\w+)/(?P<obj_id>[0-9]+)/$',
         views.boundary_layer_detail, name='boundary_layer_detail'),
 )

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -189,17 +189,17 @@ def start_rwd(request, format=None):
 
 @decorators.api_view(['POST'])
 @decorators.permission_classes((AllowAny, ))
-def start_mapshed(request, format=None):
+def start_gwlfe(request, format=None):
     """
-    Starts a job to run Mapshed.
+    Starts a job to run GWLF-E.
     """
     user = request.user if request.user.is_authenticated() else None
     created = now()
-    input = request.POST['input']
+    model_input = request.POST['model_input']
     job = Job.objects.create(created_at=created, result='', error='',
                              traceback='', user=user, status='started')
 
-    task_list = _initiate_mapshed_job_chain(input, job.id)
+    task_list = _initiate_gwlfe_job_chain(model_input, job.id)
 
     job.uuid = task_list.id
     job.save()
@@ -212,13 +212,13 @@ def start_mapshed(request, format=None):
     )
 
 
-def _initiate_mapshed_job_chain(input, job_id):
+def _initiate_gwlfe_job_chain(model_input, job_id):
     exchange = MAGIC_EXCHANGE
     routing_key = choose_worker()
 
-    return chain(tasks.start_mapshed_job.s(input)
+    return chain(tasks.start_gwlfe_job.s(model_input)
                  .set(exchange=exchange, routing_key=routing_key),
-                 save_job_result.s(job_id, input)) \
+                 save_job_result.s(job_id, model_input)) \
         .apply_async(link_error=save_job_error.s(job_id))
 
 

--- a/src/mmw/js/src/analyze/templates/resultsWindow.html
+++ b/src/mmw/js/src/analyze/templates/resultsWindow.html
@@ -7,14 +7,31 @@
             </a>
         </li>
         <li>
-            <a aria-controls="home" aria-expanded="false">
+            <a class="back-button" aria-controls="home" aria-expanded="false">
                 <button type="button" class="btn btn-lg" data-url="/">
                     Back
                 </button>
-                <button type="button" class="btn btn-lg btn-active" data-url="/project">
-                    Model
-                </button>
             </a>
+
+            <div class="dropdown">
+              <button class="btn btn-lg btn-active dropdown-toggle" type="button" data-toggle="dropdown">Model
+              <span class="caret"></span></button>
+              <ul class="dropdown-menu dropdown-menu-right">
+                {% for modelPackage in modelPackages %}
+                    <li>
+                        {% if modelPackage.disabled %}
+                            <a class="disabled" href="#">
+                                {{ modelPackage.display_name }} (Coming Soon)
+                            </a>
+                        {% else %}
+                            <a href="#" data-url="/project/new/{{ modelPackage.name }}">
+                                {{ modelPackage.display_name }}
+                            </a>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+              </ul>
+            </div>
         </li>
     </ul>
 </div>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -5,6 +5,7 @@ var $ = require('jquery'),
     Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
     models = require('./models'),
+    settings = require('../core/settings'),
     coreModels = require('../core/models'),
     chart = require('../core/chart'),
     utils = require('../core/utils'),
@@ -41,6 +42,12 @@ var ResultsView = Marionette.LayoutView.extend({
         this.analyzeRegion.show(new AnalyzeWindow({
             model: this.model
         }));
+    },
+
+    templateHelpers: function() {
+        return {
+            modelPackages: settings.get('model_packages')
+        };
     },
 
     transitionInCss: {

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -8,7 +8,8 @@ var defaultSettings = {
     boundary_layers: {},
     draw_tools: [],
     map_controls: [],
-    vizer_urls: {}
+    vizer_urls: {},
+    model_packages: []
 };
 
 var settings = (function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -24,7 +24,9 @@
     projectMenuTmpl = require('./templates/projectMenu.html'),
     scenarioToolbarTabContentTmpl = require('./templates/scenarioToolbarTabContent.html'),
     tr55RunoffViews = require('./tr55/runoff/views.js'),
-    tr55QualityViews = require('./tr55/quality/views.js');
+    tr55QualityViews = require('./tr55/quality/views.js'),
+    gwlfeRunoffViews = tr55RunoffViews, // TODO actually make views for gwlfe
+    gwlfeQualityViews = tr55QualityViews;
 
 var ENTER_KEYCODE = 13,
     ESCAPE_KEYCODE = 27;
@@ -838,12 +840,22 @@ function triggerBarChartRefresh() {
 
 function getResultView(modelPackage, resultName) {
     switch (modelPackage) {
-        case 'tr-55':
+        case models.TR55_PACKAGE:
             switch(resultName) {
                 case 'runoff':
                     return tr55RunoffViews.ResultView;
                 case 'quality':
                     return tr55QualityViews.ResultView;
+                default:
+                    console.log('Result not supported.');
+            }
+            break;
+        case models.GWLFE:
+            switch(resultName) {
+                case 'runoff':
+                    return gwlfeRunoffViews.ResultView;
+                case 'quality':
+                    return gwlfeQualityViews.ResultView;
                 default:
                     console.log('Result not supported.');
             }

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -11,6 +11,7 @@ var router = require('./router').router,
 
 router.addRoute(/^/, DrawController, 'draw');
 router.addRoute(/^analyze/, AnalyzeController, 'analyze');
+router.addRoute('project/new/:modelPackage(/)', ModelingController, 'makeNewProject');
 router.addRoute('project(/:projectId)(/scenario/:scenarioId)(/)', ModelingController, 'project');
 router.addRoute('project/:projectId/clone(/)', ModelingController, 'projectClone');
 router.addRoute('project/:projectId/draw(/)', ModelingController, 'projectDraw');

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -394,4 +394,22 @@ MAP_CONTROLS = [
     'ZoomControl',
 ]
 
+GWLFE = 'gwlfe'
+TR55_PACKAGE = 'tr-55'
+
+MODEL_PACKAGES = [
+    {
+        'name': TR55_PACKAGE,
+        'display_name': 'Site Storm Model',
+        'description': '',
+    },
+    {
+        'name': GWLFE,
+        'display_name': 'Watershed Multi-Year Model',
+        'description': '',
+    },
+]
+
+DISABLED_MODEL_PACKAGES = []
+
 # END UI CONFIGURATION

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -108,6 +108,8 @@ MAP_CONTROLS = [
     'ZoomControl',
 ]
 
+DISABLED_MODEL_PACKAGES = [GWLFE]
+
 # END UI CONFIGURATION
 
 # Google API key for production deployment

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -18,6 +18,14 @@
     transform: translateX(100%);
   }
 
+  .back-button {
+      display: inline-block;
+  }
+
+  .disabled {
+      text-decoration: none;
+  }
+
   &.analyze {
     top: $height-lg;
   }


### PR DESCRIPTION
The user can now select the model package (TR-55 or GWLF-E) for a project. The dropdown will be replaced by a better one after the prototype is finished. 

To test, try with `disabled` set to both `true` and `false` [here](https://github.com/lewfish/model-my-watershed/blob/feature/select-gwlfe/src/mmw/js/src/modeling/models.js#L27). TR-55 should work as before, and GWLF-E should poll the gwlfe endpoint, which will return empty results, leading to blank Runoff and Water Quality views and error messages in the console. Hitting back in the model view should work as before. Also, test while logged in.

![screen shot 2016-04-01 at 1 47 37 pm 2](https://cloud.githubusercontent.com/assets/1896461/14215355/6a73585c-f810-11e5-8b97-0e8e06d99662.png)

Connects #1200 