### PR TITLE
Fix layer selector text from being always disabled

### DIFF
--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -77,7 +77,7 @@
   height: 100%;
 }
 
-#overlay-subclass-vector, #overlay-subclass-raster .disabled {
+#overlay-subclass-vector .disabled, #overlay-subclass-raster .disabled {
   color: $black-54;
 }
 


### PR DESCRIPTION
Fixes a bug introduced in 5655f726 that resulted in all Boundary layer
text in being disabled "looking" even when they were in fact enabled.

#### Test
Ensure that when zooming high to low, and in and out of PA that the Boundary layers disabled styling updates accordingly.

Before: 
![screenshot from 2016-07-20 11 36 55](https://cloud.githubusercontent.com/assets/1014341/16992675/48336bc4-4e6e-11e6-986c-cf1bc711b667.png)

After:
![screenshot from 2016-07-20 11 37 37](https://cloud.githubusercontent.com/assets/1014341/16992695/5f6c7a38-4e6e-11e6-930d-7dda0d55e9ad.png)
