### PR TITLE
Add table for GWLF-E quality results

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -338,7 +338,4 @@ def run_gwlfe(model_input):
     gms_file = open(gms_filename, 'r')
     z = parser.GmsReader(gms_file).read()
 
-    # The frontend expects an object with runoff and quality as keys.
-    response_json = {'runoff': gwlfe.run(z)}
-
-    return response_json
+    return gwlfe.run(z)

--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
@@ -1,0 +1,1 @@
+<div class="quality-table-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
@@ -1,0 +1,35 @@
+{% macro table(columnNames, rows, isSortable) %}
+    <table class="table custom-hover" data-toggle="table">
+        <thead>
+            <tr>
+                {% for columnName in columnNames %}
+                    {% if isSortable %}
+                        <th data-sortable="true" data-sorter="window.numericSort">{{ columnName }}</th>
+                    {% else %}
+                        <th>{{ columnName }}</th>
+                    {% endif %}
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
+                <tr>
+                    {% for value in row %}
+                        {% if loop.index0 == 0 %}
+                            <td class="text-left">{{ value }}</td>
+                        {% else %}
+                            <td class="strong text-right">{{ value|round(2)|toLocaleString(2) }}</td>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endmacro %}
+
+
+<div class="mean-flow">
+    Mean Flow: {{ MeanFlow|round(0)|toLocaleString }} (m<sup>3</sup>/year) and {{ MeanFlowPerSecond|round(0)|toLocaleString }} (m<sup>3</sup>/s)
+</div>
+{{ table(columnNames, landUseRows, true) }}
+{{ table(columnNames, summaryRows, false) }}

--- a/src/mmw/js/src/modeling/gwlfe/quality/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/quality/views.js
@@ -1,0 +1,70 @@
+"use strict";
+
+var $ = require('jquery'),
+    _ = require('underscore'),
+    Marionette = require('../../../../shim/backbone.marionette'),
+    resultTmpl = require('./templates/result.html'),
+    tableTmpl = require('./templates/table.html');
+
+var ResultView = Marionette.LayoutView.extend({
+    className: 'tab-pane',
+
+    template: resultTmpl,
+
+    regions: {
+        tableRegion: '.quality-table-region',
+    },
+
+    modelEvents: {
+        'change': 'onShow'
+    },
+
+    initialize: function(options) {
+        this.compareMode = options.compareMode;
+        this.scenario = options.scenario;
+    },
+
+    onShow: function() {
+        var result = this.model.get('result');
+        this.tableRegion.reset();
+
+        if (result && result.Loads) {
+            if (!this.compareMode) {
+                this.tableRegion.show(new TableView({
+                    model: this.model,
+                }));
+            }
+        }
+    }
+});
+
+var TableView = Marionette.CompositeView.extend({
+    template: tableTmpl,
+
+    onAttach: function() {
+        $('[data-toggle="table"]').bootstrapTable();
+    },
+
+    templateHelpers: function() {
+        function makeRow(load) {
+            return [load.Source, load.Sediment, load.TotalN, load.TotalP];
+        }
+
+        var result = this.model.get('result'),
+            columnNames = ['Sources', 'Sediment (kg)', 'Total Nitrogen (kg)', 'Total Phosphorus (kg)'],
+            landUseRows = _.map(result.Loads.slice(0,15), makeRow),
+            summaryRows = _.map(result.Loads.slice(15), makeRow);
+
+        return {
+            MeanFlow: result.MeanFlow,
+            MeanFlowPerSecond: result.MeanFlowPerSecond,
+            columnNames: columnNames,
+            landUseRows: landUseRows,
+            summaryRows: summaryRows
+        };
+    }
+});
+
+module.exports = {
+    ResultView: ResultView
+};

--- a/src/mmw/js/src/modeling/gwlfe/runoff/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/runoff/templates/table.html
@@ -7,7 +7,7 @@
                         {{ columnName }}
                     </th>
                 {% else %}
-                    <th class="text-left" data-sortable="true" data-sorter="window.numericSort">{{ columnName }}</th>
+                    <th data-sortable="true" data-sorter="window.numericSort">{{ columnName }}</th>
                 {% endif %}
             {% endfor %}
         </tr>
@@ -17,9 +17,9 @@
             <tr>
                 {% for value in row %}
                     {% if loop.index0 == 0 %}
-                        <td data-month="{{ value }}">{{ monthNames[value] }}</td>
+                        <td class="text-left" data-month="{{ value }}">{{ monthNames[value] }}</td>
                     {% else %}
