### PR TITLE
Clear outdated cached results in old scenarios

### DIFF
--- a/src/mmw/apps/modeling/migrations/0020_old_scenarios.py
+++ b/src/mmw/apps/modeling/migrations/0020_old_scenarios.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def clear_old_scenario_results(apps, schema_editor):
+    Scenario = apps.get_model('modeling', 'Scenario')
+    old_scenarios = Scenario.objects.filter(
+            project__model_package='tr-55'
+        ).filter(
+            results__contains='"result": {"pc_modified"'
+        )
+
+    for scenario in old_scenarios:
+        scenario.results = '[]'
+        scenario.modification_hash = ''
+        scenario.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0019_project_gis_data'),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_old_scenario_results)
+    ]


### PR DESCRIPTION
## Overview

Around May 2016, when we were adding GWLF-E scenarios, the scenario result structured was revised. I have been unable to find the exact commit when this happened, but a clear break can be seen around May on the staging site:

```sql
SELECT project_id, id, created_at, modified_at
FROM modeling_scenario
WHERE results LIKE '%"result": {"pc_modified"%'
ORDER BY created_at DESC
LIMIT 5;

 project_id |  id  |          created_at           |          modified_at
------------+------+-------------------------------+-------------------------------
        599 | 1125 | 2016-05-05 18:26:51.866153+00 | 2016-05-05 18:30:31.51302+00
        599 | 1124 | 2016-05-05 18:26:51.81586+00  | 2016-05-05 18:27:23.315427+00
        594 | 1119 | 2016-04-15 16:42:10.595113+00 | 2016-04-15 16:42:15.839574+00
        594 | 1118 | 2016-04-15 16:42:10.580187+00 | 2016-04-15 16:42:14.106239+00
        593 | 1117 | 2016-04-15 16:40:33.07025+00  | 2016-04-15 16:40:37.642629+00
(5 rows)
```

```sql
SELECT project_id, id, created_at, modified_at
FROM modeling_scenario
WHERE results LIKE '%"result": {"modification_hash"%'
ORDER BY created_at
LIMIT 5;

 project_id |  id  |          created_at           |          modified_at
------------+------+-------------------------------+-------------------------------
        604 | 1134 | 2016-06-01 05:33:52.168537+00 | 2016-06-01 05:33:55.121672+00
        604 | 1135 | 2016-06-01 05:33:52.215917+00 | 2016-06-01 05:33:55.812022+00
        605 | 1136 | 2016-06-01 14:43:04.471317+00 | 2016-06-01 14:43:09.62326+00
        605 | 1137 | 2016-06-01 14:43:04.520311+00 | 2016-06-01 14:43:09.210441+00
        616 | 1158 | 2016-06-13 14:21:03.066325+00 | 2016-06-13 14:23:37.457155+00
(5 rows)
```

Furthermore, it can be observed that there are only four types of scenario caches in the system for TR-55 projects:

```sql
SELECT COUNT(*)
FROM modeling_scenario s INNER JOIN modeling_project p ON s.project_id = p.id AND p.model_package = 'tr-55'
WHERE results NOT LIKE '%"result": {"modification_hash"%'
  AND results NOT LIKE '%"result": {"pc_modified"%'
  AND results NOT LIKE '%"result": null%'
  AND results <> '[]';

 count
-------
     0
(1 row)
```

Where the clauses correspond to:

 * `"result": {"modification_hash"`: new structure that works correctly. Example [staging-660-1249](https://staging.app.wikiwatershed.org/project/660/scenario/1249)
 * `"result": {"pc_modified"`: old structure that causes crashes. Example [staging-599-1124](https://staging.app.wikiwatershed.org/project/599/scenario/1124)
 * `"result": null`: failed scenario runs that are simply recalculated. Example [staging-621-1170](https://staging.app.wikiwatershed.org/project/621/scenario/1170)
 * `[]`: empty scenarios with no cache that are simply recalculated. Example [staging-330-640](https://staging.app.wikiwatershed.org/project/333/scenario/640)

These older projects, when loaded by a front-end that expects the new structure, caused crashes. By resetting them to `[]` we allow the front-end to recalculate and recache their values.

## Testing Instructions

First, ensure that you have some old scenarios to test with. Run this query on your database:

```bash
$ ./scripts/manage.sh dbshell
```

```sql
SELECT project_id, id, created_at, modified_at
FROM modeling_scenario
WHERE results LIKE '%"result": {"pc_modified"%'
ORDER BY created_at DESC
LIMIT 5;

 project_id |  id  |          created_at           |          modified_at
------------+------+-------------------------------+-------------------------------
        599 | 1125 | 2016-05-05 18:26:51.866153+00 | 2016-05-05 18:30:31.51302+00
        599 | 1124 | 2016-05-05 18:26:51.81586+00  | 2016-05-05 18:27:23.315427+00
        594 | 1119 | 2016-04-15 16:42:10.595113+00 | 2016-04-15 16:42:15.839574+00
        594 | 1118 | 2016-04-15 16:42:10.580187+00 | 2016-04-15 16:42:14.106239+00
        593 | 1117 | 2016-04-15 16:40:33.07025+00  | 2016-04-15 16:40:37.642629+00
(5 rows)
```

Using any one of the results, open that on your local machine on `develop`. For example, if we wanted to open the first one above it would be at [http://localhost:8000/project/599/scenario/1125](http://localhost:8000/project/599/scenario/1125). Open dev tools, ensure that you see a failure when loading the page:

![image](https://cloud.githubusercontent.com/assets/1430060/20852345/5b320c44-b8b3-11e6-85f7-8cc0020986dd.png)

Then, checkout this branch, and run migrations:

```bash
./scripts/manage.sh migrate
```

Go to the failing scenario again. It should now load correctly.

Refresh the page, it should now load faster since the newly calculated values have now been cached in the right structure.

Connects #1628 