### PR TITLE
Remove remaining Ansible 2.0 deprecation warnings

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -43,7 +43,7 @@
 - src: azavea.mapnik
   version: 0.1.0
 - src: azavea.beaver
-  version: 0.1.3
+  version: 1.0.1
 - src: azavea.java
   version: 0.2.1
 - src: azavea.docker

--- a/deployment/ansible/roles/model-my-watershed.app/tasks/configuration.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/configuration.yml
@@ -5,7 +5,7 @@
         owner=root
         group=mmw
         mode=0750
-  with_dict: app_config
+  with_dict: "{{ app_config }}"
   notify:
     - Restart mmw-app
 

--- a/deployment/ansible/roles/model-my-watershed.base/tasks/configuration.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/tasks/configuration.yml
@@ -25,7 +25,7 @@
         owner=root
         group=mmw
         mode=0750
-  with_dict: envdir_config
+  with_dict: "{{ envdir_config }}"
   notify:
     - Restart mmw-app
     - Restart Celery

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/configuration.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/configuration.yml
@@ -5,6 +5,6 @@
         owner=root
         group=mmw
         mode=0750
-  with_dict: app_config
+  with_dict: "{{ app_config }}"
   notify:
     - Restart Celery


### PR DESCRIPTION
Stops use of "bare" variables along with `with_dict` and updates Beaver role that was doing something similar.

---

**Testing**

Use Vagrant to re-provision locally and ensure that the modified tasks no longer spit out purple colored deprecation warnings.