### PR TITLE
Include goats in sheep count

### DIFF
--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -134,6 +134,7 @@ def animal_energy_units(geom):
           SELECT SUM(beef_ha * totalha * clip_percent) AS beef_cows,
                  SUM(broiler_ha * totalha * clip_percent) AS broilers,
                  SUM(dairy_ha * totalha * clip_percent) AS dairy_cows,
+                 SUM(goat_ha * totalha * clip_percent) +
                  SUM(sheep_ha * totalha * clip_percent) AS sheep,
                  SUM(hog_ha * totalha * clip_percent) AS hogs,
                  SUM(horse_ha * totalha * clip_percent) AS horses,


### PR DESCRIPTION
From BME:

> Yes, include both goats and sheep in the "Sheep" category. Thanks.

Before:

```
    beef_cows     |     broilers     |    dairy_cows    |      sheep       |       hogs       |      horses      |      layers      |     turkeys      
------------------+------------------+------------------+------------------+------------------+------------------+------------------+------------------
 299.779487357229 | 102110.982701653 | 207.148229899953 | 656.656073848423 | 613.369111513422 | 28837.9543177855 | 10985.3384931695 | 18.8222402678298
(1 row)
```

After:

```
    beef_cows     |     broilers     |    dairy_cows    |      sheep       |       hogs       |      horses      |      layers      |     turkeys      
------------------+------------------+------------------+------------------+------------------+------------------+------------------+------------------
 299.779487357229 | 102110.982701653 | 207.148229899953 | 1271.72268876914 | 613.369111513422 | 28837.9543177855 | 10985.3384931695 | 18.8222402678298
(1 row)
```