### PR TITLE
Upgrade to GWLF-E 0.6.0

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -10,7 +10,7 @@ python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
 tr55==1.1.3
-gwlf-e==0.5.0
+gwlf-e==0.6.0
 requests==2.9.1
 rollbar==0.12.1
 retry==0.9.1


### PR DESCRIPTION
This PR updates the app's requirements file to use GWLF-E 0.6.0, up from 0.5.0.

**Testing**
- grab this branch, `vagrant provision worker`, then `vagrant up`
- visit `localhost:8000` and run some mapshed jobs and verify that everything works as it should.

Connects #1415 