### PR TITLE
Use more precise Apache version

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -30,6 +30,8 @@ elasticsearch_cluster_name: "logstash"
 
 nodejs_npm_version: 2.1.17
 
+apache_version: "2.4.7-*"
+
 java_version: "7u101-*"
 
 graphite_carbon_version: "0.9.13-pre1"


### PR DESCRIPTION
Previously, the default glob for Apache was `2.4.*`, which captures a more recent 2.4.10 package. Pinning to `2.4.7-*` ensures that everyone is on the same version in the Ubuntu repositories.

---

**Testing**

Will be hard to test for anyone not willing to blow away their `services` virtual machine, but should hopefully get people past Apache package installation errors.