### PR TITLE
Process overlapping BMPs/land usage polygons

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -226,8 +226,13 @@ def run_tr55(censuses, model_input, cached_aoi_census=None):
     # Calculate total areas for each type modification
     area_sums = {}
     for piece in modification_pieces:
-        kind = piece['value']
+        kinds = piece['value']
         area = piece['area']
+
+        if 'bmp' in kinds:
+            kind = kinds['bmp']
+        else:
+            kind = kinds['reclass']
 
         if kind in area_sums:
             area_sums[kind] += area
@@ -322,9 +327,9 @@ def build_tr55_modification_input(pieces, censuses):
         value = modification['value']
 
         if name == 'landcover':
-            return {'change': ':%s:' % value}
+            return {'change': ':%s:' % value['reclass']}
         elif name == 'conservation_practice':
-            return {'change': '::%s' % value}
+            return {'change': '::%s' % value['bmp']}
         elif name == 'both':
             return {'change': ':%s:%s' % (value['reclass'], value['bmp'])}
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -389,6 +389,7 @@ function _alterModifications(rawModifications) {
                         overlapPiece.value.reclass = newPiece.value;
                     }
 
+                    overlapPiece.area = turfArea(overlapPiece.shape);
                     pieces.push(overlapPiece);
 
                     /* remove the overlapping portion from both parents */
@@ -413,7 +414,20 @@ function _alterModifications(rawModifications) {
         pieces = _.filter(pieces, validShape);
     }
 
-    return pieces;
+    return _.map(pieces, function(piece) { //ensures 'value' is uniform type for each piece
+      var p = piece;
+      if ( typeof p.value === 'string') {
+        var v = {};
+        if (p.name === reclass) { 
+          v.reclass = p.value; 
+        }
+        else if (p.name === bmp) { 
+          v.bmp = p.value; 
+        }
+        p.value = v;
+      }
+      return p;
+    });
 }
 
 var alterModifications = _.memoize(_alterModifications, function(_, hash) {return hash;});


### PR DESCRIPTION
This fixes a bug that prevented proper model processing for scenarios in which land usage / BMP polygons overlapped. When modelling a scenario that involved 2+ overlapping polygons from both the "Land Cover" and "Conservation Practice" categories, the server will not return any data and the UI component will be empty. This appeared to be the case for any combination of the different land/BMP types.

The problem was a type mismatch, due to the client-side app sending an inconsistently typed 'value', which was eventually caught on the server. The necessary change required the client to send a consistent type, as well as the server to 'expect' a different (but constant) type. Also notable was that the client-side app didn't send a value for 'area' for the overlapping sections, which was also caught on the server and similarly prevented any data being returned to the client.

**To test this as a fix**: create modelling scenarios that have at least 1 overlapping area b/w a land cover area and a conservation area. The original issue #1155  indicated that a land cover of "forest" and a conservation area of "green roof" produced the error, and I found that any random combination I tried produced the error as well.