### PR TITLE
Use Precalculated LS, C, and P for Agricultural Land Uses

### DIFF
--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -254,7 +254,7 @@ def ag_ls_c_p(geom):
         return ag_lscp(*(cursor.fetchone()))
 
 
-def ls_factors(lu_strms, total_strm_len, areas, avg_slope):
+def ls_factors(lu_strms, total_strm_len, areas, avg_slope, ag_lscp):
     results = [0.0] * len(lu_strms)
     if 0 <= avg_slope <= 1.0:
         m = 0.2
@@ -265,7 +265,10 @@ def ls_factors(lu_strms, total_strm_len, areas, avg_slope):
     else:
         m = 0.5
 
-    for i in range(len(lu_strms)):
+    results[0] = ag_lscp.hp_ls
+    results[1] = ag_lscp.crop_ls
+
+    for i in xrange(2, 16):
         results[i] = (ls_factor(lu_strms[i] * total_strm_len * KM_PER_M,
                       areas[i], avg_slope, m))
 
@@ -639,7 +642,7 @@ def sed_a_factor(landuse_pct_vals, cn, AEU, AvKF, AvSlope):
             (0.000001 * AvSlope) - 0.000036)
 
 
-def p_factors(avg_slope):
+def p_factors(avg_slope, ag_lscp):
     """
     Given the average slope, calculates the P Factor for rural land use types.
 
@@ -657,8 +660,8 @@ def p_factors(avg_slope):
         ag_p = 0.74
 
     return [
-        ag_p,  # Hay/Pasture
-        ag_p,  # Cropland
+        ag_lscp.hp_p,    # Hay/Pasture
+        ag_lscp.crop_p,  # Cropland
         ag_p,  # Forest
         0.1,   # Wetland
         0.1,   # Disturbed

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -19,6 +19,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
                                          et_adjustment,
                                          kv_coefficient,
                                          animal_energy_units,
+                                         ag_ls_c_p,
                                          ls_factors,
                                          p_factors,
                                          manure_spread,
@@ -111,6 +112,10 @@ def collect_data(geop_result, geojson):
     z['WxYrs'] = z['WxYrEnd'] - z['WxYrBeg'] + 1
 
     # Data from the County Animals dataset
+    ag_lscp = ag_ls_c_p(geom)
+    z['C'][0] = ag_lscp.hp_c
+    z['C'][1] = ag_lscp.crop_c
+
     livestock_aeu, poultry_aeu, population = animal_energy_units(geom)
     z['AEU'] = livestock_aeu / (area * ACRES_PER_SQM)
     z['n41j'] = livestock_aeu
@@ -180,9 +185,9 @@ def collect_data(geop_result, geojson):
                                    z['CN'], z['AEU'], z['AvKF'], z['AvSlope'])
 
     z['LS'] = ls_factors(geop_result['lu_stream_pct'], z['StreamLength'],
-                         z['Area'], z['AvSlope'])
+                         z['Area'], z['AvSlope'], ag_lscp)
 
-    z['P'] = p_factors(z['AvSlope'])
+    z['P'] = p_factors(z['AvSlope'], ag_lscp)
 
     return z
 


### PR DESCRIPTION
## Overview

Original MapShed uses a Flow Accumulation method to calculate the LS factor for a given area of interest. However, due to missing data, we have been using the Stream Flow method. Unfortunately, this is less accurate, especially for agricultural land uses such as Hay/Pasture and Cropland.

To alleviate this, Dr. Barry Evans has provided us with an updated county data file, which we import to the `ms_county_animals` table, that includes these new columns:

+    `crop_ls` numeric(6,3),
+    `hp_ls` numeric(6,3),
+    `crop_c` numeric(6,3),
+    `crop_p` numeric(6,3),
+    `hp_c` numeric(6,3),
+    `hp_p` numeric(6,3)

Which correspond to the LS, C and P factor values for Hay/Pasture and Cropland for each county.

Our new approach is to calculated the area-weighted average of each of these values for all counties in an area of interest, and use them instead of the regular calculations. Regular calculations are still used for all other land use types.

## Testing Instructions

Choose a standard shape, such as a HUC-12, on `develop`, create a MapShed project and export a GMS file from the Current Conditions scenario.

Check out this branch. Update the `ms_county_animals` dataset to include the new columns:

```bash
$ vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -f ms_county_animals.sql.gz'
```

Run Celery in the debugger to make sure it picks up new changes:

```bash
$ ./scripts/debugcelery.sh
```

Create a new MapShed project with the same standard shape as before, and export another GMS file from the Current Conditions scenario. You should see differences in the LS, C, and P values of Hay/Pasture and Cropland:

```diff
--- Little_Neshaminy_develop_20160816__Current_Conditions.gms	2016-08-16 13:32:14.000000000 -0400
+++ Little_Neshaminy_with_Corrected_LS_C_P__Current_Conditions.gms	2016-08-16 15:51:56.000000000 -0400
@@ -17,8 +17,8 @@
 Oct,1.0457270621091717,10.8,0,0.091,0,0,1.385
 Nov,1.0087081300568108,9.7,0,0.091,0,0,1.385
 Dec,0.9872371494664416,9.1,0,0.091,0,0,1.385
-Hay/Past,803.1,75,0.2714132968948771,0.22836631257618079,0.03,0.45
-Cropland,571.1,82,0.27604142433856804,0.22735773644384383,0.42,0.45
+Hay/Past,803.1,75,0.2714132968948771,0.849484581102515,0.01,1
+Cropland,571.1,82,0.27604142433856804,0.738799109654387,0.258101173614922,0.773079185225836
 Forest,2071.0,73,0.27157785493664266,0.2151564164245495,0.002,0.45
 Wetland,364.7,88.5,0.31307519406197576,0.20441617849311078,0.01,0.1
 Disturbed,0.0,0,0,0,0.08,0.1
```

## Deployment Notes

The `ms_county_animals` table will have to be reloaded on Staging and Production whenever this is deployed. This should be very straightforward as nothing links to that table, and the `DROP` will be handled by the script itself. Run the deployment equivalent of this Vagrant command:

```bash
$ vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -f ms_county_animals.sql.gz'
```

Connects #1418 