### PR TITLE
Update EBS Snapshot for RWD Worker instances

### DIFF
--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -63,7 +63,7 @@
             "ami_block_device_mappings": [
                 {
                     "device_name": "/dev/sdf",
-                    "snapshot_id": "snap-02a616c405bf39079",
+                    "snapshot_id": "snap-0211cbbff8a81266f",
                     "volume_type": "gp2",
                     "delete_on_termination": true
                 }


### PR DESCRIPTION
## Overview
Due to issues uncovered in
https://github.com/WikiWatershed/rapid-watershed-delineation/issues/68

It was required to update the DRB RWD files and generate a new snapshot from the volume.

Connects #https://github.com/WikiWatershed/rapid-watershed-delineation/issues/68

Local to the ec2 instance used to update the volume, I tested both DRB & NHD RWD requests, including those points previously known to cause the Ocean exception referenced in the attached issue.  Once this new snapshot is deployed, we can test the two services via the app.


## Testing Instructions

 * Check that the newly updated snapshot id is correct and the the snapshot itself has the appropriate Account Permission set.
