### PR TITLE
Update TR-55 to 1.2.1

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -9,7 +9,7 @@ django-registration-redux==1.2
 python-omgeo==1.7.2
 rauth==0.7.1
 djangorestframework-gis==0.8.2
-tr55==1.2.0
+tr55==1.2.1
 gwlf-e==0.6.2
 requests==2.9.1
 rollbar==0.13.8


### PR DESCRIPTION
## Overview

AOIs with `perennial_ice` in their `aoi_census` cause the tr55 model to fail:
 `[2016-11-14 13:49:27,470: ERROR/Worker-1] Bad input data to TR55: u'Unknown land use: perennial_ice'` We've created a new patch release of the model to restore perennial ice as an option.

Before the HUC-12 Basin `Woody Creek` would fail, and now it doesn't:
<img width="660" alt="screen shot 2016-11-14 at 4 35 29 pm" src="https://cloud.githubusercontent.com/assets/7633670/20283772/6046fc14-aa88-11e6-9281-e9ebcfb6fd54.png">

## Testing Instructions
Pull this branch - assuming you already had your VM's provisioned:
```
vagrant ssh worker
sudo pip install -r /vagrant/src/mmw/requirements/base.txt --upgrade
```
- At `localhost:8000` search with the geocoder for "Woody Creek" and select the one in Colorado
- Select By Boundary --> HUC-12 
- Zoom out a bit and select the boundary titled "Woody Creek"
![screen shot 2016-11-14 at 4 40 03 pm](https://cloud.githubusercontent.com/assets/7633670/20283921/0b1184a2-aa89-11e6-853b-97ffa00db7bb.png)

- Run the Site Storm Model
- Confirm there are no errors in the UI or while running `./scripts/debugcelery.sh`

Connects #1611 