### PR TITLE
Fix Google Tile Layer screenshots

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -122,18 +122,55 @@ function RestAPI() {
 }
 
 function initializeShutterbug() {
+    var googleTileLayerSelector = '#map > .leaflet-google-layer > div > div > div:nth-child(1) > div:nth-child(1)';
+
     $(window)
         .on('shutterbug-saycheese', function() {
             // Set fixed width before screenshot to constrain width to viewport
             $('#model-output-wrapper, body > .map-container').css({
                 'width': window.innerWidth
             });
+
+            var mapView = App.getMapView(),
+                activeBaseLayer = mapView.baseLayers[mapView.getActiveBaseLayerName()],
+                googleLayerVisible = !!activeBaseLayer._google;
+
+            if (googleLayerVisible) {
+                // Convert Google Maps CSS Transforms to Left / Right
+                var $googleTileLayer = $(googleTileLayerSelector),
+                    transform = $googleTileLayer.css('transform').split(','),
+                    left = parseFloat(transform[4]),
+                    top = parseFloat(transform[5]);
+
+                $googleTileLayer.css({
+                    transform: 'none',
+                    left: left,
+                    top: top,
+                });
+            }
         })
         .on('shutterbug-asyouwere', function() {
             // Reset after screenshot has been taken
             $('#model-output-wrapper, body > .map-container').css({
                 'width': ''
             });
+
+            var mapView = App.getMapView(),
+                activeBaseLayer = mapView.baseLayers[mapView.getActiveBaseLayerName()],
+                googleLayerVisible = !!activeBaseLayer._google;
+
+            if (googleLayerVisible) {
+                var $googleTileLayer = $(googleTileLayerSelector),
+                    left = parseFloat($googleTileLayer.css('left')),
+                    top = parseFloat($googleTileLayer.css('top')),
+                    transform = 'matrix(1, 0, 0, 1, ' + left + ', ' + top + ')';
+
+                $googleTileLayer.css({
+                    transform: transform,
+                    left: '',
+                    top: '',
+                });
+            }
         });
 
     shutterbug.enable('body');


### PR DESCRIPTION
## Overview

The Google Maps JavaScript API always uses CSS transforms, which are not supported by PhantomJS. We convert the CSS transform values to CSS left and top values before each screenshot, and restore them immediately afterwards. This allows the screenshot to capture the map accurately.

Got the idea from here: https://github.com/niklasvh/html2canvas/issues/345#issuecomment-71774787

## Testing Instructions

Check out the branch and bundle the scripts. `ngrok` your local app.

 * Open Firefox.
 * Go to https://authoring.concord.org/activities/5644.
 * Open the dev tools, and replace the iframe `src` to your ngrok rather than `app.wikiwatershed.org`. Preserve the `itsi_embed` flag. It should look like something like this: `https://b011c760.ngrok.io?itsi_embed=true`.
 * Take screenshots with all four basemap types. Ensure that they render correctly.

Do the same test in Chrome.

Connects #1639 