### PR TITLE
Fix Google Maps Key

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -54,7 +54,7 @@
 
     {% block javascript %}
         <script type="text/javascript"
-                src="https://maps.googleapis.com/maps/api/js?key={{ client_settings.google_maps_api_key }}">
+                src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_api_key }}">
         </script>
         <script type="text/javascript">
             window.clientSettings = {{ client_settings | safe }};

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -133,10 +133,10 @@ def get_client_settings(request):
             'stream_layers': get_layer_config(['stream', 'overlay']),
             'draw_tools': settings.DRAW_TOOLS,
             'map_controls': settings.MAP_CONTROLS,
-            'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,
             'vizer_urls': settings.VIZER_URLS,
             'model_packages': get_model_packages(),
-        })
+        }),
+        'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,
     }
 
     return client_settings


### PR DESCRIPTION
## Overview

Previously it was embedded inside a `json.dumps` call. Since it is never used by any JavaScript code, we extract it from client_settings and include it directly.

## Testing Instructions

Checkout the branch and open up [http://localhost:8000/](http://localhost:8000/). Open up developer tools. They should **NOT** look like this:

![image](https://cloud.githubusercontent.com/assets/1430060/16350920/d3fdf35c-3a2f-11e6-84e3-d83ca8619abe.png)

The `maps.googleapis.com` URL should have a real key, and the two Google Maps API warnings should not be present.

Connects #1041 