### PR TITLE
Calculate Curve Number and Sediment Phosphorus

### DIFF
--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import numpy as np
+
 from os.path import join, dirname, abspath
 from ast import literal_eval as make_tuple
 
@@ -124,6 +126,9 @@ def collect_data(geop_result, geojson):
     z.AgLength = geop_result['AgStreamPct'] * z.StreamLength
     z.UrbLength = z.StreamLength - z.AgLength
 
+    z.CN = np.array(geop_result['CN'])
+    z.SedPhos = geop_result['SedPhos']
+
     # TODO pass real input to model instead of reading it from gms file
     gms_filename = join(dirname(abspath(__file__)), 'data/sample_input.gms')
     gms_file = open(gms_filename, 'r')
@@ -185,17 +190,109 @@ def nlcd_streams(sjs_result):
     }
 
 
+@shared_task(throws=Exception)
+def nlcd_soils(sjs_result):
+    """
+    Get Curve Number and Sediment Phosphorus from NLCD, Soil Group and Texture.
+
+    Results are expected to be in the format:
+    {
+      (NLCD ID, Soil Group ID, Soil Texture ID): Count,
+    }
+
+    Curve Number is determined by calculating the average hydrological soil
+    group for each land use type, rounded to the nearest integer, and looking
+    up the value in the CURVE_NUMBER table in gwlfe_settings.
+
+    Sediment Phosphorus has agricultural and non-agricultural values for each
+    texture type in the SOILP table in gwlfe_settings. NLCD IDs 81 and 82 are
+    considered agricultural, and the rest non-agricultural. We average each
+    pairing to get the final value.
+    """
+    if 'error' in sjs_result:
+        raise Exception('[nlcd_soils] {}'.format(sjs_result['error']))
+
+    result = parse_sjs_result(sjs_result)
+
+    def calc_cn(inputs):
+        # We don't need Soil Texture to calculate Curve Number, so reduce the
+        # inputs to disregard it. Also, since we use only a subset of
+        # available soil groups, map each value to its subset value stored in
+        # the SOIL_GROUP table in gwlfe_settings.
+
+        # Reduce [(n, g, t): c] to [n: sum(c)] and [(n, g): sum(c)]
+        n_count = {}
+        ng_count = {}
+        for (n, g, t) in inputs:
+            # Map soil group values to usable subset
+            g2 = settings.SOIL_GROUP[g]
+            n_count[n] = inputs[(n, g, t)] + n_count.get(n, 0)
+            ng_count[(n, g2)] = inputs[(n, g, t)] + ng_count.get((n, g2), 0)
+
+        # Reduce [(n, g): c] to [n: avg(g * c)]
+        n_gavg = {}
+        for (n, g) in ng_count:
+            n_gavg[n] = (float(g) * ng_count[(n, g)] / n_count[n] +
+                         n_gavg.get(n, 0))
+
+        def cni(nlcd):
+            # Helper method to lookup values from CURVE_NUMBER table
+            return settings.CURVE_NUMBER[nlcd][int(round(n_gavg.get(nlcd, 0)))]
+
+        def cni_avg(xs):
+            # Helper method to average non-zero values only
+            vals = [cni(x) for x in xs]
+            sum_vals = sum(vals)
+            nonzero_vals = len([v for v in vals if v > 0])
+
+            return sum_vals / nonzero_vals if nonzero_vals > 0 else 0
+
+        return [
+            cni(81),  # Hay/Pasture
+            cni(82),  # Cropland
+            cni_avg([41, 42, 43, 52]),  # Forest
+            cni_avg([90, 95]),  # Wetland
+            0,  # Disturbed
+            0,  # Turf Grass
+            cni_avg([21, 71]),  # Open Land
+            cni_avg([12, 31]),  # Bare Rock
+            0,  # Sandy Areas
+            0,  # Unpaved Road
+            0, 0, 0, 0, 0, 0  # Urban Land Use Types
+        ]
+
+    def calc_sedp(inputs):
+        # Soil Concentration of Phosphorus
+        ag_textures = {}
+        nag_textures = {}
+        total = sum(inputs.values())
+        for (n, g, t) in inputs:
+            if n in [81, 82]:
+                ag_textures[t] = inputs[(n, g, t)] + ag_textures.get(t, 0)
+            else:
+                nag_textures[t] = inputs[(n, g, t)] + nag_textures.get(t, 0)
+
+        ag_sedp = sum(count * settings.SOILP[t][0]
+                      for t, count in ag_textures.iteritems())
+        nag_sedp = sum(count * settings.SOILP[t][1]
+                       for t, count in nag_textures.iteritems())
+
+        return float(ag_sedp + nag_sedp) / total
+
+    return {
+        'CN': calc_cn(result),
+        'SedPhos': calc_sedp(result)
+    }
+
+
 def geop_tasks(geom, errback):
     # List of tuples of (opname, data, callback) for each geop task
     definitions = [
         ('nlcd_streams',
          {'polygon': [geom.geojson], 'vector': streams(geom)},
          nlcd_streams),
-        # TODO Remove this second dummy call with actual geop task
-        # We need at least two for the flatten to work correctly.
-        ('nlcd_streams',
-         {'polygon': [geom.geojson], 'vector': streams(geom)},
-         nlcd_streams)
+
+        ('nlcd_soils', {'polygon': [geom.geojson]}, nlcd_soils),
     ]
 
     return [(mapshed_start.s(opname, data) |

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -13,7 +13,7 @@ from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 
 from layer_settings import LAYERS, VIZER_URLS  # NOQA
-from gwlfe_settings import GWLFE_DEFAULTS, GWLFE_CONFIG  # NOQA
+from gwlfe_settings import GWLFE_DEFAULTS, GWLFE_CONFIG, SOIL_GROUP, SOILP, CURVE_NUMBER  # NOQA
 
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.
@@ -390,6 +390,20 @@ GEOP = {
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterLinesJoin',
+                'zoom': 0
+            }
+        },
+        'nlcd_soils': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'nlcd-2011-30m-epsg5070-0.10.0',
+                    'ssurgo-hydro-groups-30m-epsg5070-0.10.0',
+                    'us-ssugro-texture-id-30m-epsg5070'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterJoin',
                 'zoom': 0
             }
         }

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -451,3 +451,86 @@ GWLFE_CONFIG = {
     'MonthDays': [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
     'WeatherNull': -99999,  # This value is used to indicate NULL in ms_weather dataset
 }
+
+# Maps NLCD + Hygrological Soil Group to a Curve Number
+CURVE_NUMBER = {
+    11: [0, 100, 100, 100, 100],  # Water
+    12: [0,  72,  82,  87,  89],  # Perennial Ice/Snow
+    21: [0,  72,  82,  87,  89],  # Developed Open Space
+    31: [0,  72,  82,  87,  89],  # Barren Land
+    41: [0,  37,  60,  73,  80],  # Deciduous Forest
+    42: [0,  37,  60,  73,  80],  # Evergreen Forest
+    43: [0,  37,  60,  73,  80],  # Mixed Forest
+    52: [0,  37,  60,  73,  80],  # Shrub/Scrub
+    71: [0,  72,  82,  87,  89],  # Grassland/Herbaceous
+    81: [0,  43,  63,  75,  81],  # Pasture/Hay
+    82: [0,  64,  75,  82,  85],  # Cultivated Crops
+    90: [0,  69,  80,  87,  90],  # Woody Wetlands
+    95: [0,  69,  80,  87,  90],  # Emergent Herbaceous Wetlands
+}
+
+# Maps Hydrological Soil Groups to subset we can use
+SOIL_GROUP = {
+    1: 1,  # A
+    2: 2,  # B
+    3: 3,  # C
+    4: 4,  # D
+    5: 3,  # AD -> C
+    6: 3,  # BD -> C
+    7: 4,  # CD -> D
+    -2147483648: 3,  # NODATA -> C
+}
+
+# Maps Soil Texture values to Agricultural and Non-Agricultural Phosphorus levels
+SOILP = {
+    1: [900, 420],    # Clay
+    2: [690, 266],    # Fine sandy loam
+    3: [0, 0],        # Boulders
+    4: [0, 0],        # Gravel
+    5: [650, 230],    # Very fine sandy loam
+    6: [300, 100],    # Gypsiferous material
+    7: [600, 200],    # Loamy coarse sand
+    8: [1000, 600],   # Muck
+    9: [0, 0],        # Marl
+    10: [870, 400],   # Clay loam
+    11: [600, 200],   # Very fine sand
+    12: [0, 0],       # Artifacts
+    13: [780, 332],   # Silt
+    14: [100, 100],   # Material
+    15: [100, 100],   # Weathered bedrock
+    16: [1000, 600],  # Mucky peat
+    17: [0, 0],       # Consolidated permafrost (ice rich)
+    18: [580, 180],   # Coarse sand
+    19: [630, 220],   # Loamy fine sand
+    20: [0, 0],       # Fragmental material
+    21: [0, 0],       # Bedrock
+    22: [600, 200],   # Fine sand
+    23: [0, 0],       #
+    24: [0, 0],       # Channers
+    25: [600, 200],   # Pumiceous
+    26: [600, 200],   # Loamy sand
+    27: [0, 0],       # Water
+    28: [660, 244],   # Sandy loam
+    29: [680, 266],   # Sandy clay loam
+    30: [1000, 600],  # Moderately decomposed plant material
+    31: [300, 100],   # Cobbles
+    32: [580, 180],   # Sand
+    33: [0, 0],       # Cinders
+    34: [840, 376],   # Silty clay loam
+    35: [650, 230],   # Loamy very fine sand
+    36: [600, 200],   # Coarse sandy loam
+    37: [0, 0],       # Paragravel
+    38: [600, 200],   # Variable
+    39: [0, 0],       # Unweathered bedrock
+    40: [720, 288],   # Loam
+    41: [780, 332],   # Silt loam
+    42: [800, 320],   # Sandy clay
+    43: [300, 100],   # Stones
+    44: [1000, 600],  # Highly decomposed plant material
+    45: [1000, 600],  # Slightly decomposed plant material
+    46: [600, 200],   # LoamGravel
+    47: [840, 376],   # Silty clay
+    48: [1000, 600],  # Peat
+    49: [300, 100],   # SandGravel
+    -2147483648: [100, 200],  # NODATA
+}


### PR DESCRIPTION
## Overview

**Curve Number** is defined in a table, mapping each MapShed Non-Urban Land Use Type and a limited subset of Hydrological Soil Group to a to value. MapShed Non-Urban Land Use Types map to NLCD as follows:

| MapShed Name  | NLCD Code     | NLCD Name                                                       |
|---------------|---------------|-----------------------------------------------------------------|
|               |               |                                                                 |
| Hay/Pasture   | 81            | Pasture/Hay                                                     |
| Cropland      | 82,---        | Cultivated Crops,---                                            |
| Forest        | 41,42,(43,52) | Deciduous Forest, Evergreen Forest, (Mixed Forest, Shrub/Scrub) |
| Wetland       | 90,95         | Woody Wetlands, Emergent Herbaceous Wetlands                    |
| Disturbed     | ---           | ---                                                             |
| Turf Grass    | ---           | ---                                                             |
| Open Land     | 21,71         | Developed Open Space, Grassland/Herbaceous                      |
| Bare Rock     | 12,31         | Perennial Ice/Snow, Barren Land                                 |
| Sandy Areas   | ---           | ---                                                             |
| Unpaved Roads | ---           | ---                                                             |

The Soil Group subset we use ranges from `A` to `D`. Other values are reduced to this subset in the `SOIL_GROUP` table. Once we have this pairing, we use the `CURVE_NUMBER` table to look up the final value for each land use type.

We restrict this calculating to Non-Urban Land Use Types only because urban land use types [have default values](https://github.com/WikiWatershed/model-my-watershed/blob/develop/src/mmw/mmw/settings/gwlfe_settings.py#L43-L46).

**Sediment Phosphorus** is the concentration of phosphorus in the top soil, and has values corresponding to different soil textures and land use types stored in the `SOILP` table. For each cell, we check if the land use of that cell is agricultural or not, and use the corresponding value. The final value is the average of each cell.

I've elected to use one geoprocessing call and unpair the results in Python because I expect multiple geoprocessing calls would have been costlier. This does unfortunately complicate the Python code.

Connects #1276 