### PR TITLE
Fix ITSI Firefox screenshots

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -148,6 +148,12 @@ function initializeShutterbug() {
                     top: top,
                 });
             }
+
+            // Fix Firefox screenshots by adding a '#' to the URL.
+            // Setting to empty string does nothing, so we first set to
+            // '/' then to empty string, which leaves a '#' in the URL.
+            document.location.hash = '/';
+            document.location.hash = '';
         })
         .on('shutterbug-asyouwere', function() {
             // Reset after screenshot has been taken


### PR DESCRIPTION
## Overview

Screenshots from Firefox only seem to work when the document location has a '#' in the URL. We add an empty one before a screenshot is taken to ensure it comes out correctly.

## Testing Instructions

 * Pull the branch and bundle the scripts
 * Run your local through `ngrok`
 * Open Firefox and go to https://authoring.concord.org/activities/5644/single_page/dec56c68-6170-4e59-b94a-82fb040e8d88
 * Replace the iframe with your ngrok instance
 * Take a screenshot
 * Play around the app. Go to different stages. Use different basemaps. Take more screenshots
 * Ensure that all screenshots correspond to the actual app

Try from Chrome and ensure that those screenshots still work.

Connects #1640