### PR TITLE
Rename and reorder PA DEP layers

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -28,28 +28,6 @@ pa_perimeter = json.load(pa_perimeter_file)
 
 LAYERS = [
     {
-        'code': 'municipalities',
-        'table_name': 'dep_municipalities',
-        'display': 'DEP PA Municipalities',
-        'short_display': 'DEP PA Municipalities',
-        'vector': True,
-        'overlay': True,
-        'minZoom': 7,
-        'perimeter': pa_perimeter,
-    },
-    {
-        'code': 'urban_areas',
-        'table_name': 'dep_urban_areas',
-        'display': 'DEP PA Urban Areas',
-        'short_display': 'DEP PA Urban Areas',
-        'raster': True,
-        'overlay': True,
-        'minZoom': 7,
-        'opacity': 0.618,
-        'has_opacity_slider': True,
-        'perimeter': pa_perimeter,
-    },
-    {
         'code': 'huc8',
         'display': 'USGS Subbasin unit (HUC-8)',
         'short_display': 'HUC-8 Subbasin',
@@ -232,6 +210,28 @@ LAYERS = [
         'googleType': 'TERRAIN',  # SATELLITE, ROADMAP, HYBRID, or TERRAIN
         'maxZoom': 20,
         'basemap': True,
+    },
+    {
+        'code': 'municipalities',
+        'table_name': 'dep_municipalities',
+        'display': 'PA Municipalities',
+        'short_display': 'PA Municipalities',
+        'vector': True,
+        'overlay': True,
+        'minZoom': 7,
+        'perimeter': pa_perimeter,
+    },
+    {
+        'code': 'urban_areas',
+        'table_name': 'dep_urban_areas',
+        'display': 'PA Urbanized Areas',
+        'short_display': 'PA Urbanized Areas',
+        'raster': True,
+        'overlay': True,
+        'minZoom': 7,
+        'opacity': 0.618,
+        'has_opacity_slider': True,
+        'perimeter': pa_perimeter,
     }
 ]
 


### PR DESCRIPTION
This PR renames the PA DEP layers and moves them to be positioned at the bottom of their respective overlays list on the layer control.
 
I made this change by moving the DEP layers to the end of the list in `layer_settings.py` so that they'll be the last objects mapped over when setting up the layer control. The result looks like this:

<img width="529" alt="screen shot 2016-07-25 at 1 28 51 pm" src="https://cloud.githubusercontent.com/assets/4165523/17110602/c6359f3c-526b-11e6-91cc-b9b8be27f160.png">

**Testing**
- get this branch, `vagrant up`
- run `./scripts/bundle.sh`
- if you do not already have the PA DEP layers loaded into the db, run `vagrant ssh app`, `cd /vagrant/scripts/aws` and `./setupdb.sh -p`
- visit `localhost:8000` in the browser, then zoom in on PA:

<img width="1025" alt="screen shot 2016-07-25 at 1 34 01 pm" src="https://cloud.githubusercontent.com/assets/4165523/17110743/7bb35b4c-526c-11e6-9c98-4b3a66acea4a.png">

- open the layers control, click on the "Overlays" tab, and verify that "PA Municipalities" is at the bottom of the "Boundaries" section and that "PA Urbanized Areas" is at the bottom of the "Coverage" section
- Toggle "PA Municipalities" on and verify that the layer appears
- Toggle "PA Urbanized Areas" on and verify that the layer appears and that you its opacity control still works properly

Connects #1395