### PR TITLE
Bump version of libpq-dev

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -21,7 +21,7 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "9.5.*.pgdg14.04+1"
+postgresql_support_libpq_version: "9.6.*.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.6"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"


### PR DESCRIPTION
Due to changes to the main PostgreSQL APT repository associated with the PostgreSQL 9.6 release.

```bash
vagrant@services:~$ sudo apt-cache policy libpq-dev
libpq-dev:
  Installed: (none)
  Candidate: 9.6.0-1.pgdg14.04+1
  Version table:
     9.6.0-1.pgdg14.04+1 0
        500 http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg/main amd64 Packages
     9.3.14-0ubuntu0.14.04 0
        500 http://archive.ubuntu.com/ubuntu/ trusty-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu/ trusty-security/main amd64 Packages
     9.3.4-1 0
        500 http://archive.ubuntu.com/ubuntu/ trusty/main amd64 Packages
```

---

**Testing**

Login to a machine that installs `libpq-dev` (`services` or `app` do for sure) and uninstall `libpq-dev`:

```bash
$ vagrant ssh services
vagrant@services:~$ sudo apt-get purge libpq-dev
```

Then, provision that VM using this branch and ensure that it completely successfully:

```bash
$ vagrant provision services
```