### PR TITLE
Increase Gunicorn worker count

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/templates/gunicorn.py.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/gunicorn.py.j2
@@ -1,4 +1,7 @@
+import multiprocessing
+
 bind = "127.0.0.1:8000"
+workers = (2 * multiprocessing.cpu_count()) + 1
 
 {% if ['development', 'test'] | some_are_in(group_names) -%}
 accesslog = "-"
@@ -7,7 +10,6 @@ loglevel = 'debug'
 preload_app = False
 reload = True
 timeout = 1800
-workers = 1
 {% else %}
 accesslog = None
 errorlog = "{{ app_gunicorn_log }}"
@@ -15,5 +17,4 @@ loglevel = 'info'
 preload_app = True
 reload = False
 timeout = 60
-workers = 2
 {% endif %}


### PR DESCRIPTION
## Overview

Based on the Gunicorn worker formula, tune the number of application server processes to align with the number of available cores.

See: http://docs.gunicorn.org/en/stable/design.html#how-many-workers

## Testing Instructions

Provision this branch locally and then inspect the number of Gunicorn workers available on the `app` virtual machine. There should be four processes (3 of which are workers):

```bash
$ vagrant up services app --provision
vagrant@app:~$ ps aux | grep guni
mmw       8260  0.0  1.2  59168 13020 ?        Ss   14:02   0:00 /usr/bin/python /usr/local/bin/gunicorn --config /etc/mmw.d/gunicorn.py mmw.wsgi
mmw       8268  0.8  6.3 425936 64408 ?        Sl   14:02   0:03 /usr/bin/python /usr/local/bin/gunicorn --config /etc/mmw.d/gunicorn.py mmw.wsgi
mmw       8272  0.8  6.3 425944 64416 ?        Sl   14:02   0:03 /usr/bin/python /usr/local/bin/gunicorn --config /etc/mmw.d/gunicorn.py mmw.wsgi
mmw       8275  0.8  6.3 425952 64428 ?        Sl   14:02   0:03 /usr/bin/python /usr/local/bin/gunicorn --config /etc/mmw.d/gunicorn.py mmw.wsgi
vagrant   8384  0.0  0.0  10460   936 pts/2    S+   14:08   0:00 grep --color=auto guni
```