### PR TITLE
Show point source and water quality data to three digits

### DIFF
--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
@@ -3,7 +3,9 @@
       <thead>
           <tr>
               <th data-sortable="true">Id</th>
-              <th data-sortable="true">Area (ha)</th>
+              <th data-sortable="true" data-sorter="window.noDataSort">
+                  Area (ha)
+              </th>
               <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
                   Total N (kg/ha)
               </th>

--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
@@ -33,13 +33,13 @@
                   Total (kg/ha)
               </td>
               <td class="catchment-water-quality-footer-item strong text-right">
-                  {{ totalTN|filterNoData()|toLocaleString() }}
+                  {{ totalTN|filterNoData()|toLocaleString(3) }}
               </td>
               <td class="catchment-water-quality-footer-item strong text-right">
-                  {{ totalTP|filterNoData()|toLocaleString() }}
+                  {{ totalTP|filterNoData()|toLocaleString(3) }}
               </td>
               <td class="catchment-water-quality-footer-item strong text-right">
-                  {{ totalTSS|filterNoData()|toLocaleString() }}
+                  {{ totalTSS|filterNoData()|toLocaleString(3) }}
               </td>
               <td class="catchment-water-quality-footer-item strong text-right">
                   --

--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTableRow.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTableRow.html
@@ -5,54 +5,54 @@
     data-nord="{{ nord }}"
     data-areaha="{{ areaha }}"
 
-    data-tn_tot_kgy="{{ tn_tot_kgy|filterNoData()|toLocaleString() }}"
-    data-tp_tot_kgy="{{ tp_tot_kgy|filterNoData()|toLocaleString() }}"
-    data-tss_tot_kg="{{ tss_tot_kg|filterNoData()|toLocaleString() }}"
+    data-tn_tot_kgy="{{ tn_tot_kgy if tn_tot_kgy else noData }}"
+    data-tp_tot_kgy="{{ tp_tot_kgy if tp_tot_kgy else noData }}"
+    data-tss_tot_kg="{{ tss_tot_kg if tss_tot_kg else noData }}"
 
-    data-tn_urban_k="{{ tn_urban_k|filterNoData()|toLocaleString() }}"
-    data-tp_urban_k="{{ tp_urban_k|filterNoData()|toLocaleString() }}"
-    data-tss_urban_="{{ tss_urban_|filterNoData()|toLocaleString() }}"
+    data-tn_urban_k="{{ tn_urban_k if tn_urban_k else noData }}"
+    data-tp_urban_k="{{ tp_urban_k if tp_urban_k else noData }}"
+    data-tss_urban_="{{ tss_urban_ if tss_urban_ else noData }}"
 
-    data-tn_riparia="{{ tn_riparia|filterNoData()|toLocaleString()}}"
-    data-tp_riparia="{{ tp_riparia|filterNoData()|toLocaleString() }}"
-    data-tss_rip_kg="{{ tss_rip_kg|filterNoData()|toLocaleString() }}"
+    data-tn_riparia="{{ tn_riparia if tn_riparia else noData }}"
+    data-tp_riparia="{{ tp_riparia if tp_riparia else noData }}"
+    data-tss_rip_kg="{{ tss_rip_kg if tss_rip_kg else noData }}"
 
-    data-tn_ag_kgyr="{{ tn_ag_kgyr|filterNoData()|toLocaleString() }}"
-    data-tp_ag_kgyr="{{ tp_ag_kgyr|filterNoData()|toLocaleString() }}"
-    data-tss_ag_kgy="{{ tss_ag_kgy|filterNoData()|toLocaleString() }}"
+    data-tn_ag_kgyr="{{ tn_ag_kgyr if tn_ag_kgyr else noData }}"
+    data-tp_ag_kgyr="{{ tp_ag_kgyr if tp_ag_kgyr else noData }}"
+    data-tss_ag_kgy="{{ tss_ag_kgy if tss_ag_kgy else noData }}"
 
-    data-tn_natural="{{ tn_natural|filterNoData()|toLocaleString() }}"
-    data-tp_natural="{{ tp_natural|filterNoData()|toLocaleString() }}"
-    data-tss_natura="{{ tss_natura|filterNoData()|toLocaleString() }}"
+    data-tn_natural="{{ tn_natural if tn_natural else noData }}"
+    data-tp_natural="{{ tp_natural if tp_natural else noData }}"
+    data-tss_natura="{{ tss_natura if tss_natura else noData }}"
 
