### PR TITLE
Bump pyrollbar to 0.12.x

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -12,5 +12,5 @@ djangorestframework-gis==0.8.2
 tr55==1.1.3
 gwlf-e==0.3.0
 requests==2.9.1
-rollbar>=0.11.0,<=0.12.0
+rollbar==0.12.1
 retry==0.9.1


### PR DESCRIPTION
Most of the changes in the `CHANGELOG` are bug fixes. There is one breaking change in the 0.12.x jump, but it pertains to Twisted support.

See also: https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md

---

**Testing**

Provision and ensure that 0.12.1 is installed.