### PR TITLE
Update DEP Layers' Tile Cache Paths

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -84,7 +84,7 @@ fi
 if [ "$load_dep" = "true" ] ; then
     # Fetch DEP layers
     FILES=("dep_urban_areas.sql.gz" "dep_municipalities.sql.gz")
-    PATHS=("dep_urbanareas" "dep_municipalities")
+    PATHS=("urban_areas" "municipalities")
 
     download_and_load $FILES
     purge_tile_cache $PATHS


### PR DESCRIPTION
The `setupdb` script had incorrect paths to the DEP Municipalities and DEP Urban Areas tile caches, so if you were to run the script with `-p` in staging or production, you wouldn't actually be purging any tiles. 

### Testing

Assuming you have production credentials, verify that the paths changed below match the output of:
```
 aws --profile mmw-prd s3 ls s3://tile-cache.app.wikiwatershed.org | egrep "urban|muni" 
```

Connects #1595 