### PR TITLE
Use R4 instance family for workers

### DIFF
--- a/deployment/cfn/utils/constants.py
+++ b/deployment/cfn/utils/constants.py
@@ -2,7 +2,8 @@ EC2_INSTANCE_TYPES = [
     't2.micro',
     't2.small',
     't2.medium',
-    't2.large'
+    't2.large',
+    'r4.large'
 ]
 
 RDS_INSTANCE_TYPES = [

--- a/deployment/cfn/worker.py
+++ b/deployment/cfn/worker.py
@@ -331,6 +331,7 @@ class Worker(StackNode):
         worker_launch_config = self.add_resource(
             asg.LaunchConfiguration(
                 worker_launch_config_name,
+                EbsOptimized=True,
                 ImageId=Ref(self.worker_ami),
                 IamInstanceProfile=Ref(self.worker_instance_profile),
                 InstanceType=Ref(self.worker_instance_type),


### PR DESCRIPTION
Add the `r4.large` instance type into the list of eligible instance types for use with EC2. Also, ensure that the `EbsOptimized` flag is enabled.

https://github.com/WikiWatershed/model-my-watershed/issues/1671 describes the scenario that we'll ultimately need to address about trying to launch instance types that do not support the EBS optimized flag.

---

**Testing**

This was already deployed and tested on staging.