### PR TITLE
Fix Type Errors

### DIFF
--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -7,6 +7,7 @@ import math
 import numpy as np
 
 from collections import namedtuple
+from decimal import Decimal
 
 from gwlfe.enums import GrowFlag
 
@@ -124,7 +125,7 @@ def kv_coefficient(ecs):
     Original at Class1.vb@1.3.0:4989-4995
     """
 
-    kv = [ec * KV_FACTOR for ec in ecs]
+    kv = ecs * Decimal(KV_FACTOR)
 
     for m in range(1, 12):
         kv[m] = (kv[m] + kv[m-1]) / 2

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -145,7 +145,7 @@ def collect_data(geop_result, geojson):
 
     z.CN = np.array(geop_result['cn'])
     z.SedPhos = geop_result['sed_phos']
-    z.Area = np.array(geop_result['landuse_pcts'] * area * HECTARES_PER_SQM)
+    z.Area = np.array(geop_result['landuse_pcts']) * area * HECTARES_PER_SQM
 
     z.NormalSys = normal_sys(z.Area)
 


### PR DESCRIPTION
Fixes

```
[2016-05-12 17:09:36,321: ERROR/Worker-1] Task d077cf0d-5f69-4827-9bfe-6a43f83eba40 run from job 2663 raised exception: can't multiply sequence by non-int of type 'float'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/opt/app/apps/modeling/mapshed/tasks.py", line 148, in collect_data
    z.Area = np.array(geop_result['landuse_pcts'] * area * HECTARES_PER_SQM)
TypeError: can't multiply sequence by non-int of type 'float'
```

and

```
[2016-05-12 17:08:36,791: ERROR/Worker-1] Task 2b17aa05-c4ec-4351-a25c-bcf5e124f51a run from job 2660 raised exception: unsupported operand type(s) for *: 'Decimal' and 'float'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/opt/app/apps/modeling/mapshed/tasks.py", line 110, in collect_data
    z.KV = kv_coefficient(z.Acoef)
  File "/opt/app/apps/modeling/mapshed/calcs.py", line 127, in kv_coefficient
    kv = [ec * KV_FACTOR for ec in ecs]
TypeError: unsupported operand type(s) for *: 'Decimal' and 'float'
```

introduced in #1299 