### PR TITLE
Fix AEU Calculation

### DIFF
--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -454,6 +454,16 @@ GWLFE_CONFIG = {
     'KvFactor': 1.16,  # Original at Class1.vb@1.3.0:4987
     'Livestock': ['dairy_cows', 'beef_cows', 'hogs', 'sheep', 'horses'],
     'Poultry': ['broilers', 'layers', 'turkeys'],
+    'AvgAnimalWt': {  # Original at Class1.vb@1.3.0:9048-9056
+        'dairy_cows': 640.0,
+        'beef_cows': 360.0,
+        'broilers': 0.9,
+        'layers': 1.8,
+        'hogs': 61.0,
+        'sheep': 50.0,
+        'horses': 500.0,
+        'turkeys': 6.8,
+    },
     'ManureSpreadingLandUseIndices': [0, 1],  # Land Use Indices where manure spreading applies. Currently Hay/Past and Cropland.
     'AgriculturalNLCDCodes': [81, 82],  # NLCD codes considered agricultural. Correspond to Hay/Past and Cropland
     'MonthDays': [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],


### PR DESCRIPTION
## Overview

Previously we were not multiplying the animal populations by weight and then dividing by 1000, as done in the source:

```vb
' Obtain AEU for each farm animal
AEU1 = ((Chicks / 2) * (BroilerWt) / 1000) + ((Chicks / 2) * (LayerWt) / 1000) ' Chickens
AEU2 = (Turkeys * TurkeyWt) / 1000 ' Turkeys
AEU3 = (Sheep * SheepWt) / 1000 ' Sheep
AEU4 = (Hogs * HogWt) / 1000 ' Hogs
AEU5 = (Horses * HorseWt) / 1000 ' Horses
AEU6 = (DairyCows * DairyWt) / 1000 ' Dairy Cows
AEU7 = (BeefCows * BeefWt) / 1000 ' Beef Cows

' Get the total AEU, Total livestock and poultry AEU
TotAEU = AEU1 + AEU2 + AEU3 + AEU4 + AEU5 + AEU6 + AEU7
TotLAEU = AEU3 + AEU4 + AEU5 + AEU6 + AEU7
TotPAEU = AEU1 + AEU2

' If the total livestock AEU > 0 then recalculate the AEU based on the basin area
If TotLAEU > 0 Then
    AEU = TotLAEU / (BasinAreaHa * 2.471)
End If
```

This adds that technique. ~~In addition, we also have a [new dataset from BME](https://github.com/WikiWatershed/model-my-watershed/issues/1360) which includes a pre-calculated `grzaeu` column which can be area-weighted and used directly.~~

~~I am in conversation with BME on whether to use the new kg weighted value or the `grzaeu` column. Will hold off on merging this until I have an answer.~~

BME says to use the technique which correctly mimics the VB code, rather than the `grzaeu` column.

## Testing Instructions

Compile and run MMW. Create a MapShed project, and export a GMS file from Current Conditions. The value of AEU in line 2 column 15 should be of the order of 0.05559663102442437 for a watershed of ~ 100 sq km.

Connects #1357 
Connects #1360 