### PR TITLE
Set default RWD data source to DRB

### DIFF
--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -171,7 +171,7 @@ def start_rwd(request, format=None):
     user = request.user if request.user.is_authenticated() else None
     created = now()
     location = request.POST['location']
-    data_source = request.POST['dataSource']
+    data_source = request.POST.get('dataSource', 'drb')
 
     # Parse out the JS style T/F to a boolean
     snappingParam = request.POST['snappingOn']


### PR DESCRIPTION
## Overview

Allows users with stale front-end code to run RWD for the DRB.

## Testing Instructions

- Make the follow code change to simulate stale front-end code:

```diff
diff --git a/src/mmw/js/src/draw/views.js b/src/mmw/js/src/draw/views.js
index 052d08c..aafead6 100644
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -511,7 +511,7 @@ var WatershedDelineationView = Marionette.ItemView.extend({
                     point.geometry.coordinates[0]
                 ]),
                 'snappingOn': snappingOn,
-                'dataSource': dataSource,
+                // 'dataSource': dataSource,
             }
         };
```
- Select "Delineate Watershed" -> "DRB Stream Network" and select somewhere in the DRB. The request should succeed.
- Now select  "Delineate Watershed" -> "NHD Mid-Atlantic Stream Network" and select somewhere in the DRB. It should use the DRB data and succeed. 

Connects to #1614