### PR TITLE
Alter owner of spatial_ref_sys on Amazon RDS

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -52,6 +52,7 @@ export PUBLIC_HOSTED_ZONE_NAME=$(cat /etc/mmw.d/env/MMW_PUBLIC_HOSTED_ZONE_NAME)
 
 # Ensure that the PostGIS extension exists
 psql -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+psql -c "ALTER TABLE spatial_ref_sys OWNER TO ${PGUSER};"
 
 # Run migrations
 envdir /etc/mmw.d/env /opt/app/manage.py migrate


### PR DESCRIPTION
For Amazon RDS environments, ensure that the spatial_ref_sys table's owner is adjusted to match the Model My Watershed database owner. This allows us to add new SRIDs to the table via Django migrations.