### PR TITLE
Feature/add alert modal

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -57,6 +57,7 @@ var ResultsView = Marionette.LayoutView.extend({
             modelPackage = _.find(modelPackages, {name: modelPackageName}),
             newProjectUrl = '/project/new/' + modelPackageName,
             projectUrl = '/project',
+            alertView,
             aoiModel = new coreModels.GeoModel({
                 shape: App.map.get('areaOfInterest'),
                 place: App.map.get('areaOfInterestName')
@@ -74,7 +75,7 @@ var ResultsView = Marionette.LayoutView.extend({
                                                          'km<sup>2</sup>');
 
             if (areaInSqKm > settings.get('mapshed_max_area')) {
-                var alertView = new modalViews.AlertView({
+                alertView = new modalViews.AlertView({
                     model: new modalModels.AlertModel({
                         alertMessage: "The selected Area of Interest is too big for " +
                                  "the Watershed Multi-Year Model. The currently " +
@@ -97,7 +98,7 @@ var ResultsView = Marionette.LayoutView.extend({
                     }));
 
             if (landCoverTotal === 0) {
-                var alertView = new modalViews.AlertView({
+                alertView = new modalViews.AlertView({
                     model: new modalModels.AlertModel({
                         alertMessage: "The selected Area of Interest doesn't " +
                                  "include any land cover to run the model.",

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -74,9 +74,15 @@ var ResultsView = Marionette.LayoutView.extend({
                                                          'km<sup>2</sup>');
 
             if (areaInSqKm > settings.get('mapshed_max_area')) {
-                window.alert("The selected Area of Interest is too big for " +
-                             "the Watershed Multi-Year Model. The currently " +
-                             "maximum supported size is 1000 km².");
+                var alertView = new modalViews.AlertView({
+                    model: new modalModels.AlertModel({
+                        alertMessage: "The selected Area of Interest is too big for " +
+                                 "the Watershed Multi-Year Model. The currently " +
+                                 "maximum supported size is 1000 km².",
+                        alertType: modalModels.AlertTypes.warn
+                    })
+                });
+                alertView.render();
                 return;
             }
         }
@@ -91,8 +97,15 @@ var ResultsView = Marionette.LayoutView.extend({
                     }));
 
             if (landCoverTotal === 0) {
-                window.alert("The selected Area of Interest doesn't " +
-                             "include any land cover to run the model.");
+                var alertView = new modalViews.AlertView({
+                    model: new modalModels.AlertModel({
+                        alertMessage: "The selected Area of Interest doesn't " +
+                                 "include any land cover to run the model.",
+                        alertType: modalModels.AlertTypes.warn
+                    })
+                });
+
+                alertView.render();
                 return;
             }
         }

--- a/src/mmw/js/src/core/error/handlers.js
+++ b/src/mmw/js/src/core/error/handlers.js
@@ -1,21 +1,36 @@
 "use strict";
 
 var router = require('../../router').router,
+    modalModels = require('../modals/models'),
+    modalViews = require('../modals/views'),
     App = require('../../app');
 
 var ErrorHandlers = {
     itsi: function() {
         router.navigate('');
-        window.alert("We're sorry, but there was an error logging you in with your" +
-            " ITSI credentials. Please log in using another method or" +
-            " continue as a guest."
-        );
+        var alertView = new modalViews.AlertView({
+            model: new modalModels.AlertModel({
+                alertMessage: "We're sorry, but there was an error logging you in with your" +
+                            " ITSI credentials. Please log in using another method or" +
+                            " continue as a guest.",
+                alertType: modalModels.AlertTypes.error
+            })
+        });
+
+        alertView.render();
         App.showLoginModal();
     },
 
     generic: function(type) {
         router.navigate('');
-        window.alert("We're sorry, but an error occurred in the application.");
+        var alertView = new modalViews.AlertView({
+            model: new modalModels.AlertModel({
+                alertMessage: "We're sorry, but an error occurred in the application.", 
+                alertType: modalModels.AlertTypes.error
+            })
+        });
+
+        alertView.render();
         console.log("[MMW] An unknown error occurred: " + type);
     }
 };

--- a/src/mmw/js/src/core/modals/models.js
+++ b/src/mmw/js/src/core/modals/models.js
@@ -33,17 +33,17 @@ var ShareModel = Backbone.Model.extend({
 var AlertTypes = {
     info: {
         alertHeader: 'Information',
-        alertIcon: '\"fa fa-info-circle\"',
+        alertIcon: 'fa-info-circle',
         dismissLabel: 'Okay'
     },
     warn: {
         alertHeader: 'Warning',
-        alertIcon: '\"fa fa-exclamation-triangle\"',
+        alertIcon: 'fa-exclamation-triangle',
         dismissLabel: 'Okay'
     },
     error: {
         alertHeader: 'Error',
-        alertIcon: '\"fa fa-ban\"',
+        alertIcon: 'fa-ban',
         dismissLabel: 'Okay'
     }
 };

--- a/src/mmw/js/src/core/modals/models.js
+++ b/src/mmw/js/src/core/modals/models.js
@@ -32,17 +32,17 @@ var ShareModel = Backbone.Model.extend({
 
 var AlertTypes = {
     info: {
-        header: 'Information',
+        alertHeader: 'Information',
         alertIcon: '\"fa fa-info-circle\"',
         dismissLabel: 'Okay'
     },
     warn: {
-        header: 'Warning',
+        alertHeader: 'Warning',
         alertIcon: '\"fa fa-exclamation-triangle\"',
         dismissLabel: 'Okay'
     },
     error: {
-        header: 'Error',
+        alertHeader: 'Error',
         alertIcon: '\"fa fa-ban\"',
         dismissLabel: 'Okay'
     }
@@ -50,7 +50,7 @@ var AlertTypes = {
 
 var AlertModel = Backbone.Model.extend({
     defaults: {
-        message: '',
+        alertMessage: '',
         alertType: AlertTypes.info,
     },
 });

--- a/src/mmw/js/src/core/modals/models.js
+++ b/src/mmw/js/src/core/modals/models.js
@@ -30,8 +30,35 @@ var ShareModel = Backbone.Model.extend({
     }
 });
 
+var AlertTypes = {
+    info: {
+        header: 'Information',
+        alertIcon: '\"fa fa-info-circle\"',
+        dismissLabel: 'Okay'
+    },
+    warn: {
+        header: 'Warning',
+        alertIcon: '\"fa fa-exclamation-triangle\"',
+        dismissLabel: 'Okay'
+    },
+    error: {
+        header: 'Error',
+        alertIcon: '\"fa fa-ban\"',
+        dismissLabel: 'Okay'
+    }
+};
+
+var AlertModel = Backbone.Model.extend({
+    defaults: {
+        message: '',
+        alertType: AlertTypes.info,
+    },
+});
+
 module.exports = {
     ConfirmModel: ConfirmModel,
     InputModel: InputModel,
-    ShareModel: ShareModel
+    ShareModel: ShareModel,
+    AlertTypes: AlertTypes,
+    AlertModel: AlertModel
 };

--- a/src/mmw/js/src/core/modals/templates/alertModal.html
+++ b/src/mmw/js/src/core/modals/templates/alertModal.html
@@ -2,7 +2,7 @@
     <div class="modal-content">
         <div class="modal-header">
           <h2>
-            <i class={{ alertIcon }}></i>
+            <i class="fa {{ alertIcon }}"></i>
             {{ alertHeader }}
           </h2>
         </div>

--- a/src/mmw/js/src/core/modals/templates/alertModal.html
+++ b/src/mmw/js/src/core/modals/templates/alertModal.html
@@ -1,0 +1,16 @@
+<div class="modal-dialog modal-dialog-sm modal-popup">
+    <div class="modal-content">
+        <div class="modal-header">
+          <h2>
+            <i class={{ alertIcon }}></i>
+            {{ alertHeader }}
+          </h2>
+        </div>
+        <div class="modal-body">
+          <p>{{ alertMessage }}</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-md btn-default" data-dismiss="modal">{{ dismissLabel }}</button>
+        </div>
+    </div>
+</div>

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -12,6 +12,7 @@ var _ = require('underscore'),
     modalInputTmpl = require('./templates/inputModal.html'),
     modalPlotTmpl = require('./templates/plotModal.html'),
     modalShareTmpl = require('./templates/shareModal.html'),
+    modalAlertTmpl = require('./templates/alertModal.html'),
     vizerUrls = require('../settings').get('vizer_urls'),
 
     ENTER_KEYCODE = 13,
@@ -198,6 +199,31 @@ var ShareView = ModalBaseView.extend({
     }
 });
 
+var AlertView = ModalBaseView.extend({
+    template: modalAlertTmpl,
+
+    ui: {
+        dismiss: '.btn-default'
+    },
+
+    events: _.defaults({
+        'click @ui.dismiss': 'dismissAction'
+    }, ModalBaseView.prototype.events),
+
+    dismissAction: function() {
+        this.triggerMethod('dismiss');
+    },
+
+    templateHelpers: function() {
+        return {
+            alertMessage: this.model.get('message'),
+            alertHeader: this.model.get('alertType').header,
+            alertIcon: this.model.get('alertType').alertIcon,
+            dismissLabel: this.model.get('alertType').dismissLabel
+        };
+    }
+});
+
 var PlotView = ModalBaseView.extend({
     template: modalPlotTmpl,
 
@@ -371,5 +397,6 @@ module.exports = {
     ShareView: ShareView,
     InputView: InputView,
     ConfirmView: ConfirmView,
-    PlotView: PlotView
+    PlotView: PlotView,
+    AlertView: AlertView
 };

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -215,12 +215,7 @@ var AlertView = ModalBaseView.extend({
     },
 
     templateHelpers: function() {
-        return {
-            alertMessage: this.model.get('message'),
-            alertHeader: this.model.get('alertType').header,
-            alertIcon: this.model.get('alertType').alertIcon,
-            dismissLabel: this.model.get('alertType').dismissLabel
-        };
+        return _.extend(this.model.get('alertType'), { alertMessage: this.model.get('alertMessage') });
     }
 });
 

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -129,8 +129,7 @@ var HeaderView = Marionette.ItemView.extend({
                             alertMessage:'There was an error trying to clone that project. ' +
                                     'Please ensure that the project ID is valid and ' +
                                     'that you have permission to view the project.',
-                            alertType:'Error',
-                            dismissLabel:'Okay'
+                            alertType: modalModels.AlertTypes.error
                         })
                     });
 

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -124,11 +124,17 @@ var HeaderView = Marionette.ItemView.extend({
                     window.location.replace(cloneUrl);
                 })
                 .fail(function() {
-                    window.alert(
-                        'There was an error trying to clone that project. ' +
-                        'Please ensure that the project ID is valid and ' +
-                        'that you have permission to view the project.'
-                    );
+                    var alertView = new modalViews.AlertView({
+                        model: new modalModels.AlertModel({
+                            alertMessage:'There was an error trying to clone that project. ' +
+                                    'Please ensure that the project ID is valid and ' +
+                                    'that you have permission to view the project.',
+                            alertType:'Error',
+                            dismissLabel:'Okay'
+                        })
+                    });
+
+                    alertView.render();
                 });
         });
         view.render();

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -20,7 +20,9 @@ var $ = require('jquery'),
     drawTmpl = require('./templates/draw.html'),
     resetDrawTmpl = require('./templates/reset.html'),
     delineationOptionsTmpl = require('./templates/delineationOptions.html'),
-    settings = require('../core/settings');
+    settings = require('../core/settings'),
+    modalModels = require('../core/modals/models'),
+    modalViews = require('../core/modals/views');
 
 var MAX_AREA = 112700; // About the size of a large state (in km^2)
 var codeToLayer = {}; // code to layer mapping
@@ -70,14 +72,27 @@ function validateShape(polygon) {
         var errorMsg = 'This watershed shape is invalid because it intersects ' +
                        'itself. Try drawing the shape again without crossing ' +
                        'over its own border.';
-        window.alert(errorMsg);
+        var alertView = new modalViews.AlertView({
+            model: new modalModels.AlertModel({
+                alertMessage: errorMsg,
+                alertType: modalModels.AlertTypes.warn
+            })
+        });
+
+        alertView.render();
         d.reject(errorMsg);
     } else if (area > MAX_AREA) {
         var message = 'Sorry, your Area of Interest is too large.\n\n' +
                       Math.floor(area).toLocaleString() + ' km² were selected, ' +
                       'but the maximum supported size is currently ' +
                       MAX_AREA.toLocaleString() + ' km².';
-        window.alert(message);
+        var alertView = new modalViews.AlertView({
+            model: new modalModels.AlertModel({
+                alertMessage: message,
+                alertType: modalModels.AlertTypes.warn
+            })
+        });
+        alertView.render();
         d.reject(message);
     } else {
         d.resolve(polygon);
@@ -474,7 +489,14 @@ var WatershedDelineationView= Marionette.ItemView.extend({
             .fail(function(message) {
                 revertLayer();
                 if (message) {
-                    window.alert(message);
+                    var alertView = new modalViews.AlertView({
+                        model: new modalModels.AlertModel({
+                            alertMessage: message,
+                            alertType: modalModels.AlertTypes.error
+                        })
+                    });
+
+                    alertView.render();
                 }
             })
             .always(function() {

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -67,12 +67,13 @@ function validateShape(polygon) {
     var area = coreUtils.changeOfAreaUnits(turfArea(polygon), 'm<sup>2</sup>', 'km<sup>2</sup>'),
         d = new $.Deferred();
     var selfIntersectingShape = turfKinks(polygon).features.length > 0;
+    var alertView;
 
     if (selfIntersectingShape) {
         var errorMsg = 'This watershed shape is invalid because it intersects ' +
                        'itself. Try drawing the shape again without crossing ' +
                        'over its own border.';
-        var alertView = new modalViews.AlertView({
+        alertView = new modalViews.AlertView({
             model: new modalModels.AlertModel({
                 alertMessage: errorMsg,
                 alertType: modalModels.AlertTypes.warn
@@ -86,7 +87,7 @@ function validateShape(polygon) {
                       Math.floor(area).toLocaleString() + ' km² were selected, ' +
                       'but the maximum supported size is currently ' +
                       MAX_AREA.toLocaleString() + ' km².';
-        var alertView = new modalViews.AlertView({
+        alertView = new modalViews.AlertView({
             model: new modalModels.AlertModel({
                 alertMessage: message,
                 alertType: modalModels.AlertTypes.warn

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -593,6 +593,7 @@ var GwlfeModificationModel = Backbone.Model.extend({
 
 var ScenarioModel = Backbone.Model.extend({
     urlRoot: '/api/modeling/scenarios/',
+    alerts: [],
 
     defaults: {
         name: '',
@@ -889,6 +890,7 @@ var ScenarioModel = Backbone.Model.extend({
 var ScenariosCollection = Backbone.Collection.extend({
     model: ScenarioModel,
     comparator: 'created_at',
+    alerts: [],
 
     initialize: function() {
         this.on('reset', this.makeFirstScenarioActive);
@@ -958,8 +960,12 @@ var ScenariosCollection = Backbone.Collection.extend({
         });
 
         if (match) {
-            window.alert("There is another scenario with the same name. " +
-                    "Please choose a unique name for this scenario.");
+            this.alerts.push({message: 'There is another scenario with the same name. ' +
+                        'Please choose a unique name for this scenario.',
+                        alertType: 'warning',
+                        dismissLabel: 'Okay'});
+
+           this.trigger('change:alerts'); 
 
             console.log('This name is already in use.');
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -593,7 +593,6 @@ var GwlfeModificationModel = Backbone.Model.extend({
 
 var ScenarioModel = Backbone.Model.extend({
     urlRoot: '/api/modeling/scenarios/',
-    alerts: [],
 
     defaults: {
         name: '',
@@ -961,14 +960,10 @@ var ScenariosCollection = Backbone.Collection.extend({
 
         if (match) {
             this.alerts.push({message: 'There is another scenario with the same name. ' +
-                        'Please choose a unique name for this scenario.',
-                        alertType: 'warning',
-                        dismissLabel: 'Okay'});
+                        'Please choose a unique name for this scenario.'});
 
-           this.trigger('change:alerts'); 
-
+            this.trigger('change:alerts'); 
             console.log('This name is already in use.');
-
             return false;
         } else if (model.get('name') !== newName) {
             return model.set('name', newName);

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -889,7 +889,6 @@ var ScenarioModel = Backbone.Model.extend({
 var ScenariosCollection = Backbone.Collection.extend({
     model: ScenarioModel,
     comparator: 'created_at',
-    alerts: [],
 
     initialize: function() {
         this.on('reset', this.makeFirstScenarioActive);
@@ -951,7 +950,7 @@ var ScenariosCollection = Backbone.Collection.extend({
 
         // Bail early if the name actually didn't change.
         if (model.get('name') === newName) {
-            return false;
+            return true;
         }
 
         var match = this.find(function(model) {
@@ -959,10 +958,6 @@ var ScenariosCollection = Backbone.Collection.extend({
         });
 
         if (match) {
-            this.alerts.push({message: 'There is another scenario with the same name. ' +
-                        'Please choose a unique name for this scenario.'});
-
-            this.trigger('change:alerts'); 
             console.log('This name is already in use.');
             return false;
         } else if (model.get('name') !== newName) {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -267,6 +267,7 @@ var ScenariosView = Marionette.LayoutView.extend({
 
     initialize: function(options) {
         this.projectModel = options.projectModel;
+        this.listenTo(this.collection, 'change:alerts', this.showAlert);
     },
 
     templateHelpers: function() {
@@ -324,6 +325,19 @@ var ScenariosView = Marionette.LayoutView.extend({
             cid = $el.data('scenario-cid');
 
         this.collection.setActiveScenarioByCid(cid);
+    },
+
+    showAlert: function() {
+        var a = this.collection.alerts.shift();
+        var alertView = new modalViews.AlertView({
+            model: new modalModels.AlertModel({
+                message: a.message,
+                alertType: a.alertType,
+                dismissLabel: a.dismissLabel
+            })
+        });
+
+        alertView.render();
     }
 });
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -194,7 +194,14 @@ var ProjectMenuView = Marionette.ItemView.extend({
             if (xhr) {
                 xhr.done(navigateAfterDelete)
                     .fail(function() {
-                        window.alert('Could not delete this project.');
+                        var alertView = new modalViews.AlertView({
+                            model: new modalModels.AlertModel({
+                                alertMessage: 'Could not delete this project.', 
+                                alertType: modalModels.AlertTypes.error
+                            })
+                        });
+
+                        alertView.render();
                     });
             } else {
                 navigateAfterDelete();
@@ -331,9 +338,8 @@ var ScenariosView = Marionette.LayoutView.extend({
         var a = this.collection.alerts.shift();
         var alertView = new modalViews.AlertView({
             model: new modalModels.AlertModel({
-                message: a.message,
-                alertType: a.alertType,
-                dismissLabel: a.dismissLabel
+                alertMessage: a.message,
+                alertType: modalModels.AlertTypes.warn
             })
         });
 

--- a/src/mmw/js/src/projects/views.js
+++ b/src/mmw/js/src/projects/views.js
@@ -152,7 +152,15 @@ var ProjectRowView = Marionette.ItemView.extend({
             self.model
                 .destroy({ wait: true })
                 .fail(function() {
-                    window.alert('Could not delete this project.');
+                    var alertView = new modalViews.AlertView({
+                        model: new modalModels.AlertModel({
+                            alertMessage: 'Could not delete this project.', 
+                            alertType: 'error',
+                            dismissLabel: 'Okay'
+                        })
+                    });
+
+                    alertView.render();
                 });
         });
     }

--- a/src/mmw/js/src/projects/views.js
+++ b/src/mmw/js/src/projects/views.js
@@ -155,8 +155,7 @@ var ProjectRowView = Marionette.ItemView.extend({
                     var alertView = new modalViews.AlertView({
                         model: new modalModels.AlertModel({
                             alertMessage: 'Could not delete this project.', 
-                            alertType: 'error',
-                            dismissLabel: 'Okay'
+                            alertType: modalModels.AlertTypes.error
                         })
                     });
 

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -138,3 +138,22 @@
   top: 1rem;
   left: 2rem;
 }
+
+.modal-popup {
+    .fa {
+      font-size: 1.0rem;
+      padding: 0 0.1rem 0 0.1rem;
+    }
+
+    .fa-info-circle {
+      color: $brand-primary;
+    }
+
+    .fa-ban {
+      color: $ui-danger;
+    }
+
+    .fa-exclamation-triangle {
+      color: $ui-warning;
+    }
+}

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -18,6 +18,7 @@ $ui-secondary: #394750; /*Medium Grey*/
 $ui-light: #eceff1; /*Light Grey*/
 $ui-grey: #787878 ; /* Output Tab Bar */
 $ui-danger: #e0412d; /*Errors*/
+$ui-warning: #e4b72f; /*Warnings*/
 $active: #51dec2; /*Bright*/
 $brand-primary: #389b9b; /*Teal*/
 $sky-blue: #bbe5f5; /*Sky*/


### PR DESCRIPTION
This adds a modal form for alerts, and replaces the existing generic `window.alert` calls with the modal form.

To test:
* clone this branch and bring up the environment
* navigate to `http://localhost:8000`
* perform user actions that should result in an error: draw a self-intersecting AoI polygon; rename a model scenario with an existing name; draw a very large AoI polygon; cause a login error
* the modal forms should show and have relevant messages

Connects #645 
