### PR TITLE
Calculate Curve Number and Sediment Phosphorus

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -13,7 +13,7 @@ from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 
 from layer_settings import LAYERS, VIZER_URLS  # NOQA
-from gwlfe_settings import GWLFE_DEFAULTS, GWLFE_CONFIG  # NOQA
+from gwlfe_settings import GWLFE_DEFAULTS, GWLFE_CONFIG, SOIL_GROUP, SOILP, CURVE_NUMBER  # NOQA
 
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.
@@ -390,6 +390,20 @@ GEOP = {
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterLinesJoin',
+                'zoom': 0
+            }
+        },
+        'nlcd_soils': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'nlcd-2011-30m-epsg5070-0.10.0',
+                    'ssurgo-hydro-groups-30m-epsg5070-0.10.0',
+                    'us-ssugro-texture-id-30m-epsg5070'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterJoin',
                 'zoom': 0
             }
         }

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -5,6 +5,8 @@ from gwlfe.enums import (LandUse as lu,
                          YesOrNo as b,
                          SweepType)
 
+NODATA = -2147483648  # Scala's Int.MinValue is NODATA in GeoTrellis
+
 GWLFE_DEFAULTS = {
     'NRur': 10,  # Number of Rural Land Use Categories
     'NUrb': 6,  # Number of Urban Land Use Categories
@@ -448,6 +450,92 @@ GWLFE_CONFIG = {
     'Livestock': ['dairy_cows', 'beef_cows', 'hogs', 'sheep', 'horses'],
     'Poultry': ['broilers', 'layers', 'turkeys'],
     'ManureSpreadingLandUseIndices': [0, 1],  # Land Use Indices where manure spreading applies. Currently Hay/Past and Cropland.
+    'AgriculturalNLCDCodes': [81, 82],  # NLCD codes considered agricultural. Correspond to Hay/Past and Cropland
     'MonthDays': [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
     'WeatherNull': -99999,  # This value is used to indicate NULL in ms_weather dataset
+}
+
+# Maps NLCD + Hygrological Soil Group to a Curve Number. Keys are NLCD Codes.
+# Array Index 0 has no value, rest map to SOIL_GROUP value.
+# Original at Class1.vb@1.3.0:4174-4315
+CURVE_NUMBER = {
+    11: [0, 100, 100, 100, 100],  # Water
+    12: [0,  72,  82,  87,  89],  # Perennial Ice/Snow
+    21: [0,  72,  82,  87,  89],  # Developed Open Space
+    31: [0,  72,  82,  87,  89],  # Barren Land
+    41: [0,  37,  60,  73,  80],  # Deciduous Forest
+    42: [0,  37,  60,  73,  80],  # Evergreen Forest
+    43: [0,  37,  60,  73,  80],  # Mixed Forest
+    52: [0,  37,  60,  73,  80],  # Shrub/Scrub
+    71: [0,  72,  82,  87,  89],  # Grassland/Herbaceous
+    81: [0,  43,  63,  75,  81],  # Pasture/Hay
+    82: [0,  64,  75,  82,  85],  # Cultivated Crops
+    90: [0,  69,  80,  87,  90],  # Woody Wetlands
+    95: [0,  69,  80,  87,  90],  # Emergent Herbaceous Wetlands
+}
+
+# Maps Hydrological Soil Groups to subset we can use
+SOIL_GROUP = {
+    1: 1,  # A
+    2: 2,  # B
+    3: 3,  # C
+    4: 4,  # D
+    5: 3,  # A/D -> C
+    6: 3,  # B/D -> C
+    7: 4,  # C/D -> D
+    NODATA: 3,  # NODATA -> C
+}
+
+# Maps Soil Texture values to Agricultural and Non-Agricultural Phosphorus levels
+SOILP = {
+    1: [900, 420],    # Clay
+    2: [690, 266],    # Fine sandy loam
+    3: [0, 0],        # Boulders
+    4: [0, 0],        # Gravel
+    5: [650, 230],    # Very fine sandy loam
+    6: [300, 100],    # Gypsiferous material
+    7: [600, 200],    # Loamy coarse sand
+    8: [1000, 600],   # Muck
+    9: [0, 0],        # Marl
+    10: [870, 400],   # Clay loam
+    11: [600, 200],   # Very fine sand
+    12: [0, 0],       # Artifacts
+    13: [780, 332],   # Silt
+    14: [100, 100],   # Material
+    15: [100, 100],   # Weathered bedrock
+    16: [1000, 600],  # Mucky peat
+    17: [0, 0],       # Consolidated permafrost (ice rich)
+    18: [580, 180],   # Coarse sand
+    19: [630, 220],   # Loamy fine sand
+    20: [0, 0],       # Fragmental material
+    21: [0, 0],       # Bedrock
+    22: [600, 200],   # Fine sand
+    23: [0, 0],       #
+    24: [0, 0],       # Channers
+    25: [600, 200],   # Pumiceous
+    26: [600, 200],   # Loamy sand
+    27: [0, 0],       # Water
+    28: [660, 244],   # Sandy loam
+    29: [680, 266],   # Sandy clay loam
+    30: [1000, 600],  # Moderately decomposed plant material
+    31: [300, 100],   # Cobbles
+    32: [580, 180],   # Sand
+    33: [0, 0],       # Cinders
+    34: [840, 376],   # Silty clay loam
+    35: [650, 230],   # Loamy very fine sand
+    36: [600, 200],   # Coarse sandy loam
+    37: [0, 0],       # Paragravel
+    38: [600, 200],   # Variable
+    39: [0, 0],       # Unweathered bedrock
+    40: [720, 288],   # Loam
+    41: [780, 332],   # Silt loam
+    42: [800, 320],   # Sandy clay
+    43: [300, 100],   # Stones
+    44: [1000, 600],  # Highly decomposed plant material
+    45: [1000, 600],  # Slightly decomposed plant material
+    46: [600, 200],   # LoamGravel
+    47: [840, 376],   # Silty clay
+    48: [1000, 600],  # Peat
+    49: [300, 100],   # SandGravel
+    NODATA: [100, 200],  # NODATA
 }


### PR DESCRIPTION
## Overview

**Curve Number** is defined in a table, mapping each MapShed Non-Urban Land Use Type and a limited subset of Hydrological Soil Group to a to value. MapShed Non-Urban Land Use Types map to NLCD as follows:

| MapShed Value | LuCount Index | MapShed Name | NLCD Code | NLCD Name |
|---------------|---------------|----------------|---------------|-----------------------------------------------------------------|
|  |  |  |  |  |
| 4 | 1 | Hay/Pasture | 81 | Pasture/Hay |
| 5,6 | 2 | Cropland | 82,--- | Cultivated Crops,--- |
| 7,8,9 | 3 | Forest | 41,42,(43,52) | Deciduous Forest, Evergreen Forest, (Mixed Forest, Shrub/Scrub) |
| 10,11 | 4 | Wetland | 90,95 | Woody Wetlands, Emergent Herbaceous Wetlands |
| 12,13,15 | 5 | Disturbed | --- | --- |
| 16 | 6 | Turf Grass | --- | --- |
| 21 | 7 | Open Land | 21,71 | Developed Open Space, Grassland/Herbaceous |
| 22 | 8 | Bare Rock | 12,31 | Perennial Ice/Snow, Barren Land |
| 14 | 9 | Sandy Areas | --- | --- |
|  |  | Unpaved Roads | --- | --- |
| 2 | 10 | LD Mixed | 22 | Developed Low Intensity |
| 20 | 11 | MD Mixed | 23 | Developed Medium Intensity |
| 3 | 12 | HD Mixed | 24 | Developed High Intensity |
| 17 | 13 | LD Residential | --- | --- |
| 18 | 14 | MD Residential | --- | --- |
| 19 | 15 | HD Residential | --- | --- |
|  |  |  |  |  |
| 1 | 16 | Water | 11 | Open Water |

The Soil Group subset we use ranges from `A` to `D`. Other values are reduced to this subset in the `SOIL_GROUP` table. Once we have this pairing, we use the `CURVE_NUMBER` table to look up the final value for each land use type.

We restrict this calculating to Non-Urban Land Use Types only because urban land use types [have default values](https://github.com/WikiWatershed/model-my-watershed/blob/develop/src/mmw/mmw/settings/gwlfe_settings.py#L43-L46).

**Sediment Phosphorus** is the concentration of phosphorus in the top soil, and has values corresponding to different soil textures and land use types stored in the `SOILP` table. For each cell, we check if the land use of that cell is agricultural or not, and use the corresponding value. The final value is the average of each cell.

## Notes

I've elected to use one geoprocessing call and unpair the results in Python because I expect multiple geoprocessing calls would have been costlier. This does unfortunately complicate the Python code.

I will most likely add NLCD-only value calculations from #1273 here, but since `CN` is needed to calculate other values I'm putting up this PR.

Connects #1276 