### PR TITLE
Add `facilityname` to dynamic point source popups within DRB

### DIFF
--- a/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
@@ -7,6 +7,7 @@
     data-city="{{ city|title if city else '' }}"
     data-state="{{ state|upper if state else '' }}"
     data-mgd="{{ mgd|toLocaleString() if mgd else noData }}"
+    data-facilityname="{{ facilityname if facilityname else '' }}"
     data-kgn_yr="{{ kgn_yr|toLocaleString() if kgn_yr else noData }}"
     data-kgp_yr="{{ kgp_yr|toLocaleString() if kgp_yr else noData }}"
   >


### PR DESCRIPTION
This PR adds the `facilityname` to the point source pop ups created dynamically when pointing the mouse over one of the point source table rows for an AOI within the DRB. It turned out we were not pulling in the facilityname column's value from the endpoint the analysis was using, so I added it to the the results for AOIs within the DRB -- and added a null column as a placeholder for AOIs outside the DRB, since the `ms_pointsource` table does not currently include a `facilityname` column.

This means that the markers for point source locations within the DRB will now display the facility name on mouseover-ing the row:

<img width="999" alt="screen shot 2016-09-28 at 3 18 44 pm" src="https://cloud.githubusercontent.com/assets/4165523/18928796/a8a19de8-858f-11e6-9b61-0e9d8b9c86f3.png">

... and those outside the DRB should render correctly without displaying the facility name:

<img width="1006" alt="screen shot 2016-09-28 at 3 21 16 pm" src="https://cloud.githubusercontent.com/assets/4165523/18928816/bf6e9e4a-858f-11e6-8602-92c811e461d8.png">

**Testing**
- get this branch, `vagrant up`, `./scripts/bundle.sh` then visit `localhost:8000` and open the browser console.
- select an AOI inside the DRB and when the point source analysis results return, verify that pointing the mouse over the row creates a popup which includes the facility name
- select an AOI outside the DRB and when the point source analysis results return, verify that pointing the mouse over the row creates a popup which does not include the facility name
- verify that you haven't seen any errors in the app or the console.

Connects #1495 