### PR TITLE
Update stream paths for cache purge

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -102,7 +102,7 @@ fi
 if [ "$load_stream" = "true" ] ; then
     # Fetch stream network layer sql files
     FILES=("nhdflowline.sql.gz")
-    PATHS=("stream")
+    PATHS=("nhd_streams_v2")
 
     download_and_load $FILES
     purge_tile_cache $PATHS
@@ -111,7 +111,7 @@ fi
 if [ "$load_drb_streams" = "true" ] ; then
     # Fetch DRB stream network layer sql file
     FILES=("drb_streams_50.sql.gz")
-    PATHS=("drb_streams")
+    PATHS=("drb_streams_v2")
 
     download_and_load $FILES
     purge_tile_cache $PATHS

--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -93,7 +93,7 @@ fi
 if [ "$load_boundary" = "true" ] ; then
     # Fetch boundary layer sql files
     FILES=("boundary_county.sql.gz" "boundary_school_district.sql.gz" "boundary_district.sql.gz" "boundary_huc12.sql.gz" "boundary_huc10.sql.gz" "boundary_huc08.sql.gz")
-    PATHS=("county" "district" "huc8" "huc10" "huc12")
+    PATHS=("county" "district" "huc8" "huc10" "huc12" "school")
 
     download_and_load $FILES
     purge_tile_cache $PATHS


### PR DESCRIPTION
### Overview
In order to see styling updates immediately and not wait for a TTL to
expire on CloudFront, these paths were updated periodically.  Now that
it's settled, syncing up correct purge paths so the cache is cleared
when the data is reloaded in the future.

### Testing
Verify that the paths associated with the datasets are the same as those used by the tiler
https://github.com/WikiWatershed/model-my-watershed/blob/develop/src/tiler/server.js#L36-L37