### PR TITLE
Remove biochemical oxygen demand component

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -149,11 +149,10 @@ def aoi_resolution(area_of_interest):
 
 
 def format_quality(model_output):
-    measures = ['Biochemical Oxygen Demand',
-                'Total Suspended Solids',
+    measures = ['Total Suspended Solids',
                 'Total Nitrogen',
                 'Total Phosphorus']
-    codes = ['bod', 'tss', 'tn', 'tp']
+    codes = ['tss', 'tn', 'tp']
 
     def fn(input):
         measure, code = input

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -234,6 +234,10 @@ var utils = {
         }
     },
 
+    filterOutOxygenDemand: function(element) {
+        return element.measure !== "Biochemical Oxygen Demand";
+    },
+
     // Reverse sorting of a Backbone Collection.
     // Taken from http://stackoverflow.com/a/12220415/2053314
     reverseSortBy: function(sortByFunction) {

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -9,7 +9,8 @@ var $ = require('jquery'),
     barChartTmpl = require('../../../core/templates/barChart.html'),
     resultTmpl = require('./templates/result.html'),
     tableRowTmpl = require('./templates/tableRow.html'),
-    tableTmpl = require('./templates/table.html');
+    tableTmpl = require('./templates/table.html'),
+    utils = require('../../../core/utils.js');
 
 var ResultView = Marionette.LayoutView.extend({
     className: 'tab-pane',
@@ -51,8 +52,9 @@ var ResultView = Marionette.LayoutView.extend({
                 }));
             } else {
                 var dataCollection = new Backbone.Collection(
-                    this.model.get('result').quality
-                );
+                    this.model.get('result').quality.filter(
+                        utils.filterOutOxygenDemand
+                ));
 
                 this.tableRegion.show(new TableView({
                     aoiVolumeModel: this.aoiVolumeModel,
@@ -168,10 +170,9 @@ var CompareChartView = Marionette.ItemView.extend({
         }
 
         var chartEl = this.$el.find('.bar-chart').get(0),
-            result = this.model.get('result').quality,
+            result = this.model.get('result').quality.filter(utils.filterOutOxygenDemand),
             aoiVolumeModel = this.options.aoiVolumeModel,
-            seriesDisplayNames = ['Oxygen Demand',
-                                  'Suspended Solids',
+            seriesDisplayNames = ['Suspended Solids',
                                   'Nitrogen',
                                   'Phosphorus'],
             data,
@@ -181,7 +182,7 @@ var CompareChartView = Marionette.ItemView.extend({
         if (result) {
             data = getData(result, seriesDisplayNames);
             chartOptions = {
-                seriesColors: ['#1589ff', '#4aeab3', '#4ebaea', '#329b9c'],
+                seriesColors: ['#4aeab3', '#4ebaea', '#329b9c'],
                 yAxisLabel: 'Loading Rate (kg/ha)',
                 yAxisUnit: 'kg/ha',
                 margin: {top: 20, right: 0, bottom: 40, left: 60},


### PR DESCRIPTION
This PR removes the "biochemical oxygen demand" factor from TR-55 visualizations. 

- remove oxygen demand from water quality graph and chart
- remove oxygen demand from "Compare" bar chart

**Testing**
- grab this branch, `vagrant up`, and `./scripts/bundle.sh`
- visit `localhost:8000` in the browser and open the developer console
- choose a Square Kilometer draw area and select a spot on the map
- when the "Analyze" sidebar box appears, choose the "Site Storm Model" option to run TR-55
- verify that "Biochemical Oxygen Demand" no longer appears in either the "Runoff" or "Water Quality" visualizations
- click on "Compare". On that page, use the select boxes to toggle between "Runoff" and "Water Quality" for each scenario and verify that "Biochemical Oxygen Demand" no longer appears in those visualization
- verify that there weren't any errors in the console.

Connects #1174 