### PR TITLE
Draw RWD watersheds before polygon validation

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -3,7 +3,8 @@
 var Backbone = require('../../shim/backbone'),
     $ = require('jquery'),
     _ = require('lodash'),
-    turfArea = require('turf-area');
+    turfArea = require('turf-area'),
+    utils = require('./utils');
 
 var MapModel = Backbone.Model.extend({
     defaults: {
@@ -30,20 +31,7 @@ var MapModel = Backbone.Model.extend({
         // object with type='MultiPolygon', a coordinates attribute
         // and nothing else.
         if (this.get('areaOfInterest')) {
-            var aoi = this.get('areaOfInterest').geometry ?
-                      this.get('areaOfInterest').geometry :
-                      this.get('areaOfInterest');
-
-            if (aoi.type !== 'MultiPolygon') {
-                if (aoi.type === 'Polygon') {
-                    aoi.coordinates = [aoi.coordinates];
-                } else if (aoi.type === 'FeatureCollection') {
-                    aoi.coordinates = [aoi.features[0].geometry.coordinates];
-                }
-
-                aoi.type = 'MultiPolygon';
-            }
-
+            var aoi = utils.toMultiPolygon(this.get('areaOfInterest'));
             this.set('areaOfInterest', aoi);
         }
     },

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -287,6 +287,20 @@ var utils = {
         return str.replace(/\w\S*/g, function(txt) {
             return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
         });
+    },
+
+    // Convert polygon to MultiPolyon (mutates original argument).
+    toMultiPolygon: function(polygon) {
+        var geom = polygon.geometry ? polygon.geometry : polygon;
+        if (geom.type !== 'MultiPolygon') {
+            if (geom.type === 'Polygon') {
+                geom.coordinates = [geom.coordinates];
+            } else if (geom.type === 'FeatureCollection') {
+                geom.coordinates = [geom.features[0].geometry.coordinates];
+            }
+            geom.type = 'MultiPolygon';
+        }
+        return geom;
     }
 };
 

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -578,7 +578,8 @@ function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {
 }
 
 function clearAoiLayer() {
-    var projectNumber = App.projectNumber;
+    var projectNumber = App.projectNumber,
+        previousShape = App.map.get('areaOfInterest');
 
     App.map.set('areaOfInterest', null);
     App.projectNumber = undefined;
@@ -586,7 +587,6 @@ function clearAoiLayer() {
     App.clearAnalyzeCollection();
 
     return function revertLayer() {
-        var previousShape = App.map.previous('areaOfInterest');
         App.map.set('areaOfInterest', previousShape);
         App.projectNumber = projectNumber;
     };

--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -27,11 +27,14 @@ var SuggestionModel = Backbone.Model.extend({
     },
 
     setMapViewToLocation: function(zoom) {
-        App.map.set({
-            lat: this.get('location').get('y'),
-            lng: this.get('location').get('x'),
-            zoom: zoom || this.get('zoom')
-        });
+        var location = this.get('location');
+        if (location) {
+            App.map.set({
+                lat: location.get('y'),
+                lng: location.get('x'),
+                zoom: zoom || this.get('zoom')
+            });
+        }
     },
 
     select: function() {


### PR DESCRIPTION
This fixes a bug where RWD shapes do not appear on the map, because the
FeatureCollection returned by RWD throws an exception during shape
validation.

Fix this by converting the watershed from a FeatureCollection to a
MultiPolygon before validation. Also decided to draw the watershed
before the validation step just in case it fails.

The rationale is that we should always err on the side of displaying the
RWD watershed, even if it fails validation. Although the shape is always
displayed now, we only navigate to the analyze view if validation
is successful.

Connects #1521