### PR TITLE
Mount RWD default folder which exists on all platforms

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     worker.vm.synced_folder "src/mmw", "/opt/app/"
 
     # Path to RWD data (ex. /media/passport/rwd-nhd)
-    worker.vm.synced_folder ENV.fetch("RWD_DATA", "/dev/null"), "/opt/rwd-data"
+    worker.vm.synced_folder ENV.fetch("RWD_DATA", "/tmp"), "/opt/rwd-data"
 
     # Docker
     worker.vm.network "forwarded_port", {


### PR DESCRIPTION
## Overview

`/dev/null` could not be mounted as a folder on macOS because it is a character file. `/tmp` should be available on all platforms.

### Notes

I'm assigning one macOS person and one Linux person to test this on all platforms we use.

## Testing Instructions

Check out this branch. Ensure `$RWD_DATA` environment variable is **not** set. Run `vagrant up`. Ensure there are no errors and the app loads correctly at [:8000/](http://localhost:8000/)