### PR TITLE
Trigger MapShed before GWLF-E

### DIFF
--- a/src/mmw/apps/modeling/migrations/0019_project_gis_data.py
+++ b/src/mmw/apps/modeling/migrations/0019_project_gis_data.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0018_postgis_add_EPSG5070'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='gis_data',
+            field=models.TextField(help_text='Serialized JSON representation of additional data gathering steps, such as MapShed.', null=True),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -39,6 +39,10 @@ class Project(models.Model):
     is_activity = models.BooleanField(
         default=False,
         help_text='Projects with special properties')
+    gis_data = models.TextField(
+        null=True,
+        help_text='Serialized JSON representation of additional'
+                  ' data gathering steps, such as MapShed.')
 
     def __unicode__(self):
         return self.name

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -119,6 +119,7 @@ var ProjectModel = Backbone.Model.extend({
         scenarios: null,                // ScenariosCollection
         user_id: 0,                     // User that created the project
         is_activity: false,             // Project that persists across routes
+        gis_data: null,                 // Additionally gathered data, such as MapShed for GWLF-E
         needs_reset: false,             // Should we overwrite project data on next save?
         allow_save: true                // Is allowed to save to the server - false in compare mode
     },

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var Backbone = require('../../shim/backbone'),
+var $ = require('jquery'),
+    Backbone = require('../../shim/backbone'),
     _ = require('lodash'),
     utils = require('../core/utils'),
     settings = require('../core/settings'),
@@ -10,6 +11,7 @@ var Backbone = require('../../shim/backbone'),
     turfErase = require('turf-erase'),
     turfIntersect = require('turf-intersect');
 
+var MAPSHED = 'mapshed';
 var GWLFE = 'gwlfe';
 var TR55_TASK = 'tr55';
 var TR55_PACKAGE = 'tr-55';
@@ -45,6 +47,16 @@ var Tr55TaskModel = coreModels.TaskModel.extend({
     defaults: _.extend(
         {
             taskName: TR55_TASK,
+            taskType: 'modeling'
+        },
+        coreModels.TaskModel.prototype.defaults
+    )
+});
+
+var MapshedTaskModel = coreModels.TaskModel.extend({
+    defaults: _.extend(
+        {
+            taskName: MAPSHED,
             taskType: 'modeling'
         },
         coreModels.TaskModel.prototype.defaults
@@ -291,6 +303,88 @@ var ProjectModel = Backbone.Model.extend({
         }
 
         return url;
+    },
+
+    /**
+     * If a project is of the GWLFE package, we trigger the mapshed GIS
+     * data gathering chain, and poll for it to finish. Once it finishes,
+     * we resolve the lock to indicate the project is ready for further
+     * processing.
+     * If the project is not of the GWLFE package, we simply resolve the
+     * lock immediately and return.
+     */
+    fetchGisData: function() {
+        if (this.get('model_package') === GWLFE) {
+            var aoi = this.get('area_of_interest'),
+                promise = $.Deferred(),
+                taskModel = createTaskModel(MAPSHED),
+                taskHelper = {
+                    postData: {
+                        mapshed_input: JSON.stringify({
+                            area_of_interest: aoi
+                        })
+                    },
+
+                    onStart: function() {
+                        console.log('Starting polling for MAPSHED');
+                    },
+
+                    startFailure: function(response) {
+                        console.log('Failed to start gathering data for MAPSHED');
+
+                        if (response.responseJSON && response.responseJSON.error) {
+                            console.log(response.responseJSON.error);
+                        }
+
+                        promise.reject();
+                    },
+
+                    pollSuccess: function() {
+                        promise.resolve(taskModel.get('result'));
+                    },
+
+                    pollFailure: function() {
+                        console.log('Failed to gather data required for MAPSHED');
+                        promise.reject();
+                    }
+                };
+
+            taskModel.start(taskHelper);
+            return promise;
+        } else {
+            // Currently there are no methods for fetching GIS Data if the
+            // model package is not GWLFE. Thus we return a resolved promise
+            // so that any execution waiting on this can continue immediately.
+            return $.when();
+        }
+    },
+
+    /**
+     * Returns a promise that completes when GIS Data has been fetched. If fetching
+     * is not required, returns an immediatley resolved promise.
+     */
+    fetchGisDataIfNeeded: function() {
+        var self = this,
+            saveProjectAndScenarios = _.bind(self.saveProjectAndScenarios, self);
+
+        if (self.get('gis_data') === null && self.fetchGisDataPromise === undefined) {
+            self.fetchGisDataPromise = self.fetchGisData();
+            self.fetchGisDataPromise
+                .done(function(result) {
+                    if (result) {
+                        self.set('gis_data', result);
+                        saveProjectAndScenarios();
+                    }
+                })
+                .always(function() {
+                    // Clear promise once it completes, so we start a new one
+                    // next time.
+                    delete self.fetchGisDataPromise;
+                });
+        }
+
+        // Return fetchGisDataPromise if it exists, else an immediately resolved one.
+        return self.fetchGisDataPromise || $.when();
     }
 });
 
@@ -612,7 +706,10 @@ var ScenarioModel = Backbone.Model.extend({
             });
 
         if (needsResults) {
-            this.fetchResults();
+            var fetchResults = _.bind(this.fetchResults, this);
+            App.currentProject
+                .fetchGisDataIfNeeded()
+                .then(fetchResults);
         }
     },
 
@@ -653,21 +750,9 @@ var ScenarioModel = Backbone.Model.extend({
         var self = this,
             results = this.get('results'),
             taskModel = this.get('taskModel'),
-            nonZeroModifications = this.get('modifications').filter(function(mod) {
-                return mod.get('effectiveArea') > 0;
-            }),
+            gisData = this.getGisData(),
             taskHelper = {
-                postData: {
-                    model_input: JSON.stringify({
-                        inputs: self.get('inputs').toJSON(),
-                        modification_pieces: alterModifications(nonZeroModifications, self.get('modification_hash')),
-                        area_of_interest: App.currentProject.get('area_of_interest'),
-                        aoi_census: self.get('aoi_census'),
-                        modification_censuses: self.get('modification_censuses'),
-                        inputmod_hash: self.get('inputmod_hash'),
-                        modification_hash: self.get('modification_hash')
-                    })
-                },
+                postData: gisData,
 
                 onStart: function() {
                     results.setPolling(true);
@@ -716,6 +801,35 @@ var ScenarioModel = Backbone.Model.extend({
         var hash = utils.getCollectionHash(this.get('modifications'));
 
         this.set('modification_hash', hash);
+    },
+
+    getGisData: function() {
+        var self = this,
+            project = App.currentProject;
+
+        switch(App.currentProject.get('model_package')) {
+            case TR55_PACKAGE:
+                var nonZeroModifications = self.get('modifications').filter(function(mod) {
+                    return mod.get('effectiveArea') > 0;
+                });
+
+                return {
+                    model_input: JSON.stringify({
+                        inputs: self.get('inputs').toJSON(),
+                        modification_pieces: alterModifications(nonZeroModifications, self.get('modification_hash')),
+                        area_of_interest: project.get('area_of_interest'),
+                        aoi_census: self.get('aoi_census'),
+                        modification_censuses: self.get('modification_censuses'),
+                        inputmod_hash: self.get('inputmod_hash'),
+                        modification_hash: self.get('modification_hash')
+                    })
+                };
+
+            case GWLFE:
+                return {
+                    model_input: JSON.stringify(project.get('gis_data'))
+                };
+        }
     }
 });
 
@@ -873,6 +987,8 @@ function createTaskModel(modelPackage) {
             return new Tr55TaskModel();
         case GWLFE:
             return new GwlfeTaskModel();
+        case MAPSHED:
+            return new MapshedTaskModel();
     }
     throw 'Model package not supported: ' + modelPackage;
 }


### PR DESCRIPTION
## Overview

In case of GWLF-E projects, we need to gather GIS data from MapShed to hand off to the GWLF-E endpoint. This gathering must be done only once per project, since its value does not depend on any modifications.

In this PR we add methods to the `ProjectModel` which support fetching GIS data from the MapShed endpoint if the model package if GWLF-E, or a simple noop if the model package is TR55. In both cases, a promise is returned, only on whose completion does the scenario polling begin. In case of TR55, we return an already resolved promise so that scenario polling can begin immediately.

## Testing Instructions

Run migrations.

```bash
$ ./scripts/manage.sh migrate
```

Test making both TR-55 and GWLF-E projects, both while logged in and while logged out, and ensure that behavior is consistent and unsurprising.

 * Logged in and logged out behavior should be the same as before for TR55.
 * For GWLF-E, making a new project should trigger a MapShed run immediately, with GWLF-E scenarios polling once it completes.
 * Nothing should be saved if you are logged out.
 * If you are logged in, the project should save right after MapShed completes successfully. The scenarios should save before GWLF-E polling begins, and after it ends.
 * If you are logged in and reloading an existing project for which a MapShed run has completed successfully, it should only run GWLF-E after reloading, not the MapShed run again.

## Notes

Currently the GWLF-E endpoint returns static values. However, we do send the true values to the endpoint.

Currently there is no user notification of MapShed polling, and also none in case of failure. These, and other such items, have been relegated to #1323.

Should we also add a `gis_data_hash` field? I can't think of a reason, but maybe someone else can.

Connects #1310 