### PR TITLE
Fix/ui error on mapshed timeout

### DIFF
--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -144,7 +144,7 @@ var ModelingController = {
                         ).census
                     );
                 })
-                .fail(projectCleanUp);
+                .fail(projectErrorState);
 
             setupNewProjectScenarios(project);
             finishProjectSetup(project, lock);
@@ -156,6 +156,10 @@ var ModelingController = {
 
     projectCleanUp: function() {
         projectCleanUp();
+    },
+
+    projectErrorState: function() {
+        projectErrorState();
     },
 
     makeNewProjectCleanUp: function() {
@@ -288,6 +292,18 @@ function projectCleanUp() {
     App.getMapView().updateModifications(null);
     App.rootView.subHeaderRegion.empty();
     App.rootView.sidebarRegion.empty();
+}
+
+function projectErrorState() {
+    if (App.currentProject) {
+        var scenarios = App.currentProject.get('scenarios');
+        App.currentProject.off('change:id', updateUrl);
+        scenarios.off('change:activeScenario change:id', updateScenario);
+        App.currentProject.set('scenarios_events_initialized', false);
+        App.projectNumber = scenarios.at(0).get('project');
+    }
+
+    App.getMapView().updateModifications(null);
 }
 
 function updateItsiFromEmbedMode() {


### PR DESCRIPTION
This fixes a bug that resulted in a bad UI state if a modeling job timed out. As a corollary, it adds a minor refactor to address the issue of null references in jQuery callbacks, which would sometimes have UI effects but were mostly just reported to the console.

To test:
* clone this branch and bring up the environment
* open the browser console
* perform various user actions, including but not limited to:
* perform sequences of analysis & modelling actions without waiting for the asynchronous calls to return;
* as in the last item, perform sequences of actions and then back out, e.g. pick an AoI, start a tr-55 / multiyear model run before the analysis job completes, back out of the model run view once it starts polling, activate the other model type and let it proceed;
* start analysis/modelling actions that will time out, e.g. select half of Kansas as an AoI and then immediately kick off a tr55 run, or select a ~1,000 sq-km AoI and start a multiyear run; 
* with a completed model run, add some scenario modifications
* with a completed model run, rename a scenario to a taken name to ensure it raises an error
* save and reload a project with nontrivial scenarios

In the course of testing, there should not be any UI errors and the app should behave as expected. In the console, there should be a handful of messages to the effect of "`Caught TypeError exception that implies a callback encountered a null reference`" followed by the specific member that was found to be null.

Connects #1559 