### PR TITLE
Upgrade Geoprocessing

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -44,7 +44,7 @@ sjs_host: "localhost"
 sjs_port: 8090
 sjs_container_image: "quay.io/azavea/spark-jobserver:0.6.1"
 
-geop_version: "0.4.0"
+geop_version: "1.0.0"
 
 nginx_cache_dir: "/var/cache/nginx"
 observation_api_url: "http://www.wikiwatershed-vs.org/"

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/spark-jobserver.conf.j2
@@ -31,7 +31,7 @@ spark {
   master = "local[*]"
 
   context-settings.passthrough.spark.serializer = "org.apache.spark.serializer.KryoSerializer"
-  context-settings.passthrough.spark.kryo.registrator = "geotrellis.spark.io.hadoop.KryoRegistrator"
+  context-settings.passthrough.spark.kryo.registrator = "geotrellis.spark.io.kryo.KryoRegistrator"
 }
 
 #########

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -368,8 +368,8 @@ GEOP = {
             'geometry': None,
             'tileCRS': 'ConusAlbers',
             'polyCRS': 'LatLng',
-            'nlcdLayer': 'nlcd-2011-30m-epsg5070',
-            'soilLayer': 'ssurgo-hydro-groups-30m-epsg5070',
+            'nlcdLayer': 'nlcd-2011-30m-epsg5070-0.10.0',
+            'soilLayer': 'ssurgo-hydro-groups-30m-epsg5070-0.10.0',
             'zoom': 0
         }
     }


### PR DESCRIPTION
## Overview

Upgrade mmw-geoprocessing service to 1.0.0, which in turn has been upgraded to use GeoTrellis 0.10.0. There are no functional or API changes. However, the NLCD and Soil Hydrology Group layers had to have their metadata updated for the new format. Since we have an older version in production right now, we created new metadata in the new format for them. This also updates the layer name references in MMW to use the new format.

## Testing Instructions

Reprovision the worker:

```
$ vagrant reload worker --provision
```

Test the app to ensure that `/analyze` and `/model` work correctly for TR-55 values.

Also tagging @hectcastro and @jamesmcclain to make sure I'm not missing anything.

Connects #1207