### PR TITLE
Add global navigation static components

### DIFF
--- a/src/mmw/img/global-navigation-arrow.svg
+++ b/src/mmw/img/global-navigation-arrow.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="6px" height="16px" viewBox="0 0 6 16" style="enable-background:new 0 0 6 16;" xml:space="preserve">
+<polyline style="fill:none;stroke:#FFFFFF;stroke-linecap:round;stroke-linejoin:bevel;" points="1,0.5 5,7.86 5,8.14 1,15.5 "/>
+</svg>

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -1,7 +1,12 @@
 <nav id="app-header" class="navbar-watershed">
     <div class="brand">
-        <a href="#">Model My Watershed: {{ current_page_title }}</a>
+        <a href="#">Model My Watershed</a>
     </div>
+    <ul class="global-navigation">
+        <li class="global-navigation-item active visible"><button>Select Area</button></li>
+        <li class="global-navigation-item visible"><button>Analyze</button></li>
+        <li class="global-navigation-item"><button>Model</button></li>
+    </ul>
     <div class="navigation">
         <ul class="main">
             <li class="header-link"><a target="_blank" href="http://www.stroudcenter.org/"><img src="/static/images/stroud-logo.png" alt="Logo" /></a></li>

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -18,7 +18,7 @@ header {
       float: left;
       line-height: $height-lg;
       font-size: 0.7rem;
-      font-weight: 400;
+      font-weight: 700;
       color: $paper;
 
       &:hover {

--- a/src/mmw/sass/components/_global-navigation.scss
+++ b/src/mmw/sass/components/_global-navigation.scss
@@ -1,0 +1,52 @@
+.modal, .modal-backdrop {
+  display: none !important;
+}
+
+.global-navigation {
+  float: left;
+  list-style: none;
+  padding: 0;
+  margin-left: 18px;
+  @include clearfix;
+}
+
+.global-navigation-item {
+  float: left;
+  position: relative;
+  &:after {
+    position: absolute;
+    content: '';
+    height: 16px;
+    width: 6px;
+    background-image: url(/static/images/global-navigation-arrow.svg);
+    top: 14px;
+    opacity: 0.5;
+    left: -11px;
+  }
+  button {
+    background: none;
+    background-color: transparent;
+    color: #fff;
+    border: 0;
+    font-size: 0.7rem;
+    line-height: 44px;
+    padding: 0 16px 0 0;
+    &::-moz-focus-inner {
+      border: 0;
+      padding: 0;
+    }
+  }
+  &:not(.visible) {
+    display: none;
+  }
+  &:not(.active) {
+    button {
+      opacity: 0.5;
+    }
+  }
+  &.active {
+    button {
+      font-weight: 500;
+    }
+  }
+}

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -59,6 +59,7 @@
   "components/slider-native",
   "components/tables",
   "components/observations",
+  "components/global-navigation",
   "components/sidebar";
 
 /**


### PR DESCRIPTION
## Overview

Add static components for breadcrumb/global navigation.

Connects #XXX

### Demo

Here's a screenshot:
![image](https://cloud.githubusercontent.com/assets/1809908/23182136/719a9268-f845-11e6-9f8f-9cc0bf6a651f.png)

### Notes

When a new project is started, only "Select Area" should be visible. Once the user enters the "Analyze" screen, that breadcrumb should become visible as well. When the user researches "Model", they should see "Select Area", "Analyze", and "Model". Add the `.active` class on the active step. So if the user is on the "Analyze" screen, "Analyze" should be active.
