### PR TITLE
Add Observations Tab To Layer Picker

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -6,7 +6,8 @@ var Backbone = require('../../shim/backbone'),
     turfArea = require('turf-area'),
     L = require('leaflet'),
     utils = require('./utils'),
-    settings = require('./settings');
+    settings = require('./settings'),
+    VizerLayers = require('./vizerLayers');
 
 var MapModel = Backbone.Model.extend({
     defaults: {
@@ -96,6 +97,10 @@ var LayerGroupModel = Backbone.Model.extend({
 });
 
 var LayersModel = Backbone.Model.extend({
+    defaults: {
+        _googleMaps: (window.google ? window.google.maps : null)
+    },
+
     initialize: function() {
         var defaultBaseLayer = _.findWhere(settings.get('base_layers'), function(layer) {
                 return layer.default === true;
@@ -105,7 +110,9 @@ var LayersModel = Backbone.Model.extend({
         this.coverageLayers = this.buildLayers('coverage_layers');
         this.boundaryLayers = this.buildLayers('boundary_layers');
         this.streamLayers = this.buildLayers('stream_layers');
-        this._googleMaps = (window.google ? window.google.maps : null);
+
+        var vizer = new VizerLayers();
+        this.observationsDeferred = vizer.getLayers();
     },
 
     buildLayers: function(layerType, initialActive) {

--- a/src/mmw/js/src/core/templates/layerPickerGroup.html
+++ b/src/mmw/js/src/core/templates/layerPickerGroup.html
@@ -1,4 +1,5 @@
 <div class="layerpicker-heading">
     {{ layerGroupName }}
 </div>
+<p>{{message}}</p>
 <div id="layerpicker-layers"></div>


### PR DESCRIPTION
# Overview
#1666 didn't implement the observations tab, so this PR does. 

# Demo

#### Layers loaded, can select multiple and have popups
![screen shot 2017-01-19 at 12 49 46 pm](https://cloud.githubusercontent.com/assets/7633670/22118561/5158b1a6-de46-11e6-8a56-8dc9e5e9a866.png)

#### On failure (needs to be styled)
![screen shot 2017-01-19 at 12 53 08 pm](https://cloud.githubusercontent.com/assets/7633670/22118559/5157430c-de46-11e6-9f7e-a0f5895a9d49.png)

#### While loading
![screen shot 2017-01-19 at 12 51 10 pm](https://cloud.githubusercontent.com/assets/7633670/22118560/5157a3a6-de46-11e6-967a-63376336f6fc.png)

# Testing Instructions
- Pull branch and re-bundle
- Select the right most tab of the layer picker
   - should say loading while loading
   - once loaded, should have the same layers as production
- Switch between tabs of the layer picker, and confirm doesn't reload layers
- Refresh page. Before clicking the observations tab, take browser offline
- Observations tab should show appropriate error message

Connects #1652 