### PR TITLE
Feature/gms output decimals

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -357,6 +357,10 @@ def to_gms_file(mapshed_data):
     """
     Given a dictionary of MapShed data, uses GWLF-E to convert it to a GMS file
     """
+
+    mapshed_areas = [round(a, 1) for a in mapshed_data['Area']]
+    mapshed_data['Area'] = mapshed_areas
+
     pre_z = parser.DataModel(mapshed_data)
     output = StringIO()
     writer = parser.GmsWriter(output)

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -357,7 +357,6 @@ def to_gms_file(mapshed_data):
     """
     Given a dictionary of MapShed data, uses GWLF-E to convert it to a GMS file
     """
-
     mapshed_areas = [round(a, 1) for a in mapshed_data['Area']]
     mapshed_data['Area'] = mapshed_areas
 

--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
@@ -1,4 +1,4 @@
-{% macro table(columnNames, rows, isSortable) %}
+{% macro table(columnNames, rows, isSortable, round_rows, default_precision) %}
 <table class="table custom-hover" data-toggle="table">
     <thead>
         <tr>
@@ -14,11 +14,17 @@
     <tbody>
         {% for row in rows %}
             <tr>
+                {% set precision = default_precision %}
                 {% for value in row %}
                     {% if loop.index0 == 0 %}
                         <td class="text-left">{{ value }}</td>
+                        {% for p in round_rows %}
+                            {% if p.source == value %}
+                                {% set precision = p.precision %}
+                            {% endif %}
+                        {% endfor %}
                     {% else %}
-                        <td class="strong text-right">{{ value|round(2)|toLocaleString(2) }}</td>
+                        <td class="strong text-right">{{ value|round(precision)|toLocaleString(precision) }}</td>
                     {% endif %}
                 {% endfor %}
             </tr>
@@ -27,9 +33,8 @@
 </table>
 {% endmacro %}
 
-
 <div class="mean-flow">
     Mean Flow: {{ MeanFlow|round(0)|toLocaleString }} (m<sup>3</sup>/year) and {{ MeanFlowPerSecond|round(2)|toLocaleString }} (m<sup>3</sup>/s)
 </div>
-{{ table(landUseColumns, landUseRows, true) }}
-{{ table(summaryColumns, summaryRows, false) }}
+{{ table(landUseColumns, landUseRows, true, renderPrecision.landUseTable, defaultPrecision.landUseTable) }}
+{{ table(summaryColumns, summaryRows, false, renderPrecision.summaryTable, defaultPrecision.summaryTable) }}

--- a/src/mmw/js/src/modeling/gwlfe/quality/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/quality/views.js
@@ -64,7 +64,19 @@ var TableView = Marionette.CompositeView.extend({
             landUseColumns: landUseColumns,
             landUseRows: landUseRows,
             summaryColumns: summaryColumns,
-            summaryRows: summaryRows
+            summaryRows: summaryRows,
+            renderPrecision: {
+                summaryTable: [
+                    {source: 'Total Loads (kg)', precision: 1},
+                    {source: 'Loading Rates (kg/ha)', precision: 2},
+                    {source: 'Mean Annual Concentration (mg/l)', precision: 2},
+                    {source: 'Mean Low-Flow Concentration (mg/l)', precision: 2}],
+                landUseTable: [],
+            },
+            defaultPrecision: {
+                summaryTable: 2,
+                landUseTable: 1,
+            },
         };
     }
 });


### PR DESCRIPTION
This changes the rounding convention for `Area` values written to the GMS file to round to one decimal place. It also updates the Water Quality table in the UI to round to one decimal place for some values, as specified in #1405 

To test, clone this branch and bring up the environment. In `src/mmw/apps/modeling/tasks.py`, add something resembling the following to the `to_gms_file` method:

`tmp = open('test_gms.txt', 'w+')`
`tmp.write(str(mapshed_data))`
`tmp.close()`

This will write the MapShed object that is later used to create the GMS file.

Execute `scripts/debugcelery.sh`, `scripts/debugserver.sh`, and `scripts/bundle.sh --debug --watch` and then navigate to `http://localhost:8000`. Go through the motions of a user and pick some geometry to analyze. When able, run the multi-year watershed model and wait for it to finish.

In `/src/mmw` directory there should be a file named `test_gms.txt` that has MapShed data, including the `Area` array that should now have a single decimal place. In the UI, the tables in the `Water Quality` pane should have one decimal place for all rows in the first table, and for the first row in the second table.

Connects #1405 