### PR TITLE
Update micro site with soil colors

### DIFF
--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -210,84 +210,84 @@
 
                     <li id="thumb-open_water">
                         <a href="#land-open_water" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-11">
-                            <img src="{% static 'images/water_balance/thumb_openwater.png' %}" alt="Open Water" data-name="open_water" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-11">
+                            <img src="{% static 'images/water_balance/thumb_openwater.png' %}" alt="Open Water" data-name="open_water" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-11">
                         </a>
                         <label>Water</label>
                     </li>
 
                     <li id="thumb-developed_open">
                         <a href="#land-developed_open" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-21">
-                            <img src="{% static 'images/water_balance/thumb_turfGrass.png' %}" alt="Developed, Open Space" data-name="developed_open" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-21" >
+                            <img src="{% static 'images/water_balance/thumb_turfGrass.png' %}" alt="Developed, Open Space" data-name="developed_open" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-21" >
                         </a>
                         <label>Developed-Open</label>
                     </li>
 
                     <li id="thumb-developed_low" class="active">
                         <a href="#land-developed_low" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-22">
-                            <img src="{% static 'images/water_balance/thumb_lir.png' %}" alt="Developed, Low Intensity" data-name="developed_low" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-22" >
+                            <img src="{% static 'images/water_balance/thumb_lir.png' %}" alt="Developed, Low Intensity" data-name="developed_low" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-22" >
                         </a>
                         <label>Developed-Low</label>
                     </li>
 
                     <li id="thumb-developed_med">
                         <a href="#land-developed_med" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-23">
-                            <img src="{% static 'images/water_balance/thumb_hir.png' %}" alt="Developed, Medium Intensity" data-name="developed_med" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-23" >
+                            <img src="{% static 'images/water_balance/thumb_hir.png' %}" alt="Developed, Medium Intensity" data-name="developed_med" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-23" >
                         </a>
                         <label>Developed-Med</label>
                     </li>
 
                     <li id="thumb-developed_high">
                         <a href="#land-developed_high" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-24">
-                            <img src="{% static 'images/water_balance/thumb_commercial.png' %}" alt="Developed High Intensity" data-name="developed_high" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-24" >
+                            <img src="{% static 'images/water_balance/thumb_commercial.png' %}" alt="Developed High Intensity" data-name="developed_high" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-24" >
                         </a>
                         <label>Developed-High</label>
                     </li>
 
                     <li id="thumb-barren_land">
                         <a href="#land-barren_land" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-31">
-                            <img src="{% static 'images/water_balance/thumb_desert.png' %}" alt="Barren Land (Rock/Sand/Clay)" data-name="barren_land" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-31" >
+                            <img src="{% static 'images/water_balance/thumb_desert.png' %}" alt="Barren Land (Rock/Sand/Clay)" data-name="barren_land" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-31" >
                         </a>
                         <label>Barren Land</label>
                     </li>
 
                     <li id="thumb-deciduous_forest">
                         <a href="#land-deciduous_forest" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-41">
-                            <img src="{% static 'images/water_balance/thumb_forest.png' %}" alt="Forest" data-container="body" data-name="deciduous_forest" data-toggle="popover" data-placement="left" data-nlcd="nlcd-41" >
+                            <img src="{% static 'images/water_balance/thumb_forest.png' %}" alt="Forest" data-container="body" data-name="deciduous_forest" data-toggle="popover" data-placement="left" data-category="nlcd-41" >
                         </a>
                         <label>Forest</label>
                     </li>
 
                     <li id="thumb-shrub">
                         <a href="#land-shrub" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-52">
-                            <img src="{% static 'images/water_balance/thumb_chaparral.png' %}" alt="Shrub/Scrub" data-name="shrub" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-52" >
+                            <img src="{% static 'images/water_balance/thumb_chaparral.png' %}" alt="Shrub/Scrub" data-name="shrub" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-52" >
                         </a>
                         <label>Shrub/Scrub</label>
                     </li>
 
                     <li id="thumb-grassland">
                         <a href="#land-grassland" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-71">
