### PR TITLE
Revert libpq version bump; update OpenJDK 7

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -30,7 +30,7 @@ elasticsearch_cluster_name: "logstash"
 
 nodejs_npm_version: 2.1.17
 
-java_version: "7u95-*"
+java_version: "7u101-*"
 
 graphite_carbon_version: "0.9.13-pre1"
 graphite_whisper_version: "0.9.13-pre1"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -21,7 +21,7 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "9.6*.pgdg14.04+1"
+postgresql_support_libpq_version: "9.5.*.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.6"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -45,6 +45,6 @@
 - src: azavea.beaver
   version: 1.0.1
 - src: azavea.java
-  version: 0.2.1
+  version: 0.2.5
 - src: azavea.docker
   version: 1.0.2


### PR DESCRIPTION
It looks like PostgreSQL reverting the `libpq-dev` version bump from earlier in the day. At the same time, Ubuntu released an update to OpenJDK to address a series of CVEs.