### PR TITLE
Feature/water quality tiles

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -130,8 +130,5 @@ if [ "$load_water_quality" = "true" ] ; then
     # Fetch water quality data
     FILES=("nhd_water_quality.sql.gz" "drb_catchment_water_quality.sql.gz")
     PATHS=("drb_catchment_water_quality_tn" "drb_catchment_water_quality_tp"
-           "drb_catchment_water_quality_tss")
-
-    download_and_load $FILES
-    purge_tile_cache $PATHS
+            "drb_catchment_water_quality_tss" "nhd_quality_tp" "nhd_quality_tn")
 fi

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -145,6 +145,30 @@ LAYERS = [
         # overlaps with perimeter polygon.
     },
     {
+        'code': 'nhd_quality_tp',
+        'display': 'Delaware River Basin TP Concentration',
+        'table_name': 'nhd_quality_tp',
+        'stream': True,
+        'overlay': True,
+        'minZoom': 3
+    },
+    {
+        'code': 'nhd_quality_tn',
+        'display': 'Delaware River Basin TN Concentration',
+        'table_name': 'nhd_quality_tn',
+        'stream': True,
+        'overlay': True,
+        'minZoom': 3
+    },
+    {
+        'code': 'nhd_quality_tss',
+        'display': 'Delaware River Basin TSS Concentration',
+        'table_name': 'nhd_quality_tss',
+        'stream': True,
+        'overlay': True,
+        'minZoom': 3
+    },
+    {
         'display': 'National Land Cover Database',
         'short_display': 'NLCD',
         'helptext': 'National Land Cover Database defines'

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -15,7 +15,7 @@ var dbUser = process.env.MMW_DB_USER,
     redisPort = process.env.MMW_CACHE_PORT,
     tileCacheBucket = process.env.MMW_TILECACHE_BUCKET,
     stackType = process.env.MMW_STACK_TYPE,
-        rollbarAccessToken = process.env.ROLLBAR_SERVER_SIDE_ACCESS_TOKEN;
+    rollbarAccessToken = process.env.ROLLBAR_SERVER_SIDE_ACCESS_TOKEN;
 
 var NHD_QUALITY_TSS_MAP = {
     'L1': [0,50],
@@ -56,6 +56,9 @@ var interactivity = {
         huc12: 'boundary_huc12',
         drb_streams_v2: 'drb_streams_50',
         nhd_streams_v2: 'nhdflowline',
+        nhd_quality_tn: 'nhd_quality_tn',
+        nhd_quality_tp: 'nhd_quality_tp',
+        nhd_quality_tss: 'nhd_quality_tss',
         municipalities: 'dep_municipalities',
         urban_areas: 'dep_urban_areas',
         // The DRB Catchment tables here use aliases to match data from different
@@ -66,6 +69,7 @@ var interactivity = {
         drb_catchment_water_quality_tss: 'drb_catchment_water_quality_tss'
     },
     drbCatchmentWaterQualityTable = 'drb_catchment_water_quality';
+    nhdQualityTable = 'nhd_water_quality',
     shouldCacheRequest = function(req) {
         // Caching can happen if the bucket to write to is defined
         // and the request is not coming from localhost.
@@ -188,7 +192,7 @@ var config = {
     },
     redis: {
         host: redisHost,
-        eort: redisPort
+        port: redisPort
     },
     log_format: '{ "timestamp": ":date[iso]", "@fields": { "remote_addr": ":remote-addr", "body_bytes_sent": ":res[content-length]", "request_time": ":response-time", "status": ":status", "request": ":method :url HTTP/:http-version", "request_method": ":method", "http_referrer": ":referrer", "http_user_agent": ":user-agent" } }',
 
@@ -251,14 +255,13 @@ var config = {
                 req.params.sql = getSqlForStreamByReq(req);
             }
 
-<<<<<<< HEAD
             if (tableId.indexOf('drb_catchment') >= 0) {
                 req.params.sql = getSqlForDRBCatchmentByTableId(tableId);
-=======
+            }
+
             if (tableId.indexOf('nhd_quality') >= 0) {
                 req.params.table = tables[tableId];
                 req.params.sql = getSqlForStreamByReq(req);
->>>>>>> Add rendering & styling for water quality data
             }
 
             req.params.dbname = dbName;

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -108,6 +108,13 @@
 }
 
 @streamColor: #1562A9;
+@wtrQualColor0: #d7191c;
+@wtrQualColor1: #fdae61;
+@wtrQualColor2: #ffffbf;
+@wtrQualColor3: #a6d96a;
+@wtrQualColor4: #1a9641;
+@wtrQualColorNA: #787878;
+
 @zoomBase: 0.5;
 
 /* DRB and NHD Streams have custom SQL which is executed for tile requests
@@ -118,19 +125,45 @@
 */
 
 #drb_streams_50 {
-    line-color: @streamColor;
-    line-join: round;
-    line-cap: round;
+  line-color: @streamColor;
+  line-join: round;
+  line-cap: round;
 }
 
 #nhdflowline {
-    line-color: @streamColor;
-    line-join: round;
-    line-cap: round;
+  line-color: @streamColor;
+  line-join: round;
+  line-cap: round;
+}
+
+#nhd_quality_tp,
+#nhd_quality_tn,
+#nhd_quality_tss {
+  [nhd_qual_grp="L1"] {
+    line-color: @wtrQualColor0;
+  }
+  [nhd_qual_grp="L2"] {
+    line-color: @wtrQualColor1;
+  }
+  [nhd_qual_grp="L3"] {
+    line-color: @wtrQualColor2;
+  }
+  [nhd_qual_grp="L4"] {
+    line-color: @wtrQualColor3;
+  }
+  [nhd_qual_grp="L5"] {
+    line-color: @wtrQualColor4;
+  }
+  [nhd_qual_grp="NA"] {
+    line-color: @wtrQualColorNA;
+  }
 }
 
 #drb_streams_50[zoom<=4],
