### PR TITLE
Simplify catchment polygon in water quality analysis

### DIFF
--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -110,7 +110,8 @@ def catchment_water_quality(geojson):
           tn_urban_k, tn_riparia, tn_ag_kgyr, tn_natural, tn_pt_kgyr,
           tp_urban_k, tp_riparia, tp_ag_kgyr, tp_natural, tp_pt_kgyr,
           tss_urban_, tss_rip_kg, tss_ag_kgy, tss_natura,
-          tn_yr_avg_, tp_yr_avg_, tss_concmg, ST_AsGeoJSON(geom) as geom
+          tn_yr_avg_, tp_yr_avg_, tss_concmg,
+          ST_AsGeoJSON(ST_Simplify(geom, 0.0003)) as geom
           FROM {table_name}
           WHERE ST_Intersects(geom, ST_SetSRID(ST_GeomFromText(%s), 4326))
           '''.format(table_name=table_name)


### PR DESCRIPTION
The water quality endpoint sends back the catchment polygons which can be large, so we simplify them as part of the DB query. Below, you can see the same catchment without and with the simplification.

![screen shot 2016-10-19 at 2 21 50 pm 2](https://cloud.githubusercontent.com/assets/1896461/19532429/a243fc5e-9609-11e6-9d7f-6cc87b56d93f.png)
![screen shot 2016-10-19 at 2 19 25 pm 2](https://cloud.githubusercontent.com/assets/1896461/19532425/a05cf56c-9609-11e6-9f10-88abd348f5d9.png)

#### Testing
* Run `./scripts/debugcelery.sh`
* Draw an AOI near the DRB and go to the Water Quality tab. When hovering over the rows, you should see polygons that are simplified relative to those when running the `develop` branch.

Connects #1545 