### PR TITLE
Remove Django Debug Toolbar

### DIFF
--- a/src/mmw/mmw/settings/development.py
+++ b/src/mmw/mmw/settings/development.py
@@ -49,29 +49,6 @@ LOGGING = {
 }
 # END LOGGING CONFIGURATION
 
-
-# TOOLBAR CONFIGURATION
-# See https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-INSTALLED_APPS += (
-    'debug_toolbar',
-)
-
-# See https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-INTERNAL_IPS = ('127.0.0.1')
-
-# See https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-MIDDLEWARE_CLASSES += (
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-)
-
-# See https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-DEBUG_TOOLBAR_CONFIG = {
-    'INTERCEPT_REDIRECTS': False,
-    'SHOW_TEMPLATE_CONTEXT': True,
-}
-
-# END TOOLBAR CONFIGURATION
-
 # API key for testing/development
 GOOGLE_MAPS_API_KEY = 'AIzaSyB0D5gjoIHpmy-xdP2cr_0I-E7K6s_L0k4'
 

--- a/src/mmw/requirements/development.txt
+++ b/src/mmw/requirements/development.txt
@@ -2,5 +2,4 @@
 
 flake8==2.4.0
 ipython==2.3.0
-django-debug-toolbar==1.5
 ipdb==0.8


### PR DESCRIPTION
The toolbar was underutilized by developers and started showing some
maintenance requirements so it was decided to remove it from the
project.

Connects #1459 

To test:
* `vagrant provision app`
* Load site and verify the toolbar has not been added to the page