### PR TITLE
Add Loading Rate to TR55 Quality Views

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -234,6 +234,7 @@ var CompareModelingView = Marionette.LayoutView.extend({
             ResultView = modelingViews.getResultView(modelPackage, resultModel.get('name'));
 
         this.resultRegion.show(new ResultView({
+            areaOfInterest: this.projectModel.get('area_of_interest'),
             model: resultModel,
             scenario: this.model,
             compareMode: true

--- a/src/mmw/js/src/modeling/tr55/models.js
+++ b/src/mmw/js/src/modeling/tr55/models.js
@@ -28,6 +28,12 @@ var AoiVolumeModel = Backbone.Model.extend({
     adjust: function(depth) {
         // Adjusted runoff is depth (cm) -> meters * the AoI area (m2)
         return (depth / 100) * this.get('aoiArea');
+    },
+
+    getLoadingRate: function(load) {
+        // The loadingRate is the load per hectare.
+        // The aoiArea is in m^2, so we divide by 10000 to get hectares.
+        return load / (this.get('aoiArea') / 10000);
     }
 });
 

--- a/src/mmw/js/src/modeling/tr55/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/table.html
@@ -3,6 +3,7 @@
         <tr>
             <th data-sortable="true">Quality Measure</th>
             <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Load (kg)</th>
+            <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Loading Rate (kg/ha)</th>
             <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Average Concentration (mg/L)</th>
         </tr>
     </thead>

--- a/src/mmw/js/src/modeling/tr55/quality/templates/tableRow.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/tableRow.html
@@ -1,3 +1,4 @@
 <td>{{ measure }}</td>
 <td class="strong text-right">{{ load|round(3)|toLocaleString(3) }}</td>
+<td class="strong text-right">{{ loadingRate|round(3)|toLocaleString(3) }}</td>
 <td class="strong text-right">{{ concentration|round(1)|toLocaleString(1) }}</td>


### PR DESCRIPTION
This PR adds Loading Rate (kg/ha) as a column to the TR55 water quality table, and changes the charts to use Loading Rate instead of loads. 

![screen shot 2016-07-26 at 1 03 17 pm](https://cloud.githubusercontent.com/assets/1896461/17147598/7a7432ea-5331-11e6-97bb-1e27ff478353.png)
![screen shot 2016-07-26 at 1 03 56 pm](https://cloud.githubusercontent.com/assets/1896461/17147592/76154608-5331-11e6-993e-df2eff39837e.png)

##### Testing
* For a 1km AOI, run TR55, go to the Quality tab and check that the Loading Rate values are 1/100 of the Loads. 
* Check that the graph y value has been changed to Loading Rate in the normal and compare views, and that the values match those in the table.

Connects #1045