### PR TITLE
Show point source analysis results on map

### DIFF
--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -52,7 +52,8 @@ def point_source_pollution(geojson):
     drb = geom.within(DRB)
     table_name = get_point_source_table(drb)
     sql = '''
-          SELECT city, npdes_id, mgd, kgn_yr, kgp_yr
+          SELECT city, state, npdes_id, mgd, kgn_yr, kgp_yr, latitude,
+                 longitude
           FROM {table_name}
           WHERE ST_Intersects(geom, ST_SetSRID(ST_GeomFromText(%s), 4326))
           '''.format(table_name=table_name)
@@ -64,10 +65,12 @@ def point_source_pollution(geojson):
             columns = [col[0] for col in cursor.description]
             point_source_results = [
                 dict(zip(columns,
-                         [row[0], row[1],
-                          float(row[2]) if row[2] else None,
+                         [row[0], row[1], row[2],
                           float(row[3]) if row[3] else None,
-                          float(row[4]) if row[4] else None]))
+                          float(row[4]) if row[4] else None,
+                          float(row[5]) if row[5] else None,
+                          float(row[6]) if row[6] else None,
+                          float(row[7]) if row[7] else None]))
                 for row in cursor.fetchall()
             ]
         else:

--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -1,4 +1,4 @@
-<table class="table custom-hover" data-toggle="table">
+<table class="table custom-hover point-source" data-toggle="table">
     <thead>
         <tr>
             <th data-sortable="true">NPDES Code</th>

--- a/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
@@ -1,4 +1,4 @@
-<td>{{ npdes_id }}</td>
+<td class="npdes-id" data-npdes-id="{{ npdes_id }}">{{ npdes_id }}</td>
 <td>{{ city|title if city else noData }}</td>
 <td class="strong text-right">{{ mgd|toLocaleString() if mgd else noData }}</td>
 <td class="strong text-right">{{ kgn_yr|toLocaleString() if kgn_yr else noData }}</td>

