### PR TITLE
Improve style of GWLF-E BMP UI

### DIFF
--- a/src/mmw/js/src/core/modificationConfig.json
+++ b/src/mmw/js/src/core/modificationConfig.json
@@ -160,7 +160,7 @@
         "name": "Animal Waste Management Systems (Poultry)",
         "shortName": "Poultry Waste Man.",
         "summary": "These are systems that are designed to collect runoff and/or wastes from confined animal operations for the purpose of breaking down organic wastes via aerobic or anaerobic processes. Typical examples include waste lagoons or holding tanks that collect the wastes and prevent their discharge to nearby streams.",
-        "copyStyle": "grassland"
+        "copyStyle": "shrub"
     },
     "buffer_strips": {
         "name": "Vegetated Buffer Strips (Rural)",

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -161,12 +161,12 @@ var ManualEntryView = Marionette.CompositeView.extend({
 
     ui: {
         'backButton': '.back-button',
-        'convertButton': '.convert-button'
+        'applyButton': '.apply-button'
     },
 
     events: {
         'click @ui.backButton': 'clearManualMod',
-        'click @ui.convertButton': 'convert',
+        'click @ui.applyButton': 'applyModification',
         'keyup': 'onKeyUp'
     },
 
@@ -191,7 +191,7 @@ var ManualEntryView = Marionette.CompositeView.extend({
 
     onKeyUp: function(e) {
         if (e.keyCode === ENTER_KEYCODE) {
-            this.convert();
+            this.applyModification();
         }
     },
 
@@ -233,7 +233,7 @@ var ManualEntryView = Marionette.CompositeView.extend({
         });
     },
 
-    convert: function() {
+    applyModification: function() {
         this.computeOutput();
         var output = this.model.get('output');
         if (output && gwlfeConfig.isValid(output.errorMessages)) {

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -111,8 +111,22 @@ var InputInfoView = Marionette.ItemView.extend({
     },
 
     templateHelpers: function() {
+        var output = this.model.get('output'),
+            errorMessage = output && output.errorMessages[this.userInputName],
+            infoMessage = output && output.infoMessages[this.userInputName],
+            isError = false,
+            message;
+
+        if (errorMessage) {
+            isError = true;
+            message = errorMessage;
+        } else if (infoMessage) {
+            message = infoMessage;
+        }
+
         return {
-            userInputName: this.userInputName
+            message: message,
+            isError: isError
         };
     }
 });
@@ -335,11 +349,14 @@ var LandCoverView = ModificationsView.extend({
         this.model.set({
             controlName: this.getControlName(),
             controlDisplayName: 'Land Cover',
-            modRows: [
-                ['open_water', 'developed_open', 'developed_low', 'developed_med'],
-                ['developed_high', 'barren_land', 'deciduous_forest', 'shrub'],
-                ['grassland', 'pasture', 'cultivated_crops', 'woody_wetlands']
-            ]
+            modRowGroups: [{
+                name: '',
+                rows: [
+                    ['open_water', 'developed_open', 'developed_low', 'developed_med'],
+                    ['developed_high', 'barren_land', 'deciduous_forest', 'shrub'],
+                    ['grassland', 'pasture', 'cultivated_crops', 'woody_wetlands']
+                ]
+            }]
         });
     },
 
@@ -354,10 +371,13 @@ var ConservationPracticeView = ModificationsView.extend({
         this.model.set({
             controlName: this.getControlName(),
             controlDisplayName: 'Conservation Practice',
-            modRows: [
-                ['rain_garden', 'infiltration_trench', 'porous_paving'],
-                ['green_roof', 'no_till', 'cluster_housing']
-            ]
+            modRowGroups: [{
+                name: '',
+                rows: [
+                    ['rain_garden', 'infiltration_trench', 'porous_paving'],
+                    ['green_roof', 'no_till', 'cluster_housing']
+                ]
+            }]
         });
     },
 
@@ -383,10 +403,18 @@ var GwlfeConservationPracticeView = ModificationsView.extend({
             controlDisplayName: 'Conservation Practice',
             manualMode: true,
             manualMod: null,
-            modRows: [
-                ['cover_crops', 'conservation_tillage', 'nutrient_management', 'waste_management_livestock'],
-                ['waste_management_poultry', 'buffer_strips', 'streambank_fencing', 'streambank_stabilization'],
-                ['urban_buffer_strips', 'urban_streambank_stabilization', 'water_retention', 'infiltration']
+            modRowGroups: [
+                {
+                    name: 'Rural',
+                    rows: [
+                        ['cover_crops', 'conservation_tillage', 'nutrient_management', 'waste_management_livestock'],
+                        ['waste_management_poultry', 'buffer_strips', 'streambank_fencing', 'streambank_stabilization']
+                    ]
+                },
+                {
+                    name: 'Urban',
+                    rows: [['urban_buffer_strips', 'urban_streambank_stabilization', 'water_retention', 'infiltration']]
+                }
             ],
             dataModel: mockDataModel,
             errorMessages: null,

--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
@@ -1,30 +1,30 @@
 {% macro table(columnNames, rows, isSortable) %}
-    <table class="table custom-hover" data-toggle="table">
-        <thead>
+<table class="table custom-hover" data-toggle="table">
+    <thead>
+        <tr>
+            {% for columnName in columnNames %}
+                {% if isSortable %}
+                    <th data-sortable="true" data-sorter="window.numericSort">{{ columnName }}</th>
+                {% else %}
+                    <th>{{ columnName }}</th>
+                {% endif %}
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in rows %}
             <tr>
-                {% for columnName in columnNames %}
-                    {% if isSortable %}
-                        <th data-sortable="true" data-sorter="window.numericSort">{{ columnName }}</th>
+                {% for value in row %}
+                    {% if loop.index0 == 0 %}
+                        <td class="text-left">{{ value }}</td>
                     {% else %}
-                        <th>{{ columnName }}</th>
+                        <td class="strong text-right">{{ value|round(2)|toLocaleString(2) }}</td>
                     {% endif %}
                 {% endfor %}
             </tr>
-        </thead>
-        <tbody>
-            {% for row in rows %}
-                <tr>
-                    {% for value in row %}
-                        {% if loop.index0 == 0 %}
-                            <td class="text-left">{{ value }}</td>
-                        {% else %}
-                            <td class="strong text-right">{{ value|round(2)|toLocaleString(2) }}</td>
-                        {% endif %}
-                    {% endfor %}
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+        {% endfor %}
+    </tbody>
+</table>
 {% endmacro %}
 
 

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -24,11 +24,11 @@ var n23Name = 'n23',
     QretentionName = 'Qretention',
     PctAreaInfilName = 'PctAreaInfil',
     UrbAreaTotalName = 'UrbAreaTotal',
-    lengthToConvertName = 'lengthToConvert',
-    lengthToConvertInAgName = 'lengthToConvertInAg',
-    areaToConvertName = 'areaToConvert',
-    percentAeuToConvertName = 'percentAeuToConvert',
-    percentAreaToConvertName = 'percentAreaToConvert',
+    lengthToModifyName = 'lengthToModify',
+    lengthToModifyInAgName = 'lengthToModifyInAg',
+    areaToModifyName = 'areaToModify',
+    percentAeuToModifyName = 'percentAeuToModify',
+    percentAreaToModifyName = 'percentAreaToModify',
     AREA = 'area',
     LENGTH = 'length',
     FilterWidthDefault = 30,
@@ -52,11 +52,11 @@ function fromPairs(pairs) {
 }
 
 var displayNames = fromPairs([
-    [percentAeuToConvertName, '% of AEUs to convert'],
-    [percentAreaToConvertName, '% of area to convert'],
-    [areaToConvertName, 'Area to convert (ha)'],
-    [lengthToConvertName, 'Length to convert (km)'],
-    [lengthToConvertInAgName, 'Length to convert in ag areas (km)'],
+    [percentAeuToModifyName, '% of AEUs to modify'],
+    [percentAreaToModifyName, '% of area to modify'],
+    [areaToModifyName, 'Area to modify (ha)'],
+    [lengthToModifyName, 'Length to modify (km)'],
+    [lengthToModifyInAgName, 'Length to modify in ag areas (km)'],
     [n23Name, 'Area of row crops (ha)'],
     [n42Name, 'Length of streams in ag areas (km)'],
     [n42bName, 'Length of streams in watershed (km)'],
@@ -175,24 +175,24 @@ function makeAgBmpConfig(outputName) {
 
     return {
         dataModelNames: [n23Name],
-        userInputNames: [areaToConvertName],
-        validate: makeThresholdValidateFn(n23Name, AREA, areaToConvertName),
-        computeOutput: makeComputeOutputFn(n23Name, areaToConvertName, getOutput)
+        userInputNames: [areaToModifyName],
+        validate: makeThresholdValidateFn(n23Name, AREA, areaToModifyName),
+        computeOutput: makeComputeOutputFn(n23Name, areaToModifyName, getOutput)
     };
 }
 
 function makeAeuBmpConfig(outputName) {
     return {
         dataModelNames: [],
-        userInputNames: [percentAeuToConvertName],
-        validate: makePercentValidateFn(percentAeuToConvertName),
+        userInputNames: [percentAeuToModifyName],
+        validate: makePercentValidateFn(percentAeuToModifyName),
         computeOutput: function(dataModel, cleanUserInput) {
-            var percentAeuToConvert = cleanUserInput[percentAeuToConvertName],
+            var percentAeuToModify = cleanUserInput[percentAeuToModifyName],
                 output = {},
                 infoMessages = {};
 
-            if (percentAeuToConvert) {
-                output[outputName] = percentAeuToConvert;
+            if (percentAeuToModify) {
+                output[outputName] = percentAeuToModify;
             }
 
             return formatOutput(infoMessages, output);
@@ -210,27 +210,27 @@ function makeRuralStreamsBmpConfig(outputName) {
 
     return {
         dataModelNames: [n42Name, n42bName],
-        userInputNames: [lengthToConvertInAgName],
-        validate: makeThresholdValidateFn(n42Name, LENGTH, lengthToConvertInAgName),
-        computeOutput: makeComputeOutputFn(n42Name, lengthToConvertInAgName, getOutput)
+        userInputNames: [lengthToModifyInAgName],
+        validate: makeThresholdValidateFn(n42Name, LENGTH, lengthToModifyInAgName),
+        computeOutput: makeComputeOutputFn(n42Name, lengthToModifyInAgName, getOutput)
     };
 }
 
 function makeUrbanStreamsBmpConfig(getOutput) {
     return {
         dataModelNames: [UrbLengthName],
-        userInputNames: [lengthToConvertName],
-        validate: makeThresholdValidateFn(UrbLengthName, LENGTH, lengthToConvertName),
-        computeOutput: makeComputeOutputFn(UrbLengthName, lengthToConvertName, getOutput)
+        userInputNames: [lengthToModifyName],
+        validate: makeThresholdValidateFn(UrbLengthName, LENGTH, lengthToModifyName),
+        computeOutput: makeComputeOutputFn(UrbLengthName, lengthToModifyName, getOutput)
     };
 }
 
 function makeUrbanAreaBmpConfig(getOutput) {
     return {
         dataModelNames: [UrbAreaTotalName],
-        userInputNames: [areaToConvertName],
-        validate: makeThresholdValidateFn(UrbAreaTotalName, AREA, areaToConvertName),
-        computeOutput: makeComputeOutputFn(UrbAreaTotalName, areaToConvertName, getOutput)
+        userInputNames: [areaToModifyName],
+        validate: makeThresholdValidateFn(UrbAreaTotalName, AREA, areaToModifyName),
+        computeOutput: makeComputeOutputFn(UrbAreaTotalName, areaToModifyName, getOutput)
     };
 }
 

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -25,6 +25,7 @@ var n23Name = 'n23',
     PctAreaInfilName = 'PctAreaInfil',
     UrbAreaTotalName = 'UrbAreaTotal',
     lengthToConvertName = 'lengthToConvert',
+    lengthToConvertInAgName = 'lengthToConvertInAg',
     areaToConvertName = 'areaToConvert',
     percentAeuToConvertName = 'percentAeuToConvert',
     percentAreaToConvertName = 'percentAreaToConvert',
@@ -51,15 +52,16 @@ function fromPairs(pairs) {
 }
 
 var displayNames = fromPairs([
-    [n23Name, 'Area of row crops (ha)'],
-    [areaToConvertName, 'Area to convert (ha)'],
     [percentAeuToConvertName, '% of AEUs to convert'],
     [percentAreaToConvertName, '% of area to convert'],
-    [n42Name, 'Total length of streams (km) in ag areas'],
-    [n42bName, 'Total length of streams (km) in entire watershed'],
+    [areaToConvertName, 'Area to convert (ha)'],
     [lengthToConvertName, 'Length to convert (km)'],
+    [lengthToConvertInAgName, 'Length to convert in ag areas (km)'],
+    [n23Name, 'Area of row crops (ha)'],
+    [n42Name, 'Length of streams in ag areas (km)'],
+    [n42bName, 'Length of streams in watershed (km)'],
     [UrbAreaTotalName, 'Total urban area (ha)'],
-    [UrbLengthName, 'Total length (km) of streams in non-ag areas']
+    [UrbLengthName, 'Length of streams in non-ag areas (km)']
 ]);
 
 function getPercentStr(fraction) {
@@ -208,9 +210,9 @@ function makeRuralStreamsBmpConfig(outputName) {
 
     return {
         dataModelNames: [n42Name, n42bName],
-        userInputNames: [lengthToConvertName],
-        validate: makeThresholdValidateFn(n42Name, LENGTH, lengthToConvertName),
-        computeOutput: makeComputeOutputFn(n42Name, lengthToConvertName, getOutput)
+        userInputNames: [lengthToConvertInAgName],
+        validate: makeThresholdValidateFn(n42Name, LENGTH, lengthToConvertInAgName),
+        computeOutput: makeComputeOutputFn(n42Name, lengthToConvertInAgName, getOutput)
     };
 }
 

--- a/src/mmw/js/src/modeling/templates/controls/inputInfo.html
+++ b/src/mmw/js/src/modeling/templates/controls/inputInfo.html
@@ -1,4 +1,3 @@
-<div>
-  {{ output.errorMessages[userInputName] }}
-  {{ output.infoMessages[userInputName] }}
-</div>
+<label class="{{ "error-message" if isError else "info-message" }}">
+  {{ message }}
+</label>

--- a/src/mmw/js/src/modeling/templates/controls/manualEntry.html
+++ b/src/mmw/js/src/modeling/templates/controls/manualEntry.html
@@ -6,18 +6,25 @@
             </button>
             <div class="name">{{ manualMod|modShortName}}</div>
         </div>
-        <svg height="40" width="200">
-            <rect height="40" width="200" fill="{{ manualMod|modFill }}"></rect>
+        <svg height="7" width="250">
+            <rect height="7" width="250" fill="{{ manualMod|modFill }}"></rect>
         </svg>
     </div>
 
-    <ul>
-        {% for dataModelName in modConfig.dataModelNames %}
-            <li>{{ displayNames[dataModelName] }}: {{ dataModel[dataModelName] }}</li>
-        {% endfor %}
-    </ul>
+    <div class="content">
+        <table class="table">
+            <tbody>
+                {% for dataModelName in modConfig.dataModelNames %}
+                    <tr>
+                        <td class="text-left">{{ displayNames[dataModelName] }}</td>
+                        <td class="strong text-right">{{ dataModel[dataModelName]|round(2)|toLocaleString(2) }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
 
-    <div id="user-input-region"></div>
+        <div id="user-input-region"></div>
 
-    <button type="button" class="btn btn-lg btn-block btn-active convert-button">Convert</button>
+        <button type="button" class="btn btn-lg btn-block btn-active convert-button">Convert</button>
+    </div class="content">
 </div>

--- a/src/mmw/js/src/modeling/templates/controls/manualEntry.html
+++ b/src/mmw/js/src/modeling/templates/controls/manualEntry.html
@@ -25,6 +25,6 @@
 
         <div id="user-input-region"></div>
 
-        <button type="button" class="btn btn-lg btn-block btn-active convert-button">Convert</button>
+        <button type="button" class="btn btn-lg btn-block btn-active apply-button">Apply</button>
     </div class="content">
 </div>

--- a/src/mmw/js/src/modeling/templates/controls/thumbSelect.html
+++ b/src/mmw/js/src/modeling/templates/controls/thumbSelect.html
@@ -1,18 +1,23 @@
 <div class="thumb-select">
     <div class="pad-1">
-        {% for modRow in modRows %}
-            <ul class="row">
-                {% for modKey in modRow %}
-                    <li>
-                        <div class="thumb" data-value="{{ modKey }}">
-                            <svg height="{{ 56 }}" width="{{ 56 }}">
-                                <rect height="{{ 56 }}" width="{{ 56 }}" fill="{{ modKey|modFill }}"></rect>
-                            </svg>
-                        </div>
-                        <label class="dark">{{ modKey|modShortName }}</label>
-                    </li>
-                {% endfor %}
-            </ul>
+        {% for modRowGroup in modRowGroups %}
+            {% if modRowGroup.name %}
+                <h5>{{ modRowGroup.name }}</h5>
+            {% endif %}    
+            {% for row in modRowGroup.rows %}
+                <ul class="row">
+                    {% for modKey in row %}
+                        <li>
+                            <div class="thumb" data-value="{{ modKey }}">
+                                <svg height="{{ 56 }}" width="{{ 56 }}">
+                                    <rect height="{{ 56 }}" width="{{ 56 }}" fill="{{ modKey|modFill }}"></rect>
+                                </svg>
+                            </div>
+                            <label class="dark">{{ modKey|modShortName }}</label>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endfor %}
         {% endfor %}
     </div>
 

--- a/src/mmw/sass/components/_dropdowns.scss
+++ b/src/mmw/sass/components/_dropdowns.scss
@@ -64,22 +64,44 @@
 }
 
 .manual-entry {
-  .header {
-    position: relative;
+  min-width: 250px;
 
+  .header {
     .header-text {
-      position: absolute;
-      top: 50%;
-      transform: translateY(-50%);
+      background-color: $ui-light;
 
       .name, .back-button {
         display: inline;
       }
     }
+
+    svg {
+      position: absolute;
+    }
   }
 
-  .amount-form {
-    margin: 10px;
+  .content {
+    padding: 1rem;
+
+    .form-group {
+      margin-bottom: 0;
+    }
+
+    .info-region {
+      min-height: 25px;
+
+      .info-message {
+        color: $ui-grey;
+      }
+
+      .error-message {
+        color: $ui-danger;
+      }
+    }
+
+    .amount-form {
+      margin: 10px;
+    }
   }
 }
 
@@ -108,7 +130,6 @@
       float: left;
       display: block;
       width: 60px;
-      height: 90px;
       margin-bottom: 0.2rem;
       transition: all 0.4s ease-out;
       margin-right: 1rem;


### PR DESCRIPTION
This improves the style of the GWLF-E BMP UI. To test, make sure functionality is intact and things are more aesthetically pleasing. Compare to https://github.com/WikiWatershed/model-my-watershed/pull/1314

* Make style of Animal Waste Management (Poultry) slightly different from (Livestock)
* Add Rural and Urban thumbnail groups
* Add more vertical space in thumbnail view so labels are fully visible
* For BMPs with multiple data model variables, change the label of the input to clarify which data model variable is being converted
* In manual entry view: change size and color of info and error messages, improve spacing, and put fill pattern in line under header to improve readability

<img width="366" alt="screen shot 2016-05-23 at 3 31 29 pm" src="https://cloud.githubusercontent.com/assets/1896461/15482055/ad696516-20fb-11e6-8568-8a3701a24317.png">
<img width="268" alt="screen shot 2016-05-24 at 5 29 57 pm" src="https://cloud.githubusercontent.com/assets/1896461/15520611/343f0026-21d5-11e6-8193-40c077872384.png">

Connects #1315 
