### PR TITLE
Scale Celery across multiple workers correctly

### DIFF
--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -445,7 +445,7 @@ def nlcd_kfactor(result):
     return output
 
 
-def geop_tasks(geom, errback):
+def geop_tasks(geom, errback, exchange, routing_key):
     # List of tuples of (opname, data, callback) for each geop task
     definitions = [
         ('nlcd_streams',
@@ -473,8 +473,10 @@ def geop_tasks(geom, errback):
                              'vector': streams(geom, drb=True)},
                             nlcd_streams_drb))
 
-    return [(mapshed_start.s(opname, data) |
-             mapshed_finish.s() |
+    return [(mapshed_start.s(opname, data).set(exchange=exchange,
+                                               routing_key=routing_key) |
+             mapshed_finish.s().set(exchange=exchange,
+                                    routing_key=routing_key) |
              callback.s().set(link_error=errback))
             for (opname, data, callback) in definitions]
 

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -257,8 +257,7 @@ def _initiate_mapshed_job_chain(mapshed_input, job_id):
     geom = GEOSGeometry(json.dumps(mapshed_input['area_of_interest']),
                         srid=4326)
 
-    chain = (group(geop_tasks(geom, errback)).set(exchange=exchange,
-                                                  routing_key=routing_key) |
+    chain = (group(geop_tasks(geom, errback, exchange, routing_key)) |
              combine.s() |
              collect_data.s(geom.geojson).set(link_error=errback) |
              save_job_result.s(job_id, mapshed_input))


### PR DESCRIPTION
## Overview

Geoprocessing tasks were spreading indiscriminately between workers, causing `mapshed_finish` to attempt to retrieve jobs from one worker that were started on another, thus failing.

By pinning `mapshed_start` and `mapshed_finish` to work on same worker, we ensure that the Spark jobs are always available.

This does create a small bottleneck since all geoprocessing tasks now occur on a single worker instead of spreading out, but that is left for later optimization if deemed necessary.

## Validating Instructions

The same code has been deployed manually to staging which has been upgraded to have multiple workers.

Once this is deployed, ensure that MapShed works on staging with multiple workers.