### PR TITLE
Switch To Bootstrap Table's Pagination

### DIFF
--- a/src/mmw/js/shim/backbone.js
+++ b/src/mmw/js/shim/backbone.js
@@ -7,6 +7,5 @@ var $ = require('jquery'),
 
 // See: https://github.com/jashkenas/backbone/issues/3291
 Backbone.$ = $;
-Backbone.PageableCollection = require('backbone.paginator');
 
 module.exports = Backbone;

--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
@@ -1,5 +1,5 @@
-<div class="pageable-table-container">
-  <table class="table custom-hover catchment-water-quality pageable-table-size" data-toggle="table">
+  <table class="table custom-hover catchment-water-quality" data-toggle="table"
+        data-pagination="true" data-page-size=50>
       <thead>
           <tr>
               <th data-sortable="true">Id</th>
@@ -52,25 +52,3 @@
           </tr>
       </tfoot>
   </table>
-</div>
-{% if totalPages > 1 %}
-    <div class="row paging-ctl-row">
-            <p>
-                {{currentPage}} of {{totalPages}}
-            </p>
-            {% if hasPreviousPage %}
-                <button class="btn-prev-page btn btn-primary"
-                  data-toggle="tooltip" title="Previous Page"
-                  data-placement="right">
-                    <span aria-hidden="true">&larr;</span>
-                </button>
-            {% endif %}
-            {% if hasNextPage %}
-                <button class="btn-next-page btn btn-primary"
-                  data-toggle="tooltip" title="Next Page"
-                  data-placement="right">
-                    <span aria-hidden="true">&rarr;</span>
-                </button>
-            {% endif %}
-    </div>
-{% endif %}

--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -1,5 +1,5 @@
-<div class="pageable-table-container">
-  <table class="table custom-hover point-source pageable-table-size" data-toggle="table">
+  <table class="table custom-hover point-source" data-toggle="table"
+        data-pagination="true" data-page-size=50 >
       <thead>
           <tr>
               <th data-sortable="true">NPDES Code</th>
@@ -34,25 +34,3 @@
           </tr>
       </tfoot>
   </table>
-</div>
-{% if totalPages > 1 %}
-    <div class="row paging-ctl-row">
-            <p>
-                {{currentPage}} of {{totalPages}}
-            </p>
-            {% if hasPreviousPage %}
-                <button class="btn-prev-page btn btn-primary"
-                  data-toggle="tooltip" title="Previous Page"
-                  data-placement="right">
-                    <span aria-hidden="true">&larr;</span>
-                </button>
-            {% endif %}
-            {% if hasNextPage %}
-                <button class="btn-next-page btn btn-primary"
-                  data-toggle="tooltip" title="Next Page"
-                  data-placement="right">
-                    <span aria-hidden="true">&rarr;</span>
-                </button>
-            {% endif %}
-    </div>
-{% endif %}

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -424,10 +424,6 @@ var PointSourceTableView = Marionette.CompositeView.extend({
                 this.collection.models, 'kgn_yr'),
             totalKGP: utils.totalForPointSourceCollection(
                 this.collection.models, 'kgp_yr'),
-            hasNextPage: this.collection.hasNextPage(),
-            hasPreviousPage: this.collection.hasPreviousPage(),
-            currentPage: this.collection.state.currentPage,
-            totalPages: this.collection.state.totalPages,
         };
     },
     childViewContainer: 'tbody',
@@ -440,8 +436,6 @@ var PointSourceTableView = Marionette.CompositeView.extend({
     ui: {
         'pointSourceTR': 'tr.point-source',
         'pointSourceId': '.point-source-id',
-        'pointSourceTblNext': '.btn-next-page',
-        'pointSourceTblPrev': '.btn-prev-page'
     },
 
     events: {
@@ -449,8 +443,6 @@ var PointSourceTableView = Marionette.CompositeView.extend({
         'mouseout @ui.pointSourceId': 'removePointSourceMarker',
         'mouseover @ui.pointSourceTR': 'addPointSourceMarkerToMap',
         'mouseout @ui.pointSourceTR': 'removePointSourceMarker',
-        'click @ui.pointSourceTblNext': 'nextPage',
-        'click @ui.pointSourceTblPrev': 'prevPage'
     },
 
     createPointSourceMarker: function(data) {
@@ -463,22 +455,6 @@ var PointSourceTableView = Marionette.CompositeView.extend({
         }).bindPopup(new pointSourceLayer.PointSourcePopupView({
           model: new Backbone.Model(data)
       }).render().el, { closeButton: false });
-    },
-
-    nextPage: function() {
-        if (this.collection.hasNextPage()) {
-            this.collection.getNextPage();
-            this.render();
-            $('[data-toggle="table"]').bootstrapTable();
-        }
-    },
-
-    prevPage: function() {
-        if (this.collection.hasPreviousPage()) {
-            this.collection.getPreviousPage();
-            this.render();
-            $('[data-toggle="table"]').bootstrapTable();
-        }
     },
 
     addPointSourceMarkerToMap: function(e) {
@@ -536,15 +512,11 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
         return {
             headerUnits: this.options.units,
             totalTN: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.fullCollection.models, 'tn_tot_kgy', 'areaha'),
+                this.collection.models, 'tn_tot_kgy', 'areaha'),
             totalTP: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.fullCollection.models, 'tp_tot_kgy', 'areaha'),
+                this.collection.models, 'tp_tot_kgy', 'areaha'),
             totalTSS: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.fullCollection.models, 'tss_tot_kg', 'areaha'),
-            hasNextPage: this.collection.hasNextPage(),
-            hasPreviousPage: this.collection.hasPreviousPage(),
-            currentPage: this.collection.state.currentPage,
-            totalPages: this.collection.state.totalPages,
+                this.collection.models, 'tss_tot_kg', 'areaha'),
         };
     },
     childViewContainer: 'tbody',
