### PR TITLE
Make New Scenario Model Open On Model Start up

### DIFF
--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -104,7 +104,7 @@ var ModelingController = {
 
                 finishProjectSetup(project, lock);
             }
-            setPageTitle();            
+            setPageTitle();
         }
     },
 
@@ -333,11 +333,11 @@ function setupNewProjectScenarios(project) {
         new models.ScenarioModel({
             name: 'Current Conditions',
             is_current_conditions: true,
-            active: true,
             aoi_census: aoiCensus
         }),
         new models.ScenarioModel({
             name: 'New Scenario',
+            active: true,
             aoi_census: aoiCensus
         })
         // Silent is set to true because we don't actually want to save the


### PR DESCRIPTION
Sets the initial `active` flag on the New Scenario scenario instead of current conditions when the user enters the Model view.

![screen shot 2016-11-02 at 3 13 23 pm](https://cloud.githubusercontent.com/assets/7633670/19943700/f5bbc2da-a10e-11e6-8b43-1c129bc6d91c.png)

## Testing
- Pull this branch
- `./scripts/bundle.sh`
- Select an AoI -> Model (either one)
- Note that the initial active scenario tab is "New Scenario"

Connects #1590 
