### PR TITLE
On Rename make scenario names selectable and fix bugs

### DIFF
--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -963,6 +963,49 @@ describe('Modeling', function() {
                     assert.isTrue(spyAlert.calledOnce);
                     assert.equal(collection.at(1).get('name'), 'New Scenario 1');
                 });
+
+                it('will not show error when trying to save name as is', function() {
+                    var collection = getTestScenarioCollection(),
+                        view = new views.ScenarioTabPanelsView({ collection: collection });
+
+                    view.render();
+                    var childViews = _.values(view.children._views);
+
+                    childViews[1].ui.rename.trigger('click');
+                    childViews[1].ui.nameField.text('New Scenario 1');
+                    childViews[1].ui.nameField.trigger('blur');
+
+                    assert.isFalse(spyAlert.calledOnce);
+                    assert.equal(collection.at(1).get('name'), 'New Scenario 1');
+                });
+
+                it('resets name if set to empty string', function() {
+                    var collection = getTestScenarioCollection(),
+                        view = new views.ScenarioTabPanelsView({ collection: collection });
+
+                    view.render();
+                    var childViews = _.values(view.children._views);
+
+                    childViews[1].ui.rename.trigger('click');
+                    childViews[1].ui.nameField.text('');
+                    childViews[1].ui.nameField.trigger('blur');
+
+                    assert.equal(collection.at(1).get('name'), 'New Scenario 1');
+                });
+
+                it('resets name if set to just spaces', function() {
+                    var collection = getTestScenarioCollection(),
+                        view = new views.ScenarioTabPanelsView({ collection: collection });
+
+                    view.render();
+                    var childViews = _.values(view.children._views);
+
+                    childViews[1].ui.rename.trigger('click');
+                    childViews[1].ui.nameField.text(' ');
+                    childViews[1].ui.nameField.trigger('blur');
+
+                    assert.equal(collection.at(1).get('name'), 'New Scenario 1');
+                });
             });
 
             describe('#duplicateScenario', function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -196,7 +196,7 @@ var ProjectMenuView = Marionette.ItemView.extend({
                     .fail(function() {
                         var alertView = new modalViews.AlertView({
                             model: new modalModels.AlertModel({
-                                alertMessage: 'Could not delete this project.', 
+                                alertMessage: 'Could not delete this project.',
                                 alertType: modalModels.AlertTypes.error
                             })
                         });
@@ -399,7 +399,9 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
                     return model.get('name').toLowerCase() === newName.toLowerCase();
                 });
 
-                if (match) {
+                if (model.get('name') === newName || !newName){
+                    return false;
+                } else if (match) {
                     console.log('This name is already in use.');
                     var alertView = new modalViews.AlertView({
                         model: new modalModels.AlertModel({
@@ -411,17 +413,27 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
 
                     alertView.render();
                     return false;
-                } else if (model.get('name') !== newName) {
+                } else {
                     return model.set('name', newName);
                 }
             },
 
-        setScenarioName = function(name) {
-            if (!updateScenarioName(self.model, name)) {
-                self.render(); // resets view state
-            }
-        };
+            setScenarioName = function(name) {
+                if (!updateScenarioName(self.model, name)) {
+                    self.render(); // resets view state
+                }
+            },
 
+            selectScenarioTabText = function() {
+                // Select scenario name's text
+                var range = document.createRange(),
+                    selection = window.getSelection();
+                range.selectNodeContents(self.ui.nameField[0]);
+                selection.removeAllRanges();
+                selection.addRange(range);
+            };
+
+        selectScenarioTabText();
         this.ui.nameField.attr('contenteditable', true).focus();
 
         this.ui.nameField.on('keyup', function(e) {
@@ -439,6 +451,12 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
 
                 setScenarioName($(this).text());
             }
+        });
+
+        this.ui.nameField.on('click', function(e) {
+            // Don't let the outer <a> swallow clicks and exit rename mode
+            // Allows selecting text on double click
+            e.stopImmediatePropagation();
         });
 
         this.ui.nameField.on('blur', function() {


### PR DESCRIPTION
## Overview

Connects #1682

Before, when renaming a scenario, the cursor began on the lefthand side of the text. Double clicking to select the whole text just clicked the tab and took you out of rename mode. 

I also noticed two additional bugs:
-  you could set a scenario's name to a blank string. 
- if you pressed the return key without making any changes the `This name already exists` modal came up

This PR starts scenario text off all selected, allows double clicking to select text as you'd expect, and fixes the two bugs above.

## Demo
![scenariorename](https://cloud.githubusercontent.com/assets/7633670/22606182/f588b2d6-ea20-11e6-9d43-02059e601beb.gif)

## Testing Instructions
- rename scenarios and makes sure the text editing behaves like a regular input
- don't make any changes and press Enter -- confirm there's no error
- confirm you can create duplicate named scenarios otherwise
- confirm if you clear out the text and press enter the name goes back to whatever it was