### PR TITLE
Clear old AOI and markers when RWD fails

### DIFF
--- a/src/mmw/js/src/core/templates/catchmentWaterQualityPopup.html
+++ b/src/mmw/js/src/core/templates/catchmentWaterQualityPopup.html
@@ -10,7 +10,7 @@
     </thead>
     <tbody>
         <tr>
-            <td>Agrarian</td>
+            <td>Agriculture</td>
             <td class="text-right">
                 {{ tn_ag_kgyr|filterNoData()|toLocaleString() }}
             </td>

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -403,9 +403,9 @@ var WatershedDelineationView = Marionette.ItemView.extend({
             map = App.getLeafletMap(),
             $item = $(e.currentTarget),
             itemName = $item.text(),
-            snappingOn = !!$item.data('snapping-on'),
-            revertLayer = clearAoiLayer();
+            snappingOn = !!$item.data('snapping-on');
 
+        clearAoiLayer();
         this.model.set('pollError', false);
         this.model.disableTools();
 
@@ -422,7 +422,7 @@ var WatershedDelineationView = Marionette.ItemView.extend({
                 navigateToAnalyze();
             })
             .fail(function(message) {
-                revertLayer();
+                clearAoiLayer();
                 if (message) {
                     var alertView = new modalViews.AlertView({
                         model: new modalModels.AlertModel({


### PR DESCRIPTION
This PR makes it so that the AOI and RWD markers are cleared when an RWD run fails after a successful one. It also changes 'Agrarian' to 'Agriculture'.

#### Testing
* Search for Bug's Airport using geocoder
* Delineate a watershed at a point as in screenshot below
![screen shot 2016-10-19 at 12 59 27 pm](https://cloud.githubusercontent.com/assets/1896461/19528978/1e024b92-95fc-11e6-9f2f-0c365b9d3855.png)
* Click back from analyze, and then click Delineate Watershed and click the same point as in the screenshot below (don't click Reset first). This should cause an error message to popup, but no AOI or markers should be shown.
![screen shot 2016-10-19 at 12 59 47 pm 2](https://cloud.githubusercontent.com/assets/1896461/19528993/287b238c-95fc-11e6-90df-7475ea4c0070.png)
* The drawing functionality should still work as before. Specifically, drawing an AOI, then clicking back, then drawing part of a polygon and hitting escape should revert to the previous AOI.
* In the Water Quality tab, click a catchment ID in the Water Quality tab and check that Agrarian has been changed to Agriculture.

Connects #1537 
Connects #1546 