-                            <img src="{% static 'images/water_balance/thumb_grassland.png' %}" alt="Grassland/Herbaceous" data-name="grassland" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-71" >
+                            <img src="{% static 'images/water_balance/thumb_grassland.png' %}" alt="Grassland/Herbaceous" data-name="grassland" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-71" >
                         </a>
                         <label>Grassland</label>
                     </li>
 
                     <li id="thumb-pasture">
                         <a href="#land-pasture" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-81">
-                            <img src="{% static 'images/water_balance/thumb_pasture.png' %}" alt="Pasture/Hay" data-name="pasture" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-81" >
+                            <img src="{% static 'images/water_balance/thumb_pasture.png' %}" alt="Pasture/Hay" data-name="pasture" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-81" >
                         </a>
                         <label>Pasture/Hay</label>
                     </li>
 
                     <li id="thumb-cultivated_crops">
                         <a href="#land-cultivated_crops" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-82">
-                            <img src="{% static 'images/water_balance/thumb_rowCrops.png' %}" alt="Cultivated Crops" data-name="cultivated_crops" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-82" >
+                            <img src="{% static 'images/water_balance/thumb_rowCrops.png' %}" alt="Cultivated Crops" data-name="cultivated_crops" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-82" >
                         </a>
                         <label>Crops</label>
                     </li>
 
                     <li id="thumb-woody_wetlands">
                         <a href="#land-woody_wetlands" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-90">
-                            <img src="{% static 'images/water_balance/thumb_wetlands.png' %}" alt="Wetlands" data-name="woody_wetlands" data-container="body" data-toggle="popover" data-placement="left" data-nlcd="nlcd-90" >
+                            <img src="{% static 'images/water_balance/thumb_wetlands.png' %}" alt="Wetlands" data-name="woody_wetlands" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-90" >
                         </a>
                         <label>Wetlands</label>
                     </li>

--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -302,29 +302,29 @@
                 <ul id="thumbs-soil" class="nav" role="tablist"> <!-- Soil Thumbs -->
 
                     <li id="thumb-sand" class="active"> <!-- Sand Thumb -->
-                        <a href="#soil-sand" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_sand.png' %}" alt="Sand" data-name="soil_a" data-container="body" data-toggle="popover" data-placement="left" >
+                        <a href="#soil-sand" aria-controls="filter-tab" role="tab" data-toggle="tab" class="soil-a">
+                            <img src="{% static 'images/water_balance/thumb_sand.png' %}" alt="Sand" data-name="soil_a" data-container="body" data-toggle="popover" data-placement="left" data-category="soil-a">
                         </a>
                         <label>A - High Infiltration</label>
                     </li>
 
                     <li id="thumb-loam"> <!-- Loam Thumb -->
-                        <a href="#soil-loam" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_loam.png' %}" alt="loam" data-name="soil_b" data-container="body" data-toggle="popover" data-placement="left" >
+                        <a href="#soil-loam" aria-controls="filter-tab" role="tab" data-toggle="tab" class="soil-b">
+                            <img src="{% static 'images/water_balance/thumb_loam.png' %}" alt="loam" data-name="soil_b" data-container="body" data-toggle="popover" data-placement="left" data-category="soil-b">
                         </a>
                         <label>B - Moderate Infiltration</label>
                     </li>
 
                     <li id="thumb-sandyClay"> <!-- Sandy Clay Thumb -->
-                        <a href="#soil-sandyClay" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_sandyClay.png' %}" alt="Sandy Clay" data-name="soil_c" data-container="body" data-toggle="popover" data-placement="left" >
+                        <a href="#soil-sandyClay" aria-controls="filter-tab" role="tab" data-toggle="tab" class="soil-c">
+                            <img src="{% static 'images/water_balance/thumb_sandyClay.png' %}" alt="Sandy Clay" data-name="soil_c" data-container="body" data-toggle="popover" data-placement="left" data-category="soil-c">
                         </a>
                         <label>C - Slow Infiltration</label>
                     </li>
 
                     <li id="thumb-clayLoam"> <!-- Clay Loam Thumb -->
