### PR TITLE
Add NLCD + Stream values

### DIFF
--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -188,6 +188,7 @@ GWLFE_DEFAULTS = {
     'n41g': 0,  # Runoff Control: Future (%)
     'n41h': 0,  # Phytase in Feed: Existing (%)
     'n41i': 0,  # Phytase in Feed: Future (%)
+    'n42c': 0,  # Unpaved Road Length (km)
     'n43': 0,  # Stream Km with Vegetated Buffer Strips: Existing
     'GRLBN': 0,  # Average Grazing Animal Loss Rate (Barnyard/Confined Area): Nitrogen
     'NGLBN': 0,  # Average Non-Grazing Animal Loss Rate (Barnyard/Confined Area): Nitrogen


### PR DESCRIPTION
## Overview

We ignore Unpaved Roads, thus n42c is initialized as 0 with all other static values. The rest are calculated from the NLCD + Streams geoprocessing call.

## Testing Instructions

Check out code and add `print(z.tojson())` [here](https://github.com/rajadain/model-my-watershed/blob/feature/mapshed-nlcd-streams/src/mmw/apps/modeling/mapshed/tasks.py#L134). Choose a polygon in an urban area, and ensure that `n46e` has a non-zero value.

Also ensure that selecting a very small AoI does not result in a Divide By Zero error when there are no streams in the AoI.

Connects #1272 
Connects #1281 