### PR TITLE
Retry Spark Submit Jobs when SJS is Full

### DIFF
--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -128,7 +128,7 @@ def sjs_retrieve(host, port, job_id, retry=None):
 
 
 @statsd.timer(__name__ + '.histogram_start')
-def histogram_start(polygons):
+def histogram_start(polygons, retry=None):
     """
     Together, histogram_start and histogram_finish implement a
     function which takes a list of polygons or multipolygons as input,
@@ -143,7 +143,7 @@ def histogram_start(polygons):
     data = settings.GEOP['json']['nlcdSoilCensus'].copy()
     data['input']['geometry'] = polygons
 
-    return sjs_submit(host, port, args, data)
+    return sjs_submit(host, port, args, data, retry)
 
 
 @statsd.timer(__name__ + '.histogram_finish')

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -46,8 +46,8 @@ def start_rwd_job(location, snapping):
     return response_json
 
 
-@shared_task
-def start_histogram_job(json_polygon):
+@shared_task(bind=True, default_retry_delay=1, max_retries=42)
+def start_histogram_job(self, json_polygon):
     """ Calls the histogram_start function to
     kick off the SJS job to generate a histogram
     of the provided polygon (i.e. AoI).
@@ -60,12 +60,12 @@ def start_histogram_job(json_polygon):
 
     return {
         'pixel_width': aoi_resolution(polygon),
-        'sjs_job_id': histogram_start([json_polygon])
+        'sjs_job_id': histogram_start([json_polygon], self.retry)
     }
 
 
-@shared_task
-def start_histograms_job(polygons):
+@shared_task(bind=True, default_retry_delay=1, max_retries=42)
+def start_histograms_job(self, polygons):
     """ Calls the histogram_start function to
     kick off the SJS job to generate a histogram
     of the provided polygons (i.e. AoI + modifications,
@@ -79,7 +79,7 @@ def start_histograms_job(polygons):
 
     return {
         'pixel_width': None,
-        'sjs_job_id': histogram_start(json_polygons)
+        'sjs_job_id': histogram_start(json_polygons, self.retry)
     }
 
 


### PR DESCRIPTION
## Overview

Since MapShed uses spawns a number of Spark Jobs, there are cases when Spark JobServer's limit for concurrent jobs has been reached and we are not allowed to submit any more jobs. In such cases, instead of failing immediately, we keep retrying to submit said jobs.

## Testing Instructions

Rebase #1287 over this and confirm that the `NO SLOTS AVAILABLE` error is no longer encountered. Instead, previously failing jobs should now retry, like this:

```
[2016-05-10 19:30:00,465: DEBUG/MainProcess] Task accepted: apps.modeling.tasks.start_histogram_job[a4dac5ac-0844-4a81-b127-da75e915597b] pid:13843
[2016-05-10 19:30:00,667: INFO/MainProcess] Task apps.modeling.tasks.start_histogram_job[a4dac5ac-0844-4a81-b127-da75e915597b] retry: Retry in 1s
```

Connects #1292 