### PR TITLE
Remove TR-55 model descriptions from Compare view

### DIFF
--- a/src/mmw/js/src/modeling/tr55/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/result.html
@@ -1,6 +1,8 @@
+{% if showModelDescription %}
 <p class="result-text text-muted">
     Total loads delivered in a 24-hour hypothetical storm event
     as simulated by EPA's STEP-L model algorithms.
 </p>
+{% endif %}
 <div class="quality-chart-region"></div>
 <div class="quality-table-region"></div>

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -21,6 +21,12 @@ var ResultView = Marionette.LayoutView.extend({
 
     template: resultTmpl,
 
+    templateHelpers: function() {
+        return {
+            showModelDescription: !this.compareMode
+        };
+    },
+
     attributes: {
         role: 'tabpanel'
     },

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
@@ -1,6 +1,8 @@
+{% if showModelDescription %}
 <p class="result-text text-muted">
     Results of a 24-hour hypothetical storm event
     as simulated by SLAMM and TR-55 model algorithms.
 </p>
+{% endif %}
 <div class="runoff-chart-region"></div>
 <div class="runoff-table-region"></div>

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -16,6 +16,12 @@ var ResultView = Marionette.LayoutView.extend({
 
     template: resultTmpl,
 
+    templateHelpers: function() {
+        return {
+            showModelDescription: !this.compareMode
+        };
+    },
+
     regions: {
         tableRegion: '.runoff-table-region',
         chartRegion: '.runoff-chart-region'


### PR DESCRIPTION
## Overview

This PR fixes a bug introduced in #1699 whereby the TR-55 model descriptions would push the bar chart underneath the precipitation slider on the compare view. The result was that the precipitation slider hovered over the bar chart.

The fix here adds some checks to show the model descriptions only when the app's not in Compare view. This restores the functionality for compare view prior to adding the descriptions, and it keeps the descriptions for the non-Compare view.

Connects #1719 

### Demo

<img width="525" alt="screen shot 2017-03-03 at 1 32 36 pm" src="https://cloud.githubusercontent.com/assets/4165523/23563745/006daaf2-0016-11e7-8b85-c5c0664c0384.png">

->

<img width="504" alt="screen shot 2017-03-03 at 1 32 40 pm" src="https://cloud.githubusercontent.com/assets/4165523/23563749/05013200-0016-11e7-85b3-aea6f53dfab5.png">

->

<img width="317" alt="screen shot 2017-03-03 at 1 33 00 pm" src="https://cloud.githubusercontent.com/assets/4165523/23563753/0a6d57b4-0016-11e7-8c45-9c994f1ad4cf.png">

->

<img width="308" alt="screen shot 2017-03-03 at 1 33 05 pm" src="https://cloud.githubusercontent.com/assets/4165523/23563759/1074c78c-0016-11e7-93de-64e530034c50.png">

### Notes

A more thorough fix would position the precipitation slider to be fixed beneath the bar chart in all cases on compare view, but if we want to pursue that line I think we should kick it to another card as it may entail more changes to the layout and style of the Compare view.

## Testing Instructions

 * get this branch, then `bundle`
 * visit the site in the browser and hard refresh to ensure you've got the latest bundle
 * select an AOI and run TR-55. When the results return verify that you see the model descriptions for both runoff and water quality
 * click "Compare" and when the results return, verify that you do not see the model descriptions and that the slider remains positioned beneath the bar chart
