### PR TITLE
Wire up global navigation

### DIFF
--- a/src/mmw/img/global-navigation-arrow.svg
+++ b/src/mmw/img/global-navigation-arrow.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="6px" height="16px" viewBox="0 0 6 16" style="enable-background:new 0 0 6 16;" xml:space="preserve">
+<polyline style="fill:none;stroke:#FFFFFF;stroke-linecap:round;stroke-linejoin:bevel;" points="1,0.5 5,7.86 5,8.14 1,15.5 "/>
+</svg>

--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -4,6 +4,7 @@ var App = require('../app'),
     router = require('../router').router,
     views = require('./views'),
     models = require('./models'),
+    utils = require('../core/utils'),
     settings = require('../core/settings');
 
 var AnalyzeController = {
@@ -54,7 +55,11 @@ var AnalyzeController = {
                 collection: viewModels
             });
 
-        App.state.set('current_page_title', 'Geospatial Analysis');
+        App.state.set({
+            'active_page': utils.analyzePageTitle,
+            'was_analyze_visible': true,
+            'was_compare_visible': false,
+        });
 
         App.rootView.sidebarRegion.show(analyzeResults);
     },

--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -6,6 +6,7 @@ var _ = require('lodash'),
     views = require('./views'),
     modelingModels = require('../modeling/models.js'),
     modelingControls = require('../modeling/controls'),
