### PR TITLE
Make .leaflet-top CSS override rule more specific

### DIFF
--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -102,7 +102,7 @@
     float: right;
 }
 
-.leaflet-top {
+.leaflet-control-container .leaflet-top {
   top: 45px;
 }
 


### PR DESCRIPTION
Only apply the modified .leaflet-top rule to elements in
.leaflet-control-container. The rule was originally added to target
these elements. Since it was applied more broadly, it caused issues
with the Google Leaflet plugin, which adds the leaflet-top class
to the container used to house the Google tiles.

**Testing**
- Turn on the NLCD layer.
- Switch between the various basemaps and ensure the NLCD overlay is generally in the same place for each layer.
- Ensure there is no gray bar across the top of the map and the attribution element is visible when the "Satellite with Roads" layer is active.

![image](https://cloud.githubusercontent.com/assets/1042475/17109906/04eaa88e-5268-11e6-91b9-543208719c4f.png)


Connects to #1237
Connects to #1238