### PR TITLE
Enable zoom/attribute dependent stream rendering

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -78,7 +78,7 @@ function validateClickedPointWithinDRB(latlng) {
     var point = L.marker(latlng).toGeoJSON(),
         d = $.Deferred(),
         streamLayers = settings.get('stream_layers'),
-        drbPerimeter = _.findWhere(streamLayers, {code:'drb_streams'}).perimeter;
+        drbPerimeter = _.findWhere(streamLayers, {code:'drb_streams_v1'}).perimeter;
     if (turfIntersect(point, drbPerimeter)) {
         d.resolve(latlng);
     } else {

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -153,7 +153,7 @@ LAYERS = [
         'table_name': 'nhdflowline',
         'stream': True,
         'overlay': True,
-        'minZoom': 10
+        'minZoom': 3
     },
     {
         'code': 'drb_streams',
@@ -161,8 +161,8 @@ LAYERS = [
         'table_name': 'drb_streams_50',
         'stream': True,
         'overlay': True,
-        'minZoom': 11,
-        'perimeter': drb_perimeter # Layer is only selectable when viewport
+        'minZoom': 5,
+        'perimeter': drb_perimeter  # Layer is only selectable when viewport
         # overlaps with perimeter polygon.
     },
     {

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -148,7 +148,7 @@ LAYERS = [
         'minZoom': 9,
     },
     {
-        'code': 'stream',
+        'code': 'nhd_streams_v1',
         'display': 'National Stream Network',
         'table_name': 'nhdflowline',
         'stream': True,
@@ -156,7 +156,7 @@ LAYERS = [
         'minZoom': 3
     },
     {
-        'code': 'drb_streams',
+        'code': 'drb_streams_v1',
         'display': 'DRB Stream Network',
         'table_name': 'drb_streams_50',
         'stream': True,

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -33,8 +33,8 @@ var interactivity = {
         huc8: 'boundary_huc08',
         huc10: 'boundary_huc10',
         huc12: 'boundary_huc12',
-        'drb_streams': 'drb_streams_50',
-        stream: 'nhdflowline',
+        drb_streams_v1: 'drb_streams_50',
+        nhd_streams_v1: 'nhdflowline',
         municipalities: 'dep_municipalities',
         urban_areas: 'dep_urban_areas'
     },

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -35,19 +35,119 @@
   }
 }
 
+@streamColor: #1562A9;
 @zoomBase: 0.5;
 
-#drb_streams_50,
-#nhdflowline
-{
-  line-color: #1562A9;
-  [zoom<=10] { line-width: 1.0 * @zoomBase; }
-  [zoom=11] { line-width: 2.0 * @zoomBase; }
-  [zoom=12] { line-width: 4.0 * @zoomBase; }
-  [zoom=13] { line-width: 6.0 * @zoomBase; }
-  [zoom=14] { line-width: 8.0 * @zoomBase; }
-  [zoom=15] { line-width: 10.0 * @zoomBase; }
-  [zoom=16] { line-width: 12.0 * @zoomBase; }
-  [zoom=17] { line-width: 14.0 * @zoomBase; }
-  [zoom=18] { line-width: 16.0 * @zoomBase; }
+/* DRB and NHD Streams have custom SQL which is executed for tile requests
+   that is dynamically generated from the requested zoom level.  This filters
+   stream features out below a certain threshold of stream_order per zoom level.
+   Ensure that any changes to which stream_order + zoom levels are rendered
+   here have appropriate coinciding filters in server.js
+*/
+#drb_streams_50[zoom<=4],
+#nhdflowline[zoom<=4] {
+  [stream_order=10] {
+    line-color: @streamColor;
+    line-width: 5.0 * @zoomBase;
+  }
+  [stream_order=9] {
+    line-color: @streamColor;
+    line-width: 3.0 * @zoomBase;
+  }
+  [stream_order<=8] {
+    line-color: @streamColor;
+    line-width: 2.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom>=5][zoom<=6],
+#nhdflowline[zoom>=5][zoom<=6] {
+  [stream_order=10] {
+    line-color: @streamColor;
+    line-width: 7.0 * @zoomBase;
+  }
+  [stream_order=9] {
+    line-color: @streamColor;
+    line-width: 4.0 * @zoomBase;
+  }
+  [stream_order<=8] {
+    line-color: @streamColor;
+    line-width: 3.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom>=7][zoom<=8],
+#nhdflowline[zoom>=7][zoom<=8] {
+  [stream_order>=9] {
+    line-color: @streamColor;
+    line-width: 10.0 * @zoomBase;
+  }
+  [stream_order<=8][stream_order>=7] {
+    line-color: @streamColor;
+    line-width: 7.0 * @zoomBase;
+  }
+  [stream_order<=6] {
+    line-color: @streamColor;
+    line-width: 4.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom>=9][zoom<=10],
+#nhdflowline[zoom>=9][zoom<=10] {
+  [stream_order>=9] {
+    line-color: @streamColor;
+    line-width: 15.0 * @zoomBase ;
+  }
+  [stream_order<=8][stream_order>=6] {
+    line-color: @streamColor;
+    line-width:  10.0 * @zoomBase;
+  }
+  [stream_order=5] {
+    line-color: @streamColor;
+    line-width: 7.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom>=11][zoom<=12],
+#nhdflowline[zoom>=11][zoom<=12] {
+  [stream_order>=9] {
+    line-color: @streamColor;
+    line-width: 18.0 * @zoomBase;
+  }
+  [stream_order<=8][stream_order>=6] {
+    line-color: @streamColor;
+    line-width: 12.0 * @zoomBase;
+  }
+  [stream_order<=5][stream_order>=4] {
+    line-color: @streamColor;
+    line-width:  9.0 * @zoomBase;
+  }
+  [stream_order=3] {
+    line-color: @streamColor;
+    line-width:  6.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom>=13],
+#nhdflowline[zoom>=13] {
+  [stream_order>=9] {
+    line-color: @streamColor;
+    line-width: 18.0 * @zoomBase;
+  }
+  [stream_order<=8][stream_order>=6] {
+    line-color: @streamColor;
+    line-width: 14.0 * @zoomBase;
+  }
+  [stream_order<=5][stream_order>=3] {
+    line-color: @streamColor;
+    line-width:  10.0 * @zoomBase;
+  }
+  [stream_order=2] {
+    line-color: @streamColor;
+    line-width:  8.0 * @zoomBase;
+  }
+  [stream_order<=1][stream_order>=0] {
+    line-color: @streamColor;
+    line-width:  5.0 * @zoomBase;
+  }
 }


### PR DESCRIPTION
#### Overview
For both NHD Plus and DRB streams, configure the cartographic styling
to limit streams of a high Stream Order (scale is 10-0, large to small)
to be visible at low zoom levels (high altitude).  As the zoom level
increases, more streams of lower stream order are shown and the stroke
width of the rendered line corresponds to the relative stream order.
The effect should be a gradual increase in detail of streams as the
user zooms in, and streams of a higher Stream Order should appear
larger than those of a smaller order.

The intent isn't to make the stream order attribute apparent from
viewing the stream, but to give a relative indication of size and limit
the number of streams shown when zoomed out.

Since the DRB and NHD streams vary considerably in density of streams
at every zoom level, some of the sizes were adjusted to accommodate a
reasonable appearance for both datasets while keeping the width of the
stream the same, per stream order, per dataset.

Connects #1409 
Connects #1411 

#### Testing
* Restart your tile and app server to ensure that the latest styling changes and zoom configurations are present
  * `vagrant ssh tiler -c "sudo service mmw-tiler restart"`
  * `vagrant ssh app -c "sudo service mmw-app restart"`
* Starting at zoom 7, enable the National Stream overlay (this is not fast, since it's doing a large geographic query, but will be cached in stage/prod)
* Zoom in, noticing that more "smaller" streams appear the closer you get
* Do the same in the DRB, starting at zoom 10

#### Code evaluation
It will be helpful to understand that in CartoCSS `[][]` is a logical `AND` and `[], []` is a logical `OR`.

This may not be the final set of zoom/attribute breaks, I'm sure the client will have feedback for a desired distribution.