-                        <a href="#soil-clayLoam" aria-controls="filter-tab" role="tab" data-toggle="tab">
-                            <img src="{% static 'images/water_balance/thumb_clayLoam.png' %}" alt="Clay Loam" data-name="soil_d" data-container="body" data-toggle="popover" data-placement="left" >
+                        <a href="#soil-clayLoam" aria-controls="filter-tab" role="tab" data-toggle="tab" class="soil-d">
+                            <img src="{% static 'images/water_balance/thumb_clayLoam.png' %}" alt="Clay Loam" data-name="soil_d" data-container="body" data-toggle="popover" data-placement="left" data-category="soil-d">
                         </a>
                         <label>D - Very Slow Infiltration</label>
                     </li>

--- a/src/mmw/js/src/main_water_balance.js
+++ b/src/mmw/js/src/main_water_balance.js
@@ -130,10 +130,10 @@ var initBootstrap = function() {
 
     $('[data-toggle="popover"]').each(function(i, popover) {
         var $popover = $(popover),
-            nlcd = $popover.data('nlcd') || 'default',
+            category = $popover.data('category') || 'default',
             template = '<div class="popover" role="tooltip">' +
                 '<div class="arrow"></div>' +
-                '<h3 class="popover-title ' + ' ' + nlcd + '"></h3>' +
+                '<h3 class="popover-title ' + ' ' + category + '"></h3>' +
                 '<div class="popover-content"></div></div>',
             entry = modificationConfig[$popover.data('name')],
             options = {

--- a/src/mmw/sass/pages/_water-balance.scss
+++ b/src/mmw/sass/pages/_water-balance.scss
@@ -440,6 +440,38 @@
               background-color: $nlcd-90;
             }
           }
+
+          &.soil-a {
+            border-color: $soil-a;
+
+            &:after {
+              background-color: $soil-a;
+            }
+          }
+
+          &.soil-b {
+            border-color: $soil-b;
+
+            &:after {
+              background-color: $soil-b;
+            }
+          }
+
+          &.soil-c {
+            border-color: $soil-c;
+
+            &:after {
+              background-color: $soil-c;
+            }
+          }
+
+          &.soil-d {
+            border-color: $soil-d;
+
+            &:after {
+              background-color: $soil-d;
+            }
+          }
         }
       }
     }
@@ -532,6 +564,24 @@
   &.nlcd-90 {
     background-color: $nlcd-90;
     color: #333;
+  }
+
+  &.soil-a {
+    background-color: $soil-a;
+    color: #333;
+  }
+
+  &.soil-b {
+    background-color: $soil-b;
+    color: #333;
+  }
+
+  &.soil-c {
+    background-color: $soil-c;
+  }
+
+  &.soil-d {
+    background-color: $soil-d;
   }
 }
 

--- a/src/mmw/sass/pages/_water-balance.scss
+++ b/src/mmw/sass/pages/_water-balance.scss
@@ -414,6 +414,7 @@
 
             &:after {
               background-color: $nlcd-71;
+              color: #333;
             }
           }
 
@@ -422,6 +423,7 @@
 
             &:after {
               background-color: $nlcd-81;
+              color: #333;
             }
           }
 
@@ -438,6 +440,7 @@
 
             &:after {
               background-color: $nlcd-90;
+              color: #333;
             }
           }
 
@@ -446,6 +449,7 @@
 
             &:after {
               background-color: $soil-a;
+              color: #333;
             }
           }
 
@@ -454,6 +458,7 @@
 
             &:after {
               background-color: $soil-b;
+              color: #333;
             }
           }
 


### PR DESCRIPTION
Apply the same colors used to symbolize the various soil types on the main site in the micro site. 

**Testing**
- Visit the micro site.
- Select the various soil types and verify that the tile checkmark appears in the correct color for the active soil type.
- Hover over each soil type and verify that the popover header appears in the correct color for the soil type that is being hovered on.

![image](https://cloud.githubusercontent.com/assets/1042475/17118170/8237a9a2-528d-11e6-9b69-e17495ef5d52.png)

Connects to #1123 