### PR TITLE
Display Point Source Data in "Analyze" Tab

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -15,7 +15,8 @@ from celery import shared_task
 from apps.modeling.geoprocessing import histogram_start, histogram_finish, \
     data_to_survey, data_to_censuses
 
-from apps.modeling.calcs import animal_population
+from apps.modeling.calcs import (animal_population,
+                                 point_source_pollution)
 
 from tr55.model import simulate_day
 from gwlfe import gwlfe, parser
@@ -114,6 +115,7 @@ def histogram_to_survey(incoming, aoi):
     results = data_to_survey(data)
     convert_result_areas(pixel_width, results)
     results.append(animal_population(aoi))
+    results.append(point_source_pollution(aoi))
 
     return results
 

--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -1,0 +1,28 @@
+<table class="table custom-hover" data-toggle="table">
+    <thead>
+        <tr>
+            <th data-sortable="true">Code</th>
+            <th data-sortable="true">City</th>
+            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                Discharge (MGD)
+            </th>
+            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                TN Load (kg/yr)
+            </th>
+            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                TP Load (kg/yr)
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+    <tfoot>
+        <tr class="ptsrc-table-footer">
+            <td></td>
+            <td class="strong text-right">Total</th>
+            <td class="ptsrc-footer-item strong text-right">{{ totalMGD|toLocaleString() }}</td>
+            <td class="ptsrc-footer-item strong text-right">{{ totalKGN|toLocaleString() }}</td>
+            <td class="ptsrc-footer-item strong text-right">{{ totalKGP|toLocaleString() }}</td>
+        </tr>
+    </tfoot>
+</table>

--- a/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
@@ -1,0 +1,5 @@
+<td>{{ npdes_id }}</td>
+<td>{{ city|title }}</td>
+<td class="strong text-right">{{ mgd|toLocaleString() if mgd else "no data" }}</td>
+<td class="strong text-right">{{ kgn_yr|toLocaleString() if kgn_yr else "no data" }}</td>
+<td class="strong text-right">{{ kgp_yr|toLocaleString() if kgp_yr else "no data" }}</td>

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -249,6 +249,10 @@ var AnimalCensusCollection = Backbone.Collection.extend({
     comparator: 'type'
 });
 
+var PointSourceCensusCollection = Backbone.Collection.extend({
+    comparator: 'city'
+});
+
 var GeoModel = Backbone.Model.extend({
     M_IN_KM: 1000000,
 
@@ -303,6 +307,7 @@ module.exports = {
     LandUseCensusCollection: LandUseCensusCollection,
     SoilCensusCollection: SoilCensusCollection,
     AnimalCensusCollection: AnimalCensusCollection,
+    PointSourceCensusCollection: PointSourceCensusCollection,
     GeoModel: GeoModel,
     AreaOfInterestModel: AreaOfInterestModel,
     AppStateModel: AppStateModel

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var _ = require('underscore'),
+    lodash = require('lodash'),
     md5 = require('blueimp-md5').md5,
     intersect = require('turf-intersect');
 
@@ -92,6 +93,18 @@ var utils = {
         } else {
             return 1;
         }
+    },
+
+    noDataSort: function(x, y) {
+        var noData = 'no data';
+        if (x === noData && y !== noData) {
+            return -1;
+        } else if (x === noData && y === noData) {
+            return 0;
+        } else if (x !== noData && y === noData) {
+            return 1;
+        }
+        return utils.numericSort(x, y);
     },
 
     // Parse query strings for Backbone
@@ -254,6 +267,12 @@ var utils = {
 
             return l < r ? 1 : l > r ? -1 : 0;
         };
+    },
+
+    totalForPointSourceCollection: function(collection, key) {
+        return lodash.sum(lodash.map(collection, function(element) {
+            return element.attributes[key] || 0;
+        }));
     }
 };
 

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -35,6 +35,10 @@ App.start();
 // is available for use in templates.
 window.numericSort = utils.numericSort;
 
+// This comparator sorts a table with "no data" fields intermixed
+// with numeric fields.
+window.noDataSort = utils.noDataSort;
+
 //
 // Expose application so we can interact with it via JS console.
 //

--- a/src/mmw/sass/components/_tables.scss
+++ b/src/mmw/sass/components/_tables.scss
@@ -62,3 +62,11 @@
         color: $brand-primary;
     }
 }
+
+.ptsrc-table-footer {
+    border-top: 1px solid #ddd;
+}
+
+.ptsrc-footer-item {
+    border-left: 1px solid #ddd;
+}


### PR DESCRIPTION
This PR adds Point Source data from the `ms_pointsource` table to MMW's "Analyze" tab:

<img width="1033" alt="screen shot 2016-08-29 at 4 56 30 pm" src="https://cloud.githubusercontent.com/assets/4165523/18067176/a3973e36-6e09-11e6-898b-8da18e282fc4.png">

Since some of the columns in that data set contain null values, I've replaced the null value with "no data" and I've added a comparator method to handle sorting the HTML table. The PR also adds a method to reduce the values in each column to a single value for the Total row in the table footer.

**Testing**
- grab this branch, `vagrant up`, `./scripts/bundle.sh` then visit `localhost:8000` and open the browser console
- hard refresh the page to load js code from this branch
- search for an AOI and verify that when the results return the Analyze tab now includes a Point Source sub-tab which presents the point source data in a table with sortable columns.

Connects #1437 