### PR TITLE
Show fewer streams

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -355,6 +355,7 @@ var MapView = Marionette.ItemView.extend({
 
         // The max available zoom level changes based on the active base layer
         this._leafletMap.on('baselayerchange', this.updateCurrentZoomLevel);
+        this._leafletMap.on('baselayerchange', this.updateDrbLayerZoomLevel);
 
         // Some Google layers have a dynamic max zoom that we need to handle.
         // Check that Google Maps API library is available before implementing
@@ -728,6 +729,29 @@ var MapView = Marionette.ItemView.extend({
                 map.setZoom(layerMaxZoom);
             }, 100);
         }
+    },
+
+    updateDrbLayerZoomLevel: function(e) {
+        var layerMaxZoom = e.layer.options.maxZoom;
+        var adjSettings = 
+            _.map(settings.get('stream_layers'),
+                  function(o) {
+                      if (o.code === 'drb_streams_v2') {
+                          o.maxZoom = layerMaxZoom;
+                          return o;
+                      } else {
+                          return o;
+                      }
+                  }
+            );
+
+        settings.set('stream_layers', adjSettings);
+
+        _.each(this._layers, function(layer) {
+          if (layer.options !== undefined && layer.options.code==='drb_streams_v2'){
+              layer.options.maxZoom = layerMaxZoom;
+          }
+        });
     },
 
     // The max zoom for a Google layer that uses satellite imagery

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -55,12 +55,22 @@ var interactivity = {
         tableName = req.params.table;
         stream_order = 0;  // All streams
 
-        if (zoom <= 5) {
-            stream_order = 7;
-        } else if (zoom <= 6) {
-            stream_order = 6;
-        } else if (zoom <= 8) {
-            stream_order = 5;
+        if (tableName === tables.drb_streams_v2) {
+            // drb_zoom_levels: { zoomLevel : stream_order }
+            drb_zoom_levels = {
+                1:7, 2:7, 3:7, 4:7, 5:7, 6:6, 7:6, 8:5, 9:5, 10:4,
+                11:3, 12:2, 13:0, 14:0, 15:0, 16:0, 17:0, 18: 0
+            }; 
+
+            stream_order = zoom in drb_zoom_levels ? drb_zoom_levels[zoom] : 0;
+        } else {
+            if (zoom <= 5) {
+                stream_order = 7;
+            } else if (zoom <= 6) {
+                stream_order = 6;
+            } else if (zoom <= 8) {
+                stream_order = 5;
+            }
         }
 
         return '(SELECT geom, stream_order FROM ' + tableName +

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -44,18 +44,28 @@
    Ensure that any changes to which stream_order + zoom levels are rendered
    here have appropriate coinciding filters in server.js
 */
+
+#drb_streams_50 {
+    line-color: @streamColor;
+    line-join: round;
+    line-cap: round;
+}
+
+#nhdflowline {
+    line-color: @streamColor;
+    line-join: round;
+    line-cap: round;
+}
+
 #drb_streams_50[zoom<=4],
 #nhdflowline[zoom<=4] {
   [stream_order=10] {
-    line-color: @streamColor;
     line-width: 5.0 * @zoomBase;
   }
   [stream_order=9] {
-    line-color: @streamColor;
     line-width: 3.0 * @zoomBase;
   }
   [stream_order<=8] {
-    line-color: @streamColor;
     line-width: 2.0 * @zoomBase;
   }
 }
@@ -63,15 +73,12 @@
 #drb_streams_50[zoom>=5][zoom<=6],
 #nhdflowline[zoom>=5][zoom<=6] {
   [stream_order=10] {
-    line-color: @streamColor;
     line-width: 7.0 * @zoomBase;
   }
   [stream_order=9] {
-    line-color: @streamColor;
     line-width: 4.0 * @zoomBase;
   }
   [stream_order<=8] {
-    line-color: @streamColor;
     line-width: 3.0 * @zoomBase;
   }
 }
