### PR TITLE
Rename 'Code' -> `NPDES Code' in Point Source analysis tab.

### DIFF
--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -1,7 +1,7 @@
 <table class="table custom-hover" data-toggle="table">
     <thead>
         <tr>
-            <th data-sortable="true">Code</th>
+            <th data-sortable="true">NPDES Code</th>
             <th data-sortable="true">City</th>
             <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
                 Discharge (MGD)

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -140,7 +140,7 @@ var tableHeaders = {
     land: ['Type', 'Area (km2)', 'Coverage (%)'],
     soil: ['Type', 'Area (km2)', 'Coverage (%)'],
     animals: ['Animal', 'Count'],
-    pointsource: ['Code', 'City', 'Discharge (MGD)', 'TN Load (kg/yr)', 'TP Load (kg/yr)'],
+    pointsource: ['NPDES Code', 'City', 'Discharge (MGD)', 'TN Load (kg/yr)', 'TP Load (kg/yr)'],
 };
 
 function tableRows(type, result) {


### PR DESCRIPTION
This PR renames 'Code' to 'NPDES Code' in the Point Source analysis tab:

<img width="1255" alt="screen shot 2016-09-09 at 9 15 11 am" src="https://cloud.githubusercontent.com/assets/4165523/18388111/4435e61e-766e-11e6-8d78-869f4421196b.png">

**Testing**
- get this branch, `vagrant up`, `./scripts/bundle.sh` then visit `localhost:8000` in the browser and open the dev console
- draw an AOI
- once the Point Source analyze results return, verify that the code column's header now reads "NPDES Code"
- verify that there aren't any errors in the console

Connects #1455 