### PR TITLE
Persist Input Of Failed Jobs

### DIFF
--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -557,7 +557,8 @@ def start_celery_job(task_list, job_input, user=None,
     """
     created = now()
     job = Job.objects.create(created_at=created, result='', error='',
-                             traceback='', user=user, status='started')
+                             traceback='', user=user, status='started',
+                             model_input=job_input)
     routing_key = routing_key if routing_key else choose_worker()
     success = save_job_result.s(job.id, job_input).set(exchange=exchange,
                                                        routing_key=routing_key)


### PR DESCRIPTION
We have been getting these mysterious timed out analyze histograms jobs on staging and production: https://rollbar.com/Azavea/MMW/items/58/ . We tried to do some sleuthing on the jobs in the production db, and found that the most useful field for sleuthing `model_input` (the AOI) isn't persisted when a job fails. 

This PR makes sure that the `model_input` persists whether success or failure for all the analysis related jobs. The plan of attack after we merge this is to wait around until the error occurs again on staging, and then go back and inspect. There could be some too-big/bad shape making its way through.


#### Testing
Pull this branch and reload.
You can: `./scripts/debugcelery.sh`
Draw a shape and confirm the analyze jobs are fine. 
Now confirm the job fails when you run something like: 
```
http --form POST http://localhost:8000/api/modeling/start/analyze/ area_of_interest=%7B%22type%22%3A%22MultiPolygon%22%2C%22coordinates%22%3A%5B%5B%5B%5B-75.87982177734375%2C41.11246878918086%5D%2C%5B-75.98007202148438%2C41.05967965145965%5D%2C%5B-75.93887329101562%2C41.009957022453015%5D%2C%5B-75.78643798828125%2C41.05967965145965%5D%2C%5B-75.80703735351562%2C41.07313973329343%5D%2C%5B-75.81390380859375%2C41.08763212467916%5D%2C%5B-75.87982177734375%2C41.11246878918086%5D%5D%5D%5D%7
```
or any other malformed analyze request of your choosing. 

Now:
``` 
ssh vagrant services
psql -h localhost -U mmw

\o model_inputs.txt
SELECT model_input, error FROM core_job ORDER BY timestamp DESC LIMIT 2;
\q

cat model_inputs.txt
```
You should see something like the following, where the first row is the malformed request which now has a `model_input`, and the second row is the good request also still with a `model_input`:
```
                                                                                                                                                                                                      model_input                                                                                                                                                                                                      |              error              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------
 %7B%22type%22%3A%22MultiPolygon%22%2C%22coordinates%22%3A%5B%5B%5B%5B-75.87982177734375%2C41.11246878918086%5D%2C%5B-75.98007202148438%2C41.05967965145965%5D%2C%5B-75.93887329101562%2C41.009957022453015%5D%2C%5B-75.78643798828125%2C41.05967965145965%5D%2C%5B-75.80703735351562%2C41.07313973329343%5D%2C%5B-75.81390380859375%2C41.08763212467916%5D%2C%5B-75.87982177734375%2C41.11246878918086%5D%5D%5D%5D%7D | No JSON object could be decoded
 {"type":"MultiPolygon","coordinates":[[[[-75.87982177734375,41.11246878918086],[-75.98007202148438,41.05967965145965],[-75.93887329101562,41.009957022453015],[-75.78643798828125,41.05967965145965],[-75.80703735351562,41.07313973329343],[-75.81390380859375,41.08763212467916],[-75.87982177734375,41.11246878918086]]]]}                                                                                         | 
(2 rows)
```
Connects #1516 