### PR TITLE
Add legends to new layerpicker

### DIFF
--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -13,46 +13,6 @@ import json
 import re
 
 
-# Here, the keys of this dictionary are NLCD numbers (found in the
-# rasters), and the values of the dictionary are arrays of length two.
-# The first element of each array is the name of the NLCD category in
-# the TR-55 code.  The second string is a short, human-readable name.
-NLCD_MAPPING = {
-    11: ['open_water', 'Open Water'],
-    12: ['perennial_ice', 'Perennial Ice/Snow'],
-    21: ['developed_open', 'Developed, Open Space'],
-    22: ['developed_low', 'Developed, Low Intensity'],
-    23: ['developed_med', 'Developed, Medium Intensity'],
-    24: ['developed_high', 'Developed, High Intensity'],
-    31: ['barren_land', 'Barren Land (Rock/Sand/Clay)'],
-    41: ['deciduous_forest', 'Deciduous Forest'],
-    42: ['evergreen_forest', 'Evergreen Forest'],
-    43: ['mixed_forest', 'Mixed Forest'],
-    52: ['shrub', 'Shrub/Scrub'],
-    71: ['grassland', 'Grassland/Herbaceous'],
-    81: ['pasture', 'Pasture/Hay'],
-    82: ['cultivated_crops', 'Cultivated Crops'],
-    90: ['woody_wetlands', 'Woody Wetlands'],
-    95: ['herbaceous_wetlands', 'Emergent Herbaceous Wetlands']
-}
-
-# The soil rasters contain the numbers 1 through 7 (the keys of this
-# dictionary).  The values of this dictionary are length-two arrays
-# containing two strings.  The first member of each array is the name
-# used for the corresponding soil-type in the TR-55 code.  The second
-# member of each array is a human-readable description of that
-# soil-type.
-SOIL_MAPPING = {
-    1: ['a', 'A - High Infiltration'],
-    2: ['b', 'B - Moderate Infiltration'],
-    3: ['c', 'C - Slow Infiltration'],
-    4: ['d', 'D - Very Slow Infiltration'],
-    5: ['ad', 'A/D - High/Very Slow Infiltration'],
-    6: ['bd', 'B/D - Medium/Very Slow Infiltration'],
-    7: ['cd', 'C/D - Medium/Very Slow Infiltration']
-}
-
-
 @statsd.timer(__name__ + '.sjs_submit')
 def sjs_submit(host, port, args, data, retry=None):
     """
@@ -222,9 +182,9 @@ def data_to_census(data):
     """
     def update_rule(nlcd, soil, count, census):
         dist = census['distribution']
-        if nlcd in NLCD_MAPPING and soil in SOIL_MAPPING:
-            nlcd_str = NLCD_MAPPING[nlcd][0]
-            soil_str = SOIL_MAPPING[soil][0]
+        if nlcd in settings.NLCD_MAPPING and soil in settings.SOIL_MAPPING:
+            nlcd_str = settings.NLCD_MAPPING[nlcd][0]
+            soil_str = settings.SOIL_MAPPING[soil][0]
             if soil_str == 'ad':
                 soil_str = 'c'
             elif soil_str == 'bd':
@@ -271,19 +231,19 @@ def data_to_survey(data):
         landCategories = survey[0]['categories']
         soilCategories = survey[1]['categories']
 
-        if nlcd in NLCD_MAPPING:
-            update_category(NLCD_MAPPING[nlcd], count, landCategories)
+        if nlcd in settings.NLCD_MAPPING:
+            update_category(settings.NLCD_MAPPING[nlcd], count, landCategories)
         else:
             update_category([nlcd, nlcd], count, landCategories)
 
-        if soil in SOIL_MAPPING:
-            update_category(SOIL_MAPPING[soil], count, soilCategories)
+        if soil in settings.SOIL_MAPPING:
+            update_category(settings.SOIL_MAPPING[soil], count, soilCategories)
         else:
             update_category([soil, soil], count, soilCategories)
 
     def after_rule(count, survey):
