### PR TITLE
Mark original clicked point on starting RWD

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -619,18 +619,11 @@ var MapView = Marionette.ItemView.extend({
 
         if (additionalShapes) {
             _.each(additionalShapes.features, function(geoJSONpoint) {
-                function createMarkerIcon(iconName) {
-                    return L.divIcon({
-                        className: 'marker-rwd marker-rwd-' + iconName,
-                        iconSize: [16,16]
-                    });
-                }
-
                 var newLayer = L.geoJson(geoJSONpoint, {
                     pointToLayer: function(feature, latLngForPoint) {
                         var customIcon = feature.properties.original ?
-                            createMarkerIcon('original-point') :
-                            createMarkerIcon('nearest-stream-point');
+                            drawUtils.createRwdMarkerIcon('original-point') :
+                            drawUtils.createRwdMarkerIcon('nearest-stream-point');
                         return L.marker(latLngForPoint, { icon: customIcon });
                     },
                     onEachFeature: function(feature, layer) {

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -72,6 +72,13 @@ function placeMarker(map, drawOpts) {
     return defer.promise();
 }
 
+function createRwdMarkerIcon(iconName) {
+    return L.divIcon({
+        className: 'marker-rwd marker-rwd-' + iconName,
+        iconSize: [16,16]
+    });
+}
+
 // Cancel any previous draw action in progress.
 function cancelDrawing(map) {
     map.fire('draw:drawstop');
@@ -94,6 +101,7 @@ function isValidForAnalysis(shape) {
 module.exports = {
     drawPolygon: drawPolygon,
     placeMarker: placeMarker,
+    createRwdMarkerIcon: createRwdMarkerIcon,
     cancelDrawing: cancelDrawing,
     polygonDefaults: polygonDefaults,
     shapeArea: shapeArea,


### PR DESCRIPTION
## Overview

This PR displays the RWD "Original Clicked Outlet Point" marker on starting RWD, then removes it when the chain of deferreds completes in success or failure. If RWD succeeds, the marker's removed to be replaced by the existing pair of markers for "Original Clicked Outlet Point" and "Outlet Point Snapped to Nearest Stream". If RWD fails, an error message shows and the marker is cleared from the map.

I set the marker up to use the same style `divIcon` and popup as the existing "Original" RWD marker. To standardize it, I moved the function which made that icon into `draw/utils.js`. I also bound a popup to it with the "Original Clicked Outlet Point" message.

Connects #1687 

## Screenshot

<img width="634" alt="screen shot 2017-02-17 at 10 49 42 am" src="https://cloud.githubusercontent.com/assets/4165523/23072183/cfbdf096-f4fe-11e6-89d0-db09bd6d5104.png">

## Testing

* get this branch, then run `bundle.sh`
* visit MMW in the browser and run RWD for both DRB and continental US. Verify that the marker clears in both the success and failure cases. (To cause a failure, I think you can try the points noted to cause an error in https://github.com/WikiWatershed/rapid-watershed-delineation/issues/65)