### PR TITLE
Add introductory text to model results

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
@@ -1,1 +1,6 @@
+<p class="result-text text-muted">
+    Average annual loads
+    from 30-years of daily fluxes
+    simulated by the GWLF-E (MapShed) model.
+</p>
 <div class="quality-table-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/runoff/templates/result.html
@@ -1,3 +1,8 @@
+<p class="result-text text-muted">
+    Average monthly water fluxes in centimeters
+    from 30-years of daily water balance
+    simulated by the GWLF-E (MapShed) model.
+</p>
 <div class="runoff-selector-region"></div>
 <div class="runoff-chart-region"></div>
 <div class="runoff-table-region"></div>

--- a/src/mmw/js/src/modeling/tr55/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/result.html
@@ -1,2 +1,6 @@
+<p class="result-text text-muted">
+    Total loads delivered in a 24-hour hypothetical storm event
+    as simulated by EPA's STEP-L model algorithms.
+</p>
 <div class="quality-chart-region"></div>
 <div class="quality-table-region"></div>

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
@@ -1,2 +1,6 @@
+<p class="result-text text-muted">
+    Results of a 24-hour hypothetical storm event
+    as simulated by SLAMM and TR-55 model algorithms.
+</p>
 <div class="runoff-chart-region"></div>
 <div class="runoff-table-region"></div>

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -49,6 +49,11 @@
     height: 100%;
     width: 100%;
 
+    .result-text {
+        font-size: 0.8rem;
+        margin-bottom: 20px;
+    }
+
     .mean-flow {
       font-size: 16px;
     }


### PR DESCRIPTION
## Overview

Adds introductory text to each type of result: Runoff and Water Quality for TR55, and Hydrology and Water Quality for GWLF-E.

Connects #1690 

### Demo

![image](https://cloud.githubusercontent.com/assets/1430060/23144158/bca9b6b0-f793-11e6-8214-b5fe544138c5.png)

![image](https://cloud.githubusercontent.com/assets/1430060/23144167/cc074adc-f793-11e6-8d8e-556cdb22599f.png)

![image](https://cloud.githubusercontent.com/assets/1430060/23144140/a20025ec-f793-11e6-8019-79304662051f.png)

![image](https://cloud.githubusercontent.com/assets/1430060/23144149/adb29abe-f793-11e6-9615-0ba586ccde4c.png)

### Notes

In this current iteration, I've copied the text as exactly specified by @ajrobbins on #1690, but would recommend considering the following changes:

 * Replace "SLAMM & TR55" with "SLAMM and TR55". The ampersand should be reserved for when the pairing is a proper noun, such as Fox & Hound or Lord & Taylor.
 * Is it "TR55" or "TR-55"? I'm not sure if we've ever referred to it in body copy before.
 * Replace "in cm (= 10 L per square meter)" with "in cm (equal to 10 L/m²)", to reuse unit conventions applied elsewhere in the application, and avoid mathematical operators in sentences.
 * This is the first time we're using "MapShed" in body copy. Should we call it that, or leave it at GWLF-E, which is the "official" name?

## Testing Instructions

 * Check out this branch and bundle scripts `./scripts/bundle.sh --debug`
 * Make a new TR55 project or load an existing one. Ensure text is above each result type.
 * Do the same for GWLF-E.
 * Ensure there are no typos.

Also tagging @ajrobbins to take a look.