### PR TITLE
Target RWD 1.1.1

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -2,4 +2,4 @@
 rwd_data_path: "/opt/rwd-data"
 rwd_host: "localhost"
 rwd_port: 5000
-rwd_docker_image: "quay.io/wikiwatershed/rwd:1.1.0"
+rwd_docker_image: "quay.io/wikiwatershed/rwd:1.1.1"


### PR DESCRIPTION
Updating to the new RWD Docker image 1.1.1. It:
- Keeps the NHD input point's original position in its original Latlng projection, so now when you do NHD Delineate Watershed both the snapped and original point will appear
- Simplifies NHD shapes based on their area. This allows us to better handle some of the excessively large delineated shapes
_Both Snapped and Original Input Points Show up & Shape Is Simplified_
![screen shot 2016-11-15 at 12 27 40 pm](https://cloud.githubusercontent.com/assets/7633670/20316451/de4636aa-ab2f-11e6-9cc5-d21cf9ff0d2a.png)

### Testing Instructions
- Pull this branch 
- Mount the RWD data on your worker VM
   - If you're on a Mac, you'll have update the  `worker.vm.synced_folder` path in the `Vagrantfile` as described [here](https://github.com/WikiWatershed/model-my-watershed/pull/1472/files), and destroy and recreate your worker VM
  - Otherwise you can just symlink with `sudo ln -s <path to RWD data> /opt/rwd-data`
- `vagrant provision worker`
- Go to `localhost:8000` and select a few points with the Delineate Watershed options
- Confirm for NHD, you can see both input points on the map, and if you click on 990 Spring Garden the shape loads (it's really big)