### PR TITLE
Restart gunicorn after exiting the debugserver

### DIFF
--- a/scripts/debugserver.sh
+++ b/scripts/debugserver.sh
@@ -7,3 +7,4 @@ set -x
 
 vagrant ssh app -c "sudo service mmw-app stop || /bin/true"
 vagrant ssh app -c "cd /opt/app/ && envdir /etc/mmw.d/env gunicorn --config /etc/mmw.d/gunicorn.py mmw.wsgi"
+vagrant ssh app -c "sudo start mmw-app"


### PR DESCRIPTION
This fixes the problem where you kill your debug server and then you
have to manually restart the gunicorn process on the app VM. Now, the
service should restart automatically, after exiting the debugserver.