### PR TITLE
Revise 'Turf Grass' to 'Developed, Open Space'

### DIFF
--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -219,7 +219,7 @@
                         <a href="#land-developed_open" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-21">
                             <img src="{% static 'images/water_balance/thumb_turfGrass.png' %}" alt="Developed, Open Space" data-name="developed_open" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-21" >
                         </a>
-                        <label>Developed, Open Space</label>
+                        <label>Developed-Open</label>
                     </li>
 
                     <li id="thumb-developed_low" class="active">

--- a/src/mmw/js/src/core/modificationConfig.json
+++ b/src/mmw/js/src/core/modificationConfig.json
@@ -51,7 +51,8 @@
         "strokeColor": "#356EB9"
     },
     "developed_open": {
-        "name": "Turf Grass",
+        "name": "Developed, Open Space",
+        "shortName": "Developed-Open",
         "summary": "NLCD Class 21: Areas with a mixture of some constructed materials, but mostly vegetation in the form of lawn grasses. Impervious surfaces account for less than 20% of total cover. These areas most commonly include large-lot single-family housing units, parks, playing fields, golf courses, and vegetation planted in developed settings for recreation, erosion control, or aesthetic purposes.",
         "strokeColor": "#172E2E"
     },


### PR DESCRIPTION
This PR changes the "Turf Grass" to "Developed, Open Space" to match the proper name used for NLCD land use code 21. I updated the `name` property & added a `shortName` property to the `developed_open` object in `modificationConfig.json`, the file which stores the labels and descriptions used across the app. That updates the text for the microsite tooltip and for the map app:

![screen shot 2016-05-16 at 3 44 09 pm](https://cloud.githubusercontent.com/assets/4165523/15301689/00fc43da-1b7d-11e6-9fd7-0b8ed87be4ca.png)

&

![screen shot 2016-05-16 at 3 50 55 pm](https://cloud.githubusercontent.com/assets/4165523/15301881/f63065de-1b7d-11e6-8e6b-615d2989cd29.png)

**Testing**
- grab this branch, `vagrant up`, then `./scripts/bundle.sh`
- visit `http://localhost:8000/micro/`and mouseover "Developed, Open Space" and verify that the tooltip popup box now reads "Developed, Open Space" as its title
- visit `http://localhost:8000/`, draw a small area of interest, click "Model" then "Site Storm Model"
- once the modeling completes, click the "+" tab to create a New Scenario, then click "Land Cover" to bring up the popup menu
- verify that second icon from the left in the top row now reads "Developed-Open" for its label, and that the title displayed on mouseover is "Developed, Open Space"

Connects #1295 