+    coreUtils = require('../core/utils'),
     synchronizer = modelingControls.PrecipitationSynchronizer;
 
 var CompareController = {
@@ -46,7 +47,10 @@ var CompareController = {
         }
         // else -- this case is caught by the backend and raises a 404
 
-        App.state.set('current_page_title', 'Compare');
+        App.state.set({
+            'active_page': coreUtils.comparePageTitle,
+            'was_compare_visible': true,
+        });
     },
 
     compareCleanUp: function() {

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -376,7 +376,10 @@ var AreaOfInterestModel = GeoModel.extend({
 
 var AppStateModel = Backbone.Model.extend({
     defaults: {
-        current_page_title: 'Select Area of Interest'
+        active_page: 'Select Area Of Interest',
+        was_analyze_visible: false,
+        was_model_visible: false,
+        was_compare_visible: false,
     }
 });
 

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -1,7 +1,13 @@
 <nav id="app-header" class="navbar-watershed">
     <div class="brand">
-        <a href="#">Model My Watershed: {{ current_page_title }}</a>
+        <a href="#">Model My Watershed</a>
     </div>
+    <ul class="global-navigation">
+        <li class="global-navigation-item {{selectAreaNavClasses}}"><button  data-url="/">Select Area</button></li>
+        <li class="global-navigation-item {{analyzeNavClasses}}"><button data-url="/analyze">Analyze</button></li>
+        <li class="global-navigation-item {{modelNavClasses}}"><button  data-url="/project">Model</button></li>
+        <li class="global-navigation-item {{compareNavClasses}}"><button  data-url="/project/compare">Compare</button></li>
+    </ul>
     <div class="navigation">
         <ul class="main">
             <li class="header-link"><a target="_blank" href="http://www.stroudcenter.org/"><img src="/static/images/stroud-logo.png" alt="Logo" /></a></li>

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -15,7 +15,8 @@ var $ = require('jquery'),
     models = require('./models'),
     AppRouter = require('../router').AppRouter,
     settings = require('./settings'),
-    testUtils = require('./testUtils');
+    testUtils = require('./testUtils'),
+    coreUtils = require('./utils');
 
 var TEST_SHAPE = {
     'type': 'Feature',
@@ -225,16 +226,29 @@ describe('Core', function() {
         });
 
         describe('HeaderView', function() {
-            it('shows the current page', function() {
+            it('shows the current page as active', function() {
                 var appState = new models.AppStateModel({
-                        current_page_title: 'Test Page'
+                        active_page: coreUtils.selectAreaPageTitle,
                     }),
                     header = new views.HeaderView({
                         model: App.user,
                         appState: appState
                     }).render();
 
-                assert.include(header.$el.find('.brand').text(), 'Test Page');
+                assert.include(header.$el.find('.global-navigation-item.active')
+                    .find('button').text(), 'Select Area');
+            });
+            it('shows past active pages as visible', function() {
+                var appState = new models.AppStateModel({
+                        active_page: coreUtils.selectAreaPageTitle,
+                        was_analyze_visible: true,
+                    }),
+                    header = new views.HeaderView({
+                        model: App.user,
+                        appState: appState
+                    }).render();
+                assert.include(header.$el.find('.global-navigation-item.visible').not('.active')
+                    .find('button').text(), 'Analyze');
             });
         });
     });

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -17,6 +17,14 @@ var utils = {
         boundary_layers: 2
     },
 
+    selectAreaPageTitle: 'Choose Area of Interest',
+
+    analyzePageTitle: 'Geospatial Analysis',
+
+    comparePageTitle: 'Compare',
+
+    projectsPageTitle: 'Projects',
+
     filterNoData: function(data) {
         if (data && !isNaN(data) && isFinite(data)) {
             return data.toFixed(3);

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -8,7 +8,9 @@ var App = require('../app'),
     settings = require('../core/settings'),
     modelingModels = require('../modeling/models'),
     models = require('./models'),
-    _ = require('underscore');
+    _ = require('underscore'),
+    utils = require('../core/utils'),
+    models = require('./models');
 
 var DrawController = {
     drawPrepare: function() {
@@ -50,7 +52,7 @@ var DrawController = {
             App.map.setDrawWithBarSize(true);
         }
 
-        App.state.set('current_page_title', 'Choose Area of Interest');
+        App.state.set('active_page', utils.selectAreaPageTitle);
     },
 
     drawCleanUp: function() {

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -569,6 +569,11 @@ var ResetDrawView = Marionette.ItemView.extend({
         utils.cancelDrawing(App.getLeafletMap());
         clearAoiLayer();
         clearBoundaryLayer(this.model);
+        App.state.set({
+            'was_analyze_visible': false,
+            'was_model_visible': false,
+            'was_compare_visible': false,
+        });
     }
 });
 

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -70,7 +70,7 @@ var ModelingController = {
                     App.currentProject = null;
                 });
 
-            App.state.set('current_page_title', 'Modeling');
+            App.state.set('active_page', 'Modeling');
         } else {
             if (App.currentProject && settings.get('activityMode')) {
                 project = App.currentProject;
@@ -104,7 +104,7 @@ var ModelingController = {
 
                 finishProjectSetup(project, lock);
             }
-            setPageTitle();            
+            setPageTitle();
         }
     },
 
@@ -270,7 +270,10 @@ function setPageTitle() {
         modelPackages = settings.get('model_packages'),
         modelPackageDisplayName = _.find(modelPackages, {name: modelPackageName}).display_name;
 
-    App.state.set('current_page_title', modelPackageDisplayName);
+    App.state.set({
+        'active_page': modelPackageDisplayName,
+        'was_model_visible': true,
+    });
 }
 
 function projectCleanUp() {

--- a/src/mmw/js/src/projects/controllers.js
+++ b/src/mmw/js/src/projects/controllers.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var App = require('../app'),
-    views = require('./views');
+    views = require('./views'),
+    coreUtils= require('../core/utils');
 
 var ProjectsController = {
     projects: function() {
@@ -9,11 +10,14 @@ var ProjectsController = {
             new views.ProjectsView()
         );
 
-        App.state.set('current_page_title', 'Projects');
+        App.rootView.layerPickerRegion.empty();
+
+        App.state.set('active_page', coreUtils.projectsPageTitle);
     },
 
     projectsCleanUp: function() {
         App.rootView.footerRegion.empty();
+        App.showLayerPicker();
     }
 };
 

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -18,7 +18,7 @@ header {
       float: left;
       line-height: $height-lg;
       font-size: 0.7rem;
-      font-weight: 400;
+      font-weight: 700;
       color: $paper;
 
       &:hover {

--- a/src/mmw/sass/components/_global-navigation.scss
+++ b/src/mmw/sass/components/_global-navigation.scss
@@ -1,0 +1,49 @@
+.global-navigation {
+  float: left;
+  list-style: none;
+  padding: 0;
+  margin-left: 18px;
+  margin-bottom: 0px;
+  @include clearfix;
+}
+
+.global-navigation-item {
+  float: left;
+  position: relative;
+  &:after {
+    position: absolute;
+    content: '';
+    height: 16px;
+    width: 6px;
+    background-image: url(/static/images/global-navigation-arrow.svg);
+    top: 14px;
+    opacity: 0.5;
+    left: -11px;
+  }
+  button {
+    background: none;
+    background-color: transparent;
+    color: #fff;
+    border: 0;
+    font-size: 0.7rem;
+    line-height: 44px;
+    padding: 0 16px 0 0;
+    &::-moz-focus-inner {
+      border: 0;
+      padding: 0;
+    }
+  }
+  &:not(.visible) {
+    display: none;
+  }
+  &:not(.active) {
+    button {
+      opacity: 0.5;
+    }
+  }
+  &.active {
+    button {
+      font-weight: 500;
+    }
+  }
+}

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -60,6 +60,7 @@
   "components/tables",
   "components/observations",
   "components/sidebar",
+  "components/global-navigation",
   "components/layerpicker";
 
 /**


### PR DESCRIPTION
## Overview

Wires up Jeff's new breadcrumb navigation from #1700 

Connects #1702 

### Demo

![bread](https://cloud.githubusercontent.com/assets/7633670/23322620/d13235e0-fab2-11e6-8249-410dd962f952.gif)

### Notes

- I didn't include Compare and Projects, as they weren't in the prototype

- If you navigate to Model, then navigate back to Select Area or Analyze, then try to navigate Model you end up in a bad state:
<img width="1278" alt="screen shot 2017-02-24 at 4 36 06 pm" src="https://cloud.githubusercontent.com/assets/7633670/23322637/e0f74934-fab2-11e6-9c07-d5299b7c334b.png">
  - As a quick fix to this, the Model breadcrumb only appears when you're actually in one of the model views

## Testing Instructions

 * `./scripts/bundle.sh --vendor` (for the svg >)
 * `./scripts/bundle.sh`
 * Navigate around the app with the new header breadcrumbs