-    data-tn_pt_kgyr="{{ tn_pt_kgyr|filterNoData()|toLocaleString() }}"
-    data-tp_pt_kgyr="{{ tp_pt_kgyr|filterNoData()|toLocaleString() }}"
+    data-tn_pt_kgyr="{{ tn_pt_kgyr if tn_pt_kgyr else noData }}"
+    data-tp_pt_kgyr="{{ tp_pt_kgyr if tp_pt_kgyr else noData }}"
 
-    data-tn_yr_avg_="{{ tn_yr_avg_|filterNoData()|toLocaleString() }}"
-    data-tp_yr_avg_="{{ tp_yr_avg_|filterNoData()|toLocaleString() }}"
-    data-tss_concmg="{{ tss_concmg|filterNoData()|toLocaleString() }}"
+    data-tn_yr_avg_="{{ tn_yr_avg_ if tn_yr_avg_ else noData }}"
+    data-tp_yr_avg_="{{ tp_yr_avg_ if tp_yr_avg_ else noData }}"
+    data-tss_concmg="{{ tss_concmg if tss_concmg else noData }}"
   >
     {{ nord }}
   </a>
 </td>
 <td class="strong text-right">
-    {{ areaha|filterNoData()|toLocaleString() }}
+    {{ areaha|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ (tn_tot_kgy/areaha)|filterNoData()|toLocaleString() }}
+    {{ (tn_tot_kgy/areaha)|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ (tp_tot_kgy/areaha)|filterNoData()|toLocaleString() }}
+    {{ (tp_tot_kgy/areaha)|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ (tss_tot_kg/areaha)|filterNoData()|toLocaleString() }}
+    {{ (tss_tot_kg/areaha)|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ tn_yr_avg_|filterNoData()|toLocaleString() }}
+    {{ tn_yr_avg_|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ tp_yr_avg_|filterNoData()|toLocaleString() }}
+    {{ tp_yr_avg_|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ tss_concmg|filterNoData()|toLocaleString() }}
+    {{ tss_concmg|filterNoData()|toLocaleString(3) }}
 </td>

--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -20,10 +20,18 @@
       <tfoot>
           <tr class="ptsrc-table-footer">
               <td></td>
-              <td class="strong text-right">Total</td>
-              <td class="ptsrc-footer-item strong text-right">{{ totalMGD|toLocaleString() }}</td>
-              <td class="ptsrc-footer-item strong text-right">{{ totalKGN|toLocaleString() }}</td>
-              <td class="ptsrc-footer-item strong text-right">{{ totalKGP|toLocaleString() }}</td>
+              <td class="strong text-right">
+                  Total
+              </td>
+              <td class="ptsrc-footer-item strong text-right">
+                  {{ totalMGD|filterNoData()|toLocaleString(3) }}
+              </td>
+              <td class="ptsrc-footer-item strong text-right">
+                  {{ totalKGN|filterNoData()|toLocaleString(3) }}
+              </td>
+              <td class="ptsrc-footer-item strong text-right">
+                  {{ totalKGP|filterNoData()|toLocaleString(3) }}
+              </td>
           </tr>
       </tfoot>
   </table>

--- a/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
@@ -6,15 +6,15 @@
     data-lng="{{ longitude }}"
     data-city="{{ city|title if city else '' }}"
     data-state="{{ state|upper if state else '' }}"
-    data-mgd="{{ mgd|filterNoData()|toLocaleString() }}"
+    data-mgd="{{ mgd if mgd else noData }}"
     data-facilityname="{{ facilityname if facilityname else '' }}"
-    data-kgn_yr="{{ kgn_yr|filterNoData()|toLocaleString() }}"
-    data-kgp_yr="{{ kgp_yr|filterNoData()|toLocaleString() }}"
+    data-kgn_yr="{{ kgn_yr if kgn_yr else noData }}"
+    data-kgp_yr="{{ kgp_yr if kgp_yr else noData }}"
   >
     {{ npdes_id }}
   </a>
 </td>
 <td>{{ city|title if city else noData }}</td>
-<td class="strong text-right">{{ mgd|filterNoData()|toLocaleString() }}</td>
-<td class="strong text-right">{{ kgn_yr|filterNoData()|toLocaleString() }}</td>
-<td class="strong text-right">{{ kgp_yr|filterNoData()|toLocaleString() }}</td>
+<td class="strong text-right">{{ mgd|filterNoData()|toLocaleString(3) }}</td>
+<td class="strong text-right">{{ kgn_yr|filterNoData()|toLocaleString(3) }}</td>
+<td class="strong text-right">{{ kgp_yr|filterNoData()|toLocaleString(3) }}</td>

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -20,6 +20,15 @@ var sandboxId = 'sandbox',
         el: sandboxSelector
     });
 
