### PR TITLE
Upgrade gwlfe

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -10,7 +10,7 @@ python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
 tr55==1.2.0
-gwlf-e==0.6.0
+gwlf-e==0.6.2
 requests==2.9.1
 rollbar==0.12.1
 retry==0.9.1


### PR DESCRIPTION
This PR upgrades GWLF-E to use 0.6.2, the most recent release.

**Testing**
- grab this branch, `vagrant up`, then `vagrant reload --provision app`, `vagrant reload --provision worker`
- `vagrant ssh app`, then run `pip show gwlf-e` to see the install info and verify that it's version 0.6.2
- `vagrant ssh worker` then run `pip show gwlf-e` to see the install info and verify that it's version 0.6.2

To see it in action:
- pan to South Florida, turn on Congressional boundaries or similar, and click to analyze, then run MapShed
- confirm that you see something like this:

![screen shot 2016-09-20 at 3 26 29 pm](https://cloud.githubusercontent.com/assets/4165523/18685668/0ff790dc-7f47-11e6-9bab-023942baa37a.png)

or this:

<img width="664" alt="screen shot 2016-09-20 at 3 27 55 pm" src="https://cloud.githubusercontent.com/assets/4165523/18685682/166ce75a-7f47-11e6-8a40-3e130825b6c0.png">

for the selected watershed when the MapShed job completes.

Connects #1473 