### PR TITLE
Fix calculation of displayed water quality data

### DIFF
--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
@@ -27,29 +27,6 @@
       <tbody>
       </tbody>
       <tfoot>
-          <tr class="catchment-water-quality-table-footer">
-              <td class="strong text-right" colspan="2">
-                  Total For Area of Interest (kg/ha)
-              </td>
-              <td class="catchment-water-quality-footer-item strong text-right">
-                  {{ totalTN|filterNoData()|toLocaleString(3) }}
-              </td>
-              <td class="catchment-water-quality-footer-item strong text-right">
-                  {{ totalTP|filterNoData()|toLocaleString(3) }}
-              </td>
-              <td class="catchment-water-quality-footer-item strong text-right">
-                  {{ totalTSS|filterNoData()|toLocaleString(3) }}
-              </td>
-              <td class="catchment-water-quality-footer-item strong text-right">
-                  --
-              </td>
-              <td class="catchment-water-quality-footer-item strong text-right">
-                  --
-              </td>
-              <td class="catchment-water-quality-footer-item strong text-right">
-                  --
-              </td>
-          </tr>
       </tfoot>
   </table>
 </div>

--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTableRow.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTableRow.html
@@ -39,13 +39,13 @@
     {{ areaha|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ (tn_tot_kgy/areaha)|filterNoData()|toLocaleString(3) }}
+    {{ tn_tot_kgy|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ (tp_tot_kgy/areaha)|filterNoData()|toLocaleString(3) }}
+    {{ tp_tot_kgy|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ (tss_tot_kg/areaha)|filterNoData()|toLocaleString(3) }}
+    {{ tss_tot_kg|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
     {{ tn_yr_avg_|filterNoData()|toLocaleString(3) }}

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -144,11 +144,11 @@ function catchmentWaterQualityTableFormatter(categories) {
         var nord = category.get('nord').toString(),
             areaha = renderPtSrcAndWQTableRowValue(category.get('areaha')),
             tn_tot_kgy = renderPtSrcAndWQTableRowValue(
-                category.get('tn_tot_kgy')/category.get('areaha')),
+                category.get('tn_tot_kgy')),
             tp_tot_kgy = renderPtSrcAndWQTableRowValue(
-                category.get('tp_tot_kgy')/category.get('areaha')),
+                category.get('tp_tot_kgy')),
             tss_tot_kg = renderPtSrcAndWQTableRowValue(
-                category.get('tss_tot_kg')/category.get('areaha')),
+                category.get('tss_tot_kg')),
             tn_yr_avg_ = renderPtSrcAndWQTableRowValue(category.get('tn_yr_avg_')),
             tp_yr_avg_ = renderPtSrcAndWQTableRowValue(category.get('tp_yr_avg_')),
             tss_concmg = renderPtSrcAndWQTableRowValue(category.get('tss_concmg'));

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -535,12 +535,6 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
     templateHelpers: function() {
         return {
             headerUnits: this.options.units,
-            totalTN: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.fullCollection.models, 'tn_tot_kgy'),
-            totalTP: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.fullCollection.models, 'tp_tot_kgy'),
-            totalTSS: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.fullCollection.models, 'tss_tot_kg'),
             hasNextPage: this.collection.hasNextPage(),
             hasPreviousPage: this.collection.hasPreviousPage(),
             currentPage: this.collection.state.currentPage,

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -536,11 +536,11 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
         return {
             headerUnits: this.options.units,
             totalTN: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.fullCollection.models, 'tn_tot_kgy', 'areaha'),
+                this.collection.fullCollection.models, 'tn_tot_kgy'),
             totalTP: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.fullCollection.models, 'tp_tot_kgy', 'areaha'),
+                this.collection.fullCollection.models, 'tp_tot_kgy'),
             totalTSS: utils.totalForCatchmentWaterQualityCollection(
-                this.collection.fullCollection.models, 'tss_tot_kg', 'areaha'),
+                this.collection.fullCollection.models, 'tss_tot_kg'),
             hasNextPage: this.collection.hasNextPage(),
             hasPreviousPage: this.collection.hasPreviousPage(),
             currentPage: this.collection.state.currentPage,

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -290,12 +290,6 @@ var utils = {
         }));
     },
 
-    totalForCatchmentWaterQualityCollection: function(collection, key) {
-        return lodash.sum(lodash.map(collection, function(element) {
-            return element.attributes[key] || 0;
-        }));
-    },
-
     geomForIdInCatchmentWaterQualityCollection: function(collection, key, id) {
         return lodash.find(collection, function(element) {
             return element.attributes[key] === id;

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -290,9 +290,9 @@ var utils = {
         }));
     },
 
-    totalForCatchmentWaterQualityCollection: function(collection, key, normalizerKey) {
+    totalForCatchmentWaterQualityCollection: function(collection, key) {
         return lodash.sum(lodash.map(collection, function(element) {
-            return element.attributes[key] / element.attributes[normalizerKey] || 0;
+            return element.attributes[key] || 0;
         }));
     },
 


### PR DESCRIPTION
This fixes an error in the front-end that resulted in an unnecessary UoM adjustment for the water
quality totals displayed. The data were already represented in units of kg-year / hectare, so the
app did a superfluous conversion.

The prior version -->
![download 8](https://cloud.githubusercontent.com/assets/18290666/20757853/e9c94adc-b6e5-11e6-89ed-22b11bb8173e.png)

This version -->
![download 9](https://cloud.githubusercontent.com/assets/18290666/20757866/f1ef978e-b6e5-11e6-9230-6298dfbda815.png)


To test:
* clone this branch and bring up the environment
* open both the local version and a staging/prod version in a browser
* pick a similar/identical AoI in both, and compare the water quality totals; the local version should show values several times (the value of the "Area" field, specifically) larger than the staging/prod version

Connects #1625 