### PR TITLE
Fix select model package in ITSI mode

### DIFF
--- a/src/mmw/js/src/analyze/templates/resultsWindow.html
+++ b/src/mmw/js/src/analyze/templates/resultsWindow.html
@@ -9,7 +9,7 @@
         <li>
             <a class="back-button" aria-controls="home" aria-expanded="false">
                 <button type="button" class="btn btn-lg" data-url="/">
-                    Back
+                    Draw
                 </button>
             </a>
 
@@ -20,11 +20,11 @@
                 {% for modelPackage in modelPackages %}
                     <li>
                         {% if modelPackage.disabled %}
-                            <a class="disabled" href="#">
+                            <a class="disabled" class="model-package" href="#" data-id="{{ modelPackage.name }}">
                                 {{ modelPackage.display_name }} (Coming Soon)
                             </a>
                         {% else %}
-                            <a href="#" data-url="/project/new/{{ modelPackage.name }}">
+                            <a href="#" class="model-package" data-id="{{ modelPackage.name }}">
                                 {{ modelPackage.display_name }}
                             </a>
                         {% endif %}

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -4,8 +4,11 @@ var $ = require('jquery'),
     _ = require('lodash'),
     Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
+    router = require('../router').router,
     models = require('./models'),
     settings = require('../core/settings'),
+    modalModels = require('../core/modals/models'),
+    modalViews = require('../core/modals/views'),
     coreModels = require('../core/models'),
     chart = require('../core/chart'),
     utils = require('../core/utils'),
@@ -28,6 +31,50 @@ var ResultsView = Marionette.LayoutView.extend({
 
     regions: {
         analyzeRegion: '#analyze-tab-contents'
+    },
+
+    ui: {
+        'modelPackageLinks': 'a.model-package',
+    },
+
+    events: {
+        'click @ui.modelPackageLinks': 'selectModelPackage',
+    },
+
+    selectModelPackage: function (e) {
+        e.preventDefault();
+
+        var modelPackages = settings.get('model_packages'),
+            modelPackageName = $(e.target).data('id'),
+            modelPackage = _.find(modelPackages, {name: modelPackageName}),
+            newProjectUrl = '/project/new/' + modelPackageName,
+            projectUrl = '/project';
+
+        if (!modelPackage.disabled) {
+            if (settings.get('itsi_embed') && App.currentProject && !App.currentProject.get('needs_reset')) {
+                var currModelPackageName = App.currentProject.get('model_package');
+                if (modelPackageName === currModelPackageName) {
+                    // Go to existing project
+                    router.navigate(projectUrl, {trigger: true});
+                } else {
+                    var confirmNewProject = new modalViews.ConfirmView({
+                        model: new modalModels.ConfirmModel({
+                            question: 'If you change the model you will lose your current work.',
+                            confirmLabel: 'Switch Model',
+                            cancelLabel: 'Cancel',
+                            feedbackRequired: true
+                        }),
+                    });
+
+                    confirmNewProject.on('confirmation', function() {
+                        router.navigate(newProjectUrl, {trigger: true});
+                    });
+                    confirmNewProject.render();
+                }
+            } else {
+                router.navigate(newProjectUrl, {trigger: true});
+            }
+        }
     },
 
     onShow: function() {


### PR DESCRIPTION
This changes the behavior of selecting a model package when `itsi_embed=true` so that 1) the user will be prompted if they select a different model package after returning from the model view, and 2) will simply return to the same model if selecting the same model package. All other behavior should be the same as before. This follows the approach in the first comment in #1222. Implementing the third point did not require any changes.

![screen shot 2016-04-18 at 11 19 30 am 2](https://cloud.githubusercontent.com/assets/1896461/14609390/97835816-0557-11e6-947c-c94019b9ea9e.png)

##### Testing
* Log in as an ITSI user and append /?itsi_embed=true the URL
* Try creating a new model, then go back to Analyze, then click on the same model package. Note the project # is the same and the results are loaded instantly.
* Do the same except select a different model package. You should be prompted. If you click Cancel, nothing should happen. If you proceed, the same project number will be used but the package and scenarios will have changed.
* The behavior should be the same as before when logged out, and for a non-itsi logged in user.

#1222 