### PR TITLE
Add EPSG:5070 spatial reference to database

### DIFF
--- a/src/mmw/apps/modeling/migrations/0018_postgis_add_EPSG5070.py
+++ b/src/mmw/apps/modeling/migrations/0018_postgis_add_EPSG5070.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0017_add_gwlfe'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+         '''INSERT INTO spatial_ref_sys (srid, auth_name, auth_srid, proj4text, srtext)
+            SELECT 5070, 'EPSG', 5070, '+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 +x_0=0 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs ', 'PROJCS["NAD83 / Conus Albers",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",29.5],PARAMETER["standard_parallel_2",45.5],PARAMETER["latitude_of_center",23],PARAMETER["longitude_of_center",-96],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","5070"]]'
+            WHERE NOT EXISTS (
+              SELECT *
+              FROM spatial_ref_sys
+              WHERE srid = 5070
+            )'''
+        )
+    ]


### PR DESCRIPTION
## Overview

For a number of MapShed operations, we need to convert data stored as EPSG:4326 (LatLng) to EPSG:5070 (ConusAlbers). To support operations such as ST_Transform(), we need to first add the spatial reference to the system.

## Testing Instructions

Run all migrations.

    ./scripts/manage.sh migrate

Regardless of whether or not it is already in your system, the migration should succeed. If 5070 is already installed, we leave the current installation. Else we add it.

## Notes

PostgreSQL 9.5 supports UPSERT operations using the much nicer syntax:

```sql
INSERT INTO <table>
VALUES <values>
ON CONFLICT DO NOTHING;
```

But since we don't have that, we use the humble `SELECT` instead.

The actual script is taken from http://epsg.io/5070.