### PR TITLE
Fix RWD bug by changing `drb_streams_v1` -> `v2`

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -78,7 +78,7 @@ function validateClickedPointWithinDRB(latlng) {
     var point = L.marker(latlng).toGeoJSON(),
         d = $.Deferred(),
         streamLayers = settings.get('stream_layers'),
-        drbPerimeter = _.findWhere(streamLayers, {code:'drb_streams_v1'}).perimeter;
+        drbPerimeter = _.findWhere(streamLayers, {code:'drb_streams_v2'}).perimeter;
     if (turfIntersect(point, drbPerimeter)) {
         d.resolve(latlng);
     } else {


### PR DESCRIPTION
We recently updated the code of `drb_streams_v1` to `drb_streams_v2`, but missed updating the code similarly in the `validateClickedPointWithinDRB` function. The outcome's that RWD is currently broken on staging; this PR fixes the error so that RWD will work again.

**Testing**
- get this branch, `vagrant up`, `./scripts/bundle.sh` and then visit `localhost:8000` and open the console
- use the RWD feature and verify that it works and that there are no errors in the console. 