### PR TITLE
Style Password Reset Pages

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -1,29 +1,5 @@
+{% include 'head.html' %}
 {% load staticfiles %}
-
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    {% block metatitle %}
-    <title>Model My Watershed</title>
-    {% endblock metatitle %}
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="{% static 'favicon.png' %}" sizes="16x16">
-    <link rel="icon" type="image/png" href="{% static 'favicon@2x.png' %}" sizes="32x32">
-    <link rel="stylesheet" href="{% static 'css/vendor.css' %}" />
-    <link rel="stylesheet" href="{% static 'css/main.css' %}" />
-    <!-- Google Analytics -->
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-        ga('create', '{{ GOOGLE_ANALYTICS_ACCOUNT }}', 'auto');
-        ga('send', 'pageview');
-    </script>
-</head>
-
 <body>
     {% block header %}
     {% endblock header %}

--- a/src/mmw/apps/core/templates/head.html
+++ b/src/mmw/apps/core/templates/head.html
@@ -1,0 +1,25 @@
+{% load staticfiles %}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {% block metatitle %}
+    <title>Model My Watershed</title>
+    {% endblock metatitle %}
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="{% static 'favicon.png' %}" sizes="16x16">
+    <link rel="icon" type="image/png" href="{% static 'favicon@2x.png' %}" sizes="32x32">
+    <link rel="stylesheet" href="{% static 'css/vendor.css' %}" />
+    <link rel="stylesheet" href="{% static 'css/main.css' %}" />
+    <!-- Google Analytics -->
+    <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '{{ GOOGLE_ANALYTICS_ACCOUNT }}', 'auto');
+        ga('send', 'pageview');
+    </script>
+</head>

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -70,4 +70,5 @@
   "pages/model",
   "pages/compare",
   "pages/projects",
-  "pages/water-balance";
+  "pages/water-balance",
+  "pages/registration";

--- a/src/mmw/sass/pages/_registration.scss
+++ b/src/mmw/sass/pages/_registration.scss
@@ -1,0 +1,12 @@
+.registration-form {
+    label {
+        display: block;
+        font-size: 1rem;
+    }
+
+    input[type=email], input[type=password] {
+        margin-bottom: 1rem;
+        width: 13rem;
+        height: 2.3rem;
+    }
+}

--- a/src/mmw/templates/registration/password_change_form.html
+++ b/src/mmw/templates/registration/password_change_form.html
@@ -7,7 +7,7 @@
 <form method="post" action="">
     {% csrf_token %}
     {{ form.as_p }}
-    <input type="submit" value="{% trans 'Change password' %}" />
+    <input class="btn btn-lg btn-primary" type="submit" value="{% trans 'Change password' %}" />
 </form>
 {% endblock %}
 

--- a/src/mmw/templates/registration/password_reset_confirm.html
+++ b/src/mmw/templates/registration/password_reset_confirm.html
@@ -8,7 +8,7 @@
 <form method="post" action="">
     {% csrf_token %}
     {{ form.as_p }}
-    <input type="submit" value="{% trans 'Set password' %}" />
+    <input class="btn btn-lg btn-primary" type="submit" value="{% trans 'Set password' %}" />
 </form>
 {% endblock %}
 

--- a/src/mmw/templates/registration/password_reset_form.html
+++ b/src/mmw/templates/registration/password_reset_form.html
@@ -12,7 +12,7 @@
 <form method="post" action="">
     {% csrf_token %}
     {{ form.as_p }}
-    <input type="submit" value="{% trans 'Reset password' %}" />
+    <input class="btn btn-lg btn-primary" type="submit" value="{% trans 'Reset password' %}" />
 </form>
 {% endblock %}
 

--- a/src/mmw/templates/registration/registration_base.html
+++ b/src/mmw/templates/registration/registration_base.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% include 'head.html' %}
 
 {% block header %}
 <header>

--- a/src/mmw/templates/registration/registration_base.html
+++ b/src/mmw/templates/registration/registration_base.html
@@ -11,7 +11,7 @@
 {% endblock header %}
 
 {% block content %}
-<div class="container-fluid top-nav">
+<div class="container-fluid top-nav registration-form">
     {% block title %}
     {% endblock %}
     {% block registration_content %}

--- a/src/mmw/templates/registration/registration_form.html
+++ b/src/mmw/templates/registration/registration_form.html
@@ -7,7 +7,7 @@
 <form method="post" action="">
     {% csrf_token %}
     {{ form.as_p }}
-    <input type="submit" value="{% trans 'Submit' %}" />
+    <input class="btn btn-lg btn-primary" type="submit" value="{% trans 'Submit' %}" />
 </form>
 {% endblock %}
 


### PR DESCRIPTION
Before, yuck:
![screen shot 2016-10-25 at 5 55 43 pm](https://cloud.githubusercontent.com/assets/7633670/19705763/47935cd2-9adc-11e6-90f8-3e1f0f9b682b.png)
After:
![screen shot 2016-10-25 at 5 46 49 pm](https://cloud.githubusercontent.com/assets/7633670/19705539/0dfc40fc-9adb-11e6-9241-391a29f51677.png)
<img width="598" alt="screen shot 2016-10-25 at 5 45 59 pm" src="https://cloud.githubusercontent.com/assets/7633670/19705538/0df81c3e-9adb-11e6-80e6-41ecb3417b54.png">

### Notes
There were a couple console errors on the registration pages because we were extending from the `base.html` template that adds a map container. It's a little repetitive, but the second commit of this PR removes `base.html` from the `registration_base.html` and just duplicates all the style loading, etc

### Testing 
- Assuming you've pulled this branch and the VMs are up, run
`./scripts/debugserver.sh`
- go to http://localhost:8000/accounts/password/reset/ and enter an email
- Copy and paste the link in the email that got logged in the debug server output into your browser

Everything should look okay throughout

Connects #1528 

