### PR TITLE
Fix Layer Controls On Narrow Screens and Touch+Mouse Devices

### DIFF
--- a/src/mmw/js/src/core/layerControl.js
+++ b/src/mmw/js/src/core/layerControl.js
@@ -69,18 +69,12 @@ module.exports = L.Control.Layers.extend({
         // from firing a mouseout event when the touch is released
         container.setAttribute('aria-haspopup', true);
 
-        // Copied directly from the parent class.
+        // Copied directly from the parent class, with addition of listContainer
+        L.DomEvent.disableClickPropagation(container);
+        L.DomEvent.disableClickPropagation(listContainer);
         if (!L.Browser.touch) {
-            L.DomEvent
-                .disableClickPropagation(container)
-                .disableScrollPropagation(container);
-
-            L.DomEvent
-                .disableClickPropagation(listContainer)
-                .disableScrollPropagation(listContainer);
-        } else {
-            L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
-            L.DomEvent.on(listContainer, 'click', L.DomEvent.stopPropagation);
+            L.DomEvent.disableScrollPropagation(container);
+            L.DomEvent.disableScrollPropagation(listContainer);
         }
 
         // Expand the layer control so that Leaflet
@@ -131,7 +125,10 @@ module.exports = L.Control.Layers.extend({
             $(input).attr('id', obj.layer.options.code);
         }
 
-        L.DomEvent.on(input, 'click', this._onInputClick, this);
+        // work around for Firefox Android issue https://github.com/Leaflet/Leaflet/issues/2033
+        L.DomEvent.on(input, 'click', function () {
+            setTimeout(L.bind(this._onInputClick, this), 0);
+        }, this);
 
         var name = document.createElement('span');
         name.innerHTML = ' ' + obj.name;

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -60,6 +60,8 @@ p.info {
 #geocode-search-region {
   display: inline-block;
 
+  // Override pointer-events: none in #search-map
+  pointer-events: auto;
   #search-results-container {
     position: absolute;
   }
@@ -69,6 +71,13 @@ p.info {
 .draw-tools-container div {
   display: inline-block;
   text-transform: none;
+  // Override pointer-events: none in #search-map
+  pointer-events: auto;
+  padding-bottom: 0.2rem;
+
+  @media(max-width: 710px) {
+    display: block;
+  }
 
   // Undo bootstrap input[type="range"] syling
   #stream-slider {

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -8,6 +8,14 @@
 
   @media(max-width: 1200px) {
     max-width: 595px;
+    // Let clicks pass through to leaflet-right controls
+    pointer-events: none;
+  }
+
+  @media(max-width: 750px) {
+    // On narrow screens, prevent overlap with
+    // leaflet-right controls
+    max-width: 320px;
   }
 
   .search-icon {


### PR DESCRIPTION
Connects #1500

We weren't able to use the layer controls on Windows devices that have both touch and mouse input, or on Android tablets/phones in portrait mode. 

- For the Windows devices the issue was that calling `L.Browser.touch` in `core/layerControl.js` returns true in Chrome for devices that have touch capability (even if you're using the mouse), and we were checking for truthiness so that we could call: 
```
 L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
 L.DomEvent.on(listContainer, 'click', L.DomEvent.stopPropagation);
```
The code now more closely matches watch the leaflet parent control library does (disabling scroll propagation if a device has touch input.) 

- For the android tablets and phones in portrait mode, the problem was just that the draw toolbar div was covering the leaflet controls, and taking all the clicks. 

### Testing
Pull this branch, and `./scripts/bundle.sh`
- Confirm that you can still use the layer controls/draw toolbar on your desktop browser
Then, accessing your build at `<your computer's name>.local:8000`
- Take our test ASUS laptop/tablet and verify you can use the draw toolbar, the layer controls, and the geolocator. 
- You should be able to close and reopen the layer controls, switch tabs, etc (switching tabs is kind of slow)

- Take our test Nexus tablet or a suite of devices in Chrome developer tools and go through the same steps as above in portrait and landscape mode