### PR TITLE
Parallelize MapShed Tasks

### DIFF
--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -460,23 +460,14 @@ def nlcd_kfactor(result):
 def geop_tasks(geom, errback, exchange, choose_worker):
     # List of tuples of (opname, data, callback) for each geop task
     definitions = [
-        ('nlcd_streams',
-         {'polygon': [geom.geojson], 'vector': streams(geom)},
-         nlcd_streams),
+        ('nlcd_streams', {'polygon': [geom.geojson],
+                          'vector': streams(geom)}, nlcd_streams),
         ('nlcd_soils', {'polygon': [geom.geojson]}, nlcd_soils),
-        ('gwn',
-         {'polygon': [geom.geojson]}, gwn),
-        ('avg_awc',
-         {'polygon': [geom.geojson]}, avg_awc),
-        ('nlcd_slope',
-         {'polygon': [geom.geojson]},
-         nlcd_slope),
-        ('slope',
-         {'polygon': [geom.geojson]},
-         slope),
-        ('nlcd_kfactor',
-         {'polygon': [geom.geojson]},
-         nlcd_kfactor)
+        ('gwn', {'polygon': [geom.geojson]}, gwn),
+        ('avg_awc', {'polygon': [geom.geojson]}, avg_awc),
+        ('nlcd_slope', {'polygon': [geom.geojson]}, nlcd_slope),
+        ('slope', {'polygon': [geom.geojson]}, slope),
+        ('nlcd_kfactor', {'polygon': [geom.geojson]}, nlcd_kfactor)
     ]
 
     tasks = zip(definitions, [choose_worker()


### PR DESCRIPTION
## Overview

Previously we would assign all MapShed tasks to the same worker. Now we choose a random one for each one, thus taking advantage of the many workers available.

### Demo

Before:

<img width="1280" alt="screen shot 2016-09-23 at 2 45 25 pm" src="https://cloud.githubusercontent.com/assets/1430060/18798326/0126dbfc-81a0-11e6-98cc-dbabf9d8b1f7.png">

After:

<img width="1280" alt="screen shot 2016-09-23 at 2 47 00 pm" src="https://cloud.githubusercontent.com/assets/1430060/18798333/0a17f17e-81a0-11e6-89ac-1d8ff7d268dc.png">

Since the choice is random, we're not guaranteed to get an equal distribution between workers in every instance, but overall we should be okay.

## Testing Instructions

Checkout this branch. Disable Celery:

```bash
vagrant ssh worker -c "sudo service celeryd stop"
```

Add a `print` statement in the beginning of `mapshed_start` ([`mapshed/tasks.py:53`](https://github.com/WikiWatershed/model-my-watershed/blob/9472dec69db0d14ac7ba25895bbd8771f4a8947d/src/mmw/apps/modeling/mapshed/tasks.py#L53)) to log the call to the console:

```python
def mapshed_start(self, opname, input_data):
    print("==> {}".format(opname))
    host = settings.GEOP['host']
    ...
```

To demonstrate multiple workers being utilized, we need to start more than one worker. Open two terminal windows. Start `debug1@worker` in the first one:

```bash
vagrant ssh worker -c "cd /opt/app/ && envdir /etc/mmw.d/env celery -A 'mmw.celery:app' worker --autoreload -l debug -n debug1@%n"
```

and `debug2@worker` in the second one:

```bash
vagrant ssh worker -c "cd /opt/app/ && envdir /etc/mmw.d/env celery -A 'mmw.celery:app' worker --autoreload -l debug -n debug2@%n"
```

Now run a MapShed job in the app. Ensure that it completes successfully. Ensure that not all tasks execute on just one worker.

Connects #1474 