### PR TITLE
Ensure that Windshaft is restarted after log rotation

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.tiler/templates/logrotate-mmw-tiler.j2
+++ b/deployment/ansible/roles/model-my-watershed.tiler/templates/logrotate-mmw-tiler.j2
@@ -3,5 +3,8 @@
   {{ tiler_log_rotate_interval }}
   compress
   missingok
+  postrotate
+    restart mmw-tiler
+  endscript
   notifempty
 }


### PR DESCRIPTION
If Windshaft isn't restarted after a log rotation event, it maintains a handle to the previous log file. This prevent new log messages from being written to `/var/log/mmw-tiler.log`, which also prevents them from being slurped up by Beaver.

Depends on https://github.com/azavea/ansible-beaver/pull/6

---

**Testing**

Provision the `tiler` and ensure that the `logrotate` configuration for `mmw-tiler` contains a directive for restarting the service after a log rotation event.