### PR TITLE
Create RWD environment variables for host and port number

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -3,3 +3,7 @@ rwd_data_path: "/opt/rwd-data"
 rwd_host: "localhost"
 rwd_port: 5000
 rwd_docker_image: "quay.io/wikiwatershed/rwd:1.2.0"
+
+app_config:
+    RWD_HOST: "{{ rwd_host }}"
+    RWD_PORT: "{{ rwd_port }}"

--- a/deployment/ansible/roles/model-my-watershed.rwd/tasks/app.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/tasks/app.yml
@@ -1,0 +1,16 @@
+---
+- name: Create RWD data directory
+  file: path="{{ rwd_data_path }}"
+        state=directory
+
+- name: Pull RWD docker container image
+  command: /usr/bin/docker pull {{ rwd_docker_image }}
+
+- name: Configure RWD service definition
+  template: src=upstart-mmw-rwd.conf.j2
+            dest=/etc/init/mmw-rwd.conf
+  notify:
+    - Restart mmw-rwd
+
+- name: Ensure service is running
+  service: name=mmw-rwd state=started

--- a/deployment/ansible/roles/model-my-watershed.rwd/tasks/configuration.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/tasks/configuration.yml
@@ -1,0 +1,10 @@
+---
+- name: Configure application
+  copy: content="{{ item.value }}"
+        dest="{{ envdir_home }}/{{ item.key }}"
+        owner=root
+        group=mmw
+        mode=0750
+  with_dict: "{{ app_config }}"
+  notify:
+    - Restart Celery

--- a/deployment/ansible/roles/model-my-watershed.rwd/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/tasks/main.yml
@@ -1,16 +1,3 @@
 ---
-- name: Create RWD data directory
-  file: path="{{ rwd_data_path }}"
-        state=directory
-
-- name: Pull RWD docker container image
-  command: /usr/bin/docker pull {{ rwd_docker_image }}
-
-- name: Configure RWD service definition
-  template: src=upstart-mmw-rwd.conf.j2
-            dest=/etc/init/mmw-rwd.conf
-  notify:
-    - Restart mmw-rwd
-
-- name: Ensure service is running
-  service: name=mmw-rwd state=started
+- { include: configuration.yml }
+- { include: app.yml }

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import os
 import logging
 import json
 import requests
@@ -30,6 +31,9 @@ ACRES_PER_SQM = 0.000247105
 
 DRB = 'drb'
 
+RWD_HOST = os.environ.get('RWD_HOST', 'localhost')
+RWD_PORT = os.environ.get('RWD_PORT', '5000')
+
 
 @shared_task
 def start_rwd_job(location, snapping, data_source):
@@ -42,7 +46,8 @@ def start_rwd_job(location, snapping, data_source):
     location = json.loads(location)
     lat, lng = location
     end_point = 'rwd' if data_source == DRB else 'rwd-nhd'
-    rwd_url = 'http://localhost:5000/%s/%f/%f' % (end_point, lat, lng)
+    rwd_url = 'http://%s:%s/%s/%f/%f' % (RWD_HOST, RWD_PORT, end_point,
+                                         lat, lng)
 
     # The Webserver defaults to enable snapping, uses 1 (true) 0 (false)
     if not snapping:

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -6,6 +6,7 @@ var $ = require('jquery'),
     turfArea = require('turf-area'),
     coreUtils = require('../core/utils');
 
+// Keep in sync with src/api/main.py in rapid-watershed-delineation.
 var MAX_AREA = 112700; // About the size of a large state (in km^2)
 
 var polygonDefaults = {


### PR DESCRIPTION
### Overview

Instead of hard-coding the RWD host and port values, make them configurable. This makes it easier to test and troubleshoot RWD source code during development.

#### Testing instructions

```
# Change the rwd_host setting (ex. foo)
vim deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
# Reprovision
vagrant reload worker --provision
```

Verify that `RWD_HOST` exists and has the value you specified.

```
vagrant ssh worker -c 'cat /etc/mmw.d/env/RWD_HOST'
```

Delineate a watershed. This should fail with a "HTTPConnectionPool" error (assuming the host you specified is unreachable).

![screenshot 2017-01-31 at 14 01 35](https://cloud.githubusercontent.com/assets/43062/22481417/296a4700-e7c3-11e6-9d75-8dafffdc82ed.png)


![screenshot 2017-01-31 at 14 39 02](https://cloud.githubusercontent.com/assets/43062/22481404/1f6c973a-e7c3-11e6-852b-bb76d7856062.png)

If you provision the worker VM with `rwd_host` set to `10.0.2.2` and execute `server.sh` in the `rapid-watershed-delineation` project, then you should be able to delineate watersheds.
