### PR TITLE
Import `drb_catchment_water_quality` table

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -11,7 +11,7 @@ where: \n
     -b  load/reload boundary data\n
     -f  load a named boundary sql.gz\n
     -s  load/reload stream data\n
-    -d load/reload DRB stream data\n
+    -d  load/reload DRB stream data\n
     -m  load/reload mapshed data\n
     -q  load/reload water quality data\n
 "
@@ -127,6 +127,6 @@ fi
 
 if [ "$load_water_quality" = "true" ] ; then
     # Fetch water quality data
-    FILES=("nhd_water_quality.sql.gz")
+    FILES=("nhd_water_quality.sql.gz" "drb_catchment_water_quality.sql.gz")
     download_and_load $FILES
 fi


### PR DESCRIPTION
This PR updates the `setupdb.sh` script to get the `drb_catchment_water_quality` table from S3. 

I imported the Shapefile mentioned in #1480, added a spatial index, `pg_dump`ed it from the instance of Postgres running on my Services VM, then uploaded it to S3. This update adds the filename to the list of files to get when using the `-q` option to get water quality data.

**Testing**
- get this branch, `vagrant up`, then `vagrant ssh app` and `cd /vagrant/scripts/aws`
- run `./setupdb.sh -q` to import the DRB catchment water quality data
- inside the services VM, run `psql -h localhost -U mmw` to login
- run `SELECT COUNT(*) FROM drb_catchment_water_quality;` and verify that you see

```sql
 count 
-------
 15004
(1 row)
```

- run `\d drb_catchment_water_quality` and verify that you see this output:

```sql
 
                                      Table "public.drb_catchment_water_quality"
   Column   |            Type             |                                 Modifiers                                 
------------+-----------------------------+---------------------------------------------------------------------------
 gid        | integer                     | not null default nextval('drb_catchment_water_quality_gid_seq'::regclass)
 nord       | numeric(10,0)               | 
 areaha     | numeric                     | 
 pop10      | numeric(10,0)               | 
 tn_tot_kgy | numeric                     | 
 tn_urban_k | numeric                     | 
 tn_riparia | numeric                     | 
 tn_ag_kgyr | numeric                     | 
 tn_natural | numeric                     | 
 tn_pt_kgyr | numeric                     | 
 tp_tot_kgy | numeric                     | 
 tp_urban_k | numeric                     | 
 tp_riparia | numeric                     | 
 tp_ag_kgyr | numeric                     | 
 tp_natural | numeric                     | 
 tp_pt_kgyr | numeric                     | 
 tss_tot_kg | numeric                     | 
 tss_urban_ | numeric                     | 
 tss_ag_kgy | numeric                     | 
 tss_natura | numeric                     | 
 tss_rip_kg | numeric                     | 
 geom       | geometry(MultiPolygon,4326) | 
Indexes:
    "drb_catchment_water_quality_pkey" PRIMARY KEY, btree (gid)
    "drb_catchment_water_quality_geom_idx" gist (geom)
```

Connects #1480 
