### PR TITLE
Add description area for analyze results

### DIFF
--- a/src/mmw/js/src/analyze/templates/analyzeDescription.html
+++ b/src/mmw/js/src/analyze/templates/analyzeDescription.html
@@ -1,0 +1,3 @@
+<div class="analyze-description">
+    {{ description }}
+</div>

--- a/src/mmw/js/src/analyze/templates/analyzeResults.html
+++ b/src/mmw/js/src/analyze/templates/analyzeResults.html
@@ -1,2 +1,3 @@
+<div class="desc-region"></div>
 <div class="chart-region"></div>
 <div class="table-region"></div>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -19,6 +19,7 @@ var $ = require('jquery'),
     pointSourceLayer = require('../core/pointSourceLayer'),
     catchmentWaterQualityLayer = require('../core/catchmentWaterQualityLayer'),
     windowTmpl = require('./templates/window.html'),
+    AnalyzeDescriptionTmpl = require('./templates/analyzeDescription.html'),
     analyzeResultsTmpl = require('./templates/analyzeResults.html'),
     aoiHeaderTmpl = require('./templates/aoiHeader.html'),
     tableTmpl = require('./templates/table.html'),
@@ -324,6 +325,10 @@ var AoiView = Marionette.ItemView.extend({
     template: aoiHeaderTmpl
 });
 
+var AnalyzeDescriptionView = Marionette.ItemView.extend({
+    template: AnalyzeDescriptionTmpl
+});
+
 var TableRowView = Marionette.ItemView.extend({
     tagName: 'tr',
     template: tableRowTmpl,
@@ -627,11 +632,13 @@ var ChartView = Marionette.ItemView.extend({
 var AnalyzeResultView = Marionette.LayoutView.extend({
     template: analyzeResultsTmpl,
     regions: {
+        descriptionRegion: '.desc-region',
         chartRegion: '.chart-region',
         tableRegion: '.table-region'
     },
 
-    showAnalyzeResults: function(CategoriesToCensus, AnalyzeTableView, AnalyzeChartView) {
+    showAnalyzeResults: function(CategoriesToCensus, AnalyzeTableView,
+        AnalyzeChartView, description) {
         var categories = this.model.get('categories'),
             largestArea = _.max(_.pluck(categories, 'area')),
             units = utils.magnitudeOfArea(largestArea),
@@ -648,37 +655,57 @@ var AnalyzeResultView = Marionette.LayoutView.extend({
                 collection: census
             }));
         }
+
+        if (description) {
+            this.descriptionRegion.show(new AnalyzeDescriptionView({
+                model: new Backbone.Model({
+                    description: description
+                })
+            }));
+        }
     }
 });
 
 var LandResultView  = AnalyzeResultView.extend({
     onShow: function() {
-        this.showAnalyzeResults(coreModels.LandUseCensusCollection, TableView, ChartView);
+        var desc = 'Land cover distribution';
+        this.showAnalyzeResults(coreModels.LandUseCensusCollection, TableView,
+            ChartView, desc);
     }
 });
 
 var SoilResultView  = AnalyzeResultView.extend({
     onShow: function() {
-        this.showAnalyzeResults(coreModels.SoilCensusCollection, TableView, ChartView);
+        var desc = 'Hydrologic soil group distribution';
+        this.showAnalyzeResults(coreModels.SoilCensusCollection, TableView,
+            ChartView, desc);
     }
 });
 
 var AnimalsResultView = AnalyzeResultView.extend({
     onShow: function() {
-        this.showAnalyzeResults(coreModels.AnimalCensusCollection, AnimalTableView);
+        var desc = 'Estimated number of agricultural animals',
+            chart = null;
+        this.showAnalyzeResults(coreModels.AnimalCensusCollection, AnimalTableView,
+            chart, desc);
     }
 });
 
 var PointSourceResultView = AnalyzeResultView.extend({
     onShow: function() {
-        this.showAnalyzeResults(coreModels.PointSourceCensusCollection, PointSourceTableView);
+        var desc = 'Point source pollution',
+            chart = null;
+        this.showAnalyzeResults(coreModels.PointSourceCensusCollection,
+            PointSourceTableView, chart, desc);
     }
 });
 
 var CatchmentWaterQualityResultView = AnalyzeResultView.extend({
     onShow: function() {
+        var desc = 'Average annual catchment loading rates and stream concentrations',
+            chart = null;
         this.showAnalyzeResults(coreModels.CatchmentWaterQualityCensusCollection,
-            CatchmentWaterQualityTableView);
+            CatchmentWaterQualityTableView, chart, desc);
     }
 });
 

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -25,3 +25,8 @@
 .analyze-message-text {
   font-size: 0.6rem;
 }
+
+.analyze-description {
+  font-size: 0.8rem;
+  padding-top: 5px;
+}


### PR DESCRIPTION
Adds a new region to the Analyze Results area and supplies some initial text for description of each category currently available.  The text is provisional; hoping to receive feedback on content from the client but including accurate blubs to encourage terse descriptions.
<hr/>

Connects #1547 

#### Testing
Run an analysis and verify that all tabs have a description along the following styles:

![screenshot from 2016-10-24 15 08 13](https://cloud.githubusercontent.com/assets/1014341/19659901/c42294a2-99fb-11e6-829a-a29495370800.png)
![screenshot from 2016-10
-24 15 08 32](https://cloud.githubusercontent.com/assets/1014341/19659900/c42045da-99fb-11e6-8017-ca86c0f3e980.png)

