### PR TITLE
Fix/stream symbology

### DIFF
--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -103,6 +103,8 @@ var interactivity = {
                 stream_order = 6;
             } else if (zoom <= 8) {
                 stream_order = 5;
+            } else if (zoom <= 9) {
+                stream_order = 4;
             }
         }
         

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -221,7 +221,7 @@
     line-width: 5.0 * @zoomBase;
   }
   [stream_order=3] {
-    line-width: 4.0 * @zoomBase;
+    line-width: 3.0 * @zoomBase;
   }
 }
 

--- a/src/tiler/styles.mss
+++ b/src/tiler/styles.mss
@@ -155,7 +155,7 @@
   }
 }
 
-#drb_streams_50[zoom<=4],
+
 #nhdflowline[zoom<=4],
 #nhd_quality_tp[zoom<=4],
 #nhd_quality_tn[zoom<=4],
@@ -171,7 +171,7 @@
   }
 }
 
-#drb_streams_50[zoom>=5][zoom<=6],
+
 #nhdflowline[zoom>=5][zoom<=6],
 #nhd_quality_tp[zoom>=5][zoom<=6],
 #nhd_quality_tn[zoom>=5][zoom<=6],
@@ -187,7 +187,7 @@
   }
 }
 
-#drb_streams_50[zoom>=7][zoom<=8],
+
 #nhdflowline[zoom>=7][zoom<=8],
 #nhd_quality_tp[zoom>=7][zoom<=8],
 #nhd_quality_tn[zoom>=7][zoom<=8],
@@ -206,7 +206,7 @@
   }
 }
 
-#drb_streams_50[zoom>=9][zoom<=10],
+
 #nhdflowline[zoom>=9][zoom<=10],
 #nhd_quality_tp[zoom>=9][zoom<=10],
 #nhd_quality_tn[zoom>=9][zoom<=10],
@@ -225,7 +225,7 @@
   }
 }
 
-#drb_streams_50[zoom>=11][zoom<=12],
+
 #nhdflowline[zoom>=11][zoom<=12],
 #nhd_quality_tp[zoom>=11][zoom<=12],
 #nhd_quality_tn[zoom>=11][zoom<=12],
@@ -251,7 +251,7 @@
 }
 
 
-#drb_streams_50[zoom>=13],
+
 #nhdflowline[zoom>=13],
 #nhd_quality_tp[zoom>=13],
 #nhd_quality_tn[zoom>=13],
@@ -270,5 +270,100 @@
   }
   [stream_order<=1][stream_order>=0] {
     line-width:  5.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom<=4]{
+  [stream_order=10] {
+    line-width: 3.0 * @zoomBase;
+  }
+  [stream_order=9] {
+    line-width: 3.0 * @zoomBase;
+  }
+  [stream_order<=8] {
+    line-width: 2.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom>=5][zoom<=6]{
+  [stream_order=10] {
+    line-width: 4.0 * @zoomBase;
+  }
+  [stream_order=9] {
+    line-width: 3.0 * @zoomBase;
+  }
+  [stream_order<=8] {
+    line-width: 2.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom>=7][zoom<=8]{
+  [stream_order>=9] {
+    line-width: 7.0 * @zoomBase;
+  }
+  [stream_order<=8][stream_order>=7] {
+    line-width: 4.0 * @zoomBase;
+  }
+  [stream_order<=6] {
+    line-width: 3.0 * @zoomBase;
+  }
+  [stream_order=5] {
+    line-width: 2.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom>=9][zoom<=10]{
+  [stream_order>=9] {
+    line-width: 10.0 * @zoomBase;
+  }
+  [stream_order<=8][stream_order>=6] {
+    line-width: 5.0 * @zoomBase;
+  }
+  [stream_order<=5][stream_order>=4] {
+    line-width: 3.0 * @zoomBase;
+  }
+  [stream_order=3] {
+    line-width: 2.0 * @zoomBase;
+  }
+}
+
+#drb_streams_50[zoom>=11][zoom<=12] {
+  [stream_order>=9] {
+    line-width: 12.0 * @zoomBase;
+  }
+  [stream_order<=8][stream_order>=6] {
+    line-width: 10.0 * @zoomBase;
+  }
+  [stream_order<=5][stream_order>=4] {
+    line-width:  6.0 * @zoomBase;
+  }
+  [stream_order=3] {
+    line-width:  5.0 * @zoomBase;
+  }
+  [stream_order=2] {
+    line-width:  4.0 * @zoomBase;
+  }
+  [stream_order<=1][stream_order>=0] {
+    line-width:  3.0 * @zoomBase;
+  }
+}
+#drb_streams_50[zoom>=13]{
+  [stream_order>=9] {
+    line-width: 14.0 * @zoomBase;
+  }
+  [stream_order<=8][stream_order>=6] {
+    line-width: 11.0 * @zoomBase;
+  }
+  [stream_order<=5][stream_order>=4] {
+    line-width:  8.0 * @zoomBase;
+  }
+  [stream_order=3] {
+    line-width:  5.0 * @zoomBase;
+  }
+  [stream_order=2] {
+    line-width:  4.0 * @zoomBase;
+  }
+  [stream_order<=1][stream_order>=0] {
+    line-width:  3.0 * @zoomBase;
   }
 }


### PR DESCRIPTION
## Overview
NHD river segments were too visually dense at zoom levels 9 and 10. Also, DRB river segments did not match visually to equivalent NHD river segments.

In first commit, edited server.js file to NOT render stream_order 3 streams at zoom level 9. Edited styles.mss to reduce line width for stream_order 3.

In second commit, attempted to reduce line width of DRB river segments to an equivalent width as NHD. Existing style rules were equivalent for NHD and DRB river segements. Separated them in styles.mss and reduced the line width equivalent to approximately reducing stream order by ~3. Should be visually checked to test.

I do not have a development environment to test this on.

Connects #1704 

## Testing Instructions

 * Pull this branch
 * Visually inspect zoom level 8, 9, and 10 of NHD river overlay for improvement: fewer segments at 9 and lighter segments at 10.
 * Visually inspect differences between DRB and NHD where segments overlap. Should be more similar than before, but may need more adjusting.
