### PR TITLE
Guard frontend AOIs without land cover

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -55,7 +55,29 @@ var ResultsView = Marionette.LayoutView.extend({
             modelPackageName = $(e.target).data('id'),
             modelPackage = _.find(modelPackages, {name: modelPackageName}),
             newProjectUrl = '/project/new/' + modelPackageName,
-            projectUrl = '/project';
+            projectUrl = '/project',
+            analysisResults = JSON.parse(App.getAnalyzeCollection()
+                                            .findWhere({taskName: 'analyze'})
+                                            .get('result')),
+            landResults = _.find(analysisResults, function(element) {
+                    return element.name === 'land';
+            });
+
+        if (landResults) {
+            var landCoverTotal = _.sum(_.map(landResults.categories,
+                    function(category) {
+                        if (category.type === 'Open Water') {
+                            return 0;
+                        }
+                        return category.area;
+                    }));
+
+            if (landCoverTotal === 0) {
+                window.alert("The selected Area of Interest doesn't " +
+                             "include any land cover to run the model.");
+                return;
+            }
+        }
 
         if (!modelPackage.disabled) {
             if (settings.get('itsi_embed') && App.currentProject && !App.currentProject.get('needs_reset')) {


### PR DESCRIPTION
This PR adds a frontend guard to show an error alert and prevent running MapShed when the analysis results have indicated that the area doesn't include any land cover:

<img width="1029" alt="screen shot 2016-09-27 at 2 52 38 pm" src="https://cloud.githubusercontent.com/assets/4165523/18887454/2c83ef68-84c2-11e6-85c2-f8d6ea9cff18.png">

This works by performing a check on the analysis results when the "Watershed Multi Year Model" button has been clicked: if there are analysis results and if the total land cover sums to 0 in them, then instead of running MapShed the app will now show an alert and return.

The guard will only work when the analysis results have returned with data; if the analysis is still underway, it's possible to click to run a MapShed job (and the code path will skip the guard block). I decided against creating a block on running MapShed until the analysis results had returned, as it's likely there are situations when one would want to skip the analyze step, and there wouldn't be anything to check for the guard anyway. In other words, we assume that the shape does include land cover until it's known that it doesn't, and any shapes with no land cover which slip through will be rejected by MapShed on the backend.

**Testing**
- get this branch, `vagrant up`, `./scripts/bundle.sh` then visit localhost:8000 and open the dev console
- select a 1 sq km AOI in Delaware Bay to analyze and wait for the results to return. Once they're in, try to kick off a MapShed job and confirm that the alert window pops up -- and that the MapShed job doesn't start
- select a different 1 sq km AOI in Delaware Bay to analyze. This time don't wait for the results to return, but instead click to start a MapShed job. Confirm that it has started and that you eventually get an error message issued from MapShed.
- zoom in very closely and draw the smallest AOI you can ( < 150 sq m if possible). Wait for the analysis results to return and confirm that if the land cover total is 0, attempting to run a MapShed job will lead to the error alert message (and not to running the MapShed job)
- select a usual AOI, like a congressional district, a sq km over land, or a HUC-12, then when the analysis results return, confirm that you can start a MapShed job

Connects #1486 