### PR TITLE
Fix DRB detection for stream delineation feature.

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -77,8 +77,8 @@ function validateShape(polygon) {
 function validateClickedPointWithinDRB(latlng) {
     var point = L.marker(latlng).toGeoJSON(),
         d = $.Deferred(),
-        boundaries = settings.get('boundary_layers'),
-        drbPerimeter = _.findWhere(boundaries, {code:'drb_streams'}).perimeter;
+        streamLayers = settings.get('stream_layers'),
+        drbPerimeter = _.findWhere(streamLayers, {code:'drb_streams'}).perimeter;
     if (turfIntersect(point, drbPerimeter)) {
         d.resolve(latlng);
     } else {


### PR DESCRIPTION
* DRB is not a boundary layer, but a stream layer. This worked
previously because of this bug:
https://github.com/WikiWatershed/model-my-watershed/pull/1218

**Testing**
- Verify that when you click to start an RWD job, an error is not thrown, and that the point is checked to see if it is in the DRB.