### PR TITLE
Bump versions of Python and Node.js clients for Rollbar

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -12,5 +12,5 @@ djangorestframework-gis==0.8.2
 tr55==1.2.0
 gwlf-e==0.6.2
 requests==2.9.1
-rollbar==0.12.1
+rollbar==0.13.8
 retry==0.9.1

--- a/src/tiler/npm-shrinkwrap.json
+++ b/src/tiler/npm-shrinkwrap.json
@@ -25,9 +25,9 @@
       }
     },
     "rollbar": {
-      "version": "0.5.12",
-      "from": "rollbar@*",
-      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-0.5.12.tgz",
+      "version": "0.6.2",
+      "from": "rollbar@0.6.2",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-0.6.2.tgz",
       "dependencies": {
         "node-uuid": {
           "version": "1.4.7",
@@ -39,6 +39,18 @@
           "from": "lru-cache@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
         "json-stringify-safe": {
           "version": "5.0.1",
           "from": "json-stringify-safe@>=5.0.0 <5.1.0",
@@ -48,6 +60,25 @@
           "version": "1.2.1",
           "from": "async@>=1.2.1 <1.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
+        },
+        "decache": {
+          "version": "3.1.0",
+          "from": "decache@>=3.0.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/decache/-/decache-3.1.0.tgz",
+          "dependencies": {
+            "find": {
+              "version": "0.2.7",
+              "from": "find@>=0.2.4 <0.3.0",
+              "resolved": "https://registry.npmjs.org/find/-/find-0.2.7.tgz",
+              "dependencies": {
+                "traverse-chain": {
+                  "version": "0.1.0",
+                  "from": "traverse-chain@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/src/tiler/package.json
+++ b/src/tiler/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "aws-sdk": "2.1.45",
-    "rollbar": "~0.5.12",
+    "rollbar": "~0.6.2",
     "windshaft": "0.36.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates versions for the Python and Node.js Rollbar clients.

See:
- https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
- https://github.com/rollbar/node_rollbar/blob/master/CHANGELOG.md

---

**Testing**

First, provision the `app` and `tiler` to ensure that the most recent versions of the Rollbar clients are installed. Then, execute the following steps on each machine:

``` bash
# Login to Rollbar and use `post_server_item` token
$ sudo vim /etc/mmw.d/env/ROLLBAR_SERVER_SIDE_ACCESS_TOKEN
# Set to Staging
$ sudo vim /etc/mmw.d/env/MMW_STACK_TYPE
# Ensure that module ends in `production`
$ sudo vim /etc/mmw.d/env/DJANGO_SETTINGS_MODULE
```

Next, make the following source code changes to test the Django application:

``` diff
diff --git a/src/mmw/apps/home/views.py b/src/mmw/apps/home/views.py
index 0cca874..52cca0d 100644
--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -16,6 +16,7 @@ from apps.modeling.models import Project, Scenario


 def home_page(request):
+    raise Exception("I'm testing a Rollbar upgrade")
     return render_to_response('home/home.html', get_context(request))


diff --git a/src/mmw/mmw/settings/production.py b/src/mmw/mmw/settings/production.py
index c44b822..a88988c 100644
--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -15,10 +15,10 @@ from boto.utils import get_instance_metadata
 from base import *  # NOQA


-instance_metadata = get_instance_metadata(timeout=5)
+# instance_metadata = get_instance_metadata(timeout=5)

-if not instance_metadata:
-    raise ImproperlyConfigured('Unable to access the instance metadata')
+# if not instance_metadata:
+#     raise ImproperlyConfigured('Unable to access the instance metadata')


 # HOST CONFIGURATION
@@ -34,7 +34,7 @@ ALLOWED_HOSTS = [

 # ELBs use the instance IP in the Host header and ALLOWED_HOSTS checks against
 # the Host header.
-ALLOWED_HOSTS.append(instance_metadata['local-ipv4'])
+# ALLOWED_HOSTS.append(instance_metadata['local-ipv4'])
 # END HOST CONFIGURATION


@@ -66,21 +66,21 @@ REST_FRAMEWORK = {
 }

 # Django Storages CONFIGURATION
-mac_metadata = instance_metadata['network']['interfaces']['macs']
-vpc_id = mac_metadata.values()[0]['vpc-id']
+# mac_metadata = instance_metadata['network']['interfaces']['macs']
+# vpc_id = mac_metadata.values()[0]['vpc-id']

 # The VPC id should stay the same for all app servers in a particular
 # environment and remain the same after a new deploy, but differ between
 # environments.  This makes it a suitable S3 bucket name
-AWS_STORAGE_BUCKET_NAME = 'django-storages-{}'.format(vpc_id)
+# AWS_STORAGE_BUCKET_NAME = 'django-storages-{}'.format(vpc_id)

 AWS_AUTO_CREATE_BUCKET = True
 DEFAULT_FILE_STORAGE = 'libs.custom_storages.PublicS3BotoStorage'

 # The PRIVATE_AWS_STORAGE_* settings configure the S3 bucket
 # used for files only accessible by census admins (e.g. data dumps)
-PRIVATE_AWS_STORAGE_BUCKET_NAME = 'django-storages-private-{}'.format(vpc_id)
-PRIVATE_AWS_STORAGE_AUTO_CREATE_BUCKET = True
+# PRIVATE_AWS_STORAGE_BUCKET_NAME = 'django-storages-private-{}'.format(vpc_id)
+# PRIVATE_AWS_STORAGE_AUTO_CREATE_BUCKET = True
 # The number of seconds that a generated link to a file in the private
 # bucket is active.
 PRIVATE_AWS_STORAGE_QUERYSTRING_EXPIRE = 30
```

Then, restart the application server and interact with the application UI:

``` bash
$ sudo restart mmw-app
```

Make the following changes to test the tile server:

``` diff
diff --git a/src/tiler/server.js b/src/tiler/server.js
index a5a1267..e2968f3 100644
--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -200,6 +200,7 @@ var config = {

     beforeTileRender: function(req, res, callback) {
         try {
+            throw new Error('oh no!');
             callback(null);
         } catch (ex) {
             rollbar.handleError(ex, req);
```

Then, restart the tile server and interact with the application UI:

``` bash
$ sudo restart mmw-tiler
```

Lastly, reprovision the `app` and `tiler` after wiping out the changes to get things back into their usual state.
