### PR TITLE
Restore sidebar collapse functionality

### DIFF
--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -119,6 +119,7 @@ var ModelingController = {
             finishProjectSetup(project, lock);
             updateUrl();
         }
+        App.rootView.showCollapsable();
     },
 
     projectCleanUp: function() {

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -103,7 +103,7 @@
 }
 
 .leaflet-top {
-  top: 10px;
+  top: 45px;
 }
 
 .leaflet-control-layers-expanded {


### PR DESCRIPTION
## Overview

The sidebar collapse functionality would previously be enabled by the pre-handler of the /project route. Since we switched to using the /project/new route to initialize each project for its chosen model package, the original handler was no longer executing, and the button wasn't enabled.

By including that instruction in the new handler, we ensure that the button is made visible. In addition, we push down the map controls a bit so they don't overlap the button.

## Testing Instructions

Checkout branch and bundle scripts. Make one each of GWLF-E and TR-55 projects, and ensure that the sidebar collapse button is visible. Collapse the sidebar. Ensure that the map controls don't obscure or be obscured by the collapse button:

![image](https://cloud.githubusercontent.com/assets/1430060/15695536/34ade102-2776-11e6-9bd2-ada79ef0e7b3.png)

Connects #1345 
Connects #1346 