### PR TITLE
Force registration of MapShed tasks

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -117,7 +117,10 @@ BROKER_URL = 'redis://{0}:{1}/2'.format(
     environ.get('MMW_CACHE_HOST', 'localhost'),
     environ.get('MMW_CACHE_PORT', 6379))
 
-CELERY_IMPORTS = ('celery.task.http',)
+CELERY_IMPORTS = ('celery.task.http',
+                  # Submodule task is not always autodiscovered
+                  'apps.modeling.mapshed.tasks',
+                  )
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'


### PR DESCRIPTION
Since MapShed tasks are defined in a submodule to a Django app, and never explicitly specified in INSTALLED_APPS, the autoloading functionality did not work reliably in all environments. Particularly, it would work in local vagrant setups, but not on the staging AWS server.

By including it in CELERY_IMPORTS we ensure that the tasks are always loaded.

Connects #1331 