### PR TITLE
Retrieve and display weighted animal population

### DIFF
--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+from django.contrib.gis.geos import GEOSGeometry
+
+from django.conf import settings
+
+from apps.modeling.mapshed.calcs import animal_energy_units
+
+ANIMAL_KEYS = settings.GWLFE_CONFIG['AnimalKeys']
+ANIMAL_NAMES = settings.GWLFE_DEFAULTS['AnimalName']
+
+ANIMAL_DISPLAY_NAMES = dict(zip(ANIMAL_KEYS, ANIMAL_NAMES))
+
+
+def animal_population(geojson):
+    """
+    Given a GeoJSON shape, call MapShed's `animal_energy_units` method
+    to calculate the area-weighted county animal population. Returns a
+    dictionary to append to the outgoing JSON for analysis results.
+    """
+    geom = GEOSGeometry(geojson, srid=4326)
+    aeu_for_geom = animal_energy_units(geom)[2]
+    aeu_return_values = []
+
+    for animal, aeu_value in aeu_for_geom.iteritems():
+        aeu_return_values.append({
+            'type': ANIMAL_DISPLAY_NAMES[animal],
+            'aeu': int(round(aeu_value)),
+        })
+
+    return {
+        'displayName': 'Animals',
+        'name': 'animals',
+        'categories': aeu_return_values
+    }

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -165,15 +165,15 @@ def animal_energy_units(geom):
                      clipped_counties.*
               FROM clipped_counties
           )
