### PR TITLE
Export GMS from Scenario instead of Project

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -826,10 +826,6 @@ var ScenarioModel = Backbone.Model.extend({
                 }
             };
 
-        // TODO remove before merging
-        console.log('gwlfe postData');
-        console.log(JSON.parse(gisData.model_input));
-
         return taskModel.start(taskHelper);
     },
 

--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -23,14 +23,6 @@
                 {% if itsi %}
                     <li role="presentation"><a role="menuitem" tabindex="-1" id="itsi-clone">Embed in ITSI</a></li>
                 {% endif %}
-                {% if gwlfe %}
-                    <form id="export-gms-form" method="post" action="/api/modeling/export/gms/" target="_blank">
-                        <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrftoken }}">
-                        <input type="hidden" name="filename" value="{{ name }}">
-                        <input type="hidden" name="mapshed_data" value='{{ gis_data }}'>
-                    </form>
-                    <li role="presentation"><a role="menuitem" tabindex="-1" id="export-gms">Export GMS</a></li>
-                {% endif %}
                 {% if user and not itsi_embed %}
                     <li role="separator" class="divider"></li>
                     <li role="presentation"><a role="menuitem" tabindex="-1" data-url="/projects/">My Projects</a></li>

--- a/src/mmw/js/src/modeling/templates/scenarioTabPanel.html
+++ b/src/mmw/js/src/modeling/templates/scenarioTabPanel.html
@@ -1,5 +1,5 @@
 <a href="#{{ cid }}" data-scenario-cid="{{ cid }}" aria-controls="home" role="tab" data-toggle="tab" class="tab-name"><span>{{ name }}</span></a>
-{% if active and editable and not is_current_conditions %}
+{% if active and editable and (gwlfe or not is_current_conditions or not is_new) %}
     <div class="scenario-btn-dropdown">
         <div class="dropdown">
             <button class="btn btn-sm btn-icon dark dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
@@ -13,6 +13,14 @@
                     <li role="presentation"><a role="menuitem" tabindex="-1" data-action="rename">Rename</a></li>
                     <li role="presentation"><a role="menuitem" tabindex="-1" data-action="duplicate">Duplicate</a></li>
                     <li role="presentation"><a role="menuitem" tabindex="-1" data-action="delete">Delete</a></li>
+                {% endif %}
+                {% if gwlfe %}
+                    <form id="export-gms-form" method="post" action="/api/modeling/export/gms/" target="_blank">
+                        <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrftoken }}">
+                        <input type="hidden" name="filename" value="{{ filename }}">
+                        <input type="hidden" name="mapshed_data" value='{{ gis_data }}'>
+                    </form>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" data-action="export-gms">Export GMS</a></li>
                 {% endif %}
             </ul>
         </div>


### PR DESCRIPTION
## Overview

Since each scenario can contribute different values to the GMS file given its modifications, we change to exporting from the scenario instead of the project.

Furthermore, we now allow Current Conditions to have a dropdown menu, since we need it to allow GMS Export. While this does allow duplication of the "Share" functionality, since sharing the Current Conditions scenario is the same as sharing the project, consistency in menus is more important, and this duplication is preferable to Current Conditions not having a Share option at all when all other scenarios have it.

## Testing Instructions

Checkout branch and bundle scripts.

Create a MapShed project. Add some modifications to New Scenario. Export a GMS file from Current Conditions and New Scenario. Diff the downloaded files and ensure that they are not identical.

Ensure that Export GMS functionality is not available on TR-55 projects.

Connects #1341 