### PR TITLE
Use datahub CDN endpoint for NLCD and SSURGO tiles

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -143,8 +143,7 @@ LAYERS = [
         'short_display': 'NLCD',
         'helptext': 'National Land Cover Database defines'
                     'land use across the U.S.',
-        'url': 'https://s3.amazonaws.com/com.azavea.datahub.tms/'
-               'nlcd/{z}/{x}/{y}.png',
+        'url': 'https://{s}.tiles.azavea.com/nlcd/{z}/{x}/{y}.png',
         'raster': True,
         'overlay': True,
         'maxNativeZoom': 13,
@@ -160,8 +159,7 @@ LAYERS = [
                     'soil\'s runoff potential. The four Hydrologic Soils Groups'
                     'are A, B, C and D. Where A\'s generally have the smallest '
                     'runoff potential and D\'s the greatest.',
-        'url': 'https://s3.amazonaws.com/com.azavea.datahub.tms/'
-               'ssurgo-hydro-group-30m/{z}/{x}/{y}.png',
+        'url': 'https://{s}.tiles.azavea.com/ssurgo-hydro-group-30m/{z}/{x}/{y}.png',
         'raster': True,
         'overlay': True,
         'maxNativeZoom': 13,


### PR DESCRIPTION
Instead of serving tiles directly from Amazon S3, use the new CDN enabled datahub endpoint.

See also: https://github.com/azavea/azavea-data-hub/pull/37

---

**Testing**

Ensure that the application makes use of the new tile endpoint, and inspect that the tiles render within the application correctly. I am in the middle of copying all of the tiles over to the origin of this CDN, so not all of the tiles may be available right away (at zoom level 13 for NLCD as I type this).