### PR TITLE
Bump Beaver version to avoid Mosquito dependency

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -40,6 +40,8 @@ docker_version: "1.9.*"
 docker_py_version: "1.2.3"
 docker_options: "--storage-driver=aufs"
 
+beaver_version: "36.2.0"
+
 sjs_host: "localhost"
 sjs_port: 8090
 sjs_container_image: "quay.io/azavea/spark-jobserver:0.6.1"


### PR DESCRIPTION
Something happened to a transitive dependency of Beaver, which caused installs to fail. This bumps to a version of Beaver that removes the broken dependency (Mosquito).

See also: https://github.com/python-beaver/python-beaver/pull/399

---

**Testing**

Provision servers with updated dependency and ensure that logs are still flowing to [Kibana](http://localhost:5601/).