### PR TITLE
Analyze Only When Needed

### DIFF
--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -1,7 +1,6 @@
 "use strict";
 
-var _ = require('underscore'),
-    App = require('../app'),
+var App = require('../app'),
     router = require('../router').router,
     views = require('./views'),
     models = require('./models'),
@@ -48,15 +47,11 @@ var AnalyzeController = {
     },
 
     analyze: function() {
-        var aoi = JSON.stringify(App.map.get('areaOfInterest')),
-            analyzeModel = App.analyzeModel || createTaskModel(aoi),
+        var aoi = App.map.get('areaOfInterest'),
+            analyzeModel = models.AnalyzeTaskModel.getSingleton(App, aoi),
             analyzeResults = new views.ResultsView({
                 model: analyzeModel
             });
-
-        if (!App.analyzeModel) {
-            App.analyzeModel = analyzeModel;
-        }
 
         App.state.set('current_page_title', 'Geospatial Analysis');
 
@@ -67,16 +62,6 @@ var AnalyzeController = {
         App.rootView.sidebarRegion.empty();
     }
 };
-
-// Pass in the serialized Area of Interest for
-// caching purposes (_.memoize returns the same
-// results for any object), and deserialize
-// the AoI for use on the model.
-var createTaskModel = _.memoize(function(aoi) {
-    return new models.AnalyzeTaskModel({
-        area_of_interest: JSON.parse(aoi)
-    });
-});
 
 module.exports = {
     AnalyzeController: AnalyzeController

--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -49,12 +49,15 @@ var AnalyzeController = {
 
     analyze: function() {
         var aoi = JSON.stringify(App.map.get('areaOfInterest')),
-            analyzeModel = createTaskModel(aoi),
+            analyzeModel = App.analyzeModel || createTaskModel(aoi),
             analyzeResults = new views.ResultsView({
                 model: analyzeModel
             });
 
-        App.analyzeModel = analyzeModel;
+        if (!App.analyzeModel) {
+            App.analyzeModel = analyzeModel;
+        }
+
         App.state.set('current_page_title', 'Geospatial Analysis');
 
         App.rootView.sidebarRegion.show(analyzeResults);

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -54,6 +54,24 @@ var AnalyzeTaskModel = coreModels.TaskModel.extend({
     }
 });
 
+AnalyzeTaskModel.getSingleton = function(App, aoi) {
+    if (!App.analyzeModel) {
+        App.analyzeModel = createTaskModel(JSON.stringify(aoi));
+    }
+
+    return App.analyzeModel;
+};
+
+// Pass in the serialized Area of Interest for
+// caching purposes (_.memoize returns the same
+// results for any object), and deserialize
+// the AoI for use on the model.
+var createTaskModel = _.memoize(function(aoi) {
+    return new AnalyzeTaskModel({
+        area_of_interest: JSON.parse(aoi)
+    });
+});
+
 module.exports = {
     AnalyzeTaskModel: AnalyzeTaskModel,
     LayerModel: LayerModel,

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -1,7 +1,8 @@
 "use strict";
 
-var Backbone = require('../../shim/backbone'),
+var $ = require('jquery'),
     _ = require('lodash'),
+    Backbone = require('../../shim/backbone'),
     coreModels = require('../core/models');
 
 var LayerModel = Backbone.Model.extend({});
@@ -20,10 +21,37 @@ var LayerCategoryCollection = Backbone.Collection.extend({
 
 var AnalyzeTaskModel = coreModels.TaskModel.extend({
     defaults: _.extend( {
+            area_of_interest: null,
             taskName: 'analyze',
             taskType: 'modeling'
         }, coreModels.TaskModel.prototype.defaults
-    )
+    ),
+
+    /**
+     * Returns a promise that completes when Analysis has been fetched. If
+     * fetching is not required, returns an immediatley resolved promise.
+     */
+    fetchAnalysisIfNeeded: function() {
+        var self = this,
+            aoi = self.get('area_of_interest'),
+            result = self.get('result');
+
+        if (aoi && !result && self.fetchAnalysisPromise === undefined) {
+            var promises = self.start({
+                postData: {
+                    'area_of_interest': JSON.stringify(aoi)
+                }
+            });
+            self.fetchAnalysisPromise = $.when(promises.startPromise,
+                                               promises.pollingPromise);
+            self.fetchAnalysisPromise
+                .always(function() {
+                    delete self.fetchAnalysisPromise;
+                });
+        }
+
+        return self.fetchAnalysisPromise || $.when();
+    }
 });
 
 module.exports = {

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -139,28 +139,13 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
 
         var self = this;
 
-        if (!this.model.get('result')) {
-            var aoi = JSON.stringify(this.model.get('area_of_interest')),
-                taskHelper = {
-                    pollSuccess: function() {
-                        self.showDetailsRegion();
-                    },
-
-                    pollFailure: function() {
-                        self.showErrorMessage();
-                    },
-
-                    startFailure: function() {
-                        self.showErrorMessage();
-                    },
-
-                    postData: {'area_of_interest': aoi}
-                };
-
-            this.model.start(taskHelper);
-        } else {
-            self.showDetailsRegion();
-        }
+        this.model.fetchAnalysisIfNeeded()
+            .done(function() {
+                self.showDetailsRegion();
+            })
+            .fail(function() {
+                self.showErrorMessage();
+            });
     },
 
     showAnalyzingMessage: function() {

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -53,6 +53,7 @@ var DrawController = {
     },
 
     drawCleanUp: function() {
+        delete App.analyzeModel;
         App.rootView.geocodeSearchRegion.empty();
         App.rootView.drawToolsRegion.empty();
         App.rootView.footerRegion.empty();

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -668,11 +668,17 @@ var ResultsView = Marionette.LayoutView.extend({
 
     onShow: function() {
         var self = this,
+            aoi = JSON.stringify(App.map.get('areaOfInterest')),
+            analyzeModel = App.analyzeModel || createTaskModel(aoi),
             tmvModel = new coreModels.TaskMessageViewModel(),
             errorHandler = function() {
                 tmvModel.setError();
                 self.modelingRegion.show(new coreViews.TaskMessageView({ model: tmvModel }));
             };
+
+        this.analyzeRegion.show(new analyzeViews.AnalyzeWindow({
+            model: analyzeModel
+        }));
 
         tmvModel.setWorking('Gathering Data');
         self.modelingRegion.show(new coreViews.TaskMessageView({ model: tmvModel }));
@@ -697,14 +703,7 @@ var ResultsView = Marionette.LayoutView.extend({
 
     showDetailsRegion: function() {
         var scenarios = this.model.get('scenarios'),
-            scenario = scenarios.getActiveScenario(),
-            aoi = JSON.stringify(App.map.get('areaOfInterest')),
-            analyzeModel = App.analyzeModel !== undefined ? App.analyzeModel :
-                            createTaskModel(aoi);
-
-        this.analyzeRegion.show(new analyzeViews.AnalyzeWindow({
-            model: analyzeModel
-        }));
+            scenario = scenarios.getActiveScenario();
 
         if (scenario) {
             this.modelingRegion.show(new ResultsDetailsView({

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -676,6 +676,10 @@ var ResultsView = Marionette.LayoutView.extend({
                 self.modelingRegion.show(new coreViews.TaskMessageView({ model: tmvModel }));
             };
 
+        if (!App.analyzeModel) {
+            App.analyzeModel = analyzeModel;
+        }
+
         this.analyzeRegion.show(new analyzeViews.AnalyzeWindow({
             model: analyzeModel
         }));

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -668,17 +668,13 @@ var ResultsView = Marionette.LayoutView.extend({
 
     onShow: function() {
         var self = this,
-            aoi = JSON.stringify(App.map.get('areaOfInterest')),
-            analyzeModel = App.analyzeModel || createTaskModel(aoi),
+            aoi = App.map.get('areaOfInterest'),
+            analyzeModel = analyzeModels.AnalyzeTaskModel.getSingleton(App, aoi),
             tmvModel = new coreModels.TaskMessageViewModel(),
             errorHandler = function() {
                 tmvModel.setError();
                 self.modelingRegion.show(new coreViews.TaskMessageView({ model: tmvModel }));
             };
-
-        if (!App.analyzeModel) {
-            App.analyzeModel = analyzeModel;
-        }
 
         this.analyzeRegion.show(new analyzeViews.AnalyzeWindow({
             model: analyzeModel
@@ -903,16 +899,6 @@ function getResultView(modelPackage, resultName) {
             console.log('Model package ' + modelPackage + ' not supported.');
     }
 }
-
-// Pass in the serialized Area of Interest for
-// caching purposes (_.memoize returns the same
-// results for any object), and deserialize
-// the AoI for use on the model.
-var createTaskModel = _.memoize(function(aoi) {
-    return new analyzeModels.AnalyzeTaskModel({
-        area_of_interest: JSON.parse(aoi)
-    });
-});
 
 module.exports = {
     ResultsView: ResultsView,


### PR DESCRIPTION
## Overview

By using the single promise pattern used in `fetchGisDataIfNeeded` and `fetchResultsIfNeeded`, we ensure that if there are multiple calls to `analyze/`, only the first one sends a request to the server. All the rest are given the promise of the first request.

We also improve UX by showing results of Analyze immediately in the Analyze tab in the Modeling view, since the results have (most likely) already been calculated. In case they rush into the Modeling view, or re-load a saved scenario, the Analyze tab will be triggered at the same time as the Results tab, and will render independently. Furthermore, we will only trigger an actual server call only once.

We further improve the UX by remembering the Analyze results when transitioning from Modeling view to Analyze view. Previously going to the Analyze view would always trigger a new request. Now we remember the result, unless coming in from Draw, in which case old results are deliberately forgotten.

## Testing Instructions

 * Going from Draw to Analyze should trigger 1 request to `/analyze`
 * Once the request is finished, going to Modeling should not trigger any requests to `/analyze`. The analysis should be immediately visible, regardless of the status of the modeling results.
 * Adding or removing scenarios should not trigger analysis
 * Reloading a saved project should trigger 1 request to `/analyze`
 * Going from Modeling to Analyze should not trigger any requests to `/analyze`
 * Going from Analyze to Draw, but not changing the Area of Interest, instead just clicking the big green button to go forward to Analyze should not trigger any requests to `/analyze`
 * Going from Analyze to Draw and changing the Area of Interest should trigger 1 new request to `/analyze`

Connects #1334 