### PR TITLE
Align animal population counts rounding

### DIFF
--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -28,7 +28,7 @@ def animal_population(geojson):
     for animal, aeu_value in aeu_for_geom.iteritems():
         aeu_return_values.append({
             'type': ANIMAL_DISPLAY_NAMES[animal],
-            'aeu': int(round(aeu_value)),
+            'aeu': int(aeu_value),
         })
 
     return {


### PR DESCRIPTION
This PR adjusts the rounding of the animal population count estimate displayed in the "Analyze" tab to round the float down rather than up so that it matches how MapShed rounds animal population counts for the GMS file.

**Testing**
- get this branch, `vagrant up`, then visit `localhost:8000` and open the browser console
- select an AOI and let the Analyze tab return results
- run a MapShed job on the AOI, then export a GMS file
- open the GMS file and search for "Dairy Cows"
- click back on the "Analyze" tab and verify that the integer count for Dairy Cows is the same as the number immediately to the right of "Dairy Cows" in the GMS file
- verify the same for the other animal population counts

Connects #1431 