### PR TITLE
Target RWD 1.1.0 and Update To Snapshot With NHD Data

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -2,4 +2,4 @@
 rwd_data_path: "/opt/rwd-data"
 rwd_host: "localhost"
 rwd_port: 5000
-rwd_docker_image: "quay.io/wikiwatershed/rwd:1.0.1"
+rwd_docker_image: "quay.io/wikiwatershed/rwd:1.1.0"

--- a/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
@@ -3,7 +3,7 @@ description "Rapid Watershed Delineation"
 {% if ['development', 'test'] | some_are_in(group_names) -%}
 start on (vagrant-mounted and started docker)
 {% else %}
-start on (filesystem and started docker)
+start on (filesystem and local-filesystems and started docker)
 {% endif %}
 stop on stopping docker
 

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -63,7 +63,7 @@
             "ami_block_device_mappings": [
                 {
                     "device_name": "/dev/sdf",
-                    "snapshot_id": "snap-4a764b4a",
+                    "snapshot_id": "snap-090ac799996dba0a4",
                     "volume_type": "gp2",
                     "delete_on_termination": true
                 }


### PR DESCRIPTION
- Build worker with updated, NHD-data-including snapshot
- Update docker-rwd version to 1.1.0

## Testing Instructions
- Reprovision worker, mount a drive with `rwd-data` and exercise "Delineate watershed" from the UI and from within the worker using the calls suggested [here](https://github.com/WikiWatershed/rapid-watershed-delineation/pull/37)

Connects #1601 

