### PR TITLE
Update the embedded micro link

### DIFF
--- a/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
@@ -10,4 +10,4 @@
     </tbody>
 </table>
 
-<p class="info text-muted">Explore how land use and soil determine runoff with our <a target="_blank" href="https://app.wikiwatershed.org/micro/">Micro Site Storm Model</a>. Info and help at <a target="_blank" href="http://wikiwatershed.org/model/">http://wikiwatershed.org/model/</a>.</p>
+<p class="info text-muted">Explore how land use and soil determine runoff with our <a target="_blank" href="https://micro.app.wikiwatershed.org/">Micro Site Storm Model</a>. Info and help at <a target="_blank" href="http://wikiwatershed.org/model/">http://wikiwatershed.org/model/</a>.</p>


### PR DESCRIPTION
The app will redirect from /micro but this puts the explicit new link
in the url.

#### Testing
Run the Site Storm Model and verify that the new static micro site URL is in link at the bottom of the results page.

![screenshot from 2016-10-24 10 48 17](https://cloud.githubusercontent.com/assets/1014341/19650448/62e6d99c-99d7-11e6-9068-8a5865175b37.png)
