### PR TITLE
Track virtual pageloads with Google Analytics

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -1,5 +1,31 @@
 {% include 'head.html' %}
 {% load staticfiles %}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {% block metatitle %}
+    <title>Model My Watershed</title>
+    {% endblock metatitle %}
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="{% static 'favicon.png' %}" sizes="16x16">
+    <link rel="icon" type="image/png" href="{% static 'favicon@2x.png' %}" sizes="32x32">
+    <link rel="stylesheet" href="{% static 'css/vendor.css' %}" />
+    <link rel="stylesheet" href="{% static 'css/main.css' %}" />
+    <!-- Google Analytics -->
+    <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '{{ GOOGLE_ANALYTICS_ACCOUNT }}', 'auto');
+        ga('send', 'pageview');
+        window.ga = ga;
+    </script>
+</head>
+
 <body>
     {% block header %}
     {% endblock header %}

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -20,3 +20,11 @@ router.addRoute('projects(/)', ProjectsController, 'projects');
 router.addRoute('error(/:type)(/)', ErrorController, 'error');
 router.addRoute('sign-up(/)', SignUpController, 'signUp');
 router.addRoute('sign-up/itsi(/:username)(/:first_name)(/:last_name)(/)', SignUpController, 'itsiSignUp');
+
+router.on('route', function() {
+    // Allow Google Analytics to track virtual pageloads following approach in
+    // https://developers.google.com/analytics/devguides/collection/
+    // analyticsjs/single-page-applications
+    window.ga('set', 'page', window.location.pathname);
+    window.ga('send', 'pageview');
+});


### PR DESCRIPTION
Since MMW is a single page app, it doesn't have many 'real' page loads as the user navigates the app. This PR makes it so that virtual page loads are recorded by Google Analytic. No changes need to be made to the account setup for Stroud. This follows the approach in https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications

<img width="1034" alt="screen shot 2016-10-26 at 12 56 07 pm" src="https://cloud.githubusercontent.com/assets/1896461/19736173/2c93df9c-9b7c-11e6-8261-650ab5ebe2f9.png">

#### Testing
* Login to Google Analytics using azaveadev@azavea.com login. The password is on the wiki.
* Click MMW - All Data
* Go to Real Time -> Content in panel on the left.
* Navigate around the app. Every time the URL updates, it should appear in Google Analytics. (Although sometimes there's a lag of a second or two).

Connects #1554 