### PR TITLE
Render DRB Catchment Water Quality tiles

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -13,6 +13,7 @@ where: \n
     -s  load/reload stream data\n
     -d  load/reload DRB stream data\n
     -m  load/reload mapshed data\n
+    -p  load/reload DEP data\n
     -q  load/reload water quality data\n
 "
 

--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -128,5 +128,9 @@ fi
 if [ "$load_water_quality" = "true" ] ; then
     # Fetch water quality data
     FILES=("nhd_water_quality.sql.gz" "drb_catchment_water_quality.sql.gz")
+    PATHS=("drb_catchment_water_quality_tn" "drb_catchment_water_quality_tp"
+           "drb_catchment_water_quality_tss")
+
     download_and_load $FILES
+    purge_tile_cache $PATHS
 fi

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -233,6 +233,36 @@ LAYERS = [
         'opacity': 0.618,
         'has_opacity_slider': True,
         'perimeter': pa_perimeter,
+    },
+    {
+        'code': 'drb_catchment_water_quality_tn',
+        'display': ('DRB Catchment Water Quality Data' +
+                    '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TN Loading Rates'),
+        'table_name': 'drb_catchment_water_quality_tn',
+        'vector': True,
+        'overlay': True,
+        'minZoom': 3,
+        'perimeter': drb_perimeter
+    },
+    {
+        'code': 'drb_catchment_water_quality_tp',
+        'display': ('DRB Catchment Water Quality Data' +
+                    '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TP Loading Rates'),
+        'table_name': 'drb_catchment_water_quality_tp',
+        'vector': True,
+        'overlay': True,
+        'minZoom': 3,
+        'perimeter': drb_perimeter
+    },
+    {
+        'code': 'drb_catchment_water_quality_tss',
+        'display': ('DRB Catchment Water Quality Data' +
+                    '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TSS Loading Rates'),
+        'table_name': 'drb_catchment_water_quality_tss',
+        'vector': True,
+        'overlay': True,
+        'minZoom': 3,
+        'perimeter': drb_perimeter
     }
 ]
 

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -35,6 +35,78 @@
   }
 }
 
+@drb_catchment_step_one_color: #A0A0A0;
+@drb_catchment_step_two_color: #888888;
+@drb_catchment_step_three_color: #707070;
+@drb_catchment_step_four_color: #484848;
+@drb_catchment_step_five_color: #202020;
+@drb_catchment_line_color: #FFF;
+@drb_catchment_line_width: 4;
+@drb_catchment_opacity: 0.65;
+
+#drb_catchment_water_quality_tn {
+    line-color: @drb_catchment_line_color;
+    line-width: @drb_catchment_line_width;
+    opacity: @drb_catchment_opacity;
+    [tn_tot_kgy >= 0][tn_tot_kgy < 5] {
+        polygon-fill: @drb_catchment_step_one_color;
+    }
+    [tn_tot_kgy >= 5][tn_tot_kgy < 10] {
+        polygon-fill: @drb_catchment_step_two_color;
+    }
+    [tn_tot_kgy >= 10][tn_tot_kgy < 15] {
+        polygon-fill: @drb_catchment_step_three_color;
+    }
+    [tn_tot_kgy >= 15][tn_tot_kgy < 20] {
+        polygon-fill: @drb_catchment_step_four_color;
+    }
+    [tn_tot_kgy >= 20] {
+        polygon-fill: @drb_catchment_step_five_color;
+    }
+}
+
+#drb_catchment_water_quality_tp {
+    line-color: @drb_catchment_line_color;
+    line-width: @drb_catchment_line_width;
+    opacity: @drb_catchment_opacity;
+    [tp_tot_kgy >= 0.0][tp_tot_kgy < 0.30] {
+        polygon-fill: @drb_catchment_step_one_color;
+    }
+    [tp_tot_kgy >= 0.30][tp_tot_kgy < 0.60] {
+        polygon-fill: @drb_catchment_step_two_color;
+    }
+    [tp_tot_kgy >= 0.60][tp_tot_kgy < 0.90] {
+        polygon-fill: @drb_catchment_step_three_color;
+    }
+    [tp_tot_kgy >= 0.90][tp_tot_kgy < 1.20] {
+        polygon-fill: @drb_catchment_step_four_color;
+    }
+    [tp_tot_kgy >= 1.20] {
+        polygon-fill: @drb_catchment_step_five_color;
+    }
+}
+
+#drb_catchment_water_quality_tss {
+    line-color: @drb_catchment_line_color;
+    line-width: @drb_catchment_line_width;
+    opacity: @drb_catchment_opacity;
+    [tss_tot_kg >= 0][tss_tot_kg < 250] {
+        polygon-fill: @drb_catchment_step_one_color;
+    }
+    [tss_tot_kg >= 250][tss_tot_kg < 500] {
+        polygon-fill: @drb_catchment_step_two_color;
+    }
+    [tss_tot_kg >= 500][tss_tot_kg < 750] {
+        polygon-fill: @drb_catchment_step_three_color;
+    }
+    [tss_tot_kg >= 750][tss_tot_kg < 1000] {
+        polygon-fill: @drb_catchment_step_four_color;
+    }
+    [tss_tot_kg >= 1000] {
+        polygon-fill: @drb_catchment_step_five_color;
+    }
+}
+
 @streamColor: #1562A9;
 @zoomBase: 0.5;
 


### PR DESCRIPTION
This PR updates the layer settings and tiler to render TN, TP, and TSS loading rates for DRB Catchments from the `drb_catchment_water_quality` table added in #1505. It also adds styling rules to establish a five-step gray color-break scheme to render the values according to the intervals noted in #1482. In addition, I've updated the `setupdb.sh` aws script to purge the tiles for these layers on reloading the table.

The result currently looks like this:

DRB Catchment TN:

![screen shot 2016-10-05 at 12 03 10 pm](https://cloud.githubusercontent.com/assets/4165523/19121276/d9a4c0d2-8af3-11e6-8f31-7aeaa209d210.png)

DRB Catchment TP:

![screen shot 2016-10-05 at 12 03 17 pm](https://cloud.githubusercontent.com/assets/4165523/19121285/de6d0be2-8af3-11e6-8f3e-e5d2b27f05ae.png)

and DRB Catchment TSS:

![screen shot 2016-10-05 at 12 03 24 pm](https://cloud.githubusercontent.com/assets/4165523/19121290/e44526da-8af3-11e6-99af-a59c3e733154.png)

**Testing**
- get this branch, `vagrant up`, `vagrant ssh app`, `cd /vagrant/scripts/aws` and `./setupdb.sh -q` to get the `drb_catchment_water_quality_table`
- visit `localhost:8000` in the browser, pan to the DRB area, and open the layer selector's overlays tab
- open the browser console, network tab, and "img" to see the tiles as they're downloaded
- the new layers are currently in the "Boundary" section. Toggle each of "DRB Catchment... TN", "TP", and "TSS" on and verify that you see the tiles rendering, that they're being requested from endpoints concluding with `_tn`, `_tp`, and `_tss` respectively, and that the values change when you toggle from one layer to another
- verify that you haven't seen any errors in the browser console

Connects #1482 