### PR TITLE
Small refactor to speed up table rendering

### DIFF
--- a/src/mmw/js/src/core/filters.js
+++ b/src/mmw/js/src/core/filters.js
@@ -2,14 +2,27 @@
 
 var nunjucks = require('nunjucks');
 var utils = require('./utils');
+var _ = require('lodash');
 
 nunjucks.env = new nunjucks.Environment();
 
+var basicFormatter = new Intl.NumberFormat('en');
+
+var specificFormatter = function(sigFig) {
+    return new Intl.NumberFormat('en',{minimumFractionDigits: sigFig});
+};
+
+var cachedFormatters = _.memoize(specificFormatter);
+
 nunjucks.env.addFilter('toLocaleString', function(val, n) {
+    if (val===undefined || isNaN(val)) {
+        return val;
+    }
+
     if (n) {
-        return val.toLocaleString('en', {minimumFractionDigits: n});
+        return cachedFormatters(n).format(val);
     } else {
-        return val.toLocaleString('en');
+        return basicFormatter.format(val);
     }
 });
 
@@ -18,3 +31,4 @@ nunjucks.env.addFilter('filterNoData', utils.filterNoData);
 nunjucks.env.addFilter('toFriendlyDate', function(date) {
     return new Date(date).toLocaleString();
 });
+


### PR DESCRIPTION
This identifies a pain point in the UI that results in slow renders in a few places in the app, and makes a small code change in one of the filter files that are used during rendering; by caching a  number formatter the time spent on each item render was reduced considerably, on average. The problem still exists, but is noticeably mitigated for large AoIs.

To test:
* clone this branch and bring up the environment
* With the following example AoI sizes: a county, a group of 5-10 counties, and then the state of Pennsylvania -->

0. if possible, use a browser profiler for each, but otherwise just make a general note of the lag
1. wait for the analysis task to complete, and then activate the Point Source and the Water Quality table tabs;
2. kick off a modelling run and then go back to the "Analyze" view once the "Model" view renders (no need to wait for the actual model results, it's the rendering that happens in the transition that's of interest)

* check that the console shows no errors (at least, none that are already being addressed by other issues)
* in general, the lag with the first two AoI sizes will probably be noticeable but tolerable
* repeat the process against either staging or a prior branch; the lag should be noticeably improved with this fix

If a profiler was used, compare the total time spent in the `showResultsIfNotDestroyed` method and it's children between this branch and whatever control version is used. I found that shorter invocations of the method sometimes took a few milliseconds longer using this fix, presumably due to instantiating the formatters and the lodash object, but the upfront cost quickly amortized if there were multiple renders of table records, with duration for each render in the long running cases dropping from 2.5-3.0ms to about 0.2ms.

Connects #1561 