### PR TITLE
GWLF-E Should Not Fail on Empty Streams

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -10,7 +10,7 @@ python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
 tr55==1.1.3
-gwlf-e==0.3.0
+gwlf-e==0.4.0
 requests==2.9.1
 rollbar==0.12.1
 retry==0.9.1


### PR DESCRIPTION
## Overview

Though the results may be inaccurate, we can add a disclaimer at a later time to notify the user. Crashing is not acceptable.

## Testing Instructions

Checkout the branch and reprovision `worker`. 

    vagrant provision worker

or

    vagrant up worker --provision

Accessing a 1 sq km stamp which does not have streams should no longer fail:

![image](https://cloud.githubusercontent.com/assets/1430060/15906852/a7e10f56-2d88-11e6-86ab-0ba90447d345.png)

Connects https://github.com/WikiWatershed/gwlf-e/issues/61