### PR TITLE
Calculate NLCD-only dependent values

### DIFF
--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -497,3 +497,21 @@ def landuse_pcts(n_count):
         0,  # Medium Density Residential
         0,  # High Density Residential
     ]
+
+
+def normal_sys(lu_area):
+    """
+    Given the land use area in hectares, estimates the number of normal septic
+    systems based on the constants SSLDR and SSLDM for Residential and Mixed
+    land uses respectively.
+    Since in this version Residential land uses are always 0, the value is
+    effectively dependent only on the area of medium density mixed land use.
+    However, we replicate the original formula for consistency.
+
+    Original at Class1.vb@1.3.0:9577-9579
+    """
+
+    SSLDR = settings.GWLFE_CONFIG['SSLDR']
+    SSLDM = settings.GWLFE_CONFIG['SSLDM']
+
+    return SSLDR * lu_area[14] + SSLDM * lu_area[11]

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.db import connection
 
 NUM_WEATHER_STATIONS = settings.GWLFE_CONFIG['NumWeatherStations']
+KV_FACTOR = settings.GWLFE_CONFIG['KvFactor']
 MONTHS = settings.GWLFE_DEFAULTS['Month']
 MONTHDAYS = settings.GWLFE_CONFIG['MonthDays']
 LIVESTOCK = settings.GWLFE_CONFIG['Livestock']
@@ -110,6 +111,25 @@ def et_adjustment(ws):
     avg_etadj = np.mean([w.etadj for w in ws])
 
     return np.array([avg_etadj] * 12)
+
+
+def kv_coefficient(ecs):
+    """
+    Given an array of erosion coefficients, returns an array of 12 decimals,
+    one for the KV coefficient of each month. The KV of a month is initialized
+    to the corresponding erosion coefficient value times the KV Factor, and
+    then averaged over the preceeding month. January being the first month is
+    not averaged.
+
+    Original at Class1.vb@1.3.0:4989-4995
+    """
+
+    kv = [ec * KV_FACTOR for ec in ecs]
+
+    for m in range(1, 12):
+        kv[m] = (kv[m] + kv[m-1]) / 2
+
+    return np.array(kv)
 
 
 def animal_energy_units(geom):

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -463,3 +463,37 @@ def sediment_delivery_ratio(area_sq_km):
                 (0.0014 * area_sq_km) + 0.198)
     else:
         return 0.451 * (area_sq_km ** (0 - 0.298))
+
+
+def landuse_pcts(n_count):
+    """
+    Given a dictionary mapping NLCD Codes to counts of cells, returns a
+    dictionary mapping MapShed Land Use Types to percent area covered.
+    """
+
+    total = sum(n_count.values())
+    if total > 0:
+        n_pct = {nlcd: float(count) / total
+                 for nlcd, count in n_count.iteritems()}
+    else:
+        n_pct = {nlcd: 0 for nlcd in n_count.keys()}
+
+    return [
+        n_pct.get(81, 0),  # Hay/Pasture
+        n_pct.get(82, 0),  # Cropland
+        n_pct.get(41, 0) + n_pct.get(42, 0) +
+        n_pct.get(43, 0) + n_pct.get(52, 0),  # Forest
+        n_pct.get(90, 0) + n_pct.get(95, 0),  # Wetland
+        0,  # Disturbed
+        0,  # Turf Grass
+        n_pct.get(21, 0) + n_pct.get(71, 0),  # Open Land
+        n_pct.get(12, 0) + n_pct.get(31, 0),  # Bare Rock
+        0,  # Sandy Areas
+        0,  # Unpaved Road
+        n_pct.get(22, 0),  # Low Density Mixed
+        n_pct.get(23, 0),  # Medium Density Mixed
+        n_pct.get(24, 0),  # High Density Mixed
+        0,  # Low Density Residential
+        0,  # Medium Density Residential
+        0,  # High Density Residential
+    ]

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -34,6 +34,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
                                          sediment_phosphorus,
                                          groundwater_nitrogen_conc,
                                          sediment_delivery_ratio,
+                                         landuse_pcts,
                                          )
 
 AG_NLCD_CODES = settings.GWLFE_CONFIG['AgriculturalNLCDCodes']
@@ -143,6 +144,7 @@ def collect_data(geop_result, geojson):
 
     z.CN = np.array(geop_result['cn'])
     z.SedPhos = geop_result['sed_phos']
