### PR TITLE
Override Beaver version in project wrapper role

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -40,8 +40,6 @@ docker_version: "1.9.*"
 docker_py_version: "1.2.3"
 docker_options: "--storage-driver=aufs"
 
-beaver_version: "36.2.0"
-
 sjs_host: "localhost"
 sjs_port: 8090
 sjs_container_image: "quay.io/azavea/spark-jobserver:0.6.1"

--- a/deployment/ansible/roles/model-my-watershed.beaver/vars/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.beaver/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-beaver_version: "33.3.0"
+beaver_version: "36.2.0"
 beaver_redis_url: "redis://{{ redis_host }}:{{ redis_port }}/0"


### PR DESCRIPTION
The top level group variable for `beaver_version` was being overwritten by the wrapper role's variable. Changing it here actually allows it to take effect on an Ansible run.

---

**Testing**

Enable verbose logging for Ansible in the `Vagrantfile` and ensure that the installation for Beaver uses version `36.2.0`:

```diff
diff --git a/Vagrantfile b/Vagrantfile
index 20b7031..7693503 100644
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -189,6 +189,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.playbook = "deployment/ansible/tile-servers.yml"
       ansible.groups = ANSIBLE_GROUPS.merge(ANSIBLE_ENV_GROUPS)
       ansible.raw_arguments = ["--timeout=60"]
+      ansible.verbose = "vvvv"
     end
   end
 end
```

Then just provision the `tiler`:

```bash
$ vagrant provision tiler
```