### PR TITLE
Reduce polling to 1 second

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -85,7 +85,7 @@ var MapModel = Backbone.Model.extend({
 
 var TaskModel = Backbone.Model.extend({
     defaults: {
-        pollInterval: 500,
+        pollInterval: 1000,
         /* The timeout is set to 45 seconds here, while in the
            src/mmw/apps/modeling/tasks.py file it is set to 42
            seconds.  That was done because the countdown starts in the


### PR DESCRIPTION
## Overview

This should halve the server load, while having minimal impact on user responsiveness since they will at most have to wait an extra half second after a multi-second wait.

### Notes

I'm having trouble provisioning MMW on my local, so haven't been able to test this myself.

## Testing Instructions

Check out the project and bundle scripts. Test to see if a TR-55 job works as it should. Test to see if a MapShed job works as it should.

Connects #1619 