### PR TITLE
Adjust stream network tile rendering

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -126,7 +126,7 @@ LAYERS = [
         'minZoom': 9,
     },
     {
-        'code': 'nhd_streams_v1',
+        'code': 'nhd_streams_v2',
         'display': 'National Stream Network',
         'table_name': 'nhdflowline',
         'stream': True,
@@ -134,7 +134,7 @@ LAYERS = [
         'minZoom': 3
     },
     {
-        'code': 'drb_streams_v1',
+        'code': 'drb_streams_v2',
         'display': ('Delaware River Basin High Resolution' +
             '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Stream Network'),
         'table_name': 'drb_streams_50',

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -57,9 +57,9 @@ var interactivity = {
 
         if (zoom <= 5) {
             stream_order = 7;
-        } else if (zoom <= 8) {
+        } else if (zoom <= 6) {
             stream_order = 6;
-        } else if (zoom <= 10) {
+        } else if (zoom <= 8) {
             stream_order = 5;
         }
 

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -33,8 +33,8 @@ var interactivity = {
         huc8: 'boundary_huc08',
         huc10: 'boundary_huc10',
         huc12: 'boundary_huc12',
-        drb_streams_v1: 'drb_streams_50',
-        nhd_streams_v1: 'nhdflowline',
+        drb_streams_v2: 'drb_streams_50',
+        nhd_streams_v2: 'nhdflowline',
         municipalities: 'dep_municipalities',
         urban_areas: 'dep_urban_areas'
     },

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -90,21 +90,29 @@
     line-color: @streamColor;
     line-width: 4.0 * @zoomBase;
   }
+  [stream_order=5] {
+    line-color: @streamColor;
+    line-width: 3.0 * @zoomBase;
+  }
 }
 
 #drb_streams_50[zoom>=9][zoom<=10],
 #nhdflowline[zoom>=9][zoom<=10] {
   [stream_order>=9] {
     line-color: @streamColor;
-    line-width: 15.0 * @zoomBase ;
+    line-width: 14.0 * @zoomBase;
   }
   [stream_order<=8][stream_order>=6] {
     line-color: @streamColor;
-    line-width:  10.0 * @zoomBase;
+    line-width: 10.0 * @zoomBase;
   }
-  [stream_order=5] {
+  [stream_order<=5][stream_order>=4] {
     line-color: @streamColor;
-    line-width: 7.0 * @zoomBase;
+    line-width: 5.0 * @zoomBase;
+  }
+  [stream_order=3] {
+    line-color: @streamColor;
+    line-width: 4.0 * @zoomBase;
   }
 }
 
@@ -125,6 +133,14 @@
   [stream_order=3] {
     line-color: @streamColor;
     line-width:  6.0 * @zoomBase;
+  }
+  [stream_order=2] {
+    line-color: @streamColor;
+    line-width:  5.0 * @zoomBase;
+  }
+  [stream_order<=1][stream_order>=0] {
+    line-color: @streamColor;
+    line-width:  4.0 * @zoomBase;
   }
 }
 


### PR DESCRIPTION
Attempts to satisfy the revisions specified in #1443.

**Testing**
- Open a tab with this branch and another with staging.
- Turn on the stream network overlay.
- Zoom in on each, compare how the streams are rendered, and check that they satisfy the revisions set in #1443.

Connects to #1443