### PR TITLE
Postpone ASG scheduled shutdown for staging

### DIFF
--- a/deployment/cfn/application.py
+++ b/deployment/cfn/application.py
@@ -173,7 +173,7 @@ class Application(StackNode):
         self.app_server_auto_scaling_schedule_end_recurrence = self.add_parameter(  # NOQA
             Parameter(
                 'AppServerAutoScalingScheduleEndRecurrence', Type='String',
-                Default='0 23 * * *',
+                Default='0 1 * * *',
                 Description='Application server ASG schedule end recurrence'
             ), 'AppServerAutoScalingScheduleEndRecurrence')
 

--- a/deployment/cfn/tiler.py
+++ b/deployment/cfn/tiler.py
@@ -164,7 +164,7 @@ class Tiler(StackNode):
         self.tile_server_auto_scaling_schedule_end_recurrence = self.add_parameter(  # NOQA
             Parameter(
                 'TileServerAutoScalingScheduleEndRecurrence', Type='String',
-                Default='0 23 * * *',
+                Default='0 1 * * *',
                 Description='Tile server ASG schedule end recurrence'
             ), 'TileServerAutoScalingScheduleEndRecurrence')
 

--- a/deployment/cfn/worker.py
+++ b/deployment/cfn/worker.py
@@ -170,7 +170,7 @@ class Worker(StackNode):
         self.worker_auto_scaling_schedule_end_recurrence = self.add_parameter(  # NOQA
             Parameter(
                 'WorkerAutoScalingScheduleEndRecurrence', Type='String',
-                Default='0 23 * * *',
+                Default='0 1 * * *',
                 Description='Worker ASG schedule end recurrence'
             ), 'WorkerAutoScalingScheduleEndRecurrence')
 

--- a/deployment/default.yml.example
+++ b/deployment/default.yml.example
@@ -29,8 +29,8 @@ AppServerAutoScalingScheduleStartCapacity: '1'
 # 8AM ET
 AppServerAutoScalingScheduleStartRecurrence: '0 13 * * 1-5'
 AppServerAutoScalingScheduleEndCapacity: '0'
-# 6PM ET
-AppServerAutoScalingScheduleEndRecurrence: '0 23 * * *'
+# 8PM ET
+AppServerAutoScalingScheduleEndRecurrence: '0 1 * * *'
 SSLCertificateARN: 'arn:aws:iam...'
 BackwardCompatSSLCertificateARN: 'arn:aws:iam...'
 TileServerInstanceType: 't2.micro'
@@ -45,8 +45,8 @@ TileServerAutoScalingScheduleStartCapacity: '1'
 # 8AM ET
 TileServerAutoScalingScheduleStartRecurrence: '0 13 * * 1-5'
 TileServerAutoScalingScheduleEndCapacity: '0'
-# 6PM ET
-TileServerAutoScalingScheduleEndRecurrence: '0 23 * * *'
+# 8PM ET
+TileServerAutoScalingScheduleEndRecurrence: '0 1 * * *'
 WorkerInstanceType: 't2.micro'
 # Leaving this commented dynamically looks up the
 # most recent AMI for this type.
@@ -59,8 +59,8 @@ WorkerAutoScalingScheduleStartCapacity: '2'
 # 8AM ET
 WorkerAutoScalingScheduleStartRecurrence: '0 13 * * 1-5'
 WorkerAutoScalingScheduleEndCapacity: '0'
-# 6PM ET
-WorkerAutoScalingScheduleEndRecurrence: '0 23 * * *'
+# 8PM ET
+WorkerAutoScalingScheduleEndRecurrence: '0 1 * * *'
 ITSIBaseURL: ''
 ITSISecretKey: ''
 RollbarServerSideAccessToken: ''


### PR DESCRIPTION
Push back the shutdown time for `AppServer`, `Worker` and `Tiler` instances in `staging`. This will enable testers in western timezones to use the staging service later into their workday.  Previous value was translated as 6PM EST (11PM UTC) and the new value is 8PM EST (1AM UTC).

This is not intended to make any alterations for the ASG scheduled actions on `production`.