### PR TITLE
Fixup Analyze Tab Paginated Tables

### DIFF
--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
@@ -3,9 +3,7 @@
       <thead>
           <tr>
               <th data-sortable="true">Id</th>
-              <th data-sortable="true" data-sorter="window.noDataSort">
-                  Area (ha)
-              </th>
+              <th data-sortable="true" data-sorter="window.noDataSort"> Area (ha)</th>
               <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
                   Total N (kg/ha)
               </th>
@@ -30,9 +28,8 @@
       </tbody>
       <tfoot>
           <tr class="catchment-water-quality-table-footer">
-              <td></td>
-              <td class="strong text-right">
-                  Total (kg/ha)
+              <td class="strong text-right" colspan="2">
+                  Total For Area of Interest (kg/ha)
               </td>
               <td class="catchment-water-quality-footer-item strong text-right">
                   {{ totalTN|filterNoData()|toLocaleString(3) }}
@@ -56,11 +53,24 @@
       </tfoot>
   </table>
 </div>
-<div class="row paging-ctl-row">
-  <button class="btn-prev-page btn btn-primary">
-    <span aria-hidden="true">&larr;</span>
-  </button>
-  <button class="btn-next-page btn btn-primary">
-    <span aria-hidden="true">&rarr;</span>
-  </button>
-</div>
+{% if totalPages > 1 %}
+    <div class="row paging-ctl-row">
+            <p>
+                {{currentPage}} of {{totalPages}}
+            </p>
+            {% if hasPreviousPage %}
+                <button class="btn-prev-page btn btn-primary"
+                  data-toggle="tooltip" title="Previous Page"
+                  data-placement="right">
+                    <span aria-hidden="true">&larr;</span>
+                </button>
+            {% endif %}
+            {% if hasNextPage %}
+                <button class="btn-next-page btn btn-primary"
+                  data-toggle="tooltip" title="Next Page"
+                  data-placement="right">
+                    <span aria-hidden="true">&rarr;</span>
+                </button>
+            {% endif %}
+    </div>
+{% endif %}

--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -19,9 +19,8 @@
       </tbody>
       <tfoot>
           <tr class="ptsrc-table-footer">
-              <td></td>
-              <td class="strong text-right">
-                  Total
+              <td class="strong text-right" colspan="2">
+                  Total For Area of Interest
               </td>
               <td class="ptsrc-footer-item strong text-right">
                   {{ totalMGD|filterNoData()|toLocaleString(3) }}
@@ -36,11 +35,24 @@
       </tfoot>
   </table>
 </div>
-<div class="row paging-ctl-row">
-  <button class="btn-prev-page btn btn-primary">
-    <span aria-hidden="true">&larr;</span>
-  </button>
-  <button class="btn-next-page btn btn-primary">
-    <span aria-hidden="true">&rarr;</span>
-  </button>
-</div>
+{% if totalPages > 1 %}
+    <div class="row paging-ctl-row">
+            <p>
+                {{currentPage}} of {{totalPages}}
+            </p>
+            {% if hasPreviousPage %}
+                <button class="btn-prev-page btn btn-primary"
+                  data-toggle="tooltip" title="Previous Page"
+                  data-placement="right">
+                    <span aria-hidden="true">&larr;</span>
+                </button>
+            {% endif %}
+            {% if hasNextPage %}
+                <button class="btn-next-page btn btn-primary"
+                  data-toggle="tooltip" title="Next Page"
+                  data-placement="right">
+                    <span aria-hidden="true">&rarr;</span>
+                </button>
+            {% endif %}
+    </div>
+{% endif %}

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -423,7 +423,11 @@ var PointSourceTableView = Marionette.CompositeView.extend({
             totalKGN: utils.totalForPointSourceCollection(
                 this.collection.models, 'kgn_yr'),
             totalKGP: utils.totalForPointSourceCollection(
-                this.collection.models, 'kgp_yr')
+                this.collection.models, 'kgp_yr'),
+            hasNextPage: this.collection.hasNextPage(),
+            hasPreviousPage: this.collection.hasPreviousPage(),
+            currentPage: this.collection.state.currentPage,
+            totalPages: this.collection.state.totalPages,
         };
     },
     childViewContainer: 'tbody',
@@ -532,11 +536,15 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
         return {
             headerUnits: this.options.units,
             totalTN: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.models, 'tn_tot_kgy', 'areaha'),
+                this.collection.fullCollection.models, 'tn_tot_kgy', 'areaha'),
             totalTP: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.models, 'tp_tot_kgy', 'areaha'),
+                this.collection.fullCollection.models, 'tp_tot_kgy', 'areaha'),
             totalTSS: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.models, 'tss_tot_kg', 'areaha')
+                this.collection.fullCollection.models, 'tss_tot_kg', 'areaha'),
+            hasNextPage: this.collection.hasNextPage(),
+            hasPreviousPage: this.collection.hasPreviousPage(),
+            currentPage: this.collection.state.currentPage,
+            totalPages: this.collection.state.totalPages,
         };
     },
     childViewContainer: 'tbody',
@@ -549,8 +557,8 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
     ui: {
         'catchmentWaterQualityTR': 'tr.catchment-water-quality',
         'catchmentWaterQualityId': '.catchment-water-quality-id',
-        'pointSourceTblNext': '.btn-next-page',
-        'pointSourceTblPrev': '.btn-prev-page'
+        'catchmentWaterQualityTblNext': '.btn-next-page',
+        'catchmentWaterQualityTblPrev': '.btn-prev-page',
     },
 
     events: {
@@ -558,8 +566,8 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
         'mouseout @ui.catchmentWaterQualityId': 'removeCatchmentPolygon',
         'mouseover @ui.catchmentWaterQualityTR': 'addCatchmentToMap',
         'mouseout @ui.catchmentWaterQualityTR': 'removeCatchmentPolygon',
-        'click @ui.pointSourceTblNext': 'nextPage',
-        'click @ui.pointSourceTblPrev': 'prevPage'
+        'click @ui.catchmentWaterQualityTblNext': 'nextPage',
+        'click @ui.catchmentWaterQualityTblPrev': 'prevPage',
     },
 
     nextPage: function() {


### PR DESCRIPTION
- Show footer with info for whole collection
- Show number of pages
- Disable pagination if no (more) pages
- Show tooltip on hover of arrow pagination button

<img width="713" alt="screen shot 2016-11-01 at 5 20 24 pm" src="https://cloud.githubusercontent.com/assets/7633670/19907984/8a81308e-a057-11e6-9806-2c346de302ae.png">
<img width="710" alt="screen shot 2016-11-01 at 5 20 34 pm" src="https://cloud.githubusercontent.com/assets/7633670/19907983/8a80e67e-a057-11e6-8ecf-d1daf8d8290f.png">

## Testing

Pull this branch
In the DRB,
- Select a 1km AoI (should have only 1 page) - confirm there are no pagination buttons on the Water Quality tab
- Select a big AoI (should have multiple pages) -
On the water quality tab
-  confirm there is no back button on the first page
-  no forward button on the last
-  tooltip on button hover
-  totals don't change as you flip page to page

Connects #1585