-#nhdflowline[zoom<=4] {
+#nhdflowline[zoom<=4],
+#nhd_quality_tp[zoom<=4],
+#nhd_quality_tn[zoom<=4],
+#nhd_quality_tss[zoom<=4] {
   [stream_order=10] {
     line-width: 5.0 * @zoomBase;
   }
@@ -143,7 +176,10 @@
 }
 
 #drb_streams_50[zoom>=5][zoom<=6],
-#nhdflowline[zoom>=5][zoom<=6] {
+#nhdflowline[zoom>=5][zoom<=6],
+#nhd_quality_tp[zoom>=5][zoom<=6],
+#nhd_quality_tn[zoom>=5][zoom<=6],
+#nhd_quality_tss[zoom>=5][zoom<=6] {
   [stream_order=10] {
     line-width: 7.0 * @zoomBase;
   }
@@ -156,7 +192,10 @@
 }
 
 #drb_streams_50[zoom>=7][zoom<=8],
-#nhdflowline[zoom>=7][zoom<=8] {
+#nhdflowline[zoom>=7][zoom<=8],
+#nhd_quality_tp[zoom>=7][zoom<=8],
+#nhd_quality_tn[zoom>=7][zoom<=8],
+#nhd_quality_tss[zoom>=7][zoom<=8] {
   [stream_order>=9] {
     line-width: 10.0 * @zoomBase;
   }
@@ -172,7 +211,10 @@
 }
 
 #drb_streams_50[zoom>=9][zoom<=10],
-#nhdflowline[zoom>=9][zoom<=10] {
+#nhdflowline[zoom>=9][zoom<=10],
+#nhd_quality_tp[zoom>=9][zoom<=10],
+#nhd_quality_tn[zoom>=9][zoom<=10],
+#nhd_quality_tss[zoom>=9][zoom<=10] {
   [stream_order>=9] {
     line-width: 14.0 * @zoomBase;
   }
@@ -188,7 +230,10 @@
 }
 
 #drb_streams_50[zoom>=11][zoom<=12],
-#nhdflowline[zoom>=11][zoom<=12] {
+#nhdflowline[zoom>=11][zoom<=12],
+#nhd_quality_tp[zoom>=11][zoom<=12],
+#nhd_quality_tn[zoom>=11][zoom<=12],
+#nhd_quality_tss[zoom>=11][zoom<=12] {
   [stream_order>=9] {
     line-width: 18.0 * @zoomBase;
   }
@@ -211,7 +256,10 @@
 
 
 #drb_streams_50[zoom>=13],
-#nhdflowline[zoom>=13] {
+#nhdflowline[zoom>=13],
+#nhd_quality_tp[zoom>=13],
+#nhd_quality_tn[zoom>=13],
+#nhd_quality_tss[zoom>=13] {
   [stream_order>=9] {
     line-width: 18.0 * @zoomBase;
   }


### PR DESCRIPTION
This builds on #1471 to add rendered tile overlays to the map.

To test:
* clone this branch and bring up an environment (if you have one running, `tiler` will probably have to be reprovisioned to pick up `underscore`, or else you can just `npm install underscore` on the VM
* navigate to `http://localhost:8000`
* try enabling the new layers from the `Overlay` tab in the layer selector; the new ones are "Deleware River Basin TP Concentration", "Deleware River Basin TN Concentration", & "Deleware River Basin TSS Concentration"; cycle through different zoom levels for each, and try switching base maps at some point
* the stream layers should render and the Delaware basin tiles should have different colors per the data binding for each layer

This will probably have merge conflicts with `develop` once #1499 gets merged in, but I think I replicated most of the parts of `styles.mss` to avoid anything gnarly. Additionally, it's probably worth taking a critical look at the color scheme provided in #1478, since I could understand how the rendered colors might be hard to see on certain base maps at certain zoom levels.

Connects #1479 & #1478 