### PR TITLE
Opacity Slider For New Layer Picker

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -149,6 +149,7 @@ var LayersModel = Backbone.Model.extend({
                 minZoom: layer.minZoom,
                 googleType: layer.googleType,
                 disabled: false,
+                hasOpacitySlider: layer.has_opacity_slider,
                 active: layer.display === initialActive ? true : false,
             });
         });

--- a/src/mmw/js/src/core/templates/layerPicker.html
+++ b/src/mmw/js/src/core/templates/layerPicker.html
@@ -1,6 +1,4 @@
-<div class="layerpicker-layers">
-    <div id="layerpicker-tab"></div>
-</div>
+<div id="layerpicker-tab"></div>
 <div class="layerpicker-nav">
     {% for layerTab in layerTabs %}
         <div

--- a/src/mmw/js/src/core/templates/layerPickerGroup.html
+++ b/src/mmw/js/src/core/templates/layerPickerGroup.html
@@ -3,4 +3,4 @@
     <div id="layerpicker-opacity-control"></div>
 </div>
 <p>{{message}}</p>
-<div id="layerpicker-layers"></div>
+<div class="layerpicker-layers" id="layerpicker-layers"></div>

--- a/src/mmw/js/src/core/templates/layerPickerGroup.html
+++ b/src/mmw/js/src/core/templates/layerPickerGroup.html
@@ -1,5 +1,6 @@
 <div class="layerpicker-heading">
     {{ layerGroupName }}
+    <div id="layerpicker-opacity-control"></div>
 </div>
 <p>{{message}}</p>
 <div id="layerpicker-layers"></div>