-          SELECT SUM(beef_ha * totalha * clip_percent) AS beef_cows,
-                 SUM(broiler_ha * totalha * clip_percent) AS broilers,
-                 SUM(dairy_ha * totalha * clip_percent) AS dairy_cows,
-                 SUM(goat_ha * totalha * clip_percent) +
-                 SUM(sheep_ha * totalha * clip_percent) AS sheep,
-                 SUM(hog_ha * totalha * clip_percent) AS hogs,
-                 SUM(horse_ha * totalha * clip_percent) AS horses,
-                 SUM(layer_ha * totalha * clip_percent) AS layers,
-                 SUM(turkey_ha * totalha * clip_percent) AS turkeys
+          SELECT SUM(beef_ha * ag_ha * clip_percent) AS beef_cows,
+                 SUM(broiler_ha * ag_ha * clip_percent) AS broilers,
+                 SUM(dairy_ha * ag_ha * clip_percent) AS dairy_cows,
+                 SUM(goat_ha * ag_ha * clip_percent) +
+                 SUM(sheep_ha * ag_ha * clip_percent) AS sheep,
+                 SUM(hog_ha * ag_ha * clip_percent) AS hogs,
+                 SUM(horse_ha * ag_ha * clip_percent) AS horses,
+                 SUM(layer_ha * ag_ha * clip_percent) AS layers,
+                 SUM(turkey_ha * ag_ha * clip_percent) AS turkeys
           FROM clipped_counties_with_area;
           '''
 

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -15,6 +15,8 @@ from celery import shared_task
 from apps.modeling.geoprocessing import histogram_start, histogram_finish, \
     data_to_survey, data_to_censuses
 
+from apps.modeling.calcs import animal_population
+
 from tr55.model import simulate_day
 from gwlfe import gwlfe, parser
 
@@ -102,7 +104,7 @@ def get_histogram_job_results(self, incoming):
 
 
 @shared_task
-def histogram_to_survey(incoming):
+def histogram_to_survey(incoming, aoi):
     """
     Converts the histogram results (aka analyze results)
     to a survey of land use, which are rendered in the UI.
@@ -111,6 +113,7 @@ def histogram_to_survey(incoming):
     data = incoming['histogram'][0]
     results = data_to_survey(data)
     convert_result_areas(pixel_width, results)
+    results.append(animal_population(aoi))
 
     return results
 

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -364,7 +364,7 @@ def _initiate_analyze_job_chain(area_of_interest, job_id, testing=False):
                  .set(exchange=exchange, routing_key=routing_key),
                  tasks.get_histogram_job_results.s()
                  .set(exchange=exchange, routing_key=routing_key),
-                 tasks.histogram_to_survey.s()
+                 tasks.histogram_to_survey.s(area_of_interest)
                  .set(exchange=exchange, routing_key=choose_worker()),
                  save_job_result.s(job_id, area_of_interest)
                  .set(exchange=exchange, routing_key=choose_worker())) \

--- a/src/mmw/js/src/analyze/templates/animalTable.html
+++ b/src/mmw/js/src/analyze/templates/animalTable.html
@@ -1,0 +1,12 @@
+<table class="table custom-hover" data-toggle="table">
+    <thead>
+        <tr>
+            <th data-sortable="true">Animal</th>
+            <th class="text-right" data-sortable="true" data-sorter="window.numericSort">
+                Count
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>

--- a/src/mmw/js/src/analyze/templates/animalTableRow.html
+++ b/src/mmw/js/src/analyze/templates/animalTableRow.html
@@ -1,0 +1,2 @@
+<td>{{ type }}</td>
+<td class="strong text-right">{{ aeu|toLocaleString() }}</td>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -18,6 +18,8 @@ var $ = require('jquery'),
     aoiHeaderTmpl = require('./templates/aoiHeader.html'),
     tableTmpl = require('./templates/table.html'),
     tableRowTmpl = require('./templates/tableRow.html'),
+    animalTableTmpl = require('./templates/animalTable.html'),
+    animalTableRowTmpl = require('./templates/animalTableRow.html'),
     tabPanelTmpl = require('../modeling/templates/resultsTabPanel.html'),
     tabContentTmpl = require('./templates/tabContent.html'),
     barChartTmpl = require('../core/templates/barChart.html'),
@@ -244,7 +246,9 @@ var TabContentView = Marionette.LayoutView.extend({
             units = utils.magnitudeOfArea(largestArea),
             census = this.model.get('name') === 'land' ?
                 new coreModels.LandUseCensusCollection(categories) :
-                new coreModels.SoilCensusCollection(categories);
+                this.model.get('name') === 'soil' ?
+                new coreModels.SoilCensusCollection(categories) :
+                new coreModels.AnimalCensusCollection(categories);
 
         this.aoiRegion.show(new AoiView({
             model: new coreModels.GeoModel({
@@ -253,15 +257,22 @@ var TabContentView = Marionette.LayoutView.extend({
             })
         }));
 
-        this.tableRegion.show(new TableView({
-            units: units,
-            collection: census
-        }));
+        if (this.model.get('name') === 'animals') {
+            this.tableRegion.show(new AnimalTableView({
+                units: units,
+                collection: census
+            }));
+        } else {
+            this.tableRegion.show(new TableView({
+                units: units,
+                collection: census
+            }));
 
-        this.chartRegion.show(new ChartView({
-            model: this.model,
-            collection: census
-        }));
+            this.chartRegion.show(new ChartView({
+                model: this.model,
+                collection: census
+            }));
+        }
     }
 });
 
@@ -313,6 +324,35 @@ var TableView = Marionette.CompositeView.extend({
     }
 });
 
+var AnimalTableRowView = Marionette.ItemView.extend({
+    tagName: 'tr',
+    template: animalTableRowTmpl,
+    templateHelpers: function() {
+        return {
+            aeu: this.model.get('aeu'),
+        };
+    }
+});
+
+var AnimalTableView = Marionette.CompositeView.extend({
+    childView: AnimalTableRowView,
+    childViewOptions: function() {
+        return {
+            units: this.options.units
+        };
+    },
+    templateHelpers: function() {
+        return {
+            headerUnits: this.options.units
+        };
+    },
+    childViewContainer: 'tbody',
+    template: animalTableTmpl,
+
+    onAttach: function() {
+        $('[data-toggle="table"]').bootstrapTable();
+    }
+});
 
 var ChartView = Marionette.ItemView.extend({
     template: barChartTmpl,

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -245,6 +245,10 @@ var SoilCensusCollection = Backbone.Collection.extend({
     comparator: 'code'
 });
 
+var AnimalCensusCollection = Backbone.Collection.extend({
+    comparator: 'type'
+});
+
 var GeoModel = Backbone.Model.extend({
     M_IN_KM: 1000000,
 
@@ -298,6 +302,7 @@ module.exports = {
     TaskMessageViewModel: TaskMessageViewModel,
     LandUseCensusCollection: LandUseCensusCollection,
     SoilCensusCollection: SoilCensusCollection,
+    AnimalCensusCollection: AnimalCensusCollection,
     GeoModel: GeoModel,
     AreaOfInterestModel: AreaOfInterestModel,
     AppStateModel: AppStateModel

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -13,7 +13,6 @@
   height: 300px;
   vertical-align: baseline;
   vertical-align: bottom;
-  margin-bottom: 20px;
 
   .nv-bar {
     fill: $brand-primary;

--- a/src/mmw/sass/components/_tables.scss
+++ b/src/mmw/sass/components/_tables.scss
@@ -47,6 +47,7 @@
 
 .fixed-table-container {
   padding-bottom: 0px !important;
+  margin-top: 20px;
 
   thead th .th-inner {
     white-space: normal;


### PR DESCRIPTION
This PR updates the "Analyze" tab results to include a livestock tab which displays the weighted animal population presented in terms of "AEU per hectare" and "AEU Proportion" -- e.g., what percentage each animal type comprises of the total animal AEU per hectare.

This works by making a database query with the input aoi to retrieve data from `ms_county_animals`, then appending it to the outgoing analyze results. There are a few commits here:

- the first commit sets up the backend to retrieve and parse the animal data, then append it to the outgoing json results
- the second updates some of the CSS to make the style rules amenable to displaying an analyze tab with just a table and no bar chart
- third handles setting up a model, view, and template for the livestock tab in the front-end code
- fourth is a fixup to remove code which retrieved what I believe is some unnecessary data pulled from the db in the first commit (I'll squash before merging)

The results currently look like this:

![screen shot 2016-08-22 at 12 25 54 pm](https://cloud.githubusercontent.com/assets/4165523/17862740/8ee2b092-6864-11e6-8fbb-1a845ac26341.png)

![screen shot 2016-08-22 at 12 26 19 pm](https://cloud.githubusercontent.com/assets/4165523/17862745/9451a10a-6864-11e6-9639-432e1b106cec.png)

**Testing**
- get this branch, `vagrant up`, `./scripts/bundle.sh`, then open the browser console and visit `localhost:8000`
- select an aoi to analyze
- verify that the results now includes a "Livestock" tab which displays AEU per hectare in one column and a percentage value in the other column
- repeat with a few more aois
- try looking at some of the other pre-existing analyze tabs and also modeling an aoi to verify that nothing has changed with them as a result of these changes
- verify that you haven't seen any errors in the console.

Connects #1424 