### PR TITLE
Remove LatLng display

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -19,7 +19,6 @@ var L = require('leaflet'),
     LayerControl = require('./layerControl'),
     OpacityControl = require('./opacityControl'),
     SidebarToggleControl = require('./sidebarToggleControl'),
-    LatLngControl = require('./latLngControl'),
     VizerLayers = require('./vizerLayers');
 
 require('leaflet.locatecontrol');
@@ -226,8 +225,6 @@ var MapView = Marionette.ItemView.extend({
             [24.2, -126.4],
             [49.8, -66.0]
         ]);
-
-        map.addControl(new LatLngControl());
 
         this._leafletMap = map;
         this._areaOfInterestLayer = new L.FeatureGroup();


### PR DESCRIPTION
## Overview
LatLngControl was added to aide in debugging RWD issues. I've left the control in the src, but removed its addition to the map so that it's not displayed on production.

See https://github.com/WikiWatershed/model-my-watershed/commit/a78d8d9ad6b5a0910d96f8980d588811e9af63af

Connects #1393 

### Demo

![screenshot from 2017-03-01 18 22 24](https://cloud.githubusercontent.com/assets/1014341/23485985/0fb4026a-feac-11e6-9b01-8d398d7e01b9.png)

### Notes

I believe we didn't want this in production, so I'm targeting that branch, but if it misses the window we can just have in the next release.

## Testing Instructions

Ensure that the LatLng control is not displayed in the lower left corner.
