### PR TITLE
Fix Various MapShed Issues

### DIFF
--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -423,7 +423,7 @@ def curve_number(n_count, ng_count):
         cni_avg([90, 95]),  # Wetland
         0,  # Disturbed
         0,  # Turf Grass
-        cni_avg([21, 71]),  # Open Land
+        cni(71),  # Open Land
         cni_avg([12, 31]),  # Bare Rock
         0,  # Sandy Areas
         0,  # Unpaved Road
@@ -525,11 +525,11 @@ def landuse_pcts(n_count):
         n_pct.get(90, 0) + n_pct.get(95, 0),  # Wetland
         0,  # Disturbed
         0,  # Turf Grass
-        n_pct.get(21, 0) + n_pct.get(71, 0),  # Open Land
+        n_pct.get(71, 0),  # Open Land
         n_pct.get(12, 0) + n_pct.get(31, 0),  # Bare Rock
         0,  # Sandy Areas
         0,  # Unpaved Road
-        n_pct.get(22, 0),  # Low Density Mixed
+        n_pct.get(21, 0) + n_pct.get(22, 0),  # Low Density Mixed
         n_pct.get(23, 0),  # Medium Density Mixed
         n_pct.get(24, 0),  # High Density Mixed
         0,  # Low Density Residential

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -616,3 +616,31 @@ def p_factors(avg_slope):
         1.0,   # Unpaved
         0, 0, 0, 0, 0, 0  # Urban Land Use Types
     ]
+
+
+def phosphorus_conc(sed_phos):
+    """
+    Given the average concentration of phosphorus dissolved in sediments for
+    the entire polygon, returns average concentration per land use type based
+    on pre-baked estimates.
+
+    Original at Class1.vb@1.3.0:8975-9001,9350-9359
+    """
+    psed = sed_phos / 1.6
+    stp = 190 * psed / 836
+    prunoff = (1.98 * stp + 79) / 1000
+    prunoff_turf = 2.9 * psed / 836
+
+    return [
+        prunoff,       # Hay/Pasture
+        prunoff,       # Cropland
+        0.01,          # Forest
+        0.01,          # Wetland
+        0.01,          # Disturbed
+        prunoff_turf,  # Turf Grass
+        0.01,          # Open Land
+        0.01,          # Bare Rock
+        0.01,          # Sandy Areas
+        0.01,          # Unpaved
+        0, 0, 0, 0, 0, 0  # Urban Land Use Types
+    ]

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -575,3 +575,35 @@ def sed_a_factor(landuse_pct_vals, cn, AEU, AvKF, AvSlope):
     return ((0.00467 * urban_pct) + (0.000863 * AEU) +
             (0.000001 * avg_cn) + (0.000425 * AvKF) +
             (0.000001 * AvSlope) - 0.000036)
+
+
+def p_factors(avg_slope):
+    """
+    Given the average slope, calculates the P Factor for rural land use types.
+
+    Original at Class1.vb@1.3.0:4393-4470
+    """
+    if 0 <= avg_slope < 2.1:
+        ag_p = 0.52
+    elif 2.1 <= avg_slope < 7.1:
+        ag_p = 0.45
+    elif 7.1 <= avg_slope < 12.1:
+        ag_p = 0.52
+    elif 12.1 <= avg_slope < 18.1:
+        ag_p = 0.66
+    else:
+        ag_p = 0.74
+
+    return [
+        ag_p,  # Hay/Pasture
+        ag_p,  # Cropland
+        ag_p,  # Forest
+        0.1,   # Wetland
+        0.1,   # Disturbed
+        0.2,   # Turf Grass
+        ag_p,  # Open Land
+        ag_p,  # Bare Rock
+        ag_p,  # Sandy Areas
+        1.0,   # Unpaved
+        0, 0, 0, 0, 0, 0  # Urban Land Use Types
+    ]

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -31,18 +31,20 @@ def day_lengths(geom):
     Given a geometry in EPSG:4326, returns an array of 12 floats, each
     representing the average number of daylight hours at that geometry's
     centroid for each month.
