### PR TITLE
Update RWD volume snapshot

### DIFF
--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -63,7 +63,7 @@
             "ami_block_device_mappings": [
                 {
                     "device_name": "/dev/sdf",
-                    "snapshot_id": "snap-05eb65ba5d3f6151b",
+                    "snapshot_id": "snap-02a616c405bf39079",
                     "volume_type": "gp2",
                     "delete_on_termination": true
                 }


### PR DESCRIPTION
## Overview

This volume contains missing shapefiles from MSsub47.zip.

Connects https://github.com/WikiWatershed/rapid-watershed-delineation/issues/65

## Testing Instructions

* Delineate a point (Delineate Watershed > Continental US Medium Resolution) downstream from Dubuque, Iowa
* Verify that a watershed is generated

![image](https://cloud.githubusercontent.com/assets/43062/23133197/5006da72-f75e-11e6-8040-74649fa4ec7f.png)

