### PR TITLE
Add NHD Water Quality Data

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -13,6 +13,7 @@ where: \n
     -s  load/reload stream data\n
     -d load/reload DRB stream data\n
     -m  load/reload mapshed data\n
+    -q  load/reload water quality data\n
 "
 
 # HTTP accessible storage for initial app data
@@ -21,8 +22,9 @@ load_boundary=false
 file_to_load=
 load_stream=false
 load_mapshed=false
+load_water_quality=false
 
-while getopts ":hbsdpmf:" opt; do
+while getopts ":hbsdpmqf:" opt; do
     case $opt in
         h)
             echo -e $usage
@@ -37,6 +39,8 @@ while getopts ":hbsdpmf:" opt; do
             load_dep=true ;;
         m)
             load_mapshed=true ;;
+        q)
+            load_water_quality=true ;;
         f)
             file_to_load=$OPTARG ;;
         \?)
@@ -118,5 +122,11 @@ if [ "$load_mapshed" = "true" ] ; then
     FILES=("ms_weather.sql.gz" "ms_weather_station.sql.gz" "ms_pointsource.sql.gz"
            "ms_pointsource_drb.sql.gz" "ms_county_animals.sql.gz")
 
+    download_and_load $FILES
+fi
+
+if [ "$load_water_quality" = "true" ] ; then
+    # Fetch water quality data
+    FILES=("nhd_water_quality.sql.gz")
     download_and_load $FILES
 fi


### PR DESCRIPTION
- Add a new table called `nhd_water_quality` to the s3 bucket 
- Add `-q` flag to the `setupdb` script to load water quality data

We'll be using this new data in #1479 to visualize the water quality of DRB streams!

#### Notes
In case it's useful to someone later, in order to load the initial dump from Scott that's on the fileshare, I...
- Created a new schema called `phase2` in the `mmw` db
- Ran `pg_restore -h localhost -d mmw  -U mmw -W -Fc --no-owner -n phase2 -t cexport_tntptssconc tntptssconc_9_29_16.backup`
  - Without the namespace, it would try to add the table to `pgcatalog`, which isn't allowed.

### Testing
Pull this branch.
```
vagrant ssh app
/vagrant/scripts/aws/setupdb.sh -q
```
And then back on your host:
```
vagrant ssh services
psql -h localhost -U mmw mmw
```
- If you do `\d` you should see `nhd_water_quality` listed.
- `select count(*) from nhd_water_quality` should be  10957
- The table should have four columns:
```
 comid  | tn_yr_avg_concmgl | tp_yr_avg_concmgl | tss_concmgl 
---------+-------------------+-------------------+-------------
 8077774 |            5.4900 |            0.2674 |     23.5334
 8076812 |            5.6346 |            0.2721 |     24.5817
 8077552 |            1.8217 |            0.1406 |      5.7325
 8076910 |            5.8411 |            0.2804 |     31.6549
 8077578 |            5.8223 |            0.2808 |     32.1015
 8077588 |            5.8003 |            0.2788 |     33.0027
 8077808 |            5.8209 |            0.2825 |     33.7476
 8077600 |            5.6570 |            0.2912 |     37.2948
 8077016 |            5.7358 |            0.3033 |     37.1882
 8077060 |            6.1020 |            0.2883 |     59.2582
```
- You should be able to join `nhdflowline` and `nhd_water_quality` on `comid` 

Connects #1471 

