### PR TITLE
Add border to Urban Areas tile renderer

### DIFF
--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -26,6 +26,10 @@
 }
 
 #dep_urban_areas {
+  ::case {
+      line-color: #7F7F7F;
+      line-width: 1;
+  }
   ::fill {
       polygon-fill: #ccc;
   }


### PR DESCRIPTION
Update style to include a light border around gray urban area features.

![screenshot from 2016-07-20 16 43 32](https://cloud.githubusercontent.com/assets/1014341/17002406/1cba9a28-4e99-11e6-9e60-952c3b227adc.png)