@@ -557,8 +529,6 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
     ui: {
         'catchmentWaterQualityTR': 'tr.catchment-water-quality',
         'catchmentWaterQualityId': '.catchment-water-quality-id',
-        'catchmentWaterQualityTblNext': '.btn-next-page',
-        'catchmentWaterQualityTblPrev': '.btn-prev-page',
     },
 
     events: {
@@ -566,24 +536,6 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
         'mouseout @ui.catchmentWaterQualityId': 'removeCatchmentPolygon',
         'mouseover @ui.catchmentWaterQualityTR': 'addCatchmentToMap',
         'mouseout @ui.catchmentWaterQualityTR': 'removeCatchmentPolygon',
-        'click @ui.catchmentWaterQualityTblNext': 'nextPage',
-        'click @ui.catchmentWaterQualityTblPrev': 'prevPage',
-    },
-
-    nextPage: function() {
-        if (this.collection.hasNextPage()) {
-            this.collection.getNextPage();
-            this.render();
-            $('[data-toggle="table"]').bootstrapTable();
-        }
-    },
-
-    prevPage: function() {
-        if (this.collection.hasPreviousPage()) {
-            this.collection.getPreviousPage();
-            this.render();
-            $('[data-toggle="table"]').bootstrapTable();
-        }
     },
 
     createCatchmentPolygon: function(data) {

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -239,14 +239,10 @@ var AnimalCensusCollection = Backbone.Collection.extend({
 
 var PointSourceCensusCollection = Backbone.PageableCollection.extend({
     comparator: 'city',
-    mode: 'client',
-    state: { pageSize: 50, firstPage: 1 }
 });
 
 var CatchmentWaterQualityCensusCollection = Backbone.PageableCollection.extend({
     comparator: 'nord',
-    mode: 'client',
-    state: { pageSize: 50, firstPage: 1 }
 });
 
 var GeoModel = Backbone.Model.extend({

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -237,11 +237,11 @@ var AnimalCensusCollection = Backbone.Collection.extend({
     comparator: 'type'
 });
 
-var PointSourceCensusCollection = Backbone.PageableCollection.extend({
+var PointSourceCensusCollection = Backbone.Collection.extend({
     comparator: 'city',
 });
 
-var CatchmentWaterQualityCensusCollection = Backbone.PageableCollection.extend({
+var CatchmentWaterQualityCensusCollection = Backbone.Collection.extend({
     comparator: 'nord',
 });
 

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "backbone": "1.1.2",
     "backbone.marionette": "2.4.1",
-    "backbone.paginator": "2.0.5",
     "blueimp-md5": "1.1.0",
     "bootstrap": "3.3.4",
     "bootstrap-select": "git://github.com/azavea/bootstrap-select",

--- a/src/mmw/sass/components/_tables.scss
+++ b/src/mmw/sass/components/_tables.scss
@@ -77,3 +77,20 @@
     .point-source .point-source-id {
   cursor: pointer;
 }
+
+.fixed-table-pagination li.active a {
+    background: $brand-primary;
+    color: $paper;
+    border-color: $brand-primary;
+    &:hover{
+        color: $paper;
+        background-color: $brand-primary;
+        border-color: $brand-primary;
+        cursor: default;
+    }
+}
+
+.fixed-table-pagination li a {
+    background: $paper;
+    color: $brand-primary;
+}

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -30,28 +30,3 @@
   font-size: 0.8rem;
   padding-top: 5px;
 }
-
-.paging-ctl-row {
-  text-align: center;
-  bottom:0rem;
-  position:fixed;
-  background-color: $paper;
-  @media (max-height: 884px) {
-    top:0.2rem;
-    position:relative;
-  }
-}
-
-.pageable-table-container {
-  overflow: visible;
-  padding-bottom:10%;
-  @media (max-height: 884px) {
-    padding-bottom:0px;
-  }
-}
-
-.pageable-table {
-  width: 650px !important;
-  max-width: 650px !important;
-  height: 100%;
-}


### PR DESCRIPTION
When we were letting Backbone handle the pagination, the bootstrap table was only able to sort the set of data on the current page instead of the expected full collection. This PR removes the Backbone paginator in favor of using the bootstrap table's own (thanks @caseypt for figuring this out!) :

<img width="631" alt="screen shot 2016-11-02 at 1 31 46 pm" src="https://cloud.githubusercontent.com/assets/7633670/19939813/d4ed01bc-a100-11e6-97ed-cb71204dd917.png">

### Testing

Pull this branch and follow the steps in the `README` to update the dependencies/rebundle the vendor.

Then, `./scripts/bundle.sh` and...
- Select an AoI in the DRB about county sized. Confirm in the catchment water quality/point source analyze tabs you can
  - go between pages smoothly
  - render time is still dow
  - the column sort sorts the whole set
- Select an small AoI with <50 water quality rows and confirm no pagination shows up


Connects #1594 