### PR TITLE
Convert decimals to floats

### DIFF
--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -305,8 +305,8 @@ def point_source_discharge(geom, area):
         cursor.execute(sql, [geom.wkt])
         mg_d, kgn_month, kgp_month = cursor.fetchone()
 
-        n_load = [kgn_month] * 12 if kgn_month else [0.0] * 12
-        p_load = [kgp_month] * 12 if kgp_month else [0.0] * 12
+        n_load = [float(kgn_month)] * 12 if kgn_month else [0.0] * 12
+        p_load = [float(kgp_month)] * 12 if kgp_month else [0.0] * 12
         discharge = [float(mg_d * days * LITERS_PER_MGAL) / area
                      for days in MONTHDAYS] if mg_d else [0.0] * 12
 


### PR DESCRIPTION
## Overview

The database returns Decimal values, however they are not JSON serializable, thus we convert them to floats which are. This is required not just for communicating to the front-end but also between Celery tasks, which use JSON serialization as the intermediate format.

## Testing Instructions

In `collect_data`, add a line to print out values of `z['PointNitr']` and `z['PointPhos']`:

```python
print('==> PointNitr: {}'.format(z['PointNitr'])
print('==> PointPhos: {}'.format(z['PointPhos'])
```

Then run `./scripts/debugcelery.sh` and make a MapShed project and inspect the output. Ensure they are floats.

Connects #1333 