### PR TITLE
Use AvGroundWater for Subsurface flow display

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/runoff/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/runoff/views.js
@@ -13,7 +13,7 @@ var runoffVars = [
         { name: 'AvPrecipitation', display: 'Precip' },
         { name: 'AvEvapoTrans', display: 'ET' },
         { name: 'AvRunoff', display: 'Surface Runoff' },
-        { name: 'AvTileDrain', display: 'Subsurface Flow' },
+        { name: 'AvGroundWater', display: 'Subsurface Flow' },
         { name: 'AvPtSrcFlow', display: 'Point Src Flow' },
         { name: 'AvStreamFlow', display: 'Stream Flow' },
     ],

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1064,7 +1064,7 @@ function createTaskResultCollection(modelPackage) {
             return new ResultCollection([
                 {
                     name: 'runoff',
-                    displayName: 'Runoff',
+                    displayName: 'Hydrology',
                     result: null
                 },
                 {


### PR DESCRIPTION
Replaces an incorrect key for display and updates the output tab from Runoff to Hydrology.

Connects #1353 

#### Testing
Run a Multi Year model on this branch and observe that Subsurface Flow results on the Hydrology tab are non-0 and that the ET, R and SsF results _roughly_ add up to Precip (they never will exactly, as ET can pull from water stored in the water table).

![screenshot from 2016-06-02 10 21 34](https://cloud.githubusercontent.com/assets/1014341/15748185/cb288700-28ab-11e6-9d73-5acf819a76ab.png)
