### PR TITLE
Restore missing lines in setupdb.sh script

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -131,4 +131,7 @@ if [ "$load_water_quality" = "true" ] ; then
     FILES=("nhd_water_quality.sql.gz" "drb_catchment_water_quality.sql.gz")
     PATHS=("drb_catchment_water_quality_tn" "drb_catchment_water_quality_tp"
             "drb_catchment_water_quality_tss" "nhd_quality_tp" "nhd_quality_tn")
+
+    download_and_load $FILES
+    purge_tile_cache $PATHS
 fi


### PR DESCRIPTION
This PR restores the missing lines needed to download the water quality tables and purge the tile cache which got cut inadvertently.

**Testing**
- run the `setupdb.sh` script with the `-q` flag to load the water quality data. Verify that the operation completes successfully and that it the database tables on your local. 

`drb_catchment_water_quality` should have 15004 rows
`nhd_water_quality` should have 10957 rows

Connects #1533 