### PR TITLE
Fix Draw Tool For Windows Touch+Mouse Devices Using Chrome

### DIFF
--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -1507,8 +1507,8 @@
     },
     "leaflet-draw": {
       "version": "0.3.0",
-      "from": "leaflet-draw@0.3.0",
-      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-0.3.0.tgz"
+      "from": "git://github.com/azavea/Leaflet.draw",
+      "resolved": "git://github.com/azavea/Leaflet.draw"
     },
     "leaflet-plugins": {
       "version": "1.3.8",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -33,7 +33,7 @@
     "jshint": "2.8.0",
     "jstify": "0.9.0",
     "leaflet": "0.7.3",
-    "leaflet-draw": "0.3.0",
+    "leaflet-draw": "git://github.com/azavea/Leaflet.draw",
     "leaflet-plugins": "git://github.com/azavea/leaflet-plugins#feature/browserify",
     "leaflet.locatecontrol": "0.43.0",
     "livereload": "0.3.7",


### PR DESCRIPTION
We use `Leaflet.Draw` for our Draw Area --> Free Draw functionality. The library, however, has a bug where if a device has both touch and mouse input, an `onMouseUp` event will fire twice when the mouse is used. When this happens one click will draw two vertices one on top of the other, and it will be impossible to close the drawn polygon.

I've created a [fork of `Leaflet.Draw`](https://github.com/arottersman/Leaflet.draw/tree/arr/master) that addresses this problem (thanks @rajadain !), and updated the dependencies of Model My Watershed to point to it so we can test the fix.

## Testing
Pull this branch
```
vagrant ssh app
cd /src/mmw
// just incase npm doesn't update...
rm -f -r node_modules/leaflet-draw/
npm cache clean
npm install
// outside the VM
./scripts/bundle.sh --vendor
```

- In the browser, go to `localhost:8000`
- Draw Area --> Free Draw
- Confirm that you can create a polygon that closes and takes you to the analyse tab

The original bug was for a Windows touch+mouse device in Chrome, but we should also test IE, and Firefox, as well as performance on desktop, iOS, and android devices.

Connects #1190 