### PR TITLE
Improved Sidebar Toggle Control

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -38,9 +38,6 @@
     </div>
 
     <div id="sidebar">
-        <button class="btn btn-primary tab-content-toggle" type="button" title="Show/Hide results sidebar">
-            <i class="fa fa-angle-right"></i>
-        </button>
         <div id="sidebar-content"></div>
     </div>
 

--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -44,6 +44,7 @@ var AnalyzeController = {
             // Modelling Controller.
             App.currentProject = null;
         }
+        App.getMapView().addSidebarToggleControl();
     },
 
     analyze: function() {
@@ -60,6 +61,7 @@ var AnalyzeController = {
 
     analyzeCleanUp: function() {
         App.rootView.sidebarRegion.empty();
+        App.getMapView().removeSidebarToggleControl();
     }
 };
 

--- a/src/mmw/js/src/core/sidebarToggleControl.js
+++ b/src/mmw/js/src/core/sidebarToggleControl.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var L = require('leaflet'),
+    $ = require('jquery'),
+    Marionette = require('../../shim/backbone.marionette'),
+    sidebarToggleControlButtonTmpl = require('./templates/sidebarToggleControlButton.html');
+
+module.exports = L.Control.extend({
+    options: {
+        position: 'bottomright'
+    },
+
+    onAdd: function() {
+        return new SidebarToggleControlButton({}).render().el;
+    }
+});
+
+var SidebarToggleControlButton = Marionette.ItemView.extend({
+    template: sidebarToggleControlButtonTmpl,
+    className: 'leaflet-control leaflet-control-sidebar-toggle',
+
+    ui: {
+        button: '.leaflet-bar-button'
+    },
+
+    events: {
+        'click @ui.button': 'toggle'
+    },
+
+    templateHelpers: function() {
+        return {
+            hidden: this.$sidebar.hasClass('hidden-sidebar')
+        };
+    },
+
+    initialize: function() {
+        this.$sidebar = $('#sidebar');
+        this.$mapContainer = $('body>div.map-container');
+    },
+
+    toggle: function() {
+        this.$sidebar.toggleClass('hidden-sidebar');
+        this.$mapContainer.toggleClass('hidden-sidebar');
+
+        this.render();
+    }
+});

--- a/src/mmw/js/src/core/templates/sidebarToggleControlButton.html
+++ b/src/mmw/js/src/core/templates/sidebarToggleControlButton.html
@@ -1,0 +1,5 @@
+<div class="layer-control-button-container leaflet-bar">
+    <a class="leaflet-bar leaflet-bar-button" href="#" title="{{ "Show" if hidden else "Hide" }} Sidebar">
+        <span class="fa fa-{{ "compress" if hidden else "expand" }}"></span>
+    </a>
+</div>

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -18,6 +18,7 @@ var L = require('leaflet'),
     settings = require('./settings'),
     LayerControl = require('./layerControl'),
     OpacityControl = require('./opacityControl'),
+    SidebarToggleControl = require('./sidebarToggleControl'),
     VizerLayers = require('./vizerLayers');
 
 require('leaflet.locatecontrol');
@@ -767,6 +768,18 @@ var MapView = Marionette.ItemView.extend({
                 });
             }
         });
