### PR TITLE
Turn off time-based caching on production

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/nginx-app.conf.j2
@@ -31,7 +31,7 @@ server {
   location /static/ {
     {% if ['packer'] | is_in(group_names) -%}
     etag on;
-    expires max;
+    expires 1h;
     {% endif %}
 
     alias {{ app_static_root }};


### PR DESCRIPTION
The production nginx configuration template makes static assets have a cache that expires way in the future due to the `expires max;` line. When static assets are updated, and the website is loaded without a refresh, the client never bothers sending a request to see if the etag is out of date, and doesn't get the update. This PR preserves etag based caching and reduces the expires timeout to 1hr.

It may be helpful to read https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching

#### Notes
* We might still want to set an expiration time for the static assets, but just make it shorter. We might also want to have a different cache policy for things like images and fonts which don't change as much. @mmcfarland 

#### Testing
* Stay on the `develop` branch.
* Run `vagrant ssh app` and `sudo vi /etc/nginx/sites-available/mmw-app.conf`
* Remove the `{% if ['packer'] | is_in(group_names) -%}` block. This is to simulate the production environment.
* Run `sudo restart nginx` 
* Go to `localhost:8000`
* Make change to some javascript file (with bundler running) and then go to website again without hitting refresh.
* The updates will not appear (you can also see in the network tab that the files are from the cache).
* Hit reload. The changes should appear.
* Edit the nginx file so that it doesn't have the `expires max;` line. Run `sudo restart nginx`. In reality the server will be using `expires 1h;` but you don't want to wait 1hr for the cache to expire while testing this.
* Go to `localhost:8000` and then hit reload. Repeat the above routine with making a change to a file. Now you shouldn't need to reload again in order to get the change because the browser will check the etag and see that it's invalid and send the new file.


Connects #1607 