### PR TITLE
Clear RWD marker on clicking reset

### DIFF
--- a/src/mmw/js/src/draw/models.js
+++ b/src/mmw/js/src/draw/models.js
@@ -20,6 +20,13 @@ var ToolbarModel = Backbone.Model.extend({
 
     disableTools: function() {
         this.set('toolsEnabled', false);
+    },
+
+    clearRwdClickedPoint: function(map) {
+        if (map && this.has('rwd-original-point')) {
+            map.removeLayer(this.get('rwd-original-point'));
+            this.unset('rwd-original-point');
+        }
     }
 });
 

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -422,8 +422,7 @@ var WatershedDelineationView = Marionette.ItemView.extend({
             $item = $(e.currentTarget),
             itemName = $item.text(),
             snappingOn = !!$item.data('snapping-on'),
-            dataSource = $item.data('data-source'),
-            rwdClickedPoint = null;
+            dataSource = $item.data('data-source');
 
         clearAoiLayer();
         this.model.set('pollError', false);
@@ -434,11 +433,12 @@ var WatershedDelineationView = Marionette.ItemView.extend({
                 return validatePointWithinDataSourceBounds(latlng, dataSource);
             })
             .then(function(latlng) {
-                // Assign `rwdClickedPoint` so it's in scope to be removed from
-                // the map when the deferred chain completes.
-                rwdClickedPoint = L.marker(latlng, {
+                // Set `rwd-original-point` in the model so it can be
+                // removed when the deferred chain completes.
+                var rwdClickedPoint = L.marker(latlng, {
                     icon: drawUtils.createRwdMarkerIcon('original-point')
                 }).bindPopup('Original clicked outlet point');
+                self.model.set('rwd-original-point', rwdClickedPoint);
                 rwdClickedPoint.addTo(map);
                 return latlng;
             })
@@ -456,9 +456,8 @@ var WatershedDelineationView = Marionette.ItemView.extend({
                 displayAlert(message, modalModels.AlertTypes.warn);
             })
             .always(function() {
-                if (rwdClickedPoint) {
-                    map.removeLayer(rwdClickedPoint);
-                }
+                self.model.clearRwdClickedPoint(map);
+
                 self.model.enableTools();
             });
     },
@@ -568,6 +567,7 @@ var ResetDrawView = Marionette.ItemView.extend({
     },
 
     resetDrawingState: function() {
+        this.model.clearRwdClickedPoint(App.getLeafletMap());
         this.rwdTaskModel.reset();
         this.model.set({
             polling: false,


### PR DESCRIPTION
## Overview

This is a UI fix to address an issue noted in #1708 whereby the RWD original clicked point marker won't clear on clicking reset. This one's just a quick UI fix which finds and clears the marker when reset's clicked.

I think the underlying issue warrants some changes to enable rejecting Deferred objects issued by `TaskModels`; it seems as if clicking "Reset" doesn't always call `.reject()`, so RWD jobs continue running even after reset.

Going to investigate that issue a bit more, but thought I'd put this up to address the UI issues.

Connects #1708 

## Testing Instructions

 * rebuild this branch and view in the browser, then open the console
 * start RWD then click reset and verify that the marker disappears. Repeat a few times to ensure everything stays in sync
 * start RWD and let it complete, then verify that the resulting shape has only two markers: one for the origin point, one for the outlet point
