### PR TITLE
Adjust staging ASG scheduled times to EDT

### DIFF
--- a/deployment/cfn/application.py
+++ b/deployment/cfn/application.py
@@ -159,7 +159,7 @@ class Application(StackNode):
         self.app_server_auto_scaling_schedule_start_recurrence = self.add_parameter(  # NOQA
             Parameter(
                 'AppServerAutoScalingScheduleStartRecurrence', Type='String',
-                Default='0 13 * * 1-5',
+                Default='0 12 * * 1-5',
                 Description='Application server ASG schedule start recurrence'
             ), 'AppServerAutoScalingScheduleStartRecurrence')
 
@@ -173,7 +173,7 @@ class Application(StackNode):
         self.app_server_auto_scaling_schedule_end_recurrence = self.add_parameter(  # NOQA
             Parameter(
                 'AppServerAutoScalingScheduleEndRecurrence', Type='String',
-                Default='0 1 * * *',
+                Default='0 0 * * *',
                 Description='Application server ASG schedule end recurrence'
             ), 'AppServerAutoScalingScheduleEndRecurrence')
 

--- a/deployment/cfn/tiler.py
+++ b/deployment/cfn/tiler.py
@@ -150,7 +150,7 @@ class Tiler(StackNode):
         self.tile_server_auto_scaling_schedule_start_recurrence = self.add_parameter(  # NOQA
             Parameter(
                 'TileServerAutoScalingScheduleStartRecurrence', Type='String',
-                Default='0 13 * * 1-5',
+                Default='0 12 * * 1-5',
                 Description='Tile server ASG schedule start recurrence'
             ), 'TileServerAutoScalingScheduleStartRecurrence')
 
@@ -164,7 +164,7 @@ class Tiler(StackNode):
         self.tile_server_auto_scaling_schedule_end_recurrence = self.add_parameter(  # NOQA
             Parameter(
                 'TileServerAutoScalingScheduleEndRecurrence', Type='String',
-                Default='0 1 * * *',
+                Default='0 0 * * *',
                 Description='Tile server ASG schedule end recurrence'
             ), 'TileServerAutoScalingScheduleEndRecurrence')
 

--- a/deployment/cfn/worker.py
+++ b/deployment/cfn/worker.py
@@ -156,7 +156,7 @@ class Worker(StackNode):
         self.worker_auto_scaling_schedule_start_recurrence = self.add_parameter(  # NOQA
             Parameter(
                 'WorkerAutoScalingScheduleStartRecurrence', Type='String',
-                Default='0 13 * * 1-5',
+                Default='0 12 * * 1-5',
                 Description='Worker ASG schedule start recurrence'
             ), 'WorkerAutoScalingScheduleStartRecurrence')
 
@@ -170,7 +170,7 @@ class Worker(StackNode):
         self.worker_auto_scaling_schedule_end_recurrence = self.add_parameter(  # NOQA
             Parameter(
                 'WorkerAutoScalingScheduleEndRecurrence', Type='String',
-                Default='0 1 * * *',
+                Default='0 0 * * *',
                 Description='Worker ASG schedule end recurrence'
             ), 'WorkerAutoScalingScheduleEndRecurrence')
 


### PR DESCRIPTION
## Overview
Cron format start and stop recurrence times for ASG Scheduled Actions
are defined in UTC which doesn't account for swapping between EST and
EDT. This manually adjusts the times to reflect starting at 8am EDT
and ending at 8pm EDT.

### Notes
This change will have to be remembered and reverted when we switch back to EST.  I don't believe there is a way to make the schedule aware of the time change.
