### PR TITLE
Add HTTP redirect for micro site

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
@@ -15,13 +15,17 @@ server {
   access_log /var/log/nginx/mmw-app.access.log logstash_json;
 
   {% if ['packer'] | is_in(group_names) -%}
-  location /version.txt {
+  location = /version.txt {
     alias /srv/version.txt;
   }
   {% endif %}
 
-  location /favicon.ico {
+  location = /favicon.ico {
     alias {{ app_static_root }}favicon.png;
+  }
+
+  location = /micro/ {
+    return 301 https://micro.$host;
   }
 
   location /static/ {
@@ -42,7 +46,7 @@ server {
     alias {{ app_media_root }};
   }
 
-  location /health-check/ {
+  location = /health-check/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;

--- a/deployment/ansible/roles/model-my-watershed.tiler/templates/nginx-mmw-tiler.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.tiler/templates/nginx-mmw-tiler.conf.j2
@@ -5,7 +5,7 @@ server {
   access_log /var/log/nginx/mmw-tiler.access.log logstash_json;
 
   {% if ['packer'] | is_in(group_names) -%}
-  location /version.txt {
+  location = /version.txt {
     alias /srv/version.txt;
   }
   {% endif %}


### PR DESCRIPTION
When a request is made to `/micro/`, it is now redirected by Nginx to `https://micro.$domain`. This ensures that the redirect will work on staging and production.

In addition, I made Nginx location blocks for `favicon.ico`, `version.txt`, and `/health-check/` be exact matches.

Along with https://github.com/WikiWatershed/mmw-micro/pull/6, resolves https://github.com/WikiWatershed/model-my-watershed/issues/1517.

---

**Testing**

First, provision the `app` and `tiler` virtual machines with Vagrant:

```bash
❯ vagrant provision app tiler
```

Then, ensure that the following HTTP interactions line up using `curl`:

```bash
❯ curl -I "http://localhost:8000/micro/"       
HTTP/1.1 301 Moved Permanently
Server: nginx/1.10.1
Date: Fri, 07 Oct 2016 17:42:09 GMT
Content-Type: text/html
Content-Length: 185
Connection: keep-alive
Location: https://micro.localhost
❯ curl -I "http://localhost:8000/favicon.ico"  
HTTP/1.1 200 OK
Server: nginx/1.10.1
Date: Fri, 07 Oct 2016 17:42:22 GMT
Content-Type: image/x-icon
Content-Length: 324
Last-Modified: Tue, 04 Oct 2016 15:57:30 GMT
Connection: keep-alive
ETag: "57f3d16a-144"
Accept-Ranges: bytes
❯ curl -I "http://localhost:8000/health-check/"
HTTP/1.1 200 OK
Server: nginx/1.10.1
Date: Fri, 07 Oct 2016 17:42:32 GMT
Content-Type: application/json
Connection: keep-alive
Vary: Accept-Encoding
```