### PR TITLE
Reduce geoprocessor calls

### DIFF
--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -303,7 +303,7 @@ def start_analyze(request, format=None):
              .set(exchange=exchange, routing_key=routing_key),
         tasks.get_histogram_job_results.s()
              .set(exchange=exchange, routing_key=routing_key),
-        tasks.histogram_to_survey.s(area_of_interest)
+        tasks.histogram_to_survey_census.s()
              .set(exchange=exchange, routing_key=choose_worker())
     ], area_of_interest, user)
 

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -277,7 +277,7 @@ var TabContentView = Marionette.LayoutView.extend({
 
     showResults: function() {
         var name = this.model.get('name'),
-            results = JSON.parse(this.model.get('taskRunner').get('result')),
+            results = JSON.parse(this.model.get('taskRunner').get('result')).survey,
             result = _.find(results, { name: name }),
             resultModel = new models.LayerModel(result),
             ResultView = AnalyzeResultViews[name];

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -135,7 +135,8 @@ var ProjectModel = Backbone.Model.extend({
         is_activity: false,             // Project that persists across routes
         gis_data: null,                 // Additionally gathered data, such as MapShed for GWLF-E
         needs_reset: false,             // Should we overwrite project data on next save?
-        allow_save: true                // Is allowed to save to the server - false in compare mode
+        allow_save: true,               // Is allowed to save to the server - false in compare mode
+        aoi_census: null                // JSON blob
     },
 
     initialize: function() {


### PR DESCRIPTION
This is a minor refactor that reduces the number of calls to the geoprocessor by bundling the AoI census into the JSON blob returned by the `analyze` endpoint, and subsequently using it when instantiating projects and scenarios so that it can be POSTed to the API modeling endpoints. The durations of the blocking geoprocessor calls are not trivial, especially for large AoI's.

To test:
* clone the branch and bring up the environment
* navigate to `http://localhost:8000`
* go through typical user actions, e.g. select an AoI for analysis, create a TR55 model, add some scenarios
* keeping the test version of the app open, switch branches to `develop` or navigate the to the staging site and perform the same user actions, trying to keep all the parameters as close to identical as possible
* compare the two to make sure the output is identical, or if the parameters of the model are slightly different, that the differences can reasonably be ignored
* in general, the test version should be faster than the baseline, especially if the AoI is somewhat large (>10k sq-km)

Connects #956 