@@ -79,19 +86,15 @@
 #drb_streams_50[zoom>=7][zoom<=8],
 #nhdflowline[zoom>=7][zoom<=8] {
   [stream_order>=9] {
-    line-color: @streamColor;
     line-width: 10.0 * @zoomBase;
   }
   [stream_order<=8][stream_order>=7] {
-    line-color: @streamColor;
     line-width: 7.0 * @zoomBase;
   }
   [stream_order<=6] {
-    line-color: @streamColor;
     line-width: 4.0 * @zoomBase;
   }
   [stream_order=5] {
-    line-color: @streamColor;
     line-width: 3.0 * @zoomBase;
   }
 }
@@ -99,19 +102,15 @@
 #drb_streams_50[zoom>=9][zoom<=10],
 #nhdflowline[zoom>=9][zoom<=10] {
   [stream_order>=9] {
-    line-color: @streamColor;
     line-width: 14.0 * @zoomBase;
   }
   [stream_order<=8][stream_order>=6] {
-    line-color: @streamColor;
     line-width: 10.0 * @zoomBase;
   }
   [stream_order<=5][stream_order>=4] {
-    line-color: @streamColor;
     line-width: 5.0 * @zoomBase;
   }
   [stream_order=3] {
-    line-color: @streamColor;
     line-width: 4.0 * @zoomBase;
   }
 }
@@ -119,51 +118,41 @@
 #drb_streams_50[zoom>=11][zoom<=12],
 #nhdflowline[zoom>=11][zoom<=12] {
   [stream_order>=9] {
-    line-color: @streamColor;
     line-width: 18.0 * @zoomBase;
   }
   [stream_order<=8][stream_order>=6] {
-    line-color: @streamColor;
     line-width: 12.0 * @zoomBase;
   }
   [stream_order<=5][stream_order>=4] {
-    line-color: @streamColor;
     line-width:  9.0 * @zoomBase;
   }
   [stream_order=3] {
-    line-color: @streamColor;
     line-width:  6.0 * @zoomBase;
   }
   [stream_order=2] {
-    line-color: @streamColor;
     line-width:  5.0 * @zoomBase;
   }
   [stream_order<=1][stream_order>=0] {
-    line-color: @streamColor;
     line-width:  4.0 * @zoomBase;
   }
 }
 
+
 #drb_streams_50[zoom>=13],
 #nhdflowline[zoom>=13] {
   [stream_order>=9] {
-    line-color: @streamColor;
     line-width: 18.0 * @zoomBase;
   }
   [stream_order<=8][stream_order>=6] {
-    line-color: @streamColor;
     line-width: 14.0 * @zoomBase;
   }
   [stream_order<=5][stream_order>=3] {
-    line-color: @streamColor;
     line-width:  10.0 * @zoomBase;
   }
   [stream_order=2] {
-    line-color: @streamColor;
     line-width:  8.0 * @zoomBase;
   }
   [stream_order<=1][stream_order>=0] {
-    line-color: @streamColor;
     line-width:  5.0 * @zoomBase;
   }
 }


### PR DESCRIPTION
This change modifies the tile server configuration to provide a more specific mapping between map zoom levels and the stream order used to make rendered tiles. More to the point, that mapping reflects a more gradual adjustment in stream orders to prevent the DRB stream overlay from severely cluttering the map.

Additionally, I noticed that the rendered stream tiles sometimes had a crayon-like texture, like so -->
![mmw_staging_drb_tile](https://cloud.githubusercontent.com/assets/18290666/18956950/490a8a9c-862b-11e6-972b-4081acac17cf.png)

I changed the CartoCSS style to try to smooth the texture out, which resulted in this -->
![mmw_test_drb_tile](https://cloud.githubusercontent.com/assets/18290666/18957039/9c059e12-862b-11e6-9174-322e5f3d1a09.png)

Despite the obvious difference in the number of streams rendered, I think the difference is apparent and the new styling is an improvement.

To test:
* clone this branch and bring up the environment
* navigate to `http://localhost:8000`
* toggle the DRB stream overlay and go through various zoom levels (it may be worth doing the same on a control version of the tile server, the easiest way being to do the same process on the staging app)


Connects #1488 