### PR TITLE
Upgrade OpenJDK to 7u121

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -32,7 +32,7 @@ nodejs_npm_version: 2.1.17
 
 apache_version: "2.4.7-*"
 
-java_version: "7u111-*"
+java_version: "7u121-*"
 
 graphite_carbon_version: "0.9.13-pre1"
 graphite_whisper_version: "0.9.13-pre1"


### PR DESCRIPTION
## Overview

Since 7u111 is no longer available, the services VM refused to provision. Upgrading to 7u121 fixes this.

## Testing Instructions

**WARNING: You will lose all your local MMW data.**

Check out this branch. Delete and recreate the `services` VM. There should not be any provisioning errors.