### PR TITLE
Analyze animals over water

### DIFF
--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -231,16 +231,16 @@ def ag_ls_c_p(geom):
           ), clipped_counties_with_area AS (
               SELECT ST_Area(geom_clipped) /
                      ST_Area(ST_SetSRID(ST_GeomFromText(%s),
-                                        4326)) AS clip_percent,
+                                        4326)) AS clip_pct,
                      clipped_counties.*
               FROM clipped_counties
           )
-          SELECT SUM(hp_ls * clip_percent) AS hp_ls,
-                 SUM(hp_c * clip_percent) AS hp_c,
-                 SUM(hp_p * clip_percent) AS hp_p,
-                 SUM(crop_ls * clip_percent) AS crop_ls,
-                 SUM(crop_c * clip_percent) AS crop_c,
-                 SUM(crop_p * clip_percent) AS crop_p
+          SELECT COALESCE(SUM(hp_ls * clip_pct), 0.0) AS hp_ls,
+                 COALESCE(SUM(hp_c * clip_pct), 0.0) AS hp_c,
+                 COALESCE(SUM(hp_p * clip_pct), 0.0) AS hp_p,
+                 COALESCE(SUM(crop_ls * clip_pct), 0.0) AS crop_ls,
+                 COALESCE(SUM(crop_c * clip_pct), 0.0) AS crop_c,
+                 COALESCE(SUM(crop_p * clip_pct), 0.0) AS crop_p
           FROM clipped_counties_with_area;
           '''
 


### PR DESCRIPTION
This PR addresses a bug whereby the Analysis tab would fail to render Animal population results for AOIs drawn entirely over water -- and for which the ms_county_animals table returned values of `None` rather than 0 for each of the animal population counts. As described in #1458, the animals analysis results would fail completely for AOIs drawn entirely over water which seemed not to be attached to a county, like Delaware Bay. These updates replace `None` values with 0.0 for animals and ag land cover so that the Animals Analysis will work:

<img width="1043" alt="screen shot 2016-09-09 at 6 16 39 pm" src="https://cloud.githubusercontent.com/assets/4165523/18404676/0343de80-76ba-11e6-9406-8b7226235ddc.png">

<img width="1035" alt="screen shot 2016-09-09 at 6 16 49 pm" src="https://cloud.githubusercontent.com/assets/4165523/18404674/ff541f6a-76b9-11e6-97cd-59d7e77b0b9f.png">

This PR partially fixes the animals bug with MapShed, but due to some division by zero errors thrown when there's no land cover in GWLF-E, users can't run a MapShed job on this AOI. I wrote fixes to the GWLF-E code to handle the division by zero errors, but after discussing with @mmcfarland decided that the better option would be to display a specific error message related to the AOI prior to trying to run GWFL-E. (I brought in #1268 to address that.)

**Testing**
- get this branch, `vagrant up`, `./scripts/debugcelery.sh` then visit `localhost:8000`
- draw an AOI like the one above in Delaware Bay and verify that the Animals analysis tab displays output (of all 0s).
- run a MapShed job, then watch the `debugcelery.sh` output to verify that the failure happens in GWLF-E and is specifically `invalid value encountered in double_scalars` noting a line of code where `z.AreaTotal` is being used as a denominator

Connects #1458 
