### PR TITLE
Bump libpq version to 9.6.x

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -21,7 +21,7 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "9.5.*.pgdg14.04+1"
+postgresql_support_libpq_version: "9.6*.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.6"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"


### PR DESCRIPTION
The main PostgreSQL APT repository bumped their version of libpq.