### PR TITLE
Add Simple Error Messages

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -137,15 +137,9 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
     onShow: function() {
         this.showAnalyzingMessage();
 
-        var self = this;
-
         this.model.fetchAnalysisIfNeeded()
-            .done(function() {
-                self.showDetailsRegion();
-            })
-            .fail(function() {
-                self.showErrorMessage();
-            });
+            .done(_.bind(this.showDetailsRegion, this))
+            .fail(_.bind(this.showErrorMessage, this));
     },
 
     showAnalyzingMessage: function() {
@@ -158,10 +152,14 @@ var AnalyzeWindow = Marionette.LayoutView.extend({
         }));
     },
 
-    showErrorMessage: function() {
+    showErrorMessage: function(err) {
         var messageModel = new coreModels.TaskMessageViewModel();
 
-        messageModel.setError();
+        if (err && err.timeout) {
+          messageModel.setTimeoutError();
+        } else {
+          messageModel.setError();
+        }
 
         this.detailsRegion.show(new coreViews.TaskMessageView({
             model: messageModel

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -183,7 +183,7 @@ var TaskModel = Backbone.Model.extend({
         // pollInterval has elapsed.
         var getResults = function() {
             if (elapsed >= self.get('timeout')) {
-                defer.reject();
+                defer.reject({timeout: true});
                 return;
             }
 
@@ -219,6 +219,14 @@ var TaskMessageViewModel = Backbone.Model.extend({
 
     setError: function() {
         this.set('message', 'Error');
+        this.set('iconClasses', 'fa fa-exclamation-triangle');
+    },
+
+    setTimeoutError: function() {
+        var message = 'Operation took too long <br />' +
+                      'Consider trying a smaller area of interest.';
+
+        this.set('message', message);
         this.set('iconClasses', 'fa fa-exclamation-triangle');
     },
 

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -62,11 +62,10 @@ function validateShape(polygon) {
         d = new $.Deferred();
 
     if (area > MAX_AREA) {
-        var message = '';
-        message += 'Sorry, your Area of Interest is too large.\n\n';
-        message += Math.floor(area) + ' square km were selected, ';
-        message += 'but the maximum supported size is currently ';
-        message += MAX_AREA + ' square km.';
+        var message = 'Sorry, your Area of Interest is too large.\n\n' +
+                      Math.floor(area).toLocaleString() + ' km² were selected, ' +
+                      'but the maximum supported size is currently ' +
+                      MAX_AREA.toLocaleString() + ' km².';
         window.alert(message);
         d.reject(message);
     } else {

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -67,6 +67,7 @@ function validateShape(polygon) {
         message += Math.floor(area) + ' square km were selected, ';
         message += 'but the maximum supported size is currently ';
         message += MAX_AREA + ' square km.';
+        window.alert(message);
         d.reject(message);
     } else {
         d.resolve(polygon);

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -349,9 +349,9 @@ var ProjectModel = Backbone.Model.extend({
                         promise.resolve(taskModel.get('result'));
                     },
 
-                    pollFailure: function() {
+                    pollFailure: function(err) {
                         console.log('Failed to gather data required for MAPSHED');
-                        promise.reject();
+                        promise.reject(err);
                     }
                 };
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -801,8 +801,12 @@ var ResultsView = Marionette.LayoutView.extend({
             aoi = App.map.get('areaOfInterest'),
             analyzeModel = analyzeModels.AnalyzeTaskModel.getSingleton(App, aoi),
             tmvModel = new coreModels.TaskMessageViewModel(),
-            errorHandler = function() {
-                tmvModel.setError();
+            errorHandler = function(err) {
+                if (err && err.timeout) {
+                  tmvModel.setTimeoutError();
+                } else {
+                  tmvModel.setError();
+                }
                 self.modelingRegion.show(new coreViews.TaskMessageView({ model: tmvModel }));
             };
 


### PR DESCRIPTION
## Overview

Adds two error messages. If you draw an area of interest that the web app cancels, it no longer cancels it silently but instead tells you why:

![image](https://cloud.githubusercontent.com/assets/1430060/16023077/04889752-3189-11e6-953b-974909b5b725.png)

If you select an area of interest that is too big for MapShed, you will see an error there as well:

![image](https://cloud.githubusercontent.com/assets/1430060/16023012/bc0abfe6-3188-11e6-9289-530edf23b208.png)

## Testing Instructions

 1. Draw an area of interest around a large state like Pennsylvania. You should see an alert message before your drawing is canceled.
 2. Select a HUC-8 and proceed to MapShed. The "Gathering Data" step should fail with a timeout message.

Connects #1330 