-        nlcd_names = [v[1] for v in NLCD_MAPPING.values()]
-        nlcd_keys = NLCD_MAPPING.keys()
+        nlcd_names = [v[1] for v in settings.NLCD_MAPPING.values()]
+        nlcd_keys = settings.NLCD_MAPPING.keys()
         used_nlcd_names = [k for k in survey[0]['categories'].keys()]
 
         for index, name in enumerate(nlcd_names):

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -646,9 +646,9 @@ var ChartView = Marionette.ItemView.extend({
     getBarClass: function(item) {
         var name = this.model.get('name');
         if (name === 'land') {
-            return 'nlcd-' + item.nlcd;
+            return 'nlcd-fill-' + item.nlcd;
         } else if (name === 'soil') {
-            return 'soil-' + item.code;
+            return 'soil-fill-' + item.code;
         }
     },
 

--- a/src/mmw/js/src/core/layerPicker.js
+++ b/src/mmw/js/src/core/layerPicker.js
@@ -11,6 +11,7 @@ var models = require('./models'),
     layerPickerTmpl = require('./templates/layerPicker.html'),
     layerPickerGroupTmpl = require('./templates/layerPickerGroup.html'),
     layerPickerLayerTmpl = require('./templates/layerPickerLayer.html'),
+    layerPickerLegendTmpl = require('./templates/layerPickerLegend.html'),
     opacityControlTmpl = require('./templates/opacityControl.html');
 
 var LayerOpacitySliderView = Marionette.ItemView.extend({
@@ -45,6 +46,17 @@ var LayerOpacitySliderView = Marionette.ItemView.extend({
     }
 });
 
+var LayerPickerLegendView = Marionette.ItemView.extend({
+    template: layerPickerLegendTmpl,
+
+    templateHelpers: function() {
+        return {
+            legendMapping: this.model.get('legendMapping'),
+            colorClass: this.model.get('cssClassPrefix')
+        };
+    }
+});
+
 /* The individual layers in each layer group */
 var LayerPickerLayerView = Marionette.ItemView.extend({
     template: layerPickerLayerTmpl,
@@ -72,7 +84,13 @@ var LayerPickerLayerView = Marionette.ItemView.extend({
     onRender: function() {
         this.ui.layerHelpIcon.popover({
             trigger: 'hover',
-            viewport: '.map-container'
+            viewport: {
+                'selector': '.map-container',
+                'padding': 10
+            },
+            content: new LayerPickerLegendView({
+                model: this.model,
+            }).render().el
         });
     },
 });

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -150,6 +150,8 @@ var LayersModel = Backbone.Model.extend({
                 googleType: layer.googleType,
                 disabled: false,
                 hasOpacitySlider: layer.has_opacity_slider,
+                legendMapping: layer.legend_mapping,
+                cssClassPrefix: layer.css_class_prefix,
                 active: layer.display === initialActive ? true : false,
             });
         });

--- a/src/mmw/js/src/core/templates/layerPickerLayer.html
+++ b/src/mmw/js/src/core/templates/layerPickerLayer.html
@@ -5,7 +5,7 @@
     >
         {{ layerDisplay }}
     </button>
-    {% if not isDisabled %}
+    {% if not isDisabled and legendMapping %}
         <a
             tabindex="-1"
             role="presentation"
@@ -14,20 +14,6 @@
             data-trigger="focus"
             class="layerpicker-info"
             data-layer-help-icon="{{layerDisplay}}"
-            data-content="<div>
-                <div class='layerpicker-legenditem'>
-                    <div class='layerpicker-legendcolor'></div>
-                    These here
-                </div>
-                <div class='layerpicker-legenditem'>
-                    <div class='layerpicker-legendcolor'></div>
-                    Are Just
-                </div>
-                <div class='layerpicker-legenditem'>
-                    <div class='layerpicker-legendcolor'></div>
-                    Placeholders
-                </div>
-            </div>"
         >
         </a>
     {% endif %}

--- a/src/mmw/js/src/core/templates/layerPickerLegend.html
+++ b/src/mmw/js/src/core/templates/layerPickerLegend.html
@@ -1,0 +1,8 @@
+<div class="layerpicker-legend">
+    {% for id, display in legendMapping %}
+        <div class="layerpicker-legenditem">
+            <div class="layerpicker-legendcolor {{colorClass}}-{{id}}"></div>
+            <div class="layerpicker-legendtext">{{ display }}</div>
+        </div>
+    {% endfor %}
+</div>

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -16,6 +16,7 @@ from layer_settings import (LAYER_GROUPS, VIZER_URLS, VIZER_IGNORE, VIZER_NAMES,
                             NHD_REGION2_PERIMETER, DRB_PERIMETER)  # NOQA
 from gwlfe_settings import (GWLFE_DEFAULTS, GWLFE_CONFIG, SOIL_GROUP, # NOQA
                             SOILP, CURVE_NUMBER)  # NOQA
+from tr55_settings import (NLCD_MAPPING, SOIL_MAPPING)
 
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -133,6 +133,7 @@ LAYER_GROUPS = {
             'perimeter': drb_simple_perimeter,
             'opacity': 0.618,
             'has_opacity_slider': True,
+            'css_class_prefix': 'catchment',
             # Defined in tiler/styles.mss
             'legend_mapping': {
                 1: 'Less than 5 kg/y',
@@ -151,6 +152,7 @@ LAYER_GROUPS = {
             'perimeter': drb_simple_perimeter,
             'opacity': 0.618,
             'has_opacity_slider': True,
+            'css_class_prefix': 'catchment',
             # Defined in tiler/styles.mss
             'legend_mapping': {
                 1: 'Less than 0.30 kg/y',
@@ -169,6 +171,7 @@ LAYER_GROUPS = {
             'perimeter': drb_simple_perimeter,
             'opacity': 0.618,
             'has_opacity_slider': True,
+            'css_class_prefix': 'catchment',
             # Defined in tiler/styles.mss
             'legend_mapping': {
                 1: 'Less than 250 kg/y',
@@ -298,6 +301,7 @@ LAYER_GROUPS = {
                         ' From SRAT'),
             'table_name': 'nhd_quality_tn',
             'minZoom': 3,
+            'css_class_prefix': 'stream',
             # Defined in tiler/server.js
             'legend_mapping': {
                 1: 'Less than 1 kg/y',
@@ -313,6 +317,7 @@ LAYER_GROUPS = {
                         ' From SRAT'),
             'table_name': 'nhd_quality_tp',
             'minZoom': 3,
+            'css_class_prefix': 'stream',
             # Defined in tiler/server.js
             'legend_mapping': {
                 1: 'Less than 0.03 kg/y',
@@ -328,6 +333,7 @@ LAYER_GROUPS = {
                         ' From SRAT'),
             'table_name': 'nhd_quality_tss',
             'minZoom': 3,
+            'css_class_prefix': 'stream',
             # Defined in tiler/server.js
             'legend_mapping': {
                 1: 'Less than 50 kg/y',

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -11,10 +11,11 @@ For basemaps, maxZoom must be defined.
 """
 
 from os.path import join, dirname, abspath
+from collections import OrderedDict
 import json
 
 from django.contrib.gis.geos import GEOSGeometry
-
+from tr55_settings import NLCD_MAPPING, SOIL_MAPPING
 
 # Full perimeter of the Delaware River Basin (DRB).
 drb_perimeter_path = join(dirname(abspath(__file__)), 'data/drb_perimeter.json')
@@ -40,8 +41,6 @@ nhd_region2_simple_perimeter_path = join(dirname(abspath(__file__)),
 nhd_region2_simple_perimeter_file = open(nhd_region2_simple_perimeter_path)
 
 NHD_REGION2_PERIMETER = json.load(nhd_region2_simple_perimeter_file)
-
-NEW_LINE_AND_TAB = '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'
 
 LAYER_GROUPS = {
     'basemap': [
@@ -80,6 +79,7 @@ LAYER_GROUPS = {
     'coverage': [
         {
             'display': 'National Land Cover Database',
+            'css_class_prefix': 'nlcd',
             'short_display': 'NLCD',
             'helptext': 'National Land Cover Database defines'
                         'land use across the U.S.',
@@ -88,10 +88,12 @@ LAYER_GROUPS = {
             'maxZoom': 18,
             'opacity': 0.618,
             'has_opacity_slider': True,
+            'legend_mapping': { key: names[1] for key, names in NLCD_MAPPING.iteritems()},
         },
         {
             'display': 'Hydrologic Soil Groups From gSSURGO',
             'short_display': 'SSURGO',
+            'css_class_prefix': 'soil',
             'helptext': 'Soils are classified by the Natural Resource Conservation '
                         'Service into four Hydrologic Soil Groups based on the '
                         'soil\'s runoff potential. The four Hydrologic Soils Groups'
@@ -102,6 +104,15 @@ LAYER_GROUPS = {
             'maxZoom': 18,
             'opacity': 0.618,
             'has_opacity_slider': True,
+            'legend_mapping': OrderedDict([
+                SOIL_MAPPING[1],
+                SOIL_MAPPING[2],
+                SOIL_MAPPING[3],
+                SOIL_MAPPING[5],
+                SOIL_MAPPING[6],
+                SOIL_MAPPING[7],
+                SOIL_MAPPING[4],
+            ]),
         },
         {
             'code': 'urban_areas',
@@ -122,6 +133,14 @@ LAYER_GROUPS = {
             'perimeter': drb_simple_perimeter,
             'opacity': 0.618,
             'has_opacity_slider': True,
+            # Defined in tiler/styles.mss
+            'legend_mapping': {
+                1: 'Less than 5 kg/y',
+                2: 'Less than 10 kg/y',
+                3: 'Less than 15 kg/y',
+                4: 'Less than 20 kg/y',
+                5: 'Greater than 20 kg/y',
+            }
         },
         {
             'code': 'drb_catchment_water_quality_tp',
@@ -132,6 +151,14 @@ LAYER_GROUPS = {
             'perimeter': drb_simple_perimeter,
             'opacity': 0.618,
             'has_opacity_slider': True,
+            # Defined in tiler/styles.mss
+            'legend_mapping': {
+                1: 'Less than 0.30 kg/y',
+                2: 'Less than 0.60 kg/y',
+                3: 'Less than 0.90 kg/y',
+                4: 'Less than 1.20 kg/y',
+                5: 'Greater than 1.20 kg/y',
+            }
         },
         {
             'code': 'drb_catchment_water_quality_tss',
@@ -142,6 +169,14 @@ LAYER_GROUPS = {
             'perimeter': drb_simple_perimeter,
             'opacity': 0.618,
             'has_opacity_slider': True,
+            # Defined in tiler/styles.mss
+            'legend_mapping': {
+                1: 'Less than 250 kg/y',
+                2: 'Less than 500 kg/y',
+                3: 'Less than 750 kg/y',
+                4: 'Less than 1000 kg/y',
+                5: 'Greater than 1000 kg/y',
+            }
         }
     ],
     'boundary': [
@@ -262,21 +297,45 @@ LAYER_GROUPS = {
             'display': ('Delaware River Basin TN Concentration' +
                         ' From SRAT'),
             'table_name': 'nhd_quality_tn',
-            'minZoom': 3
+            'minZoom': 3,
+            # Defined in tiler/server.js
+            'legend_mapping': {
+                1: 'Less than 1 kg/y',
+                2: 'Less than 2 kg/y',
+                3: 'Less than 3 kg/y',
+                4: 'Less than 4 kg/y',
+                'NA': 'No Data'
+            }
         },
         {
             'code': 'nhd_quality_tp',
             'display': ('Delaware River Basin TP Concentration' +
                         ' From SRAT'),
             'table_name': 'nhd_quality_tp',
-            'minZoom': 3
+            'minZoom': 3,
+            # Defined in tiler/server.js
+            'legend_mapping': {
+                1: 'Less than 0.03 kg/y',
+                2: 'Less than 0.06 kg/y',
+                3: 'Less than 0.09 kg/y',
+                4: 'Less than 0.12 kg/y',
+                'NA': 'No Data'
+            }
         },
         {
             'code': 'nhd_quality_tss',
             'display': ('Delaware River Basin TSS Concentration' +
                         ' From SRAT'),
             'table_name': 'nhd_quality_tss',
-            'minZoom': 3
+            'minZoom': 3,
+            # Defined in tiler/server.js
+            'legend_mapping': {
+                1: 'Less than 50 kg/y',
+                2: 'Less than 100 kg/y',
+                3: 'Less than 150 kg/y',
+                4: 'Less than 200 kg/y',
+                'NA': 'No Data'
+            }
         },
     ],
 }

--- a/src/mmw/mmw/settings/tr55_settings.py
+++ b/src/mmw/mmw/settings/tr55_settings.py
@@ -1,0 +1,38 @@
+# Here, the keys of this dictionary are NLCD numbers (found in the
+# rasters), and the values of the dictionary are arrays of length two.
+# The first element of each array is the name of the NLCD category in
+# the TR-55 code.  The second string is a short, human-readable name.
+NLCD_MAPPING = {
+    11: ['open_water', 'Open Water'],
+    12: ['perennial_ice', 'Perennial Ice/Snow'],
+    21: ['developed_open', 'Developed, Open Space'],
+    22: ['developed_low', 'Developed, Low Intensity'],
+    23: ['developed_med', 'Developed, Medium Intensity'],
+    24: ['developed_high', 'Developed, High Intensity'],
+    31: ['barren_land', 'Barren Land (Rock/Sand/Clay)'],
+    41: ['deciduous_forest', 'Deciduous Forest'],
+    42: ['evergreen_forest', 'Evergreen Forest'],
+    43: ['mixed_forest', 'Mixed Forest'],
+    52: ['shrub', 'Shrub/Scrub'],
+    71: ['grassland', 'Grassland/Herbaceous'],
+    81: ['pasture', 'Pasture/Hay'],
+    82: ['cultivated_crops', 'Cultivated Crops'],
+    90: ['woody_wetlands', 'Woody Wetlands'],
+    95: ['herbaceous_wetlands', 'Emergent Herbaceous Wetlands']
+}
+
+# The soil rasters contain the numbers 1 through 7 (the keys of this
+# dictionary).  The values of this dictionary are length-two arrays
+# containing two strings.  The first member of each array is the name
+# used for the corresponding soil-type in the TR-55 code.  The second
+# member of each array is a human-readable description of that
+# soil-type.
+SOIL_MAPPING = {
+    1: ['a', 'A - High Infiltration'],
+    2: ['b', 'B - Moderate Infiltration'],
+    3: ['c', 'C - Slow Infiltration'],
+    4: ['d', 'D - Very Slow Infiltration'],
+    5: ['ad', 'A/D - High/Very Slow Infiltration'],
+    6: ['bd', 'B/D - Medium/Very Slow Infiltration'],
+    7: ['cd', 'C/D - Medium/Very Slow Infiltration']
+}

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -18,27 +18,17 @@
     fill: $brand-primary;
   }
 
-  // Official NLCD legend colors for classes selected for display
-  .nlcd-11 { fill: $nlcd-11; }
-  .nlcd-21 { fill: $nlcd-21; }
-  .nlcd-22 { fill: $nlcd-22; }
-  .nlcd-23 { fill: $nlcd-23; }
-  .nlcd-24 { fill: $nlcd-24; }
-  .nlcd-31 { fill: $nlcd-31; }
-  .nlcd-41 { fill: $nlcd-41; }
-  .nlcd-52 { fill: $nlcd-52; }
-  .nlcd-71 { fill: $nlcd-71; }
-  .nlcd-81 { fill: $nlcd-81; }
-  .nlcd-82 { fill: $nlcd-82; }
-  .nlcd-90 { fill: $nlcd-90; }
+  @each $id, $color in $nlcdColors {
+    .nlcd-fill-#{$id} {
+      fill: $color;
+    }
+  }
 
-  .soil-a { fill: $soil-a; }
-  .soil-b { fill: $soil-b; }
-  .soil-c { fill: $soil-c; }
-  .soil-d { fill: $soil-d; }
-  .soil-ad { fill: $soil-ad; }
-  .soil-bd { fill: $soil-bd; }
-  .soil-cd { fill: $soil-cd; }
+  @each $id, $color in $soilColors {
+    .soil-fill-#{$id} {
+      fill: $color;
+    }
+  }
 
   svg {
     width: 450px;

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -7,6 +7,10 @@
   background-color: #fff;
   border-radius: 2px;
   box-shadow: 0 0 6px $black-74;
+
+  .popover > .popover-content {
+      border: #fff 1px solid;
+  }
 }
 
 .layerpicker-layers {
@@ -100,12 +104,8 @@
 
 .layerpicker-legend {
   font-size: 13px;
-  position: absolute;
-  left: 244px;
   width: 200px;
   background-color: #fff;
-  padding: 10px;
-  bottom: 0;
 }
 
 .layerpicker-legenditem {
@@ -115,11 +115,14 @@
 .layerpicker-legendcolor {
   width: 12px;
   height: 12px;
-  margin-right: 6px;
-  background-color: tomato;
   float: left;
   position: relative;
   top: 3px;
+  border: 1px solid #ccc
+}
+
+.layerpicker-legendtext {
+    margin-left: 18px;
 }
 
 #layerpicker-opacity-control {

--- a/src/mmw/sass/pages/_water-balance.scss
+++ b/src/mmw/sass/pages/_water-balance.scss
@@ -345,136 +345,24 @@
             text-align: center;
           }
 
-          &.nlcd-11 {
-            border-color: $nlcd-11;
+          @each $id, $color in $nlcdColors {
+            &.nlcd-#{$id} {
+                border-color: $color;
 
-            &:after {
-              background-color: $nlcd-11;
+                &:after {
+                  background-color: $color;
+                }
             }
           }
 
-          &.nlcd-21 {
-            border-color: $nlcd-21;
+          @each $id, $color in $soilColors {
+            &.soil-#{$id} {
+                border-color: $color;
 
-            &:after {
-              background-color: $nlcd-21;
-            }
-          }
-
-          &.nlcd-22 {
-            border-color: $nlcd-22;
-
-            &:after {
-              background-color: $nlcd-22;
-            }
-          }
-
-          &.nlcd-23 {
-            border-color: $nlcd-23;
-
-            &:after {
-              background-color: $nlcd-23;
-            }
-          }
-
-          &.nlcd-24 {
-            border-color: $nlcd-24;
-
-            &:after {
-              background-color: $nlcd-24;
-            }
-          }
-
-          &.nlcd-31 {
-            border-color: $nlcd-31;
-
-            &:after {
-              background-color: $nlcd-31;
-            }
-          }
-
-          &.nlcd-41 {
-            border-color: $nlcd-41;
-
-            &:after {
-              background-color: $nlcd-41;
-            }
-          }
-
-          &.nlcd-52 {
-            border-color: $nlcd-52;
-
-            &:after {
-              background-color: $nlcd-52;
-            }
-          }
-
-          &.nlcd-71 {
-            border-color: $nlcd-71;
-
-            &:after {
-              background-color: $nlcd-71;
-              color: #333;
-            }
-          }
-
-          &.nlcd-81 {
-            border-color: $nlcd-81;
-
-            &:after {
-              background-color: $nlcd-81;
-              color: #333;
-            }
-          }
-
-          &.nlcd-82 {
-            border-color: $nlcd-82;
-
-            &:after {
-              background-color: $nlcd-82;
-            }
-          }
-
-          &.nlcd-90 {
-            border-color: $nlcd-90;
-
-            &:after {
-              background-color: $nlcd-90;
-              color: #333;
-            }
-          }
-
-          &.soil-a {
-            border-color: $soil-a;
-
-            &:after {
-              background-color: $soil-a;
-              color: #333;
-            }
-          }
-
-          &.soil-b {
-            border-color: $soil-b;
-
-            &:after {
-              background-color: $soil-b;
-              color: #333;
-            }
-          }
-
-          &.soil-c {
-            border-color: $soil-c;
-
-            &:after {
-              background-color: $soil-c;
-            }
-          }
-
-          &.soil-d {
-            border-color: $soil-d;
-
-            &:after {
-              background-color: $soil-d;
+                &:after {
+                  background-color: $color;
+                  color: #333;
+                }
             }
           }
         }
@@ -519,75 +407,6 @@
   border: 0;
   background-color: $brand-primary;
   border-radius: 0;
-
-  &.nlcd-11 {
-    background-color: $nlcd-11;
-  }
-
-  &.nlcd-21 {
-    background-color: $nlcd-21;
-  }
-
-  &.nlcd-22 {
-    background-color: $nlcd-22;
-  }
-
-  &.nlcd-23 {
-    background-color: $nlcd-23;
-  }
-
-  &.nlcd-24 {
-    background-color: $nlcd-24;
-  }
-
-  &.nlcd-31 {
-    background-color: $nlcd-31;
-  }
-
-  &.nlcd-41 {
-    background-color: $nlcd-41;
-  }
-
-  &.nlcd-52 {
-    background-color: $nlcd-52;
-  }
-
-  &.nlcd-71 {
-    background-color: $nlcd-71;
-    color: #333;
-  }
-
-  &.nlcd-81 {
-    background-color: $nlcd-81;
-    color: #333;
-  }
-
-  &.nlcd-82 {
-    background-color: $nlcd-82;
-  }
-
-  &.nlcd-90 {
-    background-color: $nlcd-90;
-    color: #333;
-  }
-
-  &.soil-a {
-    background-color: $soil-a;
-    color: #333;
-  }
-
-  &.soil-b {
-    background-color: $soil-b;
-    color: #333;
-  }
-
-  &.soil-c {
-    background-color: $soil-c;
-  }
-
-  &.soil-d {
-    background-color: $soil-d;
-  }
 }
 
 .popover-content {

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -43,28 +43,78 @@ $sidebar-tab-subheader-height: 60px;
 //Border-radius
 $radius-sm: 2px;
 
-//NLCD
-$nlcd-11: #5475A8;
-$nlcd-21: #E8D1D1;
-$nlcd-22: #E29E8C;
-$nlcd-23: #ff0000;
-$nlcd-24: #B50000;
-$nlcd-31: #D2CDC0;
-$nlcd-41: #85C77E;
-$nlcd-52: #DCCA8F;
-$nlcd-71: #FDE9AA;
-$nlcd-81: #FBF65D;
-$nlcd-82: #CA9146;
-$nlcd-90: #C8E6F8;
+$nlcdColors: (
+    11: #5475A8,
+    12: #FFFFFF,
+    21: #E8D1D1,
+    22: #E29E8C,
+    23: #ff0000,
+    24: #B50000,
+    31: #D2CDC0,
+    41: #85C77E,
+    42: #38814E,
+    43: #D4E7B0,
+    52: #DCCA8F,
+    71: #FDE9AA,
+    81: #FBF65D,
+    82: #CA9146,
+    90: #C8E6F8,
+    95: #64B3D5,
+);
+
+@each $id, $color in $nlcdColors {
+  .nlcd-#{$id} {
+    background-color: $color;
+  }
+}
+
 
 //Hydrologic Soil Groups
-$soil-a: #ffffd4;
-$soil-b: #fee391;
-$soil-c: #fec44f;
-$soil-d: #8c2d04;
-$soil-ad: #fe9929;
-$soil-bd: #ec7014;
-$soil-cd: #cc4c02;
+$soilColors: (
+    a: #ffffd4,
+    b: #fee391,
+    c: #fec44f,
+    d: #8c2d04,
+    ad: #fe9929,
+    bd: #ec7014,
+    cd: #cc4c02,
+);
+
+@each $id, $color in $soilColors {
+  .soil-#{$id} {
+    background-color: $color;
+  }
+}
+
+// From tiler/styles.mss
+$streamWaterQualityColors: (
+    0: #1a9641,
+    1: #a6d96a,
+    2: #ffffbf,
+    3: #fdae61,
+    4: #d7191c,
+    NA: #9E9E9E,
+);
+
+@each $id, $color in $streamWaterQualityColors {
+  .stream-#{$id} {
+    background-color: $color;
+  }
+}
+
+$catchmentWaterQualityColors: (
+    1: #A0A0A0,
+    2: #888888,
+    3: #707070,
+    4: #484848,
+    5: #202020,
+);
+
+@each $id, $color in $catchmentWaterQualityColors {
+  .catchment-#{$id} {
+    background-color: $color;
+  }
+}
 
 //Type
 $font-family: 'Roboto', helvetica, arial, sans-serif;

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -17,6 +17,7 @@ var dbUser = process.env.MMW_DB_USER,
     stackType = process.env.MMW_STACK_TYPE,
     rollbarAccessToken = process.env.ROLLBAR_SERVER_SIDE_ACCESS_TOKEN;
 
+// Updates to steps should also be made to the legend_mappings in mmw/settings/layer_settings
 var NHD_QUALITY_TSS_MAP = {
     'L1': [0,50],
     'L2': [50,100],
@@ -105,7 +106,7 @@ var interactivity = {
                 stream_order = 5;
             }
         }
-        
+
         var caseSql = function(mapping, field) {
             var sql = []
             for (var category in mapping) {
@@ -141,7 +142,7 @@ var interactivity = {
         } else {
             return '(SELECT geom, stream_order FROM ' + tableName +
               ' WHERE stream_order >= ' + stream_order + ') as q';
-        }     
+        }
     },
 
     getSqlForDRBCatchmentByTableId = function(tableId) {

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -35,6 +35,9 @@
   }
 }
 
+// Updates to steps should also be made to the legend_mappings
+// in mmw/settings/layer_settings
+// Any updates to colors must also be made in _variables.scss
 @drb_catchment_step_one_color: #A0A0A0;
 @drb_catchment_step_two_color: #888888;
 @drb_catchment_step_three_color: #707070;
@@ -103,6 +106,7 @@
     }
 }
 
+// Any updates to colors should also be made in _variables.scss
 @streamColor: #1562A9;
 @wtrQualColor0: #1a9641;
 @wtrQualColor1: #a6d96a;


### PR DESCRIPTION
## Overview

Certain layers display legends when you hover over their info icons.

The first commit sets up the `layer_settings` to gather all necessary info for the legends. 
- For NLCD and Soils there were already mappings for `id`s and titles, but they were buried in `geoprocessing.py`  – I've moved them into their own settings file so we can use them in `geoprocessing` and `layer_settings`
- For the stream and catchment layers, there's no preexisting text for the legend. `tiler/styles.mss` and `tiler/server.js` define the ranges for each step of the colors. I've transcribed them directly into `layer_settings` and added comments to `tiler/` that they should be kept synced up

The second commit has the app consume the new `layer_settings`. It...
- reorganizes the way we store the nlcd and soil colors into a `map` to better leverage sass
- adds sass maps for the stream and catchment colors
- adds a new `LayerPickerLegendView`

Connects #1674 

### Demo
![screen shot 2017-02-17 at 5 11 02 pm](https://cloud.githubusercontent.com/assets/7633670/23085484/0821d006-f536-11e6-92ae-25121e2f7195.png)
![screen shot 2017-02-17 at 5 11 09 pm](https://cloud.githubusercontent.com/assets/7633670/23085485/0825c3aa-f536-11e6-8349-3fca23661cf1.png)
![screen shot 2017-02-17 at 5 26 29 pm](https://cloud.githubusercontent.com/assets/7633670/23085522/3fe3c30a-f536-11e6-87f1-83914d24ab49.png)

### Notes
- Jeff doesn't want this to touch the bottom
<img width="348" alt="screen shot 2017-02-17 at 5 10 55 pm" src="https://cloud.githubusercontent.com/assets/7633670/23085482/081e66d2-f536-11e6-81aa-5fcc35ed26b1.png">

## Testing Instructions
- pull this branch, `./scripts/bundle.sh`
- Confirm there are only "i" icons for layers with legends
- Confirm hovering over the "i" shows a legend
