### PR TITLE
Update water quality analysis tab description

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -744,7 +744,7 @@ var PointSourceResultView = AnalyzeResultView.extend({
 
 var CatchmentWaterQualityResultView = AnalyzeResultView.extend({
     onShow: function() {
-        var desc = 'River Basin only: Stream Reach Assessment Tool model estimates',
+        var desc = 'Delaware River Basin only: Stream Reach Assessment Tool model estimates',
             chart = null;
         this.showAnalyzeResults(coreModels.CatchmentWaterQualityCensusCollection,
             CatchmentWaterQualityTableView, chart, desc);


### PR DESCRIPTION
This PR adds "Delaware" to the Water Quality analysis tab description. It's the first part of #1586, and I'm pushing it here to separate it off from the work for the second part of that card.

**Testing**
- get this branch, bring up the dev env, run `./scripts/bundle.sh`, then open the browser and console and analyze an aoi within the drb
- verify that the water quality analysis tab now reads "Delaware River Basin..." and that everything else works as it should and that there aren't any errors in the console.

Connects #1586 