+    },
+
+    addSidebarToggleControl: function() {
+        this._sidebarToggleControl = new SidebarToggleControl();
+        this._leafletMap.addControl(this._sidebarToggleControl);
+    },
+
+    removeSidebarToggleControl: function() {
+        if (this._sidebarToggleControl) {
+            this._leafletMap.removeControl(this._sidebarToggleControl);
+            delete this._sidebarToggleControl;
+        }
     }
 });
 

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -27,7 +27,6 @@ require('leaflet-plugins/layer/tile/Google');
 var RootView = Marionette.LayoutView.extend({
     el: 'body',
     ui: {
-        collapse: '.tab-content-toggle',
         mapContainer: '.map-container',
         sidebar: '#sidebar'
     },
@@ -43,23 +42,7 @@ var RootView = Marionette.LayoutView.extend({
         footerRegion: '#footer'
     },
     events: {
-        'click @ui.collapse': 'collapseSidebar',
         'transitionend @ui.mapContainer': 'onMapResized'
-    },
-
-    collapseSidebar: function() {
-        // Toggle appropriate classes to show and hide
-        // the sidebar / make the map full/partial width
-        this.$el.find(this.ui.sidebar).toggleClass('hidden-sidebar');
-        this.$el.find(this.ui.mapContainer).toggleClass('hidden-sidebar');
-    },
-
-    showCollapsable: function() {
-        $(this.ui.collapse).show();
-    },
-
-    hideCollapsable: function() {
-        $(this.ui.collapse).hide();
     },
 
     onMapResized: function(e) {

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -11,11 +11,11 @@ var $ = require('jquery'),
 
 var ModelingController = {
     projectPrepare: function(projectId) {
-        App.rootView.showCollapsable();
         if (!projectId && !App.map.get('areaOfInterest')) {
             router.navigate('', { trigger: true });
             return false;
         }
+        App.getMapView().addSidebarToggleControl();
     },
 
     project: function(projectId, scenarioParam) {
@@ -123,7 +123,7 @@ var ModelingController = {
             finishProjectSetup(project, lock);
             updateUrl();
         }
-        App.rootView.showCollapsable();
+        App.getMapView().addSidebarToggleControl();
         setPageTitle();
     },
 
@@ -243,7 +243,6 @@ function setPageTitle() {
 }
 
 function projectCleanUp() {
-    App.rootView.hideCollapsable();
     if (App.currentProject) {
         var scenarios = App.currentProject.get('scenarios');
 
@@ -258,6 +257,7 @@ function projectCleanUp() {
         App.projectNumber = scenarios.at(0).get('project');
     }
 
+    App.getMapView().removeSidebarToggleControl();
     App.getMapView().updateModifications(null);
     App.rootView.subHeaderRegion.empty();
     App.rootView.sidebarRegion.empty();

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -40,18 +40,6 @@ p.info {
   margin-top: 20px;
 }
 
-button.btn.tab-content-toggle {
-  position: absolute;
-  z-index: 1000;
-  top: 161px;
-  right: 10px;
-  display:none;
-
-  .hidden-sidebar & i {
-    transform: rotate(-180deg);
-  }
-}
-
 #footer {
 
   &.top-nav {

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -102,10 +102,6 @@
     float: right;
 }
 
-.leaflet-control-container .leaflet-top {
-  top: 45px;
-}
-
 .leaflet-control-layers-expanded {
   padding: 0;
   background-color: transparent;

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -78,12 +78,4 @@
       width: 100%;
     }
   }
-  // TODO: Remove this class and any associated HTML.
-  .tab-content-toggle {
-    display: none;
-    position: absolute;
-    margin: 0.5rem;
-    right: 0.5rem;
-    outline: none;
-  }
 }


### PR DESCRIPTION
## Overview

This changes the sidebar collapse button to be a Leaflet control which conforms better to the app's visual style than the grey button previously. The button is also updated in the modeling view.

### Demo

| View | Before | After |
|-------------------|--------|-------|
| Analyze (Open) | ![image](https://cloud.githubusercontent.com/assets/1430060/18400073/47c96b6e-76a2-11e6-9ddc-108f676fa4be.png) | ![image](https://cloud.githubusercontent.com/assets/1430060/18400070/3f6a122a-76a2-11e6-8b36-7922f563b8c0.png) |
| Analyze (Closed) | - | ![image](https://cloud.githubusercontent.com/assets/1430060/18400083/5391c0c2-76a2-11e6-8972-939b5184ed1e.png) |
| Modeling (Open) | ![image](https://cloud.githubusercontent.com/assets/1430060/18400002/f51330b2-76a1-11e6-8283-0a0503bbdc5d.png) | ![image](https://cloud.githubusercontent.com/assets/1430060/18399999/ec37c1d8-76a1-11e6-8f8a-0be53f4fa56d.png) |
| Modeling (Closed) | ![image](https://cloud.githubusercontent.com/assets/1430060/18400013/02439ee8-76a2-11e6-90cb-88f7168d1a3b.png) | ![image](https://cloud.githubusercontent.com/assets/1430060/18400021/0ba9bfd0-76a2-11e6-8547-57cb869022d8.png) |

### Notes

Since this moves the placement of the collapse button in the Modeling (Open) state, our users may have to retrain their muscle memory.

## Testing Instructions

Check out this branch and bundle dependencies:

```bash
./scripts/bundle.sh --debug
```

 * Open the app. Ensure there is no sidebar collapse control in the Draw view
 * Draw / Select an area of interest to move to the Analyze view. Ensure there _is_ a sidebar collapse button, that it works as expected, and has the right tooltip in both states.
 * Move back to Draw and ensure that the sidebar toggle button goes away.
 * Move back to Analyze and go forward to Modeling. Ensure that the button is still there and works as expected.
 * Hide the sidebar and move back to Analyze. Ensure that the sidebar stays collapsed and the button is in the right state.
 * Load an existing project (or go to a previously saved project's URL) to start directly in the Modeling view. Ensure that the button still works.

Connects #1453 