### PR TITLE
Allow display of very large and invalid watersheds

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -4,7 +4,9 @@ var Backbone = require('../../shim/backbone'),
     $ = require('jquery'),
     _ = require('lodash'),
     turfArea = require('turf-area'),
-    utils = require('./utils');
+    utils = require('./utils'),
+    drawUtils = require('../draw/utils');
+
 
 var MapModel = Backbone.Model.extend({
     defaults: {
@@ -257,6 +259,7 @@ var GeoModel = Backbone.Model.extend({
         shape: null,        // GeoJSON
         area: '0',
         units: 'm<sup>2</sup>',
+        isValidForAnalysis: true
     },
 
     initialize: function() {
@@ -266,6 +269,7 @@ var GeoModel = Backbone.Model.extend({
 
     update: function() {
         this.setDisplayArea();
+        this.setValidForAnalysis();
     },
 
     setDisplayArea: function(shapeAttr, areaAttr, unitsAttr) {
@@ -285,6 +289,11 @@ var GeoModel = Backbone.Model.extend({
             this.set(area, areaInMeters / this.M_IN_KM);
             this.set(units, 'km<sup>2</sup>');
         }
+    },
+
+    setValidForAnalysis: function() {
+        var shape = this.get('shape');
+        this.set('isValidForAnalysis', drawUtils.isValidForAnalysis(shape));
     }
 });
 

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -260,6 +260,11 @@ var GeoModel = Backbone.Model.extend({
     },
 
     initialize: function() {
+        this.update();
+        this.listenTo(this, 'change:shape', this.update);
+    },
+
+    update: function() {
         this.setDisplayArea();
     },
 

--- a/src/mmw/js/src/core/templates/areaOfInterestHeader.html
+++ b/src/mmw/js/src/core/templates/areaOfInterestHeader.html
@@ -8,7 +8,9 @@
 
     <div class="title">
         <h2 class="light">{{ place }}</h2>
+        {% if area > 0 %}
         <label class="light">{{ area|round|toLocaleString }} {{ units }}</label>
+        {% endif %}
     </div>
     <div class="cta-wrapper">
         <a data-url="/{{ url }}" class="btn btn-lg btn-cta"><i class="fa fa-arrow-right"></i></a>

--- a/src/mmw/js/src/core/templates/areaOfInterestHeader.html
+++ b/src/mmw/js/src/core/templates/areaOfInterestHeader.html
@@ -12,9 +12,11 @@
         <label class="light">{{ area|round|toLocaleString }} {{ units }}</label>
         {% endif %}
     </div>
+    {% if isValidForAnalysis %}
     <div class="cta-wrapper">
         <a data-url="/{{ url }}" class="btn btn-lg btn-cta"><i class="fa fa-arrow-right"></i></a>
         <label class="paper center-block text-center">{{ next_label }}</label>
     </div>
+    {% endif %}
 </div>
 {% endif %}

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -875,13 +875,16 @@ var AreaOfInterestView = Marionette.ItemView.extend({
     template: areaOfInterestTmpl,
     initialize: function() {
         this.map = this.options.App.map;
-        this.listenTo(this.map, 'change areaOfInterest', this.syncArea);
+        this.listenTo(this.map, 'change:areaOfInterest', this.syncArea);
     },
 
-    modelEvents: { 'change shape': 'render' },
+    modelEvents: { 'change:shape': 'render' },
 
     syncArea: function() {
-        this.model.set('shape', this.map.get('areaOfInterest'));
+        this.model.set({
+            'shape': this.map.get('areaOfInterest'),
+            'place': this.map.get('areaOfInterestName'),
+        });
     }
 });
 

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -32,20 +32,21 @@ var DrawController = {
 
         enableSingleProjectModeIfActivity();
 
-        if (App.map.get('areaOfInterest')) {
-            var aoiView = new coreViews.AreaOfInterestView({
-                    id: 'aoi-header-wrapper',
-                    App: App,
-                    model: new coreModels.AreaOfInterestModel({
-                        can_go_back: false,
-                        next_label: 'Analyze',
-                        url: 'analyze',
-                        shape: App.map.get('areaOfInterest'),
-                        place: App.map.get('areaOfInterestName')
-                    })
-            });
+        var aoiView = new coreViews.AreaOfInterestView({
+                id: 'aoi-header-wrapper',
+                App: App,
+                model: new coreModels.AreaOfInterestModel({
+                    can_go_back: false,
+                    next_label: 'Analyze',
+                    url: 'analyze',
+                    shape: App.map.get('areaOfInterest'),
+                    place: App.map.get('areaOfInterestName')
+                })
+        });
 
-            App.rootView.footerRegion.show(aoiView);
+        App.rootView.footerRegion.show(aoiView);
+
+        if (App.map.get('areaOfInterest')) {
             App.map.setDrawWithBarSize(true);
         }
 

--- a/src/mmw/js/src/draw/tests.js
+++ b/src/mmw/js/src/draw/tests.js
@@ -16,9 +16,15 @@ var $ = require('jquery'),
 
 var sandboxId = 'sandbox',
     sandboxSelector = '#' + sandboxId,
+    // City Hall
     TEST_SHAPE = {
         'type': 'MultiPolygon',
-        'coordinates': [[[-5e6, -1e6], [-4e6, 1e6], [-3e6, -1e6]]]
+        'coordinates': [[[
+          [-75.16472339630127, 39.953446247674904],
+          [-75.16255617141724, 39.95311727224624],
+          [-75.16287803649902, 39.95161218948083],
+          [-75.16518473625183, 39.95194939669509],
+          [-75.16472339630127, 39.953446247674904]]]]
     };
 
 var SandboxRegion = Marionette.Region.extend({

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -2,7 +2,11 @@
 
 var $ = require('jquery'),
     L = require('leaflet'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    turfArea = require('turf-area'),
+    coreUtils = require('../core/utils');
+
+var MAX_AREA = 112700; // About the size of a large state (in km^2)
 
 var polygonDefaults = {
         fillColor: '#E77471',
@@ -72,11 +76,28 @@ function cancelDrawing(map) {
     map.fire('draw:drawstop');
 }
 
+// Return shape area in km2.
+function shapeArea(shape) {
+    return coreUtils.changeOfAreaUnits(turfArea(shape),
+            'm<sup>2</sup>', 'km<sup>2</sup>');
+}
+
+function isValidForAnalysis(shape) {
+    if (shape) {
+        var area = shapeArea(shape);
+        return area > 0 && area <= MAX_AREA;
+    }
+    return false;
+}
+
 module.exports = {
     drawPolygon: drawPolygon,
     placeMarker: placeMarker,
     cancelDrawing: cancelDrawing,
     polygonDefaults: polygonDefaults,
+    shapeArea: shapeArea,
+    isValidForAnalysis: isValidForAnalysis,
     NHD: 'nhd',
     DRB: 'drb',
+    MAX_AREA: MAX_AREA
 };

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -57,7 +57,8 @@ function validateRwdShape(result) {
     var d = new $.Deferred();
     if (result.watershed) {
         if (result.watershed.features[0].geometry.type === 'MultiPolygon') {
-            d.reject('Unable to generate a valid watershed area at this location');
+            d.reject('Unfortunately, the watershed generated at this ' +
+                     'location is not available for analysis');
         }
         validateShape(result.watershed)
             .done(function() {
@@ -81,11 +82,12 @@ function validateShape(polygon) {
                        'over its own border.';
         d.reject(errorMsg);
     } else if (!utils.isValidForAnalysis(polygon)) {
-        var area = utils.shapeArea(polygon);
-        var message = 'Sorry, your Area of Interest is too large.\n\n' +
-                      Math.floor(area).toLocaleString() + ' km² were selected, ' +
-                      'but the maximum supported size is currently ' +
-                      utils.MAX_AREA.toLocaleString() + ' km².';
+        var maxArea = utils.MAX_AREA.toLocaleString(),
+            selectedArea = Math.floor(utils.shapeArea(polygon)).toLocaleString(),
+            message = 'Sorry, the area you have delineated is too large ' +
+                      'to analyze or model. ' + selectedArea + ' km² were ' +
+                      'selected, but the maximum supported size is ' +
+                      'currently ' + maxArea + ' km².';
         d.reject(message);
     } else {
         d.resolve(polygon);

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -442,7 +442,6 @@ var WatershedDelineationView = Marionette.ItemView.extend({
                 navigateToAnalyze();
             })
             .fail(function(message) {
-                clearAoiLayer();
                 displayAlert(message, modalModels.AlertTypes.warn);
             })
             .always(function() {

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -643,15 +643,22 @@ function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {
 
 function clearAoiLayer() {
     var projectNumber = App.projectNumber,
-        previousShape = App.map.get('areaOfInterest');
+        previousShape = App.map.get('areaOfInterest'),
+        previousShapeName = App.map.get('areaOfInterestName');
 
-    App.map.set('areaOfInterest', null);
+    App.map.set({
+        'areaOfInterest': null,
+        'areaOfInterestName': ''
+    });
     App.projectNumber = undefined;
     App.map.setDrawSize(false);
     App.clearAnalyzeCollection();
 
     return function revertLayer() {
-        App.map.set('areaOfInterest', previousShape);
+        App.map.set({
+            'areaOfInterest': previousShape,
+            'areaOfInterestName': previousShapeName
+        });
         App.projectNumber = projectNumber;
     };
 }

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -462,9 +462,18 @@ var WatershedDelineationView = Marionette.ItemView.extend({
 
             pollSuccess: function(response) {
                 self.model.set('polling', false);
-                var result = JSON.parse(response.result);
-                // Convert watershed to MultiPolygon to pass shape validation.
-                result.watershed = coreUtils.toMultiPolygon(result.watershed);
+
+                var result;
+                try {
+                    result = JSON.parse(response.result);
+                } catch (ex) {
+                    return this.pollFailure();
+                }
+
+                if (result.watershed) {
+                    // Convert watershed to MultiPolygon to pass shape validation.
+                    result.watershed = coreUtils.toMultiPolygon(result.watershed);
+                }
                 deferred.resolve(result);
             },
 

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -675,14 +675,14 @@ describe('Modeling', function() {
                     });
 
                     model.updateModificationHash();
-                    assert.equal(model.get('modification_hash'), '65af065d7205cd998aeb0bf15c41f256');
+                    assert.equal(model.get('modification_hash'), '582b6178186440159bd4ea25f0260892');
 
                     var mod = new models.ModificationModel(mocks.modifications.sample2);
                     model.get('modifications').add(mod);
-                    assert.equal(model.get('modification_hash'), 'ae69e823f926824a2fc22d9a5f1ea62c');
+                    assert.equal(model.get('modification_hash'), 'd95d0c983f0e3d0b171aaa0a84540205');
 
                     model.get('modifications').remove(mod);
-                    assert.equal(model.get('modification_hash'), '65af065d7205cd998aeb0bf15c41f256');
+                    assert.equal(model.get('modification_hash'), '582b6178186440159bd4ea25f0260892');
                 });
 
                 it('is called when the modifications for a scenario changes', function() {


### PR DESCRIPTION
#### Changes
* Graceful RWD error handling, and better messages
* Display invalid watersheds
* Hide "Analyze" button for invalid watersheds

#### Demo

We now handle errors much more consistently instead of having the UI stuck in a bad state.

![image](https://cloud.githubusercontent.com/assets/43062/22088973/fc99337e-ddb5-11e6-88e3-a9434b7b5db5.png)

For invalid (multipolygon) watersheds, we now display a better error message. Since we can't calculate the area, it is hidden in the analyze footer.

![image](https://cloud.githubusercontent.com/assets/43062/22088934/a34ae1be-ddb5-11e6-9dd8-a33efbc9106d.png)

For valid watersheds that are too large (I have set the limit to 5km^2 for testing purposes) we display the generated watershed along with a warning, and hide the "Analyze" button in the footer.

![image](https://cloud.githubusercontent.com/assets/43062/22089049/8f9df89e-ddb6-11e6-9d61-117d1d925ec8.png)

Connects #1657 