+    z.Area = np.array(geop_result['landuse_pcts'] * area * HECTARES_PER_SQM)
 
     # Additional calculated values
     z.SedDelivRatio = sediment_delivery_ratio(area * SQKM_PER_SQM)
@@ -254,6 +256,7 @@ def nlcd_soils(sjs_result):
     return {
         'cn': curve_number(n_count, ng_count),
         'sed_phos': sediment_phosphorus(nt_count),
+        'landuse_pcts': landuse_pcts(n_count),
     }
 
 

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -149,7 +149,12 @@ def collect_data(geop_result, geojson):
 
     z.NormalSys = normal_sys(z.Area)
 
-    # Additional calculated values
+    # Original at Class1.vb@1.3.0:9803-9807
+    z.n23 = z.Area[1]    # Row Crops Area
+    z.n23b = z.Area[13]  # High Density Mixed Urban Area
+    z.n24 = z.Area[0]    # Hay/Pasture Area
+    z.n24b = z.Area[11]  # Low Density Mixed Urban Area
+
     z.SedDelivRatio = sediment_delivery_ratio(area * SQKM_PER_SQM)
     z.TotArea = area * HECTARES_PER_SQM
     z.GrNitrConc = geop_result['gr_nitr_conc']

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -23,6 +23,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
                                          growing_season,
                                          erosion_coeff,
                                          et_adjustment,
+                                         kv_coefficient,
                                          animal_energy_units,
                                          manure_spread,
                                          streams,
@@ -104,6 +105,7 @@ def collect_data(geop_result, geojson):
     z.Grow = growing_season(ws)
     z.Acoef = erosion_coeff(ws, z.Grow)
     z.PcntET = et_adjustment(ws)
+    z.KV = kv_coefficient(z.Acoef)
     z.WxYrBeg = max([w.begyear for w in ws])
     z.WxYrEnd = min([w.endyear for w in ws])
     z.WxYrs = z.WxYrEnd - z.WxYrBeg + 1

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -35,6 +35,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
                                          groundwater_nitrogen_conc,
                                          sediment_delivery_ratio,
                                          landuse_pcts,
+                                         normal_sys,
                                          )
 
 AG_NLCD_CODES = settings.GWLFE_CONFIG['AgriculturalNLCDCodes']
@@ -145,6 +146,8 @@ def collect_data(geop_result, geojson):
     z.CN = np.array(geop_result['cn'])
     z.SedPhos = geop_result['sed_phos']
     z.Area = np.array(geop_result['landuse_pcts'] * area * HECTARES_PER_SQM)
+
+    z.NormalSys = normal_sys(z.Area)
 
     # Additional calculated values
     z.SedDelivRatio = sediment_delivery_ratio(area * SQKM_PER_SQM)

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -454,6 +454,8 @@ GWLFE_CONFIG = {
     'ManureSpreadingLandUseIndices': [0, 1],  # Land Use Indices where manure spreading applies. Currently Hay/Past and Cropland.
     'AgriculturalNLCDCodes': [81, 82],  # NLCD codes considered agricultural. Correspond to Hay/Past and Cropland
     'MonthDays': [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+    'SSLDR': 4.4,
+    'SSLDM': 2.2,
     'WeatherNull': -99999,  # This value is used to indicate NULL in ms_weather dataset
 }
 

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -448,6 +448,7 @@ GWLFE_DEFAULTS = {
 
 GWLFE_CONFIG = {
     'NumWeatherStations': 2,  # Number of weather stations to consider for each polygon
+    'KvFactor': 1.16,  # Original at Class1.vb@1.3.0:4987
     'Livestock': ['dairy_cows', 'beef_cows', 'hogs', 'sheep', 'horses'],
     'Poultry': ['broilers', 'layers', 'turkeys'],
     'ManureSpreadingLandUseIndices': [0, 1],  # Land Use Indices where manure spreading applies. Currently Hay/Past and Cropland.


### PR DESCRIPTION
## Overview

Adds values that only depend on NLCD. Piggy-backs on the `nlcd_soils` geoprocessing call since that is giving us NLCD counts already.

## Testing Instructions

Compare implementation with original VB code referenced in original card and in the Python code.

Connects #1273 