### PR TITLE
Increase SJS JVM stack size to avoid stack overflow

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/upstart-spark-jobserver.conf.j2
@@ -24,7 +24,7 @@ exec /usr/bin/docker run \
   --volume {{ geop_home }}:{{ geop_home }} \
   --volume {{ sjs_data_dir }}:{{ sjs_data_dir }} \
   --log-driver syslog \
-  {{ sjs_container_image }} --driver-memory {{ sjs_driver_memory }}
+  {{ sjs_container_image }} --driver-memory {{ sjs_driver_memory }} --driver-java-options "-Xss5m -Dlog4j.configuration=file:log4j.properties"
 
 post-stop script
   /usr/bin/docker kill spark-jobserver || true


### PR DESCRIPTION
The serializers Kryo provides use the call stack when serializing nested objects. This change increases the JVM stack size to 5MB so that Kryo serialization can squeeze through.

The stack size increase here is for all threads, so it is possible that this change has a negative impact in other areas if the number of threads grows large.

See: https://github.com/EsotericSoftware/kryo#stack-size

**Testing**

Provision the `worker`, then try to analyze the NJ-04 congressional district. When that's complete, attempt to the Watershed Multi-Year Model. It should complete successfully.