+
+    Original at Class1.vb@1.3.0:8878-8889
     """
     latitude = geom.centroid[1]
     lengths = [0.0] * 12
 
-    for month in range(12):
+    for m in range(12):
         # Magic formula taken from original MapShed source
-        lengths[month] = 7.63942 * math.acos(0.43481 *
-                                             math.tan(latitude * 0.017453) *
-                                             math.cos(0.0172 *
-                                                      (month * 30.4375 - 5)))
+        lengths[m] = 7.63942 * math.acos(0.43481 *
+                                         math.tan(0.017453 * latitude) *
+                                         math.cos(0.0172 *
+                                                  ((m + 1) * 30.4375 - 5)))
 
-    return lengths
+    return [round(l, 1) for l in lengths]
 
 
 def nearest_weather_stations(geom, n=NUM_WEATHER_STATIONS):

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -189,8 +189,8 @@ def nlcd_streams(sjs_result):
     each, return a dictionary with keys 'ag_stream_pct', 'low_urban_stream_pct'
     and 'med_high_urban_stream_pct' which indicate the percent of streams in
     agricultural areas (namely NLCD 81 Pasture/Hay and 82 Cultivated Crops),
-    low density urban areas (NLCD 22), and medium and high density urban areas
-    (NLCD 23 and 24) respectively.
+    low density urban areas (NLCD 21 and 22), and medium and high density urban
+    areas (NLCD 23 and 24) respectively.
 
     In addition, we inspect the result to see if it includes an 'error' key.
     If so, it would indicate that a preceeding task has thrown an exception,
@@ -225,7 +225,7 @@ def nlcd_streams(sjs_result):
     result = parse_sjs_result(sjs_result)
 
     ag_count = sum(result.get(nlcd, 0) for nlcd in AG_NLCD_CODES)
-    low_urban_count = result.get(22, 0)
+    low_urban_count = sum(result.get(nlcd, 0) for nlcd in [21, 22])
     med_high_urban_count = sum(result.get(nlcd, 0) for nlcd in [23, 24])
     total = sum(result.values())
 
@@ -468,11 +468,11 @@ def get_lu_index(nlcd):
         lu_index = 3
     elif nlcd in [90, 95]:
         lu_index = 4
-    elif nlcd in [21, 71]:
+    elif nlcd == 71:
         lu_index = 7
     elif nlcd in [12, 31]:
         lu_index = 8
-    elif nlcd == 22:
+    elif nlcd in [21, 22]:
         lu_index = 11
     elif nlcd == 23:
         lu_index = 12

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -28,6 +28,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
                                          weather_data,
                                          curve_number,
                                          sediment_phosphorus,
+                                         phosphorus_conc,
                                          groundwater_nitrogen_conc,
                                          sediment_delivery_ratio,
                                          landuse_pcts,
@@ -146,6 +147,7 @@ def collect_data(geop_result, geojson):
     z['Area'] = [percent * area * HECTARES_PER_SQM
                  for percent in geop_result['landuse_pcts']]
     z['UrbAreaTotal'] = sum(z['Area'][NRur:])
+    z['PhosConc'] = phosphorus_conc(z['SedPhos'])
 
     z['NormalSys'] = normal_sys(z['Area'])
 

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -105,7 +105,6 @@ def collect_data(geop_result, geojson):
     z['Grow'] = growing_season(ws)
     z['Acoef'] = erosion_coeff(ws, z['Grow'])
     z['PcntET'] = et_adjustment(ws)
-    z['KV'] = kv_coefficient(z['Acoef'])
     z['WxYrBeg'] = int(max([w.begyear for w in ws]))
     z['WxYrEnd'] = int(min([w.endyear for w in ws]))
     z['WxYrs'] = z['WxYrEnd'] - z['WxYrBeg'] + 1
@@ -159,6 +158,8 @@ def collect_data(geop_result, geojson):
 
     z['AvKF'] = geop_result['avg_kf']
     z['KF'] = geop_result['kf']
+
+    z['KV'] = kv_coefficient(geop_result['landuse_pcts'], z['Grow'])
 
     # Original at Class1.vb@1.3.0:9803-9807
     z['n23'] = z['Area'][1]    # Row Crops Area

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -20,6 +20,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
                                          kv_coefficient,
                                          animal_energy_units,
                                          ls_factors,
+                                         p_factors,
                                          manure_spread,
                                          streams,
                                          stream_length,
@@ -178,6 +179,8 @@ def collect_data(geop_result, geojson):
 
     z['LS'] = ls_factors(geop_result['lu_stream_pct'],
                          ls_stream_length, z['Area'], z['AvSlope'])
+
+    z['P'] = p_factors(z['AvSlope'])
 
     return z
 

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -40,6 +40,8 @@ GWLFE_DEFAULTS = {
                 ],
     'Imper': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,         # Impervious surface area percentage
               0.15, 0.52, 0.87, 0.15, 0.52, 0.87],  # only defined for urban land use types
+    'C': [0.03, 0.42, 0.002, 0.01, 0.08, 0.03, 0.04, 0.001, 0.01, 0.8,  # C Factor Defaults
+          0, 0, 0, 0, 0, 0],                                            # only defined for rural land use types
     'CNI': [[0] * 16,
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  # Curve Number for Impervious Surfaces
              92, 98, 98, 92, 92, 92],       # only defined for urban land use types
@@ -469,6 +471,7 @@ GWLFE_CONFIG = {
         'AntMoist',
         'Area',
         'AvgAnimalWt',
+        'C',
         'CN',
         'CNI',
         'CNP',
@@ -515,6 +518,7 @@ GWLFE_CONFIG = {
         'NumPondSys',
         'NumSewerSys',
         'NumShortSys',
+        'P',
         'PcntET',
         'PctGrazing',
         'PctStreams',

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -27,11 +27,11 @@ GWLFE_DEFAULTS = {
                 lu.WETLAND,    # Maps NLCD 90, 95
                 lu.DISTURBED,       # Does not map to NLCD
                 lu.TURFGRASS,       # Does not map to NLCD
-                lu.OPEN_LAND,  # Maps NLCD 21, 71
+                lu.OPEN_LAND,  # Maps NLCD 71
                 lu.BARE_ROCK,  # Maps NLCD 12, 31
                 lu.SANDY_AREAS,     # Does not map to NLCD
                 lu.UNPAVED_ROAD,    # Does not map to NLCD
-                lu.LD_MIXED,   # Maps NLCD 22
+                lu.LD_MIXED,   # Maps NLCD 21, 22
                 lu.MD_MIXED,   # Maps NLCD 23
                 lu.HD_MIXED,   # Maps NLCD 24
                 lu.LD_RESIDENTIAL,  # Does not map to NLCD
@@ -537,7 +537,6 @@ GWLFE_CONFIG = {
 CURVE_NUMBER = {
     11: [0, 100, 100, 100, 100],  # Water
     12: [0,  72,  82,  87,  89],  # Perennial Ice/Snow
-    21: [0,  72,  82,  87,  89],  # Developed Open Space
     31: [0,  72,  82,  87,  89],  # Barren Land
     41: [0,  37,  60,  73,  80],  # Deciduous Forest
     42: [0,  37,  60,  73,  80],  # Evergreen Forest

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -463,6 +463,42 @@ GWLFE_CONFIG = {
     'SSLDR': 4.4,
     'SSLDM': 2.2,
     'WeatherNull': -99999,  # This value is used to indicate NULL in ms_weather dataset
+    'ETGrowCoeff': [
+        1.00,  # Hay/Pasture
+        0.80,  # Cropland
+        0.77,  # Forest
+        1.00,  # Wetlands
+        0.30,  # Disturbed
+        1.00,  # Turf Grass
+        1.00,  # Open Land
+        0.10,  # Bare Rock
+        0.30,  # Sandy Areas
+        1.00,  # Unpaved Roads
+        0.85,  # Low Density Mixed
+        0.48,  # Medium Density Mixed
+        0.70,  # High Density Mixed
+        0.85,  # Low Density Residential
+        0.48,  # Medium Density Residential
+        0.13,  # High Density Residential
+    ],
+    'ETDormCoeff': [
+        0.80,  # Hay/Pasture
+        0.30,  # Cropland
+        0.51,  # Forest
+        1.00,  # Wetlands
+        0.30,  # Disturbed
+        0.80,  # Turf Grass
+        0.80,  # Open Land
+        0.10,  # Bare Rock
+        0.30,  # Sandy Areas
+        1.00,  # Unpaved Roads
+        0.80,  # Low Density Mixed
+        0.48,  # Medium Density Mixed
+        0.70,  # High Density Mixed
+        0.85,  # Low Density Residential
+        0.48,  # Medium Density Residential
+        0.13,  # High Density Residential
+    ],
     'ArrayFields': [  # These may be optionally converted to numpy arrays before running the model # NOQA
         'Acoef',
         'AnimalDailyN',

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -70,9 +70,6 @@ GWLFE_DEFAULTS = {
     'NitrConc': [0.75, 2.90, 0.19, 0.19, 0.02,  # Dissolved Runoff Coefficient: Nitrogen mg/l
                  2.50, 0.50, 0.30, 0.10, 0.19,  # only defined for rural land use types
                  0, 0, 0, 0, 0, 0],
-    'PhosConc': [0.01, 0.01, 0.01, 0.01, 0.01,  # Dissolved Runoff Coefficient: Phosphorus mg/l
-                 0.01, 0.01, 0.01, 0.01, 0.01,  # only defined for rural land use types
-                 0, 0, 0, 0, 0, 0],
     'Nqual': 3,  # Number of Contaminants (Default = 3)
     'Contaminant': ['Nitrogen', 'Phosphorus', 'Sediment'],
     'LoadRateImp': [[], [], [], [], [], [], [], [], [], [],  # Load Rate on Impervious Surfaces per urban land use per contaminant


### PR DESCRIPTION
## Overview

Fixes the following issues:

 * Maps NLCD 21 to Low Density Mixed instead of Open Land
 * Looks up C and P values which were previously missing
 * Corrects day length calculation caused by an index mismatch
 * Corrects LS calculation which was previously mixing NHD stream percentages with DRB stream lengths
 * Corrects KV calculation which was previously using erosion coefficients instead of evapotranspiration coefficients

## Testing Instructions

Checkout the branch. Debug Celery

    ./scripts/debugcelery.sh

Select the **LIttle Neshaminy Creek** HUC12 right above Philadelphia as an area of interest.

![image](https://cloud.githubusercontent.com/assets/1430060/15948610/b59033c4-2e6f-11e6-9c78-799dd19ef347.png)

Create a MapShed project and export "Current Conditions" as a GMS file.

Move the GMS file to a Windows VM. Open the GMS file using GWLF-E 1.4.0 which can be found at smb://fileshare/projects/Stroud_ModelMyWatershed/downloads/mapshed/GWLF-E-1.4.0.exe.

Compare the results of Transport Data and Nutrient Data with that of [`input_365.gms`](https://github.com/WikiWatershed/model-my-watershed/files/308010/input_365.gms.txt). The values will not be exact, since the data sources are different, but they should be within each others ballpark.

Connects #1357 