### PR TITLE
Prefer DRB Stream Length for LS

### DIFF
--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -37,6 +37,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
 NLU = settings.GWLFE_CONFIG['NLU']
 NRur = settings.GWLFE_DEFAULTS['NRur']
 AG_NLCD_CODES = settings.GWLFE_CONFIG['AgriculturalNLCDCodes']
+DRB = settings.DRB_PERIMETER
 ACRES_PER_SQM = 0.000247105
 HECTARES_PER_SQM = 0.0001
 SQKM_PER_SQM = 0.000001
@@ -172,8 +173,11 @@ def collect_data(geop_result, geojson):
     z['SedAFactor'] = sed_a_factor(geop_result['landuse_pcts'],
                                    z['CN'], z['AEU'], z['AvKF'], z['AvSlope'])
 
+    ls_stream_length = (stream_length(geom, drb=True) if geom.within(DRB)
+                        else z['StreamLength'])
+
     z['LS'] = ls_factors(geop_result['lu_stream_pct'],
-                         z['StreamLength'], z['Area'], z['AvSlope'])
+                         ls_stream_length, z['Area'], z['AvSlope'])
 
     return z
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -12,7 +12,7 @@ from os import environ
 from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 
-from layer_settings import LAYERS, VIZER_URLS  # NOQA
+from layer_settings import LAYERS, VIZER_URLS, DRB_PERIMETER  # NOQA
 from gwlfe_settings import (GWLFE_DEFAULTS, GWLFE_CONFIG, SOIL_GROUP, # NOQA
                             SOILP, CURVE_NUMBER)  # NOQA
 

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -13,6 +13,8 @@ For basemaps, maxZoom must be defined.
 from os.path import join, dirname, abspath
 import json
 
+from django.contrib.gis.geos import GEOSGeometry
+
 
 # Simplified perimeter of the Delaware River Basin (DRB).
 drb_perimeter_path = join(dirname(abspath(__file__)), 'data/drb_perimeter.json')
@@ -207,6 +209,9 @@ LAYERS = [
         'basemap': True,
     }
 ]
+
+DRB_PERIMETER = GEOSGeometry(json.dumps(drb_perimeter['geometry']), srid=4326)
+
 # Vizer observation meta data URL.  Happens to be proxied through a local app
 # server to avoid Cross Domain request errors
 VIZER_ROOT = '/observation/services/get_asset_info.php?'


### PR DESCRIPTION
## Overview

We prefer DRB Stream Length for LS calculations if possible for the selected Area of Interest. If the AoI is outside the DRB, then we fall back to using standard NHD+ stream length.

## Testing Instructions

Add the following line [here](https://github.com/rajadain/model-my-watershed/blob/4132d48d10e418b77f1ce9919c9a2329e36849f4/src/mmw/apps/modeling/mapshed/calcs.py#L255):

```python
print("==> Calculating Stream Length Using {}".format('DRB' if drb else 'NHD+'))
```

And then run `./scripts/debugcelery.sh`. The DRB region looks like this:

![image](https://cloud.githubusercontent.com/assets/1430060/15681948/5862312c-2729-11e6-8c10-d26d68a8ebf7.png)

When you draw a shape within this area, you should see two messages in the Celery log:

```
[WARNING] ==> Calculating Stream Length Using NHD+
[WARNING] ==> Calculating Stream Length Using DRB
```

If you draw a shape outside this area, you should see only one message for NHD+.

Connects #1335 