### PR TITLE
Upgrade Leaflet Draw to 0.3.0

### DIFF
--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -1506,9 +1506,9 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
     },
     "leaflet-draw": {
-      "version": "0.2.3",
-      "from": "../../tmp/npm-20250-abe6eb52/1438892615591-0.05360055458731949/e753b7d0eb9d1de8864ca85d5dafbf9ac955759c",
-      "resolved": "git://github.com/michaelguild13/Leaflet.draw#e753b7d0eb9d1de8864ca85d5dafbf9ac955759c"
+      "version": "0.3.0",
+      "from": "leaflet-draw@0.3.0",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-0.3.0.tgz"
     },
     "leaflet-plugins": {
       "version": "1.3.8",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -33,7 +33,7 @@
     "jshint": "2.8.0",
     "jstify": "0.9.0",
     "leaflet": "0.7.3",
-    "leaflet-draw": "git://github.com/michaelguild13/Leaflet.draw#e753b7d",
+    "leaflet-draw": "0.3.0",
     "leaflet-plugins": "git://github.com/azavea/leaflet-plugins#feature/browserify",
     "leaflet.locatecontrol": "0.43.0",
     "livereload": "0.3.7",


### PR DESCRIPTION
## Overview

Improves touch behavior on Windows touchscreens in Edge and Internet Explorer 11. Chrome still has issues when using the mouse, and Firefox when using the touchscreen.

## Testing Instructions

Test drawing a shape on various browsers on a Windows touchscreen device, using both the mouse and touchscreen.

Connects #649 