### PR TITLE
Show units in summary loads in GWLFE quality tables

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
@@ -31,5 +31,5 @@
 <div class="mean-flow">
     Mean Flow: {{ MeanFlow|round(0)|toLocaleString }} (m<sup>3</sup>/year) and {{ MeanFlowPerSecond|round(0)|toLocaleString }} (m<sup>3</sup>/s)
 </div>
-{{ table(columnNames, landUseRows, true) }}
-{{ table(columnNames, summaryRows, false) }}
+{{ table(landUseColumns, landUseRows, true) }}
+{{ table(summaryColumns, summaryRows, false) }}

--- a/src/mmw/js/src/modeling/gwlfe/quality/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/quality/views.js
@@ -46,20 +46,24 @@ var TableView = Marionette.CompositeView.extend({
     },
 
     templateHelpers: function() {
-        function makeRow(load) {
-            return [load.Source, load.Sediment, load.TotalN, load.TotalP];
+        function makeRow(addUnit, load) {
+            var source = addUnit ? load.Source + ' (' + load.Unit + ')'
+                : load.Source;
+            return [source, load.Sediment, load.TotalN, load.TotalP];
         }
 
         var result = this.model.get('result'),
-            columnNames = ['Sources', 'Sediment (kg)', 'Total Nitrogen (kg)', 'Total Phosphorus (kg)'],
-            landUseRows = _.map(result.Loads.slice(0,15), makeRow),
-            summaryRows = _.map(result.Loads.slice(15), makeRow);
+            landUseColumns = ['Sources', 'Sediment (kg)', 'Total Nitrogen (kg)', 'Total Phosphorus (kg)'],
+            landUseRows = _.map(result.Loads, _.partial(makeRow, false)),
+            summaryColumns = ['Sources', 'Sediment', 'Total Nitrogen', 'Total Phosphorus'],
+            summaryRows = _.map(result.SummaryLoads, _.partial(makeRow, true));
 
         return {
             MeanFlow: result.MeanFlow,
             MeanFlowPerSecond: result.MeanFlowPerSecond,
-            columnNames: columnNames,
+            landUseColumns: landUseColumns,
             landUseRows: landUseRows,
+            summaryColumns: summaryColumns,
             summaryRows: summaryRows
         };
     }

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -10,7 +10,7 @@ python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
 tr55==1.1.3
-gwlf-e==0.4.0
+gwlf-e==0.5.0
 requests==2.9.1
 rollbar==0.12.1
 retry==0.9.1


### PR DESCRIPTION
This PR adds units to the rows and removes them for the columns in the summary table in the Quality view. The first table is unchanged. Before testing, run `vagrant provision worker` 

![screen shot 2016-06-15 at 2 16 49 pm 2](https://cloud.githubusercontent.com/assets/1896461/16092021/2c71b510-3304-11e6-977a-87139a37da89.png)

Connects #1364 