--- a/src/mmw/js/src/core/templates/opacityControl.html
+++ b/src/mmw/js/src/core/templates/opacityControl.html
@@ -1,0 +1,8 @@
+<input title="Drag to change opacity of overlay"
+   type="range"
+   min="0"
+   max="99"
+   step="3"
+   class="layerpicker-slider slider-leaflet"
+   value="{{ sliderValue }}"
+>

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -87,6 +87,7 @@ LAYER_GROUPS = {
             'maxNativeZoom': 13,
             'maxZoom': 18,
             'opacity': 0.618,
+            'has_opacity_slider': True,
         },
         {
             'display': 'Hydrologic Soil Groups From gSSURGO',
@@ -100,6 +101,7 @@ LAYER_GROUPS = {
             'maxNativeZoom': 13,
             'maxZoom': 18,
             'opacity': 0.618,
+            'has_opacity_slider': True,
         },
         {
             'code': 'urban_areas',
@@ -108,6 +110,7 @@ LAYER_GROUPS = {
             'short_display': 'PA Urbanized Areas',
             'minZoom': 7,
             'opacity': 0.618,
+            'has_opacity_slider': True,
             'perimeter': pa_perimeter,
         },
         {
@@ -118,6 +121,7 @@ LAYER_GROUPS = {
             'minZoom': 3,
             'perimeter': drb_simple_perimeter,
             'opacity': 0.618,
+            'has_opacity_slider': True,
         },
         {
             'code': 'drb_catchment_water_quality_tp',
@@ -127,6 +131,7 @@ LAYER_GROUPS = {
             'minZoom': 3,
             'perimeter': drb_simple_perimeter,
             'opacity': 0.618,
+            'has_opacity_slider': True,
         },
         {
             'code': 'drb_catchment_water_quality_tss',
@@ -136,6 +141,7 @@ LAYER_GROUPS = {
             'minZoom': 3,
             'perimeter': drb_simple_perimeter,
             'opacity': 0.618,
+            'has_opacity_slider': True,
         }
     ],
     'boundary': [

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -42,6 +42,7 @@
   font-size: 15px;
   font-weight: 700;
   padding: 6px;
+  display: flex;
 }
 
 .layerpicker-navbutton {
@@ -116,4 +117,89 @@
   float: left;
   position: relative;
   top: 3px;
+}
+
+#layerpicker-opacity-control {
+    margin-left: auto;
+    margin-top: auto;
+    margin-bottom: auto;
+    margin-right: 5px;
+}
+
+// Generated and considerably refined from http://danielstern.ca/range.css/
+.layerpicker-slider {
+    -webkit-appearance: none;
+    width: 90px !important;
+    margin: auto;
+    display: inline;
+    cursor: pointer;
+    &:focus {
+        outline: none;
+    }
+
+    &.slider-leaflet {
+        background-color: transparent;
+        cursor: pointer;
+
+        &::-webkit-slider-thumb {
+            background: $brand-primary;
+            width: 12px;
+            height: 12px;
+            border: 1px solid $brand-primary;
+            border-radius: 50px;
+            margin-top: -5px;
+            -webkit-appearance: none;
+        }
+
+        &:focus::-webkit-slider-thumb {
+            background: $brand-primary;
+        }
+
+        &::-webkit-slider-runnable-track {
+            width: 100%;
+            height: 2.2px;
+            cursor: pointer;
+            background: #999;
+        }
+
+        &::-moz-range-track {
+            background: #999;
+        }
+        &::-moz-range-thumb {
+            background: $brand-primary;
+            width: 12px;
+            height: 12px;
+            border: 1px solid $brand-primary;
+            border-radius: 50px;
+        }
+
+        &::-ms-track {
+            background: transparent;
+            border-color: transparent;
+            color: transparent;
+        }
+        &::-ms-thumb {
+            background: $brand-primary;
+            width: 14px;
+            height: 14px;
+            border: 1px solid $brand-primary;
+            border-radius: 50px;
+        }
+        &::-ms-fill-lower {
+            background:#999;
+            border: #999;
+        }
+        &::-ms-fill-upper {
+            background: #999;
+            border: #999;
+        }
+        &:focus::-ms-fill-lower {
+            background:  #999;
+            border:  #999;
+        }
+        &:focus::-ms-fill-upper {
+            background: #999;
+            border:  #999;
+        }
+    }
 }

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -22,7 +22,7 @@
 
 .layerpicker-title {
   float: left;
-  width: 204px;
+  width: 91%;
   padding: 0;
   text-align: left;
   border: 0;
@@ -145,6 +145,7 @@
         border-top: 11px solid transparent;
         border-bottom: 11px solid transparent;
         cursor: pointer;
+        padding: 0;
 
         &::-webkit-slider-thumb {
             background: $brand-primary;
@@ -181,12 +182,16 @@
         &::-ms-track {
             background: transparent;
             border-color: transparent;
+            width: 100%;
+            height: 2.2px;
+            cursor: pointer;
+            border-width: 6px 0;
             color: transparent;
         }
         &::-ms-thumb {
             background: $brand-primary;
-            width: 14px;
-            height: 14px;
+            width: 12px;
+            height: 12px;
             border: 1px solid $brand-primary;
             border-radius: 50px;
         }
@@ -201,10 +206,12 @@
         &:focus::-ms-fill-lower {
             background:  #999;
             border:  #999;
+            border-radius: 7px;
         }
         &:focus::-ms-fill-upper {
             background: #999;
             border:  #999;
+            border-radius: 7px;
         }
     }
 }

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -1,21 +1,23 @@
 .layerpicker {
-  z-index: 500000;
+  z-index: 500;
   position: absolute;
   bottom: 20px;
   left: 10px;
   width: 240px;
   background-color: #fff;
+  border-radius: 2px;
+  box-shadow: 0 0 6px $black-74;
 }
 
 .layerpicker-layers {
-  max-height: 97px;
+  max-height: 104px;
   overflow: auto;
 }
 
 .layerpicker-layer {
   @include clearfix;
   font-size: 13px;
-  padding: 6px;
+  padding: 4px 6px;
 }
 
 .layerpicker-title {
@@ -51,6 +53,7 @@
   float: left;
   padding: 6px;
   background-color: #ddd;
+  cursor: pointer;
   &.open {
     background-color: #fff;
   }
@@ -139,6 +142,8 @@
 
     &.slider-leaflet {
         background-color: transparent;
+        border-top: 11px solid transparent;
+        border-bottom: 11px solid transparent;
         cursor: pointer;
 
         &::-webkit-slider-thumb {


### PR DESCRIPTION
# Overview
Adds the opacity slider to the layer picker from #1666 

It will only appear for coverage layers.

# Demo
#### Wireframe
![image](https://cloud.githubusercontent.com/assets/7633670/22082680/b06278fe-dd96-11e6-9568-e54b97c315b6.png)

#### Firefox
<img width="332" alt="screen shot 2017-01-18 at 3 52 42 pm" src="https://cloud.githubusercontent.com/assets/7633670/22082541/3632ade2-dd96-11e6-9145-866777eb2fe5.png">

#### Chrome
<img width="400" alt="screen shot 2017-01-18 at 3 46 53 pm" src="https://cloud.githubusercontent.com/assets/7633670/22082553/40d8236c-dd96-11e6-8f7e-cc6e0bf9e08b.png">

#### IE 11

![screen shot 2017-01-18 at 3 48 28 pm](https://cloud.githubusercontent.com/assets/7633670/22082557/459cf864-dd96-11e6-92b1-7eea1eea4047.png)

😮 
<img width="400" alt="screen shot 2017-01-18 at 3 48 50 pm" src="https://cloud.githubusercontent.com/assets/7633670/22082559/475a8202-dd96-11e6-835e-f022106549cd.png">

# Testing Instructions
- Pull branch and rebundle
- Confirm other layers work as before and coverage grid layers display a slider in the heading.
  -  The slider should re-render to its start position on each selection of a new layer, and disappear when all the coverage grid layers are off, or when switching to a non-coverage layer tab

Connects #1652 
Connects #1677 