### PR TITLE
Disable invalid BMPs 

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -44,7 +44,19 @@ var ThumbSelectView = Marionette.ItemView.extend({
     template: thumbSelectTmpl,
 
     initialize: function(options) {
-        this.model.set('activeMod', null);
+        var modKeys = _.flatten(_.pluck(this.model.get('modRowGroups'), 'rows'), true),
+            dataModel = this.model.get('dataModel'),
+            manualMode = this.model.get('manualMode'),
+            modEnabled = {};
+
+        _.forEach(modKeys, function(modKey) {
+            modEnabled[modKey] = manualMode ? gwlfeConfig.configs[modKey].validateDataModel(dataModel) : true;
+        });
+
+        this.model.set({
+            activeMod: null,
+            modEnabled: modEnabled
+        });
         this.addModification = options.addModification;
     },
 
@@ -63,8 +75,8 @@ var ThumbSelectView = Marionette.ItemView.extend({
     },
 
     onThumbHover: function(e) {
-        var value = $(e.currentTarget).data('value');
-        this.model.set('activeMod', value);
+        var modKey = $(e.currentTarget).data('value');
+        this.model.set('activeMod', modKey);
     },
 
     onThumbClick: function(e) {
@@ -72,10 +84,12 @@ var ThumbSelectView = Marionette.ItemView.extend({
             controlName = this.model.get('controlName'),
             controlValue = $el.data('value');
 
-        if (this.model.get('manualMode')) {
-            this.startManual(controlName, controlValue);
-        } else {
-            this.startDrawing(controlName, controlValue);
+        if (this.model.get('modEnabled')[controlValue]) {
+            if (this.model.get('manualMode')) {
+                this.startManual(controlName, controlValue);
+            } else {
+                this.startDrawing(controlName, controlValue);
+            }
         }
     },
 

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -169,6 +169,16 @@ function makeComputeOutputFn(dataModelName, inputName, getOutput) {
     };
 }
 
+// Returns a function that checks that each variable in dataModelNames
+// is positive. Useful for checking if a BMP is applicable to an AOI.
+function makeValidateDataModelFn(dataModelNames) {
+    return function(dataModel) {
+        return _.every(dataModelNames, function(dataModelName) {
+            return dataModel[dataModelName] > 0;
+        });
+    };
+}
+
 function makeAgBmpConfig(outputName) {
     function getOutput(inputVal, fractionVal) {
         return fromPairs([
@@ -178,6 +188,7 @@ function makeAgBmpConfig(outputName) {
 
     return {
         dataModelNames: [n23Name],
+        validateDataModel: makeValidateDataModelFn([n23Name]),
         userInputNames: [areaToModifyName],
         validate: makeThresholdValidateFn(n23Name, AREA, areaToModifyName),
         computeOutput: makeComputeOutputFn(n23Name, areaToModifyName, getOutput)
@@ -187,6 +198,7 @@ function makeAgBmpConfig(outputName) {
 function makeAeuBmpConfig(outputName) {
     return {
         dataModelNames: [],
+        validateDataModel: makeValidateDataModelFn([]),
         userInputNames: [percentAeuToModifyName],
         validate: makePercentValidateFn(percentAeuToModifyName),
         computeOutput: function(dataModel, cleanUserInput) {
@@ -213,6 +225,7 @@ function makeRuralStreamsBmpConfig(outputName) {
 
     return {
         dataModelNames: [n42Name, n42bName],
+        validateDataModel: makeValidateDataModelFn([n42Name]),
         userInputNames: [lengthToModifyInAgName],
         validate: makeThresholdValidateFn(n42Name, LENGTH, lengthToModifyInAgName),
         computeOutput: makeComputeOutputFn(n42Name, lengthToModifyInAgName, getOutput)
@@ -222,6 +235,7 @@ function makeRuralStreamsBmpConfig(outputName) {
 function makeUrbanStreamsBmpConfig(getOutput) {
     return {
         dataModelNames: [UrbLengthName],
+        validateDataModel: makeValidateDataModelFn([UrbLengthName]),
         userInputNames: [lengthToModifyName],
         validate: makeThresholdValidateFn(UrbLengthName, LENGTH, lengthToModifyName),
         computeOutput: makeComputeOutputFn(UrbLengthName, lengthToModifyName, getOutput)
@@ -231,6 +245,7 @@ function makeUrbanStreamsBmpConfig(getOutput) {
 function makeUrbanAreaBmpConfig(getOutput) {
     return {
         dataModelNames: [UrbAreaTotalName],
+        validateDataModel: makeValidateDataModelFn([UrbAreaTotalName]),
         userInputNames: [areaToModifyName],
         validate: makeThresholdValidateFn(UrbAreaTotalName, AREA, areaToModifyName),
         computeOutput: makeComputeOutputFn(UrbAreaTotalName, areaToModifyName, getOutput)
@@ -242,6 +257,8 @@ function makeUrbanAreaBmpConfig(getOutput) {
     to generate the UI for that modification.
     - dataModelNames is a list of variable names in the Mapshed data model
     (received from the backend) which should be displayed to the user.
+    - validateDataModel is a function which validates the values of the
+    dataModel which can be used to tell if the BMP is valid for an AOI
     - userInputNames is a list of non-Mapshed variables used to reference values
     the user enters into the UI. currently all the BMPs only reference a single
     user input variable, so using a list is overkill, but it could be useful in

--- a/src/mmw/js/src/modeling/templates/controls/thumbSelect.html
+++ b/src/mmw/js/src/modeling/templates/controls/thumbSelect.html
@@ -3,17 +3,17 @@
         {% for modRowGroup in modRowGroups %}
             {% if modRowGroup.name %}
                 <h5>{{ modRowGroup.name }}</h5>
-            {% endif %}    
+            {% endif %}
             {% for row in modRowGroup.rows %}
                 <ul class="row">
                     {% for modKey in row %}
                         <li>
-                            <div class="thumb" data-value="{{ modKey }}">
+                            <div class="thumb {{ "disabled" if not modEnabled[modKey] }}" data-value="{{ modKey }}">
                                 <svg height="{{ 56 }}" width="{{ 56 }}">
                                     <rect height="{{ 56 }}" width="{{ 56 }}" fill="{{ modKey|modFill }}"></rect>
                                 </svg>
                             </div>
-                            <label class="dark">{{ modKey|modShortName }}</label>
+                            <label class="dark {{ "disabled" if not modEnabled[modKey] }}">{{ modKey|modShortName }}</label>
                         </li>
                     {% endfor %}
                 </ul>

--- a/src/mmw/sass/components/_dropdowns.scss
+++ b/src/mmw/sass/components/_dropdowns.scss
@@ -147,11 +147,15 @@
         margin-bottom: 0.2rem;
         display: block;
 
-        &:hover {
+        &:not(.disabled):hover {
           border-color: $ui-primary;
           cursor: pointer;
         }
       }
+    }
+
+    .disabled {
+      opacity: 0.4;
     }
   }
 }


### PR DESCRIPTION
This PR disables BMPs that are invalid for an AOI. BMPs can be invalid for an AOI when the areas and lengths to modify are zero. If a BMP is disabled, the thumbnail is grayed out, the cursor remains an arrow, and clicking does not work.

Only the last commit is relevant to this PR.

![screen shot 2016-05-26 at 4 55 29 pm 2](https://cloud.githubusercontent.com/assets/1896461/15589901/df1c0a1e-2362-11e6-8402-b5c9211044b2.png)

To test, try out different AOIs. Check that all enabled BMPs have non-zero values for the areas/lengths being modified. In urban AOIs, BMPs involving crops and streams should be disabled. 

Connects #1338 