-                        <td class="strong text-left">{{ value|round(2)|toLocaleString }}</td>
+                        <td class="strong text-right">{{ value|round(2)|toLocaleString(2) }}</td>
                     {% endif %}
                 {% endfor %}
             </tr>

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -625,9 +625,9 @@ var ScenarioModel = Backbone.Model.extend({
             this.get('results').forEach(function(resultModel) {
                 var resultName = resultModel.get('name');
 
-                if (serverResults[resultName]) {
+                if (serverResults) {
                     resultModel.set({
-                        'result': serverResults[resultName],
+                        'result': serverResults,
                         'inputmod_hash': serverResults.inputmod_hash
                     });
                 } else {

--- a/src/mmw/js/src/modeling/tr55/quality/templates/tableRow.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/tableRow.html
@@ -1,3 +1,3 @@
 <td>{{ measure }}</td>
-<td class="strong text-left">{{ load|round(3)|toLocaleString }}</td>
-<td class="strong text-left">{{ concentration|round(1)|toLocaleString }}</td>
+<td class="strong text-right">{{ load|round(3)|toLocaleString(3) }}</td>
+<td class="strong text-right">{{ concentration|round(1)|toLocaleString(1) }}</td>

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -50,7 +50,7 @@ var ResultView = Marionette.LayoutView.extend({
                 }));
             } else {
                 var dataCollection = new Backbone.Collection(
-                    this.model.get('result')
+                    this.model.get('result').quality
                 );
 
                 this.tableRegion.show(new TableView({
@@ -161,7 +161,7 @@ var CompareChartView = Marionette.ItemView.extend({
         }
 
         var chartEl = this.$el.find('.bar-chart').get(0),
-            result = this.model.get('result'),
+            result = this.model.get('result').quality,
             seriesDisplayNames = ['Oxygen Demand',
                                   'Suspended Solids',
                                   'Nitrogen',

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/tableRow.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/tableRow.html
@@ -1,3 +1,3 @@
 <td>{{ runoffType }}</td>
-<td class="strong text-left">{{ depth|round(3)|toLocaleString }}</td>
-<td class="strong text-left">{{ adjustedVolume|round(2)|toLocaleString }}</td>
+<td class="strong text-right">{{ depth|round(3)|toLocaleString(3) }}</td>
+<td class="strong text-right">{{ adjustedVolume|round(2)|toLocaleString(2) }}</td>

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -88,7 +88,7 @@ var ChartView = Marionette.ItemView.extend({
         }
 
         var chartEl = this.$el.find('.bar-chart').get(0),
-            result = this.model.get('result'),
+            result = this.model.get('result').runoff,
             seriesNames = ['inf', 'runoff', 'et'],
             seriesDisplayNames = ['Infiltration', 'Runoff', 'Evapotranspiration'],
             labelNames,
@@ -155,7 +155,7 @@ var TableView = Marionette.CompositeView.extend({
 
     initialize: function() {
         this.aoiVolumeModel = this.options.aoiVolumeModel;
-        this.tr55Results = this.model.get('result');
+        this.tr55Results = this.model.get('result').runoff;
 
         this.collection = this.formatData();
     },

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -26,7 +26,7 @@
     tr55RunoffViews = require('./tr55/runoff/views.js'),
     tr55QualityViews = require('./tr55/quality/views.js'),
     gwlfeRunoffViews = require('./gwlfe/runoff/views.js'),
-    gwlfeQualityViews = tr55QualityViews; // TODO make gwlfe quality views
+    gwlfeQualityViews = require('./gwlfe/quality/views.js');
 
 var ENTER_KEYCODE = 13,
     ESCAPE_KEYCODE = 27;

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -49,6 +49,10 @@
     height: 100%;
     width: 100%;
 
+    .mean-flow {
+      font-size: 16px;
+    }
+
     .runoff-chart-container {
       height: 300px;
       width: 100%;


### PR DESCRIPTION
Add tables for GWLF-E quality results.

To test, `cd src/mmw/requirements/src/gwlf-e/` and then check out the branch from https://github.com/WikiWatershed/gwlf-e/pull/50 to get the latest GWLF-E code that computes quality results, and then run `debugcelery.sh` and `debugserver.sh`.

![screen shot 2016-05-19 at 10 42 51 am 2](https://cloud.githubusercontent.com/assets/1896461/15397625/de7c4754-1dae-11e6-8558-5a4c7735ebae.png)
![screen shot 2016-05-19 at 10 42 54 am 2](https://cloud.githubusercontent.com/assets/1896461/15397658/ffafd60c-1dae-11e6-8851-70e9aa4e9a12.png)

Connects #1270