### PR TITLE
Show Total Averages For Whole Table On Point Source Analyze Tab

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -419,11 +419,11 @@ var PointSourceTableView = Marionette.CompositeView.extend({
         return {
             headerUnits: this.options.units,
             totalMGD: utils.totalForPointSourceCollection(
-                this.collection.models, 'mgd'),
+                this.collection.fullCollection.models, 'mgd'),
             totalKGN: utils.totalForPointSourceCollection(
-                this.collection.models, 'kgn_yr'),
+                this.collection.fullCollection.models, 'kgn_yr'),
             totalKGP: utils.totalForPointSourceCollection(
-                this.collection.models, 'kgp_yr'),
+                this.collection.fullCollection.models, 'kgp_yr'),
             hasNextPage: this.collection.hasNextPage(),
             hasPreviousPage: this.collection.hasPreviousPage(),
             currentPage: this.collection.state.currentPage,


### PR DESCRIPTION
While working on #1592 I addressed showing an AOI's total averages on the Water Quality analysis tab, and forgot that we have to do the same for the Point Source tab.

With the `Backbone.paginator` `this.collection.models` refers to all the models of the page, and to get all the models in the collection you have to use `this.collection.fullCollection.models`

## Testing Instructions
Pull this branch and rebundle: `./scripts/bundle.sh`
On `localhost:8000`: 
- Select By Boundary -> HUC-8 Subbasin -> Lower Susquehanna
- Go to the Point Sources analyze tab (the table should be two pages long)
- Flip between pages and confirm none of the total averages change between pages (ie they are the totals for the whole AOI
<img width="481" alt="screen shot 2016-11-07 at 9 59 35 am" src="https://cloud.githubusercontent.com/assets/7633670/20062225/eab7b112-a4d0-11e6-9af4-64d8b8c2e05c.png">
<img width="479" alt="screen shot 2016-11-07 at 9 59 40 am" src="https://cloud.githubusercontent.com/assets/7633670/20062229/ece5ea30-a4d0-11e6-9743-18e13e37392f.png">



Connects #1603 