### PR TITLE
Display Mean Flow m^3/s to two decimal places

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
@@ -29,7 +29,7 @@
 
 
 <div class="mean-flow">
-    Mean Flow: {{ MeanFlow|round(0)|toLocaleString }} (m<sup>3</sup>/year) and {{ MeanFlowPerSecond|round(0)|toLocaleString }} (m<sup>3</sup>/s)
+    Mean Flow: {{ MeanFlow|round(0)|toLocaleString }} (m<sup>3</sup>/year) and {{ MeanFlowPerSecond|round(2)|toLocaleString }} (m<sup>3</sup>/s)
 </div>
 {{ table(landUseColumns, landUseRows, true) }}
 {{ table(summaryColumns, summaryRows, false) }}


### PR DESCRIPTION
This PR updates the display of the "Mean Flow" m<sup>3</sup>/s value in MapShed's Water Quality table to include two decimal places:

<img width="543" alt="screen shot 2016-08-10 at 10 14 46 am" src="https://cloud.githubusercontent.com/assets/4165523/17557021/93733d32-5ee3-11e6-9fe3-20d89f8e3671.png">

**Testing**
- get this branch, `vagrant up`, `./scripts/bundle.sh && ./scripts/debugserver.sh`
- visit `localhost:8000` in the browser
- draw an AOI somewhere on the map
- click on the "Model" tab in the "Analyze" window and select "Watershed Multi-Year Model" to run MapShed
- when MapShed polling completes, click on the `Water Quality` tab and verify that the value for "Mean Flow" m<sup>3</sup>/s has two decimal places.

Connects #1406  