### PR TITLE
Upgrade Firefox

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/tasks/dev-and-test-dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/dev-and-test-dependencies.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Firefox for UI tests
-  apt: pkg="firefox=4*" state=present
+  apt: pkg="firefox=5*" state=present
 
 - name: Install Xvfb for JavaScript tests
   apt: pkg="xvfb=2:1.15.1*" state=present


### PR DESCRIPTION
## Overview

Firefox just upgraded from 49.0.2 to 50.0.1, causing problems during provisioning.

## Testing Instructions

Check out this branch. Reprovision the `app` VM. There should be no errors.

Run the UI tests via Firefox and ensure they still work:

```bash
$ ./scripts/test.sh
```