### PR TITLE
Guard against AOIs without enough land cover

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -217,7 +217,7 @@ var TabContentView = Marionette.LayoutView.extend({
         if (err && err.timeout) {
             tmvModel.setTimeoutError();
         } else {
-            tmvModel.setError();
+            tmvModel.setError('Error');
         }
 
         this.resultRegion.show(new coreViews.TaskMessageView({

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -217,8 +217,8 @@ var TaskMessageViewModel = Backbone.Model.extend({
     message: null,
     iconClass: null,
 
-    setError: function() {
-        this.set('message', 'Error');
+    setError: function(message) {
+        this.set('message', message);
         this.set('iconClasses', 'fa fa-exclamation-triangle');
     },
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -803,9 +803,12 @@ var ResultsView = Marionette.LayoutView.extend({
             tmvModel = new coreModels.TaskMessageViewModel(),
             errorHandler = function(err) {
                 if (err && err.timeout) {
-                  tmvModel.setTimeoutError();
+                    tmvModel.setTimeoutError();
                 } else {
-                  tmvModel.setError();
+                    var message = err.error === 'NO_LAND_COVER' ?
+                        'Selected area of interest doesn\'t include any land ' +
+                        'cover to run the model' : 'Error';
+                    tmvModel.setError(message);
                 }
                 self.modelingRegion.show(new coreViews.TaskMessageView({ model: tmvModel }));
             };


### PR DESCRIPTION
This PR adds some backend guards and a specific frontend error message to guard against AOIs without enough land cover. Such AOIs include both shapes drawn entirely over water, like this one --

<img width="1030" alt="screen shot 2016-09-13 at 1 23 47 pm" src="https://cloud.githubusercontent.com/assets/4165523/18484546/e8c77f12-79b6-11e6-87b6-e7393d3709dc.png">

-- as well as AOIs too small to have any land cover types, like this one:

<img width="1031" alt="screen shot 2016-09-13 at 1 25 08 pm" src="https://cloud.githubusercontent.com/assets/4165523/18484569/03b9ccda-79b7-11e6-883a-a0543df2d3c3.png">

To accomplish this, I added two Exceptions in `tasks.py` thrown when either `z['Area']` is entirely zeroes or when the `nt_count` in the `nlcd_soils` method doesn't include any values. (This one had caused an error on small AOIs because it's used elsewhere as a denominator.

I've set these guards up to fail mapshed immediately and throw a specific error message; when the frontend sees this new error message, the code will now display "Selected area of interest doesn't include enough land cover" in place of "Error" in the error message.

One consequence of these exceptions is that the GMS file will fail to be created for these AOIs as well. In theory I think we could move these exceptions to the end of the processing steps and have it fail after a GMS file can be created, but I don't know whether the values in that file would be worthwhile. (I put up this PR for GWLF-E which might also handle them both -- https://github.com/WikiWatershed/gwlf-e/pull/71 -- but for the water aoi at least I think it would display results which may not be worthwhile/accurate).

**Testing**
- get this branch, `vagrant up`, `./scripts/bundle.sh` then visit localhost:8000 and open the browser console
- draw an AOI over water, then run a MapShed job and confirm that you see the specific error message
- draw a tiny AOI, then run MapShed and confirm that you see the same error message
- draw a larger AOI, then run MapShed and confirm that the results return and that you're able to export a GMS file

Connects #1268 