### PR TITLE
Fix point null ref exception when rwdClickedPoint's undefined

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -423,7 +423,7 @@ var WatershedDelineationView = Marionette.ItemView.extend({
             itemName = $item.text(),
             snappingOn = !!$item.data('snapping-on'),
             dataSource = $item.data('data-source'),
-            rwdClickedPoint;
+            rwdClickedPoint = null;
 
         clearAoiLayer();
         this.model.set('pollError', false);
@@ -456,7 +456,9 @@ var WatershedDelineationView = Marionette.ItemView.extend({
                 displayAlert(message, modalModels.AlertTypes.warn);
             })
             .always(function() {
-                map.removeLayer(rwdClickedPoint);
+                if (rwdClickedPoint) {
+                    map.removeLayer(rwdClickedPoint);
+                }
                 self.model.enableTools();
             });
     },


### PR DESCRIPTION
## Overview

This PR fixes a null reference exception described in #1708 whereby the app would try to remove a null original clicked RWD point marker from a map.

To fix it, I added a guard to check that the marker had actually been created before removing it in the `.always` clause.

Connects #1708 

## Testing Instructions

 * rebuild this branch then follow the steps described in the first issue reported in #1708 to verify that this fixes the bug

Going to work on another branch to fix the second issue noted there.
