### PR TITLE
MapShed Export GMS File

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -343,14 +343,23 @@ def run_gwlfe(model_input):
     directly we would have to replicate all that logic. Thus, it is easier to
     simply create a GMS file and have it read that.
     """
-    pre_z = parser.DataModel(model_input)
+    output = to_gms_file(model_input)
+
+    reader = parser.GmsReader(output)
+    z = reader.read()
+
+    return gwlfe.run(z)
+
+
+def to_gms_file(mapshed_data):
+    """
+    Given a dictionary of MapShed data, uses GWLF-E to convert it to a GMS file
+    """
+    pre_z = parser.DataModel(mapshed_data)
     output = StringIO()
     writer = parser.GmsWriter(output)
     writer.write(pre_z)
 
     output.seek(0)
 
-    reader = parser.GmsReader(output)
-    z = reader.read()
-
-    return gwlfe.run(z)
+    return output

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -29,4 +29,5 @@ urlpatterns = patterns(
     url(r'start/gwlfe/$', views.start_gwlfe, name='start_gwlfe'),
     url(r'boundary-layers/(?P<table_code>\w+)/(?P<obj_id>[0-9]+)/$',
         views.boundary_layer_detail, name='boundary_layer_detail'),
+    url(r'export/gms/?$', views.export_gms, name='export_gms'),
 )

--- a/src/mmw/js/src/core/csrf.js
+++ b/src/mmw/js/src/core/csrf.js
@@ -41,3 +41,7 @@ exports.jqueryAjaxSetupOptions = {
         }
     }
 };
+
+exports.getToken = function() {
+    return getCookie('csrftoken');
+}

--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -23,6 +23,14 @@
                 {% if itsi %}
                     <li role="presentation"><a role="menuitem" tabindex="-1" id="itsi-clone">Embed in ITSI</a></li>
                 {% endif %}
+                {% if gwlfe %}
+                    <form id="export-gms-form" method="post" action="/api/modeling/export/gms/" target="_blank">
+                        <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrftoken }}">
+                        <input type="hidden" name="filename" value="{{ name }}">
+                        <input type="hidden" name="mapshed_data" value='{{ gis_data }}'>
+                    </form>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" id="export-gms">Export GMS</a></li>
+                {% endif %}
                 {% if user and not itsi_embed %}
                     <li role="separator" class="divider"></li>
                     <li role="presentation"><a role="menuitem" tabindex="-1" data-url="/projects/">My Projects</a></li>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -5,6 +5,7 @@
     Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
     settings = require('../core/settings'),
+    csrf = require('../core/csrf'),
     models = require('./models'),
     controls = require('./controls'),
     analyzeViews = require('../analyze/views.js'),
@@ -95,6 +96,8 @@ var ProjectMenuView = Marionette.ItemView.extend({
         print: '#print-project',
         save: '#save-project',
         privacy: '#project-privacy',
+        exportGms: '#export-gms',
+        exportGmsForm: '#export-gms-form',
         itsiClone: '#itsi-clone'
     },
 
@@ -105,6 +108,7 @@ var ProjectMenuView = Marionette.ItemView.extend({
         'click @ui.print': 'printProject',
         'click @ui.save': 'saveProjectOrLoginUser',
         'click @ui.privacy': 'setProjectPrivacy',
+        'click @ui.exportGms': 'downloadGmsFile',
         'click @ui.itsiClone': 'getItsiEmbedLink'
     },
 
@@ -115,6 +119,11 @@ var ProjectMenuView = Marionette.ItemView.extend({
             itsi: App.user.get('itsi'),
             itsi_embed: settings.get('itsi_embed'),
             editable: isEditable(this.model),
+            csrftoken: csrf.getToken(),
+            gwlfe: this.model.get('model_package') === models.GWLFE &&
+                   this.model.get('gis_data') !== null &&
+                   this.model.get('gis_data') !== '' &&
+                   this.model.get('gis_data') !== '{}',
             is_new: this.model.isNew()
         };
     },
@@ -229,6 +238,13 @@ var ProjectMenuView = Marionette.ItemView.extend({
             self.model.set('is_private', !self.model.get('is_private'));
             self.model.saveProjectAndScenarios();
         });
+    },
+
+    downloadGmsFile: function() {
+        // We can't download a file from an AJAX call. One either has to
+        // load the data in an iframe, or submit a form that responds with
+        // Content-Disposition: attachment. We prefer submitting a form.
+        this.ui.exportGmsForm.submit();
     },
 
     getItsiEmbedLink: function() {


### PR DESCRIPTION
## Overview

Adds ability to export GMS file to MapShed projects. Only the final two commits are related to this work.

## Testing Instructions

Checkout and bundle.

 * Create a TR-55 project, ensure that there is no Export GMS option in the project dropdown
 * Create a MapShed project. Ensure that there _is_ an Export GMS option once MapShed data has run:
  ![image](https://cloud.githubusercontent.com/assets/1430060/15516591/75f973fc-21c1-11e6-8d49-584e90852544.png)
 * Ensure clicking it downloads a GMS file

## Notes

The generated GMS file _should_ work with a copy of GWLF-E 1.4.0, although this has not been tested.

Builds on top of #1326
Connects #1327 