### PR TITLE
Adjust `NormalSys` values in pre-processor

### DIFF
--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -554,7 +554,7 @@ def landuse_pcts(n_count):
     ]
 
 
-def normal_sys(lu_area):
+def num_normal_sys(lu_area):
     """
     Given the land use area in hectares, estimates the number of normal septic
     systems based on the constants SSLDR and SSLDM for Residential and Mixed
@@ -563,13 +563,18 @@ def normal_sys(lu_area):
     effectively dependent only on the area of medium density mixed land use.
     However, we replicate the original formula for consistency.
 
+    Returns an array with an integer value for each month of the
+    year as input for GWLF-E.
+
     Original at Class1.vb@1.3.0:9577-9579
     """
 
     SSLDR = settings.GWLFE_CONFIG['SSLDR']
     SSLDM = settings.GWLFE_CONFIG['SSLDM']
 
-    return SSLDR * lu_area[14] + SSLDM * lu_area[11]
+    normal_sys_estimate = SSLDR * lu_area[14] + SSLDM * lu_area[11]
+    normal_sys_int = int(round(normal_sys_estimate))
+    return [normal_sys_int for n in xrange(12)]
 
 
 def sed_a_factor(landuse_pct_vals, cn, AEU, AvKF, AvSlope):

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -32,7 +32,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
                                          groundwater_nitrogen_conc,
                                          sediment_delivery_ratio,
                                          landuse_pcts,
-                                         normal_sys,
+                                         num_normal_sys,
                                          sed_a_factor
                                          )
 
@@ -148,7 +148,7 @@ def collect_data(geop_result, geojson):
     z['UrbAreaTotal'] = sum(z['Area'][NRur:])
     z['PhosConc'] = phosphorus_conc(z['SedPhos'])
 
-    z['NormalSys'] = normal_sys(z['Area'])
+    z['NumNormalSys'] = num_normal_sys(z['Area'])
 
     z['AgSlope3'] = geop_result['ag_slope_3_pct'] * area * HECTARES_PER_SQM
     z['AgSlope3To8'] = (geop_result['ag_slope_3_8_pct'] *


### PR DESCRIPTION
This PR updates some of the code by which MMW creates its MapShed dictionary for GWLF-E by changing the names of `NormalSys` values to match GWLF-E's expected key -- `NumNormalSys`. It also changes the value of that key to an array of 12 ints, which is what GWLF-E expects to receive for calculating the "Total Nitrogen" value for Septic Systems.

![screen shot 2016-08-15 at 11 40 37 am](https://cloud.githubusercontent.com/assets/4165523/17669816/28aa736e-62dd-11e6-8486-47aa8b9096d9.png)

The result so far only addresses the Total Nitrogen value: "Sediment" and "Total Phosphorus" remain 0 because we are using hard-coded 0 values for each.

The GWLF-E code returns a 0 for Septic/Sediment here: 
https://github.com/WikiWatershed/gwlf-e/blob/develop/gwlfe/WriteOutputFiles.py#L887

MMW hard codes the values necessary to generate "Total Phosphorus" to an array of 12 zeroes here:
https://github.com/WikiWatershed/model-my-watershed/blob/develop/src/mmw/mmw/settings/gwlfe_settings.py#L99

**Testing**
- grab this branch, `vagrant up`, `./scripts/bundle.sh` then visit `localhost:8000`
- select an area of interest to analyze, then run the MapShed model
- when modeling's done, select the "Water Quality" tab and scroll down to verify that there's a value for "Total Nitrogen"
- create a new scenario, then export a gms file
- from the command line run `cat <your-gms-file>.gms | sed '85,97!d'` and verify that position 1 at each of the lines after the first has a value

Connects #1370 