### PR TITLE
Rename `DRB` -> `Delaware River Basin`

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -135,7 +135,8 @@ LAYERS = [
     },
     {
         'code': 'drb_streams_v1',
-        'display': 'DRB Stream Network',
+        'display': ('Delaware River Basin High Resolution' +
+            '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Stream Network'),
         'table_name': 'drb_streams_50',
         'stream': True,
         'overlay': True,


### PR DESCRIPTION
This PR renames "DRB Stream Network" to "Delaware River Basin Stream Network" in the frontend layer selector control:

<img width="617" alt="screen shot 2016-08-26 at 9 56 35 am" src="https://cloud.githubusercontent.com/assets/4165523/18007893/da887858-6b73-11e6-8eca-aafddbf7c866.png">

**Testing**
- get this branch, `vagrant up`, `'./scripts/bundle.sh`, then visit `localhost:8000` and open the browser console
- click on the layer selector control, select the "Overlays" tab, and verify that "DRB Stream Network" now reads "Delaware River Basin Stream Network", that the selector still works to toggle the layer, and that there are no errors in the console

Connects #1429 