--- a/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
@@ -1,4 +1,18 @@
-<td class="npdes-id" data-npdes-id="{{ npdes_id }}">{{ npdes_id }}</td>
+<td>
+  <a
+    class="point-source-id"
+    data-npdes_id="{{ npdes_id }}"
+    data-lat="{{ latitude }}"
+    data-lng="{{ longitude }}"
+    data-city="{{ city|title if city else '' }}"
+    data-state="{{ state|upper if state else '' }}"
+    data-mgd="{{ mgd|toLocaleString() if mgd else noData }}"
+    data-kgn_yr="{{ kgn_yr|toLocaleString() if kgn_yr else noData }}"
+    data-kgp_yr="{{ kgp_yr|toLocaleString() if kgp_yr else noData }}"
+  >
+    {{ npdes_id }}
+  </a>
+</td>
 <td>{{ city|title if city else noData }}</td>
 <td class="strong text-right">{{ mgd|toLocaleString() if mgd else noData }}</td>
 <td class="strong text-right">{{ kgn_yr|toLocaleString() if kgn_yr else noData }}</td>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -335,6 +335,7 @@ var AnimalTableView = Marionette.CompositeView.extend({
 
 var PointSourceTableRowView = Marionette.ItemView.extend({
     tagName: 'tr',
+    className: 'point-source',
     template: pointSourceTableRowTmpl,
 
     templateHelpers: function() {
@@ -371,18 +372,19 @@ var PointSourceTableView = Marionette.CompositeView.extend({
     },
 
     ui: {
+        'pointSourceTR': 'tr.point-source',
         'pointSourceId': '.point-source-id'
     },
 
     events: {
-        'mouseover @ui.pointSourceId': 'showPointSourceMarker',
-        'mouseout @ui.pointSourceId': 'removePointSourceMarker'
+        'click @ui.pointSourceId': 'panToPointSourceMarker',
+        'mouseout @ui.pointSourceId': 'removePointSourceMarker',
+        'mouseover @ui.pointSourceTR': 'addPointSourceMarkerToMap',
+        'mouseout @ui.pointSourceTR': 'removePointSourceMarker'
     },
 
-    showPointSourceMarker: function(e) {
-        var data = $(e.currentTarget).data(),
-            latLng = L.latLng([data.lat, data.lng]),
-            map = App.getLeafletMap();
+    createPointSourceMarker: function(data) {
+        var latLng = L.latLng([data.lat, data.lng]);
 
         this.marker = L.circleMarker(latLng, {
             fillColor: "#ff7800",
@@ -391,6 +393,24 @@ var PointSourceTableView = Marionette.CompositeView.extend({
         }).bindPopup(new pointSourceLayer.PointSourcePopupView({
           model: new Backbone.Model(data)
         }).render().el);
+    },
+
+    addPointSourceMarkerToMap: function(e) {
+        var data = $(e.currentTarget).find('.point-source-id').data(),
+            map = App.getLeafletMap();
+
+        this.createPointSourceMarker(data);
+
+        this.marker.addTo(map);
+    },
+
+    panToPointSourceMarker: function(e) {
+        var map = App.getLeafletMap();
+
+        if (!this.marker) {
+          var data = $(e.currentTarget).data();
+          this.createPointSourceMarker(data);
+        }
 
         this.marker.addTo(map);
         map.panTo(this.marker.getLatLng());

--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -36,7 +36,7 @@ module.exports = L.Control.Layers.extend({
                 for (i in observationLayers) {
                     self._addLayer(observationLayers[i], i, 'observation');
                 }
-                self._addLayer(pointSourceLayer.createLayer(pointSourceData[0],
+                self._addLayer(pointSourceLayer.Layer.createLayer(pointSourceData[0],
                     self._map), 'DRB Point Source', 'observation');
                 self._update();
             })

--- a/src/mmw/js/src/core/pointSourceLayer.js
+++ b/src/mmw/js/src/core/pointSourceLayer.js
@@ -13,7 +13,7 @@ var markerSizesForZoomLevels = [
     2, 2.25, 3, 6, 8, 10, 10, 10, 10, 10
 ];
 
-module.exports = {
+var Layer = {
     createLayer: function(geojsonFeatureCollection, leafletMap) {
         return L.geoJson($.parseJSON(geojsonFeatureCollection), {
             pointToLayer: function (feature, latlng) {
@@ -52,3 +52,6 @@ var PointSourcePopupView = Marionette.ItemView.extend({
         };
     }
 });
+
+module.exports.Layer = Layer;
+module.exports.PointSourcePopupView = PointSourcePopupView;

--- a/src/mmw/js/src/core/pointSourceLayer.js
+++ b/src/mmw/js/src/core/pointSourceLayer.js
@@ -8,8 +8,10 @@ var L = require('leaflet'),
     pointSourcePopupTmpl = require('./templates/pointSourcePopup.html');
 
 // Increase or decrease the marker size based on the map zoom level
-var markerSizesForZoomLevels = [0.05, 0.1, 0.2, 0.25, 0.5, 0.75, 1, 1.25, 1.75,
-    2, 2.25, 3, 6, 8, 10, 10, 10, 10, 10];
+var markerSizesForZoomLevels = [
+    0.05, 0.1, 0.2, 0.25, 0.5, 0.75, 1, 1.25, 1.75,
+    2, 2.25, 3, 6, 8, 10, 10, 10, 10, 10
+];
 
 module.exports = {
     createLayer: function(geojsonFeatureCollection, leafletMap) {
@@ -21,15 +23,19 @@ module.exports = {
                     fillOpacity: 0.75
                 });
             },
+
             onEachFeature: function(feature, marker) {
                 var model = new Backbone.Model(feature.properties),
-                    view = new PointSourcePopupView({model: model});
+                    view = new PointSourcePopupView({ model: model });
+
                 leafletMap.on('zoomend', function(e) {
                     var newZoomLevel = e.target._zoom;
+
                     marker.setStyle({
                         radius: markerSizesForZoomLevels[newZoomLevel]
                     });
                 });
+
                 marker.bindPopup(view.render().el);
             },
         });
@@ -39,6 +45,7 @@ module.exports = {
 var PointSourcePopupView = Marionette.ItemView.extend({
     template: pointSourcePopupTmpl,
     className: 'point-source-popup',
+
     templateHelpers: function() {
         return {
             noData: utils.noData

--- a/src/mmw/js/src/core/templates/pointSourcePopup.html
+++ b/src/mmw/js/src/core/templates/pointSourcePopup.html
@@ -1,9 +1,9 @@
 <h2 class="measurements-name">NPDES Code: {{ npdes_id }}</h2>
 <div class="measurements-platform">
-    {{ facilityname if facilityname else noData }}
+    {{ facilityname if facilityname else '' }}
 </div>
 <div class="measurements-platform">
-    {{ city if city else noData }}, {{ state if state else noData }}
+    {{ city if city else '' }}{{ ', ' + state if state else '' }}
 </div>
 <table class="table">
     <thead>

--- a/src/mmw/sass/components/_tables.scss
+++ b/src/mmw/sass/components/_tables.scss
@@ -70,3 +70,7 @@
 .ptsrc-footer-item {
     border-left: 1px solid #ddd;
 }
+
+.point-source .point-source-id {
+  cursor: pointer;
+}


### PR DESCRIPTION
Hovering over the point source location id in the point source analysis results table will add a marker at the location of the point source, pan the map to that location, and open a popup with the information from the table for that source.

To make this possible, the latitude and longitude of each location are returned in the analysis results (the state was also added too).

Some modifications were made to the popup template to make the text cleaner in cases where there is no data for some of the header information. For example, I thought showing "Philadelphia" was better than showing "Philadelphia, No Data" for cases where the state is missing. Similarly, showing "No data" by itself on a line when there is no facility name was confusing. Instead, we render now render an empty string.

**Notes**
- For reasons that remain unknown, I was unable to attach an event handler in `PointSourceTableRowView`. I tried many different approaches, but nothing worked. I ended up attaching the events in the parent class (and using data attributes as opposed to directly using the model), which does have benefit of making it easier to manage one marker on the map.

**Testing**
- Draw an AoI that will include a few point sources outside of the DRB.
- When the analysis completes, activate the "Point Source" tab.
- Hovering over the NPDES code should add a marker to the map, pan to that location, and open a pop up with the information that is displayed in the table for that particular source.
- Repeat the above process with an AoI that is within the DRB. The behavior should be the same.

Connects to #1445