### PR TITLE
Support Anonymous ITSI Sessions

### DIFF
--- a/src/mmw/apps/user/middleware.py
+++ b/src/mmw/apps/user/middleware.py
@@ -1,34 +1,18 @@
 # -*- coding: utf-8 -*-
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
-from django.shortcuts import redirect
 
-from apps.user.views import itsi_login
 
 EMBED_FLAG = settings.ITSI['embed_flag']
-LOGIN_URL = reverse(itsi_login)
 
 
 class ItsiAuthenticationMiddleware(object):
     """
-    Middleware for automatically logging in ITSI users
-    and setting relevant flags.
+    Middleware for setting relevant ITSI flags.
     """
 
     def process_request(self, request):
-        """
-        Check if ITSI EMBED FLAG is set, and if so attempt to log
-        the user in with their ITSI credentials and redirect them
-        to current page.
-        """
-
-        # If flag is not set then return None so Django can proceed
-        # with the request as-is
-        if request.GET.get(EMBED_FLAG, 'false') != 'true':
-            return None
-
-        # Flag is set. Assume user is not logged in. Set session flag and
-        # Redirect them to ITSI LOGIN URL, with the current URL to return to
-        request.session[EMBED_FLAG] = True
-        return redirect('{0}?next={1}'.format(LOGIN_URL, request.path))
+        # If flag is set then set a session variable so it can be passed to
+        # front-end
+        if request.GET.get(EMBED_FLAG, 'false') == 'true':
+            request.session[EMBED_FLAG] = True

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -24,6 +24,7 @@ var App = new Marionette.Application({
         // Initialize embed interface if in activity mode
         if (activityMode) {
             this.itsi = new itsi.ItsiEmbed(this);
+            this.itsi.getAuthInfo();
         }
 
         // This view is intentionally not attached to any region.

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -86,6 +86,12 @@ var App = new Marionette.Application({
         return this._mapView._leafletMap;
     },
 
+    getUserOrShowLoginIfNotItsiEmbed: function() {
+        if (!settings.get('itsi_embed')) {
+            this.getUserOrShowLogin();
+        }
+    },
+
     getUserOrShowLogin: function() {
         this.user.fetch().always(function() {
             if (App.user.get('guest')) {

--- a/src/mmw/js/src/core/itsiEmbed.js
+++ b/src/mmw/js/src/core/itsiEmbed.js
@@ -53,10 +53,22 @@ var ItsiEmbed = function(App) {
         this.phone.post('extendedSupport', this.extendedSupport);
     };
 
+    this.getAuthInfo = function() {
+        this.phone.post('getAuthInfo');
+    };
+
+    this.authInfo = function(info) {
+        if (info && info.loggedIn && App.user.get('guest')) {
+            window.location.href = '/user/itsi/login?itsi_embed=true&next=/' +
+                                   Backbone.history.getFragment();
+        }
+    };
+
     this.phone.addListener('getExtendedSupport', _.bind(this.getExtendedSupport, this));
     this.phone.addListener('getLearnerUrl', _.bind(this.sendLearnerUrlOnlyFromProjectView, this));
     this.phone.addListener('getInteractiveState', _.bind(this.sendLearnerUrlOnlyFromProjectView, this));
     this.phone.addListener('loadInteractive', _.bind(this.loadInteractive, this));
+    this.phone.addListener('authInfo', _.bind(this.authInfo, this));
     this.phone.initialize();
 };
 

--- a/src/mmw/js/src/core/itsiEmbed.js
+++ b/src/mmw/js/src/core/itsiEmbed.js
@@ -40,9 +40,11 @@ var ItsiEmbed = function(App) {
 
     this.loadInteractive = function(interactiveState) {
         // Only redirect if route specified and different
+        // and user is logged in
         if (interactiveState &&
             interactiveState.route &&
-            interactiveState.route !== Backbone.history.getFragment()) {
+            interactiveState.route !== Backbone.history.getFragment() &&
+            !App.user.get('guest')) {
 
             App.currentProject = null;
             router.navigate(interactiveState.route, { trigger: true });

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -23,7 +23,7 @@ App.on('start', function() {
 
     // Show login modal only if landing on home page
     if (Backbone.history.getFragment() === '') {
-        this.getUserOrShowLogin();
+        this.getUserOrShowLoginIfNotItsiEmbed();
     } else {
         this.user.fetch();
     }

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -246,7 +246,7 @@ var LoginModalView = ModalBaseView.extend({
 
         var loginURL = '/user/itsi/login?next=/' + Backbone.history.getFragment();
         if (window.clientSettings.itsi_embed) {
-            loginURL = '/?itsi_embed=true&next=/' + Backbone.history.getFragment();
+            loginURL += '&itsi_embed=true';
         }
         window.location.href = loginURL;
     }


### PR DESCRIPTION
## Overview

The original ITSI embed implementation assumed that it would only ever be used in a logged in environment, prompting design decisions to automatically log in users with their ITSI credentials if they are in that environment. This assumption is no longer valid as there are now anonymous users that use / preview the app without logging in first. They are taken to the ITSI login page when activating the app and can not access it at all.

This PR makes the following changes to allow anonymous users to use the app when embedded inside ITSI:

 * Users are no longer made to log in with their ITSI credentials on start.
 * Users are no longer shown the log in popup on start.
 * The app asks the parent frame for login status using the LARA Interactive API. If the response indicates that the user is logged in, we trigger the ITSI login procedure. If they already have an account in the app, they will be logged in as that. If they don't, a new one will be created for them.
 * We defer resuming old sessions until the user is logged in to the app, since without logging in they may not have access to the project in the old session.

There was initial concern about the time it would take to communicate with LARA, and if the user starts working before that is done they may lose that work. Initial testing indicates that communication to be pretty snappy, so we may not have anything to worry about.

## Testing Instructions

 * Pull the branch and bundle the scripts.
 * Go to [http://localhost:8000/?itsi_embed=true](http://localhost:8000/?itsi_embed=true). Ensure that you are not redirected to log in via ITSI, and that the login modal doesn't show up automatically.
 * Expose your local on `ngrok` and follow ITSI embed setup instructions from #675.
 * Ensure that you aren't auto logged in while editing the activity as `mmwterence`.
 * Log in as `tstudent2` to ITSI, go to the activity. Ensure that you are logged in automatically, and that the session resumes to the modeling stage of some pre-saved project.

Connects #1555 