### PR TITLE
Add Point Source locations layer to Observations tab

### DIFF
--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -30,4 +30,5 @@ urlpatterns = patterns(
     url(r'boundary-layers/(?P<table_code>\w+)/(?P<obj_id>[0-9]+)/$',
         views.boundary_layer_detail, name='boundary_layer_detail'),
     url(r'export/gms/?$', views.export_gms, name='export_gms'),
+    url(r'point-source/$', views.drb_point_sources, name='drb_point_sources'),
 )

--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -5,7 +5,8 @@ var L = require('leaflet'),
     _ = require('underscore'),
     Marionette = require('../../shim/backbone.marionette'),
     layerControlListTmpl = require('./templates/layerControlList.html'),
-    layerControlButtonTmpl = require('./templates/layerControlButton.html');
+    layerControlButtonTmpl = require('./templates/layerControlButton.html'),
+    pointSourceLayer = require('./pointSourceLayer.js');
 
 module.exports = L.Control.Layers.extend({
 
@@ -28,13 +29,15 @@ module.exports = L.Control.Layers.extend({
             this._addLayer(overlays[i], i, 'overlay');
         }
 
-        observationsDeferred
-            .done(function(observationLayers) {
+        var pointSrcAPIUrl = '/api/modeling/point-source/';
+
+        $.when(observationsDeferred, $.ajax({ 'url': pointSrcAPIUrl, 'type': 'GET'}))
+            .done(function(observationLayers, pointSourceData) {
                 for (i in observationLayers) {
                     self._addLayer(observationLayers[i], i, 'observation');
                 }
-
-                // Redraw the UI with the new layers
+                self._addLayer(pointSourceLayer.createLayer(pointSourceData[0],
+                    self._map), 'DRB Point Source', 'observation');
                 self._update();
             })
             .fail(function(reason) {

--- a/src/mmw/js/src/core/pointSourceLayer.js
+++ b/src/mmw/js/src/core/pointSourceLayer.js
@@ -1,0 +1,47 @@
+"use strict";
+
+var L = require('leaflet'),
+    $ = require('jquery'),
+    utils = require('./utils'),
+    Backbone = require('../../shim/backbone'),
+    Marionette = require('../../shim/backbone.marionette'),
+    pointSourcePopupTmpl = require('./templates/pointSourcePopup.html');
+
+// Increase or decrease the marker size based on the map zoom level
+var markerSizesForZoomLevels = [0.05, 0.1, 0.2, 0.25, 0.5, 0.75, 1, 1.25, 1.75,
+    2, 2.25, 3, 6, 8, 10, 10, 10, 10, 10];
+
+module.exports = {
+    createLayer: function(geojsonFeatureCollection, leafletMap) {
+        return L.geoJson($.parseJSON(geojsonFeatureCollection), {
+            pointToLayer: function (feature, latlng) {
+                return L.circleMarker(latlng, {
+                    fillColor: "#ff7800",
+                    weight: 0,
+                    fillOpacity: 0.75
+                });
+            },
+            onEachFeature: function(feature, marker) {
+                var model = new Backbone.Model(feature.properties),
+                    view = new PointSourcePopupView({model: model});
+                leafletMap.on('zoomend', function(e) {
+                    var newZoomLevel = e.target._zoom;
+                    marker.setStyle({
+                        radius: markerSizesForZoomLevels[newZoomLevel]
+                    });
+                });
+                marker.bindPopup(view.render().el);
+            },
+        });
+    }
+};
+
+var PointSourcePopupView = Marionette.ItemView.extend({
+    template: pointSourcePopupTmpl,
+    className: 'point-source-popup',
+    templateHelpers: function() {
+        return {
+            noData: utils.noData
+        };
+    }
+});

--- a/src/mmw/js/src/core/templates/pointSourcePopup.html
+++ b/src/mmw/js/src/core/templates/pointSourcePopup.html
@@ -1,0 +1,35 @@
+<h2 class="measurements-name">NPDES Code: {{ npdes_id }}</h2>
+<div class="measurements-platform">
+    {{ facilityname if facilityname else noData }}
+</div>
+<div class="measurements-platform">
+    {{ city if city else noData }}, {{ state if state else noData }}
+</div>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Type</th>
+            <th class="text-right">Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Discharge (MGD)</td>
+            <td class="text-right">
+                {{ mgd|toLocaleString() if mgd else noData }}
+            </td>
+        </tr>
+        <tr>
+            <td>TN Load (kg/yr)</td>
+            <td class="text-right">
+                {{ kgn_yr|toLocaleString() if kgn_yr else noData }}
+            </td>
+        </tr>
+        <tr>
+            <td>TP Load (kg/yr)</td>
+            <td class="text-right">
+                {{ kgp_yr|toLocaleString() if kgp_yr else noData }}
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/src/mmw/requirements/development.txt
+++ b/src/mmw/requirements/development.txt
@@ -2,5 +2,5 @@
 
 flake8==2.4.0
 ipython==2.3.0
-django-debug-toolbar==1.3
+django-debug-toolbar==1.5
 ipdb==0.8


### PR DESCRIPTION
This PR adds a DRB Point Source locations marker layer to the Observations tab. To retrieve the DRB point source data, the PR creates an API endpoint at `/api/modeling/point-source` which queries `ms_pointsource_drb` to retrieve the relevant columns, then sends the data back as a GeoJSON FeatureCollection. The endpoint response includes a header to cache the results for a week on the client side, since the data presumably will not be updated very often.

On the client side, the changes involved creating the DRB Point Source marker layer, then adding it as an option to the Observations tab via the `layerControl.js` file. Creating the markers happens in a `pointSourceLayer.js` file, and the PR adds a new template for the popups in `pointSourcePopup.html` which looks like this:

<img width="315" alt="screen shot 2016-09-07 at 3 50 24 pm" src="https://cloud.githubusercontent.com/assets/4165523/18326235/d15a484e-7512-11e6-8a8a-02474768b573.png">

The markers currently resize contextually based on the zoom level in order to keep them from clustering together: each zoom level from 0-18 has a corresponding number indexed in a `markerSizesForZoomLevels` array. That means that the markers look like this when zoomed in closely:

<img width="1257" alt="screen shot 2016-09-07 at 3 52 26 pm" src="https://cloud.githubusercontent.com/assets/4165523/18326302/1df76f10-7513-11e6-92ab-accd4b98ca95.png">

...and like this when you zoom out:

<img width="1274" alt="screen shot 2016-09-07 at 3 43 30 pm" src="https://cloud.githubusercontent.com/assets/4165523/18325999/d9032c10-7511-11e6-9385-cf6be46f803c.png">

...

<img width="1062" alt="screen shot 2016-09-07 at 3 43 46 pm" src="https://cloud.githubusercontent.com/assets/4165523/18326015/e5e115c8-7511-11e6-889f-7d6f3fa83d1f.png">

The first commit here upgrades `django-debug-toolbar` from version 1.3 to 1.5 to incorporate a bug fix addressing a bug which otherwise crashed the api endpoint in development. You'll have to reprovision your app VM to upgrade the library.

**Testing**
- get this branch, `vagrant provision app`, `./scripts/bundle.sh`, then visit `localhost:8000` and open the dev console
- open the layer selector and click on the Observations tab
- toggle the "DRB Point Source" layer on and verify that you see orange markers appear on the map
- click on a few point source markers and verify that you see the pop ups appear and that they're formatted properly (note that some of the fields will read "no data" if the database has null values for them
- zoom out and verify that the markers gradually decrease in size as you move further out, and that they increase in size as you zoom back in
- toggle some of the other layers in the control on and off to verify that they still work
- verify that you haven't seen any errors in the console

Connects #1444 