### PR TITLE
Update animal display names for analysis results

### DIFF
--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -12,10 +12,17 @@ from apps.modeling.mapshed.calcs import (animal_energy_units,
                                          get_point_source_table)
 
 DRB = settings.DRB_PERIMETER
-ANIMAL_KEYS = settings.GWLFE_CONFIG['AnimalKeys']
-ANIMAL_NAMES = settings.GWLFE_DEFAULTS['AnimalName']
 
-ANIMAL_DISPLAY_NAMES = dict(zip(ANIMAL_KEYS, ANIMAL_NAMES))
+ANIMAL_DISPLAY_NAMES = {
+    'sheep': 'Sheep',
+    'horses': 'Horses',
+    'turkeys': 'Turkeys',
+    'layers': 'Chickens, Layers',
+    'beef_cows': 'Cows, Beef',
+    'hogs': 'Pigs/Hogs/Swine',
+    'dairy_cows': 'Cows, Dairy',
+    'broilers': 'Chickens, Broilers',
+}
 
 
 def animal_population(geojson):


### PR DESCRIPTION
This PR updates the animal display names for the frontend only to match the names specified in #1494:

```
Beef Cows --> Cows, Beef
Broilers --> Chickens, Broilers
Dairy Cows --> Cows, Dairy
Hogs/Swine --> Pigs/Hogs/Swine
Horses
Layers --> Chickens, Layers
Sheep
Turkeys
```
<img width="1258" alt="screen shot 2016-09-28 at 2 07 54 pm" src="https://cloud.githubusercontent.com/assets/4165523/18928948/5a2d43e6-8590-11e6-89a7-d36590a97b15.png">

The changes will only affect the frontend; the MapShed GMS files will still have the prior names set in `gwlfe_settings.py`. To make the change from the frontend, I replaced the imported values from `gwlfe_settings` used for the `animal_population` method with a set of hard coded `ANIMAL_DISPLAY_NAMES` representing the values above.

**Testing**
- get this branch, `vagrant up`, then visit `localhost:8000` and open the browser console.
- pick an area of interest to analyze, then check the "Animals" tab and verify that the animals are named as above.

Connects #1494 