+function renderPtSrcAndWQTableRowValue(n) {
+    if (n && !_.isNaN(n)) {
+        return Number(n.toFixed(3)).toLocaleString('en',
+            { minimumFractionDigits: 3 });
+    } else {
+        return coreUtils.noData;
+    }
+}
+
 describe('Analyze', function() {
     before(function() {
         if ($(sandboxSelector).length === 0) {
@@ -121,9 +130,9 @@ function pointsourceTableFormatter(categories) {
     return collection.map(function(category) {
         var code = category.get('npdes_id'),
             city = coreUtils.toTitleCase(category.get('city')),
-            discharge = coreUtils.filterNoData(category.get('mgd')).toLocaleString(),
-            tn_load = coreUtils.filterNoData(category.get('kgn_yr')).toLocaleString(),
-            tp_load = coreUtils.filterNoData(category.get('kgp_yr')).toLocaleString();
+            discharge = renderPtSrcAndWQTableRowValue(category.get('mgd')),
+            tn_load = renderPtSrcAndWQTableRowValue(category.get('kgn_yr')),
+            tp_load = renderPtSrcAndWQTableRowValue(category.get('kgp_yr'));
 
         return [code, city, discharge, tn_load, tp_load];
     });
@@ -133,13 +142,16 @@ function catchmentWaterQualityTableFormatter(categories) {
     var collection = new coreModels.CatchmentWaterQualityCensusCollection(categories);
     return collection.map(function(category) {
         var nord = category.get('nord').toString(),
-            areaha = coreUtils.filterNoData(category.get('areaha')).toLocaleString(),
-            tn_tot_kgy = coreUtils.filterNoData((category.get('tn_tot_kgy')/category.get('areaha'))).toLocaleString(),
-            tp_tot_kgy = coreUtils.filterNoData((category.get('tp_tot_kgy')/category.get('areaha'))).toLocaleString(),
-            tss_tot_kg = coreUtils.filterNoData((category.get('tss_tot_kg')/category.get('areaha'))).toLocaleString(),
-            tn_yr_avg_ = coreUtils.filterNoData((category.get('tn_yr_avg_'))).toLocaleString(),
-            tp_yr_avg_ = coreUtils.filterNoData((category.get('tp_yr_avg_'))).toLocaleString(),
-            tss_concmg = coreUtils.filterNoData((category.get('tss_concmg'))).toLocaleString();
+            areaha = renderPtSrcAndWQTableRowValue(category.get('areaha')),
+            tn_tot_kgy = renderPtSrcAndWQTableRowValue(
+                category.get('tn_tot_kgy')/category.get('areaha')),
+            tp_tot_kgy = renderPtSrcAndWQTableRowValue(
+                category.get('tp_tot_kgy')/category.get('areaha')),
+            tss_tot_kg = renderPtSrcAndWQTableRowValue(
+                category.get('tss_tot_kg')/category.get('areaha')),
+            tn_yr_avg_ = renderPtSrcAndWQTableRowValue(category.get('tn_yr_avg_')),
+            tp_yr_avg_ = renderPtSrcAndWQTableRowValue(category.get('tp_yr_avg_')),
+            tss_concmg = renderPtSrcAndWQTableRowValue(category.get('tss_concmg'));
 
         return [nord, areaha, tn_tot_kgy, tp_tot_kgy, tss_tot_kg, tn_yr_avg_,
             tp_yr_avg_, tss_concmg];

--- a/src/mmw/js/src/core/templates/catchmentWaterQualityPopup.html
+++ b/src/mmw/js/src/core/templates/catchmentWaterQualityPopup.html
@@ -12,34 +12,34 @@
         <tr>
             <td>Agriculture</td>
             <td class="text-right">
-                {{ tn_ag_kgyr|filterNoData()|toLocaleString() }}
+                {{ tn_ag_kgyr|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tp_ag_kgyr|filterNoData()|toLocaleString() }}
+                {{ tp_ag_kgyr|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tss_ag_kgy|filterNoData()|toLocaleString() }}
+                {{ tss_ag_kgy|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
         <tr>
             <td>Natural</td>
             <td class="text-right">
-                {{ tn_natural|filterNoData()|toLocaleString() }}
+                {{ tn_natural|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tp_natural|filterNoData()|toLocaleString() }}
+                {{ tp_natural|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tss_natura|filterNoData()|toLocaleString() }}
+                {{ tss_natura|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
         <tr>
             <td>Point Source</td>
             <td class="text-right">
-                {{ tn_pt_kgyr|filterNoData()|toLocaleString() }}
+                {{ tn_pt_kgyr|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tp_pt_kgyr|filterNoData()|toLocaleString() }}
+                {{ tp_pt_kgyr|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
                 {{ noData }}
@@ -48,25 +48,25 @@
         <tr>
             <td>Riparian</td>
             <td class="text-right">
-                {{ tn_riparia|filterNoData()|toLocaleString() }}
+                {{ tn_riparia|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tp_riparia|filterNoData()|toLocaleString() }}
+                {{ tp_riparia|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tss_rip_kg|filterNoData()|toLocaleString() }}
+                {{ tss_rip_kg|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
         <tr>
             <td>Urban</td>
             <td class="text-right">
-                {{ tn_urban_k|filterNoData()|toLocaleString() }}
+                {{ tn_urban_k|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tp_urban_k|filterNoData()|toLocaleString() }}
+                {{ tp_urban_k|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tss_urban_|filterNoData()|toLocaleString() }}
+                {{ tss_urban_|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
     </tbody>
@@ -82,13 +82,13 @@
         <tr>
             <td></td>
             <td class="text-right">
-                {{ tn_yr_avg_|filterNoData()|toLocaleString() }}
+                {{ tn_yr_avg_|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tp_yr_avg_|filterNoData()|toLocaleString() }}
+                {{ tp_yr_avg_|filterNoData()|toLocaleString(3) }}
             </td>
             <td class="text-right">
-                {{ tss_concmg|filterNoData()|toLocaleString() }}
+                {{ tss_concmg|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
     </tbody>

--- a/src/mmw/js/src/core/templates/pointSourcePopup.html
+++ b/src/mmw/js/src/core/templates/pointSourcePopup.html
@@ -16,19 +16,19 @@
         <tr>
             <td>Discharge (MGD)</td>
             <td class="text-right">
-                {{ mgd|filterNoData()|toLocaleString() }}
+                {{ mgd|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
         <tr>
             <td>TN Load (kg/yr)</td>
             <td class="text-right">
-                {{ kgn_yr|filterNoData()|toLocaleString() }}
+                {{ kgn_yr|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
         <tr>
             <td>TP Load (kg/yr)</td>
             <td class="text-right">
-                {{ kgp_yr|filterNoData()|toLocaleString() }}
+                {{ kgp_yr|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
     </tbody>

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -12,7 +12,7 @@ var noData = 'No Data';
 var utils = {
     filterNoData: function(data) {
         if (data && !isNaN(data) && isFinite(data)) {
-            return data;
+            return data.toFixed(3);
         } else {
             return noData;
         }


### PR DESCRIPTION
This PR updates the point source and water quality analysis tabs and popups to display the data to three digits. Previously we'd been displaying it haphazardly, which made it difficult to compare at a glance. With these changes, we force each value in these tables to be three digits (and do the same with the associated popups):

![screen shot 2016-11-01 at 4 48 04 pm](https://cloud.githubusercontent.com/assets/4165523/19906884/ffee787c-a052-11e6-8266-729f010cd040.png)

&

![screen shot 2016-11-01 at 4 48 04 pm](https://cloud.githubusercontent.com/assets/4165523/19906890/041a20a4-a053-11e6-9e0e-fb6ce8aff27f.png)

and

![screen shot 2016-11-01 at 4 49 24 pm](https://cloud.githubusercontent.com/assets/4165523/19906930/2e0ee4b2-a053-11e6-8252-82ec62b496f1.png)

&

![screen shot 2016-11-01 at 4 49 29 pm](https://cloud.githubusercontent.com/assets/4165523/19906934/32368be4-a053-11e6-8cf1-c74a5b1d5334.png)


The second commit here adds a method to sort the area column of the water quality table; the third updates the tests.

**Testing**
- get this branch, `vagrant up` and `./scripts/bundle.sh`, then open the browser and console and visit `localhost:8000`.
- select a known AOI to analyze within the DRB and verify that when the results return the point source and water quality tabs have three digits for each column but otherwise resemble the data for the same AOI on staging
- click to open a few popups from each tab and verify that the popups show three digits, too
- verify that you haven't seen any errors in the console

Connects #1586 