### PR TITLE
Upgrade Geoprocessing to 1.1.0

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -44,7 +44,7 @@ sjs_host: "localhost"
 sjs_port: 8090
 sjs_container_image: "quay.io/azavea/spark-jobserver:0.6.1"
 
-geop_version: "1.0.0"
+geop_version: "1.1.0"
 
 nginx_cache_dir: "/var/cache/nginx"
 observation_api_url: "http://www.wikiwatershed-vs.org/"


### PR DESCRIPTION
## Overview

This adds support for MapshedJob which will be used for calculating various values needed for running GWLF-E.

## Testing Instructions

Checkout the branch, then reprovision the worker:

```
vagrant provision worker
```

Then open [http://localhost:8000/](http://localhost:8000/) and make a MapShed project. You should successfully see an output.

![image](https://cloud.githubusercontent.com/assets/1430060/15049037/456e38b4-12ba-11e6-9f7a-294ae18c8e3a.png)

Connects #1269 