### PR TITLE
Export GMS files with correctly replaced underscores

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -455,8 +455,8 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
         // We can't download a file from an AJAX call. One either has to
         // load the data in an iframe, or submit a form that responds with
         // Content-Disposition: attachment. We prefer submitting a form.
-        var filename = App.currentProject.get('name').replace(' ', '_') +
-                       '__' + this.model.get('name').replace(' ', '_');
+        var filename = App.currentProject.get('name').replace(/\s/g, '_') +
+                       '__' + this.model.get('name').replace(/\s/g, '_');
 
         this.ui.exportGmsForm.find('.gms-filename').val(filename);
         this.ui.exportGmsForm.submit();


### PR DESCRIPTION
## Overview

For friendlier file handling, we replace spaces with underscores in both the project and scenario name before downloading it. The previous implementation only replaced the first space inside the string, rather than all of them. This is an unfortunate although known quirk of JavaScript.

This solution replaces all occurrence of all whitespace within a project or scenario's name with an underscore. Sourced from this post in StackOverflow: http://stackoverflow.com/a/3795130/2053314

## Testing Instructions

Make a MapShed project. Rename it to something that has multiple spaces in it, for example "Little Neshaminy Creek without DRB factors" or something. Export a GMS file from the Current Conditions tab. It should download with the filename `Little_Neshaminy_Creek_without_DRB_factors__Current_Conditions.gms`.