### PR TITLE
Improve info message in manual entry UI

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -432,7 +432,7 @@ var GwlfeConservationPracticeView = ModificationsView.extend({
                     rows: [['urban_buffer_strips', 'urban_streambank_stabilization', 'water_retention', 'infiltration']]
                 }
             ],
-            dataModel: JSON.parse(App.currentProject.get('gis_data')),
+            dataModel: gwlfeConfig.cleanDataModel(JSON.parse(App.currentProject.get('gis_data'))),
             errorMessages: null,
             infoMessages: null
         });

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -64,8 +64,17 @@ var displayNames = fromPairs([
     [UrbLengthName, 'Length of streams in non-ag areas (km)']
 ]);
 
-function getPercentStr(fraction) {
-    return Math.round(fraction * 100) + '%';
+var shortDisplayNames = fromPairs([
+    [n23Name, 'area of row crops'],
+    [n42Name, 'length of streams in ag areas'],
+    [n42bName, 'length of streams in watershed'],
+    [UrbAreaTotalName, 'total urban area'],
+    [UrbLengthName, 'length of streams in non-ag areas']
+]);
+
+function getPercentStr(fraction, dataModelName) {
+    var dataModelDisplayName = shortDisplayNames[dataModelName] || displayNames[dataModelName];
+    return Math.round(fraction * 100) + '% of ' + dataModelDisplayName;
 }
 
 function convertToNumber(x) {
@@ -161,7 +170,7 @@ function makeComputeOutputFn(dataModelName, inputName, getOutput) {
 
         if (inputVal) {
             fractionVal = inputVal / dataModelVal;
-            infoMessages[inputName] = getPercentStr(fractionVal);
+            infoMessages[inputName] = getPercentStr(fractionVal, dataModelName);
             output = getOutput(inputVal, fractionVal);
         }
 

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -72,6 +72,12 @@ var shortDisplayNames = fromPairs([
     [UrbLengthName, 'length of streams in non-ag areas']
 ]);
 
+function cleanDataModel(dataModel) {
+    return _.mapValues(dataModel, function(val, varName) {
+        return varName === UrbLengthName ? val / 1000 : val;
+    });
+}
+
 function getPercentStr(fraction, dataModelName) {
     var dataModelDisplayName = shortDisplayNames[dataModelName] || displayNames[dataModelName];
     return Math.round(fraction * 100) + '% of ' + dataModelDisplayName;
@@ -310,6 +316,7 @@ var configs = {
 };
 
 module.exports = {
+    cleanDataModel: cleanDataModel,
     displayNames: displayNames,
     isValid: isValid,
     aggregateOutput: aggregateOutput,


### PR DESCRIPTION
We've improved the info message in the manual entry UI. See below. To test, make sure info message makes sense for all BMPs.

![screen shot 2016-05-27 at 3 10 25 pm 2](https://cloud.githubusercontent.com/assets/1896461/15618785/f849d320-241d-11e6-8c1d-d1348111d0e9.png)

Connects #1343 