### PR TITLE
Feature/add table pagination

### DIFF
--- a/src/mmw/js/shim/backbone.js
+++ b/src/mmw/js/shim/backbone.js
@@ -7,5 +7,6 @@ var $ = require('jquery'),
 
 // See: https://github.com/jashkenas/backbone/issues/3291
 Backbone.$ = $;
+Backbone.PageableCollection = require('backbone.paginator');
 
 module.exports = Backbone;

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var $ = require('jquery'),
-    _ = require('lodash'),
+    lodash = require('lodash'),
     Backbone = require('../../shim/backbone'),
     coreModels = require('../core/models');
 
@@ -20,7 +20,7 @@ var LayerCategoryCollection = Backbone.Collection.extend({
 });
 
 var AnalyzeTaskModel = coreModels.TaskModel.extend({
-    defaults: _.extend( {
+    defaults: lodash.extend( {
             area_of_interest: null,
             taskName: 'analyze',
             taskType: 'modeling'

--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
@@ -1,54 +1,64 @@
-<table class="table custom-hover catchment-water-quality" data-toggle="table">
-    <thead>
-        <tr>
-            <th data-sortable="true">Id</th>
-            <th data-sortable="true">Area (ha)</th>
-            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                Total N (kg/ha)
-            </th>
-            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                Total P (kg/ha)
-            </th>
-            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                Total TSS (kg/ha)
-            </th>
-            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                Avg TN (mg/l)
-            </th>
-            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                Avg TP (mg/l)
-            </th>
-            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                Avg TSS (mg/l)
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-    </tbody>
-    <tfoot>
-        <tr class="catchment-water-quality-table-footer">
-            <td></td>
-            <td class="strong text-right">
-                Total (kg/ha)
-            </td>
-            <td class="catchment-water-quality-footer-item strong text-right">
-                {{ totalTN|filterNoData()|toLocaleString() }}
-            </td>
-            <td class="catchment-water-quality-footer-item strong text-right">
-                {{ totalTP|filterNoData()|toLocaleString() }}
-            </td>
-            <td class="catchment-water-quality-footer-item strong text-right">
-                {{ totalTSS|filterNoData()|toLocaleString() }}
-            </td>
-            <td class="catchment-water-quality-footer-item strong text-right">
-                --
-            </td>
-            <td class="catchment-water-quality-footer-item strong text-right">
-                --
-            </td>
-            <td class="catchment-water-quality-footer-item strong text-right">
-                --
-            </td>
-        </tr>
-    </tfoot>
-</table>
+<div class="pageable-table-container">
+  <table class="table custom-hover catchment-water-quality pageable-table-size" data-toggle="table">
+      <thead>
+          <tr>
+              <th data-sortable="true">Id</th>
+              <th data-sortable="true">Area (ha)</th>
+              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                  Total N (kg/ha)
+              </th>
+              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                  Total P (kg/ha)
+              </th>
+              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                  Total TSS (kg/ha)
+              </th>
+              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                  Avg TN (mg/l)
+              </th>
+              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                  Avg TP (mg/l)
+              </th>
+              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                  Avg TSS (mg/l)
+              </th>
+          </tr>
+      </thead>
+      <tbody>
+      </tbody>
+      <tfoot>
+          <tr class="catchment-water-quality-table-footer">
+              <td></td>
+              <td class="strong text-right">
+                  Total (kg/ha)
+              </td>
+              <td class="catchment-water-quality-footer-item strong text-right">
+                  {{ totalTN|filterNoData()|toLocaleString() }}
+              </td>
+              <td class="catchment-water-quality-footer-item strong text-right">
+                  {{ totalTP|filterNoData()|toLocaleString() }}
+              </td>
+              <td class="catchment-water-quality-footer-item strong text-right">
+                  {{ totalTSS|filterNoData()|toLocaleString() }}
+              </td>
+              <td class="catchment-water-quality-footer-item strong text-right">
+                  --
+              </td>
+              <td class="catchment-water-quality-footer-item strong text-right">
+                  --
+              </td>
+              <td class="catchment-water-quality-footer-item strong text-right">
+                  --
+              </td>
+          </tr>
+      </tfoot>
+  </table>
+</div>
+<div class="row paging-ctl-row">
+  <button class="btn-prev-page btn btn-primary">
+    <span aria-hidden="true">&larr;</span>
+  </button>
+  <button class="btn-next-page btn btn-primary">
+    <span aria-hidden="true">&rarr;</span>
+  </button>
+</div>

--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -1,28 +1,38 @@
-<table class="table custom-hover point-source" data-toggle="table">
-    <thead>
-        <tr>
-            <th data-sortable="true">NPDES Code</th>
-            <th data-sortable="true">City</th>
-            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                Discharge (MGD)
-            </th>
-            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                TN Load (kg/yr)
-            </th>
-            <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                TP Load (kg/yr)
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-    </tbody>
-    <tfoot>
-        <tr class="ptsrc-table-footer">
-            <td></td>
-            <td class="strong text-right">Total</td>
-            <td class="ptsrc-footer-item strong text-right">{{ totalMGD|toLocaleString() }}</td>
-            <td class="ptsrc-footer-item strong text-right">{{ totalKGN|toLocaleString() }}</td>
-            <td class="ptsrc-footer-item strong text-right">{{ totalKGP|toLocaleString() }}</td>
-        </tr>
-    </tfoot>
-</table>
+<div class="pageable-table-container">
+  <table class="table custom-hover point-source pageable-table-size" data-toggle="table">
+      <thead>
+          <tr>
+              <th data-sortable="true">NPDES Code</th>
+              <th data-sortable="true">City</th>
+              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                  Discharge (MGD)
+              </th>
+              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                  TN Load (kg/yr)
+              </th>
+              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
+                  TP Load (kg/yr)
+              </th>
+          </tr>
+      </thead>
+      <tbody>
+      </tbody>
+      <tfoot>
+          <tr class="ptsrc-table-footer">
+              <td></td>
+              <td class="strong text-right">Total</td>
+              <td class="ptsrc-footer-item strong text-right">{{ totalMGD|toLocaleString() }}</td>
+              <td class="ptsrc-footer-item strong text-right">{{ totalKGN|toLocaleString() }}</td>
+              <td class="ptsrc-footer-item strong text-right">{{ totalKGP|toLocaleString() }}</td>
+          </tr>
+      </tfoot>
+  </table>
+</div>
+<div class="row paging-ctl-row">
+  <button class="btn-prev-page btn btn-primary">
+    <span aria-hidden="true">&larr;</span>
+  </button>
+  <button class="btn-next-page btn btn-primary">
+    <span aria-hidden="true">&rarr;</span>
+  </button>
+</div>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var $ = require('jquery'),
-    _ = require('lodash'),
+    lodash = require('lodash'),
     L = require('leaflet'),
     Marionette = require('../../shim/backbone.marionette'),
     Backbone = require('../../shim/backbone'),
@@ -58,7 +58,7 @@ var ResultsView = Marionette.LayoutView.extend({
 
         var modelPackages = settings.get('model_packages'),
             modelPackageName = $(e.target).data('id'),
-            modelPackage = _.find(modelPackages, {name: modelPackageName}),
+            modelPackage = lodash.find(modelPackages, {name: modelPackageName}),
             newProjectUrl = '/project/new/' + modelPackageName,
             projectUrl = '/project',
             alertView,
@@ -69,7 +69,7 @@ var ResultsView = Marionette.LayoutView.extend({
             analysisResults = JSON.parse(App.getAnalyzeCollection()
                                             .findWhere({taskName: 'analyze'})
                                             .get('result') || "{}"),
-            landResults = _.find(analysisResults, function(element) {
+            landResults = lodash.find(analysisResults, function(element) {
                     return element.name === 'land';
             });
 
@@ -93,7 +93,7 @@ var ResultsView = Marionette.LayoutView.extend({
         }
 
         if (landResults) {
-            var landCoverTotal = _.sum(_.map(landResults.categories,
+            var landCoverTotal = lodash.sum(lodash.map(landResults.categories,
                     function(category) {
                         if (category.type === 'Open Water') {
                             return 0;
@@ -168,7 +168,7 @@ var ResultsView = Marionette.LayoutView.extend({
 
     animateIn: function(fitToBounds) {
         var self = this,
-            fit = _.isUndefined(fitToBounds) ? true : fitToBounds;
+            fit = lodash.isUndefined(fitToBounds) ? true : fitToBounds;
 
         this.$el.animate({ width: '400px' }, 200, function() {
             App.map.setNoHeaderSidebarSize(fit);
@@ -178,7 +178,7 @@ var ResultsView = Marionette.LayoutView.extend({
 
     animateOut: function(fitToBounds) {
         var self = this,
-            fit = _.isUndefined(fitToBounds) ? true : fitToBounds;
+            fit = lodash.isUndefined(fitToBounds) ? true : fitToBounds;
 
         // Change map to full size first so there isn't empty space when
         // results window animates out
@@ -259,8 +259,8 @@ var TabContentView = Marionette.LayoutView.extend({
         this.showAnalyzingMessage();
 
         this.model.get('taskRunner').fetchAnalysisIfNeeded()
-            .done(_.bind(this.showResultsIfNotDestroyed, this))
-            .fail(_.bind(this.showErrorIfNotDestroyed, this));
+            .done(lodash.bind(this.showResultsIfNotDestroyed, this))
+            .fail(lodash.bind(this.showErrorIfNotDestroyed, this));
     },
 
     showAnalyzingMessage: function() {
@@ -296,7 +296,7 @@ var TabContentView = Marionette.LayoutView.extend({
     showResults: function() {
         var name = this.model.get('name'),
             results = JSON.parse(this.model.get('taskRunner').get('result')).survey,
-            result = _.find(results, { name: name }),
+            result = lodash.find(results, { name: name }),
             resultModel = new models.LayerModel(result),
             ResultView = AnalyzeResultViews[name];
 
@@ -435,14 +435,18 @@ var PointSourceTableView = Marionette.CompositeView.extend({
 
     ui: {
         'pointSourceTR': 'tr.point-source',
-        'pointSourceId': '.point-source-id'
+        'pointSourceId': '.point-source-id',
+        'pointSourceTblNext': '.btn-next-page',
+        'pointSourceTblPrev': '.btn-prev-page'
     },
 
     events: {
         'click @ui.pointSourceId': 'panToPointSourceMarker',
         'mouseout @ui.pointSourceId': 'removePointSourceMarker',
         'mouseover @ui.pointSourceTR': 'addPointSourceMarkerToMap',
-        'mouseout @ui.pointSourceTR': 'removePointSourceMarker'
+        'mouseout @ui.pointSourceTR': 'removePointSourceMarker',
+        'click @ui.pointSourceTblNext': 'nextPage',
+        'click @ui.pointSourceTblPrev': 'prevPage'
     },
 
     createPointSourceMarker: function(data) {
@@ -455,6 +459,22 @@ var PointSourceTableView = Marionette.CompositeView.extend({
         }).bindPopup(new pointSourceLayer.PointSourcePopupView({
           model: new Backbone.Model(data)
       }).render().el, { closeButton: false });
+    },
+
+    nextPage: function() {
+        if (this.collection.hasNextPage()) {
+            this.collection.getNextPage();
+            this.render();
+            $('[data-toggle="table"]').bootstrapTable();
+        }
+    },
+
+    prevPage: function() {
+        if (this.collection.hasPreviousPage()) {
+            this.collection.getPreviousPage();
+            this.render();
+            $('[data-toggle="table"]').bootstrapTable();
+        }
     },
 
     addPointSourceMarkerToMap: function(e) {
@@ -528,14 +548,34 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
 
     ui: {
         'catchmentWaterQualityTR': 'tr.catchment-water-quality',
-        'catchmentWaterQualityId': '.catchment-water-quality-id'
+        'catchmentWaterQualityId': '.catchment-water-quality-id',
+        'pointSourceTblNext': '.btn-next-page',
+        'pointSourceTblPrev': '.btn-prev-page'
     },
 
     events: {
         'click @ui.catchmentWaterQualityId': 'panToCatchmentPolygon',
         'mouseout @ui.catchmentWaterQualityId': 'removeCatchmentPolygon',
         'mouseover @ui.catchmentWaterQualityTR': 'addCatchmentToMap',
-        'mouseout @ui.catchmentWaterQualityTR': 'removeCatchmentPolygon'
+        'mouseout @ui.catchmentWaterQualityTR': 'removeCatchmentPolygon',
+        'click @ui.pointSourceTblNext': 'nextPage',
+        'click @ui.pointSourceTblPrev': 'prevPage'
+    },
+
+    nextPage: function() {
+        if (this.collection.hasNextPage()) {
+            this.collection.getNextPage();
+            this.render();
+            $('[data-toggle="table"]').bootstrapTable();
+        }
+    },
+
+    prevPage: function() {
+        if (this.collection.hasPreviousPage()) {
+            this.collection.getPreviousPage();
+            this.render();
+            $('[data-toggle="table"]').bootstrapTable();
+        }
     },
 
     createCatchmentPolygon: function(data) {
@@ -611,7 +651,7 @@ var ChartView = Marionette.ItemView.extend({
     addChart: function() {
         var self = this,
             chartEl = this.$el.find('.bar-chart').get(0),
-            data = _.map(this.collection.toJSON(), function(model) {
+            data = lodash.map(this.collection.toJSON(), function(model) {
                 return {
                     x: model.type,
                     y: model.coverage,
@@ -622,7 +662,7 @@ var ChartView = Marionette.ItemView.extend({
             chartOptions = {
                yAxisLabel: 'Coverage',
                isPercentage: true,
-               barClasses: _.pluck(data, 'class')
+               barClasses: lodash.pluck(data, 'class')
            };
 
         chart.renderHorizontalBarChart(chartEl, data, chartOptions);
@@ -640,7 +680,7 @@ var AnalyzeResultView = Marionette.LayoutView.extend({
     showAnalyzeResults: function(CategoriesToCensus, AnalyzeTableView,
         AnalyzeChartView, description) {
         var categories = this.model.get('categories'),
-            largestArea = _.max(_.pluck(categories, 'area')),
+            largestArea = lodash.max(lodash.pluck(categories, 'area')),
             units = utils.magnitudeOfArea(largestArea),
             census = new CategoriesToCensus(categories);
 

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -237,12 +237,16 @@ var AnimalCensusCollection = Backbone.Collection.extend({
     comparator: 'type'
 });
 
-var PointSourceCensusCollection = Backbone.Collection.extend({
-    comparator: 'city'
+var PointSourceCensusCollection = Backbone.PageableCollection.extend({
+    comparator: 'city',
+    mode: 'client',
+    state: { pageSize: 50, firstPage: 1 }
 });
 
-var CatchmentWaterQualityCensusCollection = Backbone.Collection.extend({
-    comparator: 'nord'
+var CatchmentWaterQualityCensusCollection = Backbone.PageableCollection.extend({
+    comparator: 'nord',
+    mode: 'client',
+    state: { pageSize: 50, firstPage: 1 }
 });
 
 var GeoModel = Backbone.Model.extend({

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -29,6 +29,11 @@
         }
       }
     },
+    "backbone.paginator": {
+      "version": "2.0.5",
+      "from": "backbone.paginator@*",
+      "resolved": "https://registry.npmjs.org/backbone.paginator/-/backbone.paginator-2.0.5.tgz"
+    },
     "blueimp-md5": {
       "version": "1.1.0",
       "from": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-1.1.0.tgz",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "backbone": "1.1.2",
     "backbone.marionette": "2.4.1",
+    "backbone.paginator": "2.0.5",
     "blueimp-md5": "1.1.0",
     "bootstrap": "3.3.4",
     "bootstrap-select": "git://github.com/azavea/bootstrap-select",

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -30,3 +30,28 @@
   font-size: 0.8rem;
   padding-top: 5px;
 }
+
+.paging-ctl-row {
+  text-align: center;
+  bottom:0rem;
+  position:fixed;
+  background-color: $paper;
+  @media (max-height: 884px) {
+    top:0.2rem;
+    position:relative;
+  }
+}
+
+.pageable-table-container {
+  overflow: visible;
+  padding-bottom:10%;
+  @media (max-height: 884px) {
+    padding-bottom:0px;
+  }
+}
+
+.pageable-table {
+  width: 650px !important;
+  max-width: 650px !important;
+  height: 100%;
+}


### PR DESCRIPTION
This adds pageable tables, specifically intended for Backbone projects, to the "Point Source" and "Water Quality" views, to address performance issues stemming from rendering the records in larger AoI's.

To test:
- clone this branch and bring up and environment, checking that `bootstrap.paginator` successfully installs
- select a larger AoI and wait for the analysis task to complete
- look at the "Point Source" and "Water Quality" tabs and make sure that the tables are paged
- test the paging buttons to ensure the table updates as expected
- test the table sorting, where approriate
- repeat the process at different viewport sizes to check that the tables are usable and that styling is reasonably consistent

To test performance, select the same AoI's on the locally hosted app and on the staging app; for both, start the profiler, then activate the point source and water quality tabs, then start a TR55 model run and back out once the model view renders. Once the analysis view renders again after the model->analysis transition, stop the profiler. Compare the sequence of actions between the two profiler sessions. For a large AoI with several records, the render time should be measurably lower in the local app.

Connects #1569 