### PR TITLE
Move Catchment Layers to Coverage and Allow Max Opacity

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -263,30 +263,36 @@ LAYERS = [
         'display': ('DRB Catchment Water Quality Data' +
                     '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TN Loading Rates'),
         'table_name': 'drb_catchment_water_quality_tn',
-        'vector': True,
+        'raster': True,
         'overlay': True,
         'minZoom': 3,
-        'perimeter': drb_perimeter
+        'perimeter': drb_perimeter,
+        'opacity': 0.618,
+        'has_opacity_slider': True
     },
     {
         'code': 'drb_catchment_water_quality_tp',
         'display': ('DRB Catchment Water Quality Data' +
                     '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TP Loading Rates'),
         'table_name': 'drb_catchment_water_quality_tp',
-        'vector': True,
+        'raster': True,
         'overlay': True,
         'minZoom': 3,
-        'perimeter': drb_perimeter
+        'perimeter': drb_perimeter,
+        'opacity': 0.618,
+        'has_opacity_slider': True
     },
     {
         'code': 'drb_catchment_water_quality_tss',
         'display': ('DRB Catchment Water Quality Data' +
                     '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TSS Loading Rates'),
         'table_name': 'drb_catchment_water_quality_tss',
-        'vector': True,
+        'raster': True,
         'overlay': True,
         'minZoom': 3,
-        'perimeter': drb_perimeter
+        'perimeter': drb_perimeter,
+        'opacity': 0.618,
+        'has_opacity_slider': True
     }
 ]
 

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -42,12 +42,10 @@
 @drb_catchment_step_five_color: #202020;
 @drb_catchment_line_color: #FFF;
 @drb_catchment_line_width: 4;
-@drb_catchment_opacity: 0.65;
 
 #drb_catchment_water_quality_tn {
     line-color: @drb_catchment_line_color;
     line-width: @drb_catchment_line_width;
-    opacity: @drb_catchment_opacity;
     [tn_tot_kgy >= 0][tn_tot_kgy < 5] {
         polygon-fill: @drb_catchment_step_one_color;
     }
@@ -68,7 +66,6 @@
 #drb_catchment_water_quality_tp {
     line-color: @drb_catchment_line_color;
     line-width: @drb_catchment_line_width;
-    opacity: @drb_catchment_opacity;
     [tp_tot_kgy >= 0.0][tp_tot_kgy < 0.30] {
         polygon-fill: @drb_catchment_step_one_color;
     }
@@ -89,7 +86,6 @@
 #drb_catchment_water_quality_tss {
     line-color: @drb_catchment_line_color;
     line-width: @drb_catchment_line_width;
-    opacity: @drb_catchment_opacity;
     [tss_tot_kg >= 0][tss_tot_kg < 250] {
         polygon-fill: @drb_catchment_step_one_color;
     }


### PR DESCRIPTION
Connects #1523

We want to be able to adjust the opacity of the catchment water quality overlay, and we don't want to be able to put other coverage overlays on the map at the same time, so this PR moves the catchment overlay out of the boundary options and into the coverage ones. 

_Default opacity when you first click on a layer_
<img width="1107" alt="screen shot 2016-10-11 at 1 29 41 pm" src="https://cloud.githubusercontent.com/assets/7633670/19281691/68a73d0e-8fb9-11e6-8e05-433c065b616f.png">

_Can make it fully opaque now_
<img width="1103" alt="screen shot 2016-10-11 at 1 27 59 pm" src="https://cloud.githubusercontent.com/assets/7633670/19281700/756a7592-8fb9-11e6-8746-36861551c081.png">

_Or real light_
<img width="1105" alt="screen shot 2016-10-11 at 1 28 07 pm" src="https://cloud.githubusercontent.com/assets/7633670/19281711/7b7ea764-8fb9-11e6-9dfa-012d9020b6a9.png">

### Testing
Pull this branch. 
I changed `styles.mss` so any catchment tiles you might have are stale. In the `app` VM, `./scripts/aws/setupdb.sh -q` and on your host `./scripts/debugtiler.sh`

Confirm that the Catchment Layers (TN, TP, TSS) are under the category "Coverage", that you can adjust the opacity, and that there are no errors from the tiler or in the console.
