### PR TITLE
Feature/delete jobs

### DIFF
--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -13,7 +13,7 @@ from apps.modeling import views
 # Third set of characters must start with a '4'.
 # Fourth set of characters must start with one of 'a,b,8,9'.
 uuid_regex = '(?P<job_uuid>[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-' \
-             + '[89abAB][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})/$'
+             + '[89abAB][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})'
 
 urlpatterns = patterns(
     '',
@@ -30,7 +30,8 @@ urlpatterns = patterns(
         views.start_analyze_catchment_water_quality,
         name='start_analyze_catchment_water_quality'),
     url(r'start/mapshed/$', views.start_mapshed, name='start_mapshed'),
-    url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
+    url(r'jobs/' + uuid_regex + r'/$', views.get_job, name='get_job'),
+    url(r'jobs/' + uuid_regex + r'/kill/$', views.kill_job, name='kill_job'),
     url(r'start/tr55/$', views.start_tr55, name='start_tr55'),
     url(r'start/rwd/$', views.start_rwd, name='start_rwd'),
     url(r'start/gwlfe/$', views.start_gwlfe, name='start_gwlfe'),

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -567,6 +567,25 @@ def drb_point_sources(request):
                     headers={'Cache-Control': 'max-age: 604800'})
 
 
+@decorators.api_view(['GET'])
+@decorators.permission_classes((AllowAny, ))
+def kill_job(request, job_uuid, format=None):
+    try:
+
+        celery.current_app.control.revoke(job_uuid,
+                                          terminate=True,
+                                          signal='SIGUSR1')
+        return Response(
+            'Job {0} was successfully terminated.'.format(
+                job_uuid))
+    except Exception as ex:
+        response_data = {
+            'errors': ['Job {0} could not be killed.'.format(job_uuid),
+                       ex.message]}
+        return Response(data=response_data,
+                        status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
 def start_celery_job(task_list, job_input, user=None,
                      exchange=MAGIC_EXCHANGE, routing_key=None):
     """

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -130,6 +130,9 @@ CELERY_WORKER_DIRECT = True
 CELERY_CREATE_MISSING_QUEUES = True
 CELERY_CHORD_PROPAGATES = True
 CELERY_CHORD_UNLOCK_MAX_RETRIES = 60
+# the time limit won't affect the polling tasks since they are short-running
+# the value of 42 coincides with the implied time limit on the polling tasks
+CELERYD_TASK_TIME_LIMIT = 42
 # CELERYD_CONCURRENCY = 2
 # END CELERY CONFIGURATION
 


### PR DESCRIPTION
This feature introduces an avenue to attempt to stop running jobs, and also modifies the app to send requests for termination where appropriate and sensible to do so.

The change to the API involves adding an endpoint at `.../jobs/[job id]/kill/` that accepts requests and attempts to stop running jobs; the celery settings have also been updated to add default timeouts. The change to the app places requests to the `kill` endpoint where it made sense to do so, and also tags expiration/timeout values onto job submission requests.

To test:
- clone this branch and bring up the environment
- with the browser console, network monitor, and `debugcelery.sh` and `debugserver.sh` output watchable: 
-  navigate to `http://localhost:8000` and go through standard user actions
-  go through user actions but back the app out of them at the earliest opportunity
-  for good measure, intersperse the two, such that you back out of an action but then proceed to let it run to completion
- check that requests are being made to the `kill` endpoint where it makes sense to do so, such as when you back out of a project action, and check if the celery output indicates that it is revoking or actively terminating jobs

Connects #1489
