### PR TITLE
Customize BMP manual entry UIs

### DIFF
--- a/src/mmw/js/src/core/modificationConfig.json
+++ b/src/mmw/js/src/core/modificationConfig.json
@@ -150,15 +150,21 @@
         "summary": "Refers to the planned use of organic and/or inorganic nutrients to sustain optimum crop production while at the same time protecting the quality of nearby water resources. This practice usually includes a farm-wide nutrient management plan that minimizes the use of animal wastes or commercial fertilizers to the greatest degree practicable.",
         "copyStyle": "pasture"
     },
-    "waste_management": {
-        "name": "Animal Waste Management Systems (Livestock &amp; Poultry)",
-        "shortName": "Waste Management",
+    "waste_management_livestock": {
+        "name": "Animal Waste Management Systems (Livestock)",
+        "shortName": "Livestock Waste Man.",
+        "summary": "These are systems that are designed to collect runoff and/or wastes from confined animal operations for the purpose of breaking down organic wastes via aerobic or anaerobic processes. Typical examples include waste lagoons or holding tanks that collect the wastes and prevent their discharge to nearby streams.",
+        "copyStyle": "grassland"
+    },
+    "waste_management_poultry": {
+        "name": "Animal Waste Management Systems (Poultry)",
+        "shortName": "Poultry Waste Man.",
         "summary": "These are systems that are designed to collect runoff and/or wastes from confined animal operations for the purpose of breaking down organic wastes via aerobic or anaerobic processes. Typical examples include waste lagoons or holding tanks that collect the wastes and prevent their discharge to nearby streams.",
         "copyStyle": "grassland"
     },
     "buffer_strips": {
-        "name": "Vegetated Buffer Strips",
-        "shortName": "Veg Buffer Strips",
+        "name": "Vegetated Buffer Strips (Rural)",
+        "shortName": "Veg Buffer Strips (Rural)",
         "summary": "Areas of trees and/or grasses planted along streams or lakes that are designed to capture and renovate surface runoff and shallow subsurface flow from agricultural and urban areas via the processes of filtration, infiltration, absorption, adsorption, uptake, denitrification, volatilization, and deposition. A buffer width of 30 m (roughly 100 ft) is assumed.",
         "copyStyle": "no_till"
     },
@@ -168,7 +174,18 @@
         "copyStyle": "cultivated_crops"
     },
     "streambank_stabilization": {
-        "name": "Streambank Stabilization",
+        "name": "Streambank Stabilization (Rural)",
+        "summary": "The use of rip-rap, gabion walls, or a “bio-engineering” solution of some type along the edges of a stream to protect the banks during periods of heavy stream flow, thereby reducing direct stream bank erosion. The banks may also be covered with rocks, grass, trees, shrubs, and other protective surfaces to reduce erosion as well.",
+        "copyStyle": "woody_wetlands"
+    },
+    "urban_buffer_strips": {
+        "name": "Vegetated Buffer Strips (Urban)",
+        "shortName": "Veg Buffer Strips (Urban)",
+        "summary": "Areas of trees and/or grasses planted along streams or lakes that are designed to capture and renovate surface runoff and shallow subsurface flow from agricultural and urban areas via the processes of filtration, infiltration, absorption, adsorption, uptake, denitrification, volatilization, and deposition. A buffer width of 30 m (roughly 100 ft) is assumed.",
+        "copyStyle": "no_till"
+    },
+    "urban_streambank_stabilization": {
+        "name": "Streambank Stabilization (Urban)",
         "summary": "The use of rip-rap, gabion walls, or a “bio-engineering” solution of some type along the edges of a stream to protect the banks during periods of heavy stream flow, thereby reducing direct stream bank erosion. The banks may also be covered with rocks, grass, trees, shrubs, and other protective surfaces to reduce erosion as well.",
         "copyStyle": "woody_wetlands"
     },

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -1,17 +1,23 @@
 "use strict";
 
 var $ = require('jquery'),
-    _ = require('underscore'),
+    _ = require('lodash'),
+    Backbone = require('../../shim/backbone'),
     Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
     drawUtils = require('../draw/utils'),
     coreUtils = require('../core/utils'),
     models = require('./models'),
     modificationConfigUtils = require('./modificationConfigUtils'),
+    gwlfeConfig = require('./gwlfeModificationConfig'),
     precipitationTmpl = require('./templates/controls/precipitation.html'),
     manualEntryTmpl = require('./templates/controls/manualEntry.html'),
+    userInputTmpl = require('./templates/controls/userInput.html'),
+    inputInfoTmpl = require('./templates/controls/inputInfo.html'),
     thumbSelectTmpl = require('./templates/controls/thumbSelect.html'),
     modDropdownTmpl = require('./templates/controls/modDropdown.html');
+
+var ENTER_KEYCODE = 13;
 
 // Simulation input controls base class.
 var ControlView = Marionette.LayoutView.extend({
@@ -93,7 +99,50 @@ var ThumbSelectView = Marionette.ItemView.extend({
     }
 });
 
-var ManualEntryView = Marionette.ItemView.extend({
+var InputInfoView = Marionette.ItemView.extend({
+    template: inputInfoTmpl,
+
+    initialize: function(options) {
+        this.userInputName = options.userInputName;
+    },
+
+    modelEvents: {
+        'change:output': 'render'
+    },
+
+    templateHelpers: function() {
+        return {
+            userInputName: this.userInputName
+        };
+    }
+});
+
+var UserInputView = Marionette.LayoutView.extend({
+    template: userInputTmpl,
+
+    initialize: function(options) {
+        this.parentModel = options.parentModel;
+    },
+
+    regions: {
+        infoRegion: '.info-region'
+    },
+
+    onShow: function() {
+        this.infoRegion.show(new InputInfoView({
+            model: this.parentModel,
+            userInputName: this.model.get('userInputName')
+        }));
+    },
+
+    templateHelpers: function() {
+        return {
+            displayNames: gwlfeConfig.displayNames
+        };
+    }
+});
+
+var ManualEntryView = Marionette.CompositeView.extend({
     template: manualEntryTmpl,
 
     ui: {
@@ -103,17 +152,83 @@ var ManualEntryView = Marionette.ItemView.extend({
 
     events: {
         'click @ui.backButton': 'clearManualMod',
-        'click @ui.convertButton': 'convert'
+        'click @ui.convertButton': 'convert',
+        'keyup': 'onKeyUp'
+    },
+
+    childView: UserInputView,
+
+    childViewContainer: '#user-input-region',
+
+    childViewOptions: function() {
+        return {
+            parentModel: this.model
+        };
+    },
+
+    templateHelpers: function() {
+        var manualMod = this.model.get('manualMod');
+        return {
+            modConfig: gwlfeConfig.configs[manualMod],
+            displayNames: gwlfeConfig.displayNames,
+            dataModel: this.model.get('dataModel')
+        };
+    },
+
+    onKeyUp: function(e) {
+        if (e.keyCode === ENTER_KEYCODE) {
+            this.convert();
+        }
+    },
+
+    onShow: function() {
+        var self = this,
+            $input = $(this.el).find('input');
+
+        $input.on('change keyup paste', function() {
+            self.computeOutput();
+        });
+
+        $input[0].focus();
     },
 
     clearManualMod: function() {
-        this.model.set('manualMod', null);
+        this.model.set({
+            manualMod: null,
+            output: null
+        });
+    },
+
+    closeDropdown: function() {
+        this.model.set('dropdownOpen', false);
+    },
+
+    computeOutput: function() {
+        var modConfig = gwlfeConfig.configs[this.model.get('manualMod')],
+            userInput = _.map(modConfig.userInputNames, function(userInputName) {
+                return $('#'+userInputName).val();
+            }),
+            output;
+
+        userInput = _.zipObject(modConfig.userInputNames, userInput);
+        output = gwlfeConfig.aggregateOutput(this.model.get('dataModel'),
+            userInput, modConfig.validate, modConfig.computeOutput);
+
+        this.model.set({
+            output: output
+        });
     },
 
     convert: function() {
-        // TODO add modification
-        this.model.set('dropdownOpen', false);
-        this.clearManualMod();
+        this.computeOutput();
+        var output = this.model.get('output');
+        if (output && gwlfeConfig.isValid(output.errorMessages)) {
+            this.clearManualMod();
+            this.closeDropdown();
+            // TODO call this.addModification after infrastructure is in place
+            // to handle Gwlfe scenarios and modifications
+            console.log(output.output);
+        }
     }
 });
 
@@ -124,12 +239,23 @@ var ModificationsView = ControlView.extend({
         ControlView.prototype.initialize.apply(this, [options]);
         var self = this;
 
-        // If clicked outside this view and dropdown is open, then close it.
-        $(document).mouseup(function(e) {
+        function closeDropdownOnOutsideClick(e) {
             var isTargetOutsideDropdown = $(e.target).parents('.dropdown-menu').length === 0;
-
             if (isTargetOutsideDropdown && self.model.get('dropdownOpen')) {
-                self.model.set('dropdownOpen', false);
+                self.closeDropdown();
+            }
+        }
+
+        /*
+            If not in manualMode, and there was a click outside this view, and dropdown is
+            open, then close the dropdown. We don't do this in  manualMode because
+            highlighting the value in the input by clicking and then dragging outside the
+            dropdown closes the dropdown, and this is not correct. A more sophisticated
+            solution is possible, but this is a quickfix for the moment.
+        */
+        $(document).on('mouseup', function(e) {
+            if (!self.model.get('manualMode')) {
+                closeDropdownOnOutsideClick(e);
             }
         });
     },
@@ -151,9 +277,28 @@ var ModificationsView = ControlView.extend({
         modContentRegion: '.mod-content-region'
     },
 
+    closeDropdown: function() {
+        this.model.set({
+            dropdownOpen: false,
+            manualMod: null,
+            output: null
+        });
+    },
+
+    openDropdown: function() {
+        this.model.set('dropdownOpen', true);
+    },
+
     onClickDropdownButton: function() {
-        if (!this.model.get('dropdownOpen')) {
-            this.model.set('dropdownOpen', true);
+        var dropdownOpen = this.model.get('dropdownOpen');
+        if (this.model.get('manualMode')) {
+            if (dropdownOpen) {
+                this.closeDropdown();
+            } else {
+                this.openDropdown();
+            }
+        } else if (!this.model.get('dropdownOpen')) {
+            this.openDropdown();
         }
     },
 
@@ -162,8 +307,19 @@ var ModificationsView = ControlView.extend({
     },
 
     updateContent: function() {
-        if (this.model.get('manualMod')) {
-            this.modContentRegion.show(new ManualEntryView({model: this.model}));
+        var manualMod = this.model.get('manualMod');
+        if (manualMod) {
+            var modConfig = gwlfeConfig.configs[manualMod],
+                userInputNames = _.map(modConfig.userInputNames, function(name) {
+                    return { userInputName: name };
+                }),
+                userInputCollection = new Backbone.Collection(userInputNames);
+
+            this.modContentRegion.show(new ManualEntryView({
+                model: this.model,
+                collection: userInputCollection,
+                addModification: this.addModification
+            }));
         } else {
             this.modContentRegion.show(new ThumbSelectView({
                 addModification: this.addModification,
@@ -210,6 +366,15 @@ var ConservationPracticeView = ModificationsView.extend({
     }
 });
 
+// TODO use the real Mapshed data model from the server
+var mockDataModel = {
+    n23: 500,
+    n42: 300,
+    n42b: 1000,
+    UrbAreaTotal: 900,
+    UrbLength: 200
+};
+
 var GwlfeConservationPracticeView = ModificationsView.extend({
     initialize: function(options) {
         ModificationsView.prototype.initialize.apply(this, [options]);
@@ -219,10 +384,13 @@ var GwlfeConservationPracticeView = ModificationsView.extend({
             manualMode: true,
             manualMod: null,
             modRows: [
-                ['cover_crops', 'conservation_tillage', 'nutrient_management'],
-                ['waste_management', 'buffer_strips', 'streambank_fencing'],
-                ['streambank_stabilization', 'water_retention', 'infiltration']
-            ]
+                ['cover_crops', 'conservation_tillage', 'nutrient_management', 'waste_management_livestock'],
+                ['waste_management_poultry', 'buffer_strips', 'streambank_fencing', 'streambank_stabilization'],
+                ['urban_buffer_strips', 'urban_streambank_stabilization', 'water_retention', 'infiltration']
+            ],
+            dataModel: mockDataModel,
+            errorMessages: null,
+            infoMessages: null
         });
     },
 

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -1,0 +1,286 @@
+"use strict";
+
+var _ = require('lodash');
+
+// These variable names include 'Name' to indicate
+// that they reference the name of the variable, and not the value.
+var n23Name = 'n23',
+    n25Name = 'n25',
+    n26Name = 'n26',
+    n28bName = 'n28b',
+    n41bName = 'n41b',
+    n41dName = 'n41d',
+    n42Name = 'n42',
+    n42bName = 'n42b',
+    n43Name = 'n43',
+    n45Name = 'n45',
+    n46cName = 'n46c',
+    n25bName = 'n25b',
+    n25cName = 'n25c',
+    UrbLengthName = 'UrbLength',
+    FilterWidthName = 'FilterWidth',
+    PctStrmBufName = 'PctStrmBuf',
+    UrbBankStabName = 'UrbBankStab',
+    QretentionName = 'Qretention',
+    PctAreaInfilName = 'PctAreaInfil',
+    UrbAreaTotalName = 'UrbAreaTotal',
+    lengthToConvertName = 'lengthToConvert',
+    areaToConvertName = 'areaToConvert',
+    percentAeuToConvertName = 'percentAeuToConvert',
+    percentAreaToConvertName = 'percentAreaToConvert',
+    AREA = 'area',
+    LENGTH = 'length',
+    FilterWidthDefault = 30,
+    QretentionDefault = 2.54;
+
+// This function converts a list of pairs to objects. We use it to
+// create objects where the keys are the values of variables, which is not
+// possible with object literal syntax. For instance,
+// x = {n23Name: 'y'} would create an object {'n23Name': 'y'} instead of
+// {'n23': 'y'} which is what we want. We could also do {n23: 'y'} but that
+// would defeat the point of using constants here which is to get
+// spell-checking from the interpreter.
+// This function is in lodash 4.12.2. In the future, we might want to upgrade
+// to get it.
+function fromPairs(pairs) {
+    var obj = {};
+    _.forEach(pairs, function(pair) {
+        obj[pair[0]] = pair[1];
+    });
+    return obj;
+}
+
+var displayNames = fromPairs([
+    [n23Name, 'Area of row crops (ha)'],
+    [areaToConvertName, 'Area to convert (ha)'],
+    [percentAeuToConvertName, '% of AEUs to convert'],
+    [percentAreaToConvertName, '% of area to convert'],
+    [n42Name, 'Total length of streams (km) in ag areas'],
+    [n42bName, 'Total length of streams (km) in entire watershed'],
+    [lengthToConvertName, 'Length to convert (km)'],
+    [UrbAreaTotalName, 'Total urban area (ha)'],
+    [UrbLengthName, 'Total length (km) of streams in non-ag areas']
+]);
+
+function getPercentStr(fraction) {
+    return Math.round(fraction * 100) + '%';
+}
+
+function convertToNumber(x) {
+    x = x.trim();
+    return (x !== '' && !isNaN(x)) ? Number(x) : null;
+}
+
+// infoMessages maps user input variable names to
+// helpful, non-error messages to display in the UI.
+function formatOutput(infoMessages, output) {
+    return {
+        infoMessages: infoMessages,
+        output: output
+    };
+}
+
+function formatValidation(cleanUserInput, errorMessages) {
+    return {
+        cleanUserInput: cleanUserInput,
+        errorMessages: errorMessages
+    };
+}
+
+function isValid(errorMessages) {
+    return _.isEmpty(errorMessages);
+}
+
+function aggregateOutput(dataModel, userInput, validate, computeOutput) {
+    var validation = validate(dataModel, userInput),
+        output = computeOutput(dataModel, validation.cleanUserInput);
+
+    return {
+        errorMessages: validation.errorMessages,
+        infoMessages: output.infoMessages,
+        output: output.output
+    };
+}
+
+function makeThresholdValidateFn(thresholdName, thresholdType, userInputName) {
+    return function(dataModel, userInput) {
+        var errorMessages = {},
+            cleanUserInput = {},
+            threshold = dataModel[thresholdName],
+            userInputVal = convertToNumber(userInput[userInputName]),
+            errorMessage = 'Enter ' + thresholdType +
+                ' > 0 and <= ' + threshold;
+
+        if (userInputVal) {
+            if (userInputVal > threshold || userInputVal <= 0) {
+                errorMessages[userInputName] = errorMessage;
+            } else {
+                cleanUserInput[userInputName] = userInputVal;
+            }
+        } else {
+           errorMessages[userInputName] = errorMessage;
+        }
+
+        return formatValidation(cleanUserInput, errorMessages);
+    };
+}
+
+function makePercentValidateFn(userInputName) {
+    return function (dataModel, userInput) {
+        var errorMessages = {},
+            cleanUserInput = {},
+            userInputVal = convertToNumber(userInput[userInputName]),
+            errorMessage = 'Enter % > 0 and <= 100';
+
+        if (userInputVal) {
+            if (userInputVal > 100 || userInputVal <= 0) {
+                errorMessages[userInputName] = errorMessage;
+            } else {
+                cleanUserInput[userInputName] = userInputVal;
+            }
+        } else {
+           errorMessages[userInputName] = errorMessage;
+        }
+
+        return formatValidation(cleanUserInput, errorMessages);
+    };
+}
+
+function makeComputeOutputFn(dataModelName, inputName, getOutput) {
+    return function(dataModel, cleanUserInput) {
+        var dataModelVal = dataModel[dataModelName],
+            inputVal = cleanUserInput[inputName],
+            output = {},
+            infoMessages = {},
+            fractionVal;
+
+        if (inputVal) {
+            fractionVal = inputVal / dataModelVal;
+            infoMessages[inputName] = getPercentStr(fractionVal);
+            output = getOutput(inputVal, fractionVal);
+        }
+
+        return formatOutput(infoMessages, output);
+    };
+}
+
+function makeAgBmpConfig(outputName) {
+    function getOutput(inputVal, fractionVal) {
+        return fromPairs([
+            [outputName, fractionVal * 100]
+        ]);
+    }
+
+    return {
+        dataModelNames: [n23Name],
+        userInputNames: [areaToConvertName],
+        validate: makeThresholdValidateFn(n23Name, AREA, areaToConvertName),
+        computeOutput: makeComputeOutputFn(n23Name, areaToConvertName, getOutput)
+    };
+}
+
+function makeAeuBmpConfig(outputName) {
+    return {
+        dataModelNames: [],
+        userInputNames: [percentAeuToConvertName],
+        validate: makePercentValidateFn(percentAeuToConvertName),
+        computeOutput: function(dataModel, cleanUserInput) {
+            var percentAeuToConvert = cleanUserInput[percentAeuToConvertName],
+                output = {},
+                infoMessages = {};
+
+            if (percentAeuToConvert) {
+                output[outputName] = percentAeuToConvert;
+            }
+
+            return formatOutput(infoMessages, output);
+        }
+
+    };
+}
+
+function makeRuralStreamsBmpConfig(outputName) {
+    function getOutput(inputVal) {
+        return fromPairs([
+            [outputName, inputVal]
+        ]);
+    }
+
+    return {
+        dataModelNames: [n42Name, n42bName],
+        userInputNames: [lengthToConvertName],
+        validate: makeThresholdValidateFn(n42Name, LENGTH, lengthToConvertName),
+        computeOutput: makeComputeOutputFn(n42Name, lengthToConvertName, getOutput)
+    };
+}
+
+function makeUrbanStreamsBmpConfig(getOutput) {
+    return {
+        dataModelNames: [UrbLengthName],
+        userInputNames: [lengthToConvertName],
+        validate: makeThresholdValidateFn(UrbLengthName, LENGTH, lengthToConvertName),
+        computeOutput: makeComputeOutputFn(UrbLengthName, lengthToConvertName, getOutput)
+    };
+}
+
+function makeUrbanAreaBmpConfig(getOutput) {
+    return {
+        dataModelNames: [UrbAreaTotalName],
+        userInputNames: [areaToConvertName],
+        validate: makeThresholdValidateFn(UrbAreaTotalName, AREA, areaToConvertName),
+        computeOutput: makeComputeOutputFn(UrbAreaTotalName, areaToConvertName, getOutput)
+    };
+}
+
+/*
+    configs contains a mapping from the BMP key to information needed
+    to generate the UI for that modification.
+    - dataModelNames is a list of variable names in the Mapshed data model
+    (received from the backend) which should be displayed to the user.
+    - userInputNames is a list of non-Mapshed variables used to reference values
+    the user enters into the UI. currently all the BMPs only reference a single
+    user input variable, so using a list is overkill, but it could be useful in
+    the future.
+    - validate is a function which validates the user input using values from
+    the data model.
+    - computeOutput is a function which computes the output of the UI for a BMP,
+    the values for a set of Mapshed variables.
+*/
+var configs = {
+    'cover_crops': makeAgBmpConfig(n25Name),
+    'conservation_tillage': makeAgBmpConfig(n26Name),
+    'nutrient_management':  makeAgBmpConfig(n28bName),
+    'waste_management_livestock': makeAeuBmpConfig(n41bName),
+    'waste_management_poultry': makeAeuBmpConfig(n41dName),
+    'buffer_strips': makeRuralStreamsBmpConfig(n43Name),
+    'streambank_fencing': makeRuralStreamsBmpConfig(n45Name),
+    'streambank_stabilization': makeRuralStreamsBmpConfig(n46cName),
+    'urban_buffer_strips': makeUrbanStreamsBmpConfig(function(inputVal, fractionVal) {
+        return fromPairs([
+            [PctStrmBufName, fractionVal],
+            [FilterWidthName, FilterWidthDefault]
+        ]);
+    }),
+    'urban_streambank_stabilization': makeUrbanStreamsBmpConfig(function(inputVal) {
+        return fromPairs([[UrbBankStabName, inputVal]]);
+    }),
+    'water_retention': makeUrbanAreaBmpConfig(function(inputVal, fractionVal) {
+        return fromPairs([
+            [n25bName, fractionVal],
+            [n25cName, fractionVal]
+        ]);
+    }),
+    'infiltration': makeUrbanAreaBmpConfig(function(inputVal, fractionVal) {
+        return fromPairs([
+            [PctAreaInfilName, fractionVal],
+            [QretentionName, QretentionDefault]
+        ]);
+    })
+};
+
+module.exports = {
+    displayNames: displayNames,
+    isValid: isValid,
+    aggregateOutput: aggregateOutput,
+    configs: configs
+};

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -23,7 +23,9 @@ var ModelPackageControlModel = Backbone.Model.extend({
         manualMod: '',
         activeMod: '',
         modRows: null,
-        dropdownOpen: false
+        dropdownOpen: false,
+        dataModel: null,
+        output: null
     },
 
     // Return true if this is an input control and false if it is a

--- a/src/mmw/js/src/modeling/templates/controls/inputInfo.html
+++ b/src/mmw/js/src/modeling/templates/controls/inputInfo.html
@@ -1,0 +1,4 @@
+<div>
+  {{ output.errorMessages[userInputName] }}
+  {{ output.infoMessages[userInputName] }}
+</div>

--- a/src/mmw/js/src/modeling/templates/controls/manualEntry.html
+++ b/src/mmw/js/src/modeling/templates/controls/manualEntry.html
@@ -10,9 +10,14 @@
             <rect height="40" width="200" fill="{{ manualMod|modFill }}"></rect>
         </svg>
     </div>
-    <div class="amount-form form-group">
-      <label for="bmp-amount">Amount</label>
-      <input type="text" class="form-control" id="bmp-amount">
-    </div>
+
+    <ul>
+        {% for dataModelName in modConfig.dataModelNames %}
+            <li>{{ displayNames[dataModelName] }}: {{ dataModel[dataModelName] }}</li>
+        {% endfor %}
+    </ul>
+
+    <div id="user-input-region"></div>
+
     <button type="button" class="btn btn-lg btn-block btn-active convert-button">Convert</button>
 </div>

--- a/src/mmw/js/src/modeling/templates/controls/userInput.html
+++ b/src/mmw/js/src/modeling/templates/controls/userInput.html
@@ -1,0 +1,5 @@
+<div class="form-group">
+  <label for="{{ userInputName }}">{{ displayNames[userInputName] }}</label>
+  <input type="text" class="form-control" id="{{ userInputName }}">
+  <div class="info-region"></div>
+</div>


### PR DESCRIPTION
This PR adds a configuration for each GWLF-E BMP to customize the manual entry UI for each BMP.

When reviewing this PR, ignore style issues including layout and word choices as they will be addressed in https://github.com/WikiWatershed/model-my-watershed/issues/1315.

Currently, this doesn't add a modification to the ScenarioModel, and uses a mock Mapshed data model. This will be addressed in https://github.com/WikiWatershed/model-my-watershed/issues/1316

#### Testing
* Check that BMP UI still works for TR55.
* For the BMP dropdown for GWLF-E models, check that back button and clicking the dropdown button works as expected (should clear things and bring back the thumbnails).
* For each BMP check that everything matches the spec at https://drive.google.com/open?id=0B8dzaPNE2DLTUV9EWC1tNXVVWDhUeHhPQzlIVlYyWVVJemxz
* Clicking Convert will not work if there are error messages.
* Clicking Convert when the input is valid will print an object to the console with the output.
![screen shot 2016-05-18 at 11 16 30 am 2](https://cloud.githubusercontent.com/assets/1896461/15364378/5755ff32-1cea-11e6-87ce-0161fb6b387d.png)
![screen shot 2016-05-18 at 11 16 52 am 2](https://cloud.githubusercontent.com/assets/1896461/15364381/5bbc4b94-1cea-11e6-997c-94b8425fc01f.png)
![screen shot 2016-05-18 at 11 16 59 am 2](https://cloud.githubusercontent.com/assets/1896461/15364383/5e88a9d0-1cea-11e6-8f83-e4d16a8d20c9.png)

Connects #1307 
