### PR TITLE
Download Analyze & Model data in CSV format

### DIFF
--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -126,6 +126,7 @@ JS_DEPS=(backbone
          leaflet-plugins/layer/tile/Google
          lodash
          moment
+         papaparse
          nunjucks
          shapefile
          turf-area

--- a/src/mmw/js/src/analyze/constants.js
+++ b/src/mmw/js/src/analyze/constants.js
@@ -1,0 +1,51 @@
+"use strict";
+
+var constants = {
+    csvColumnMaps: {
+        nlcd: {
+            'nlcd': 'nlcd_id',
+            'area': 'area_sq_m',
+            'coverage': 'coverage_pct',
+        },
+        soil: {
+            'code': 'soil_code',
+            'area': 'area_sq_m',
+            'coverage': 'coverage_pct'
+        },
+        animals: {
+            'aeu': 'animal_count',
+            'type': 'animal_type'
+        },
+        pointSource: {
+            'kgp_yr': 'phosphorus_load_kg_per_yr',
+            'mgd': 'discharge_million_gallon_per_day',
+            'kgn_yr': 'nitrogen_load_kg_per_yr'
+        },
+        waterQuality: {
+            'nord': 'nord',
+            'areaha': 'area_hectares',
+            'tss_tot_kg': 'total_suspended_solids_kg_yr_per_ha',
+            'tp_tot_kgy': 'total_phosphorus_kg_yr_per_ha',
+            'tn_tot_kgy': 'total_nitrogen_kg_yr_per_ha',
+            'tss_urban_': 'total_suspended_solids_urban_kg_yr_per_ha',
+            'tp_urban_k': 'total_phosphorus_urban_kg_yr_per_ha',
+            'tn_urban_k': 'total_nitrogen_urban_kg_yr_per_ha',
+            'tss_rip_kg': 'total_suspended_solids_riparian_kg_yr_per_ha',
+            'tn_riparia': 'total_nitrogen_riparian_kg_yr_per_ha',
+            'tp_riparia': 'total_phosphorus_riparian_kg_yr_per_ha',
+            'tp_pt_kgyr': 'total_phosphorus_point_source_kg_yr_per_ha',
+            'tn_pt_kgyr': 'total_nitrogen_point_source_kg_yr_per_ha',
+            'tss_natura': 'total_suspended_solids_natural_kg_yr_per_ha',
+            'tn_natural': 'total_nitrogen_natural_kg_yr_per_ha',
+            'tp_natural': 'total_phosphorus_natural_kg_yr_per_ha',
+            'tss_ag_kgy': 'total_suspended_solids_agricultural_kg_yr_per_ha',
+            'tn_ag_kgyr': 'total_nitrogen_agricultural_kg_yr_per_ha',
+            'tp_ag_kgyr': 'total_phosphorus_agricultural_kg_yr_per_ha',
+            'tss_concmg': 'total_suspended_solids_concentration_mg_per_l',
+            'tp_yr_avg_': 'total_phosphorus_concentration_mg_per_l',
+            'tn_yr_avg_': 'total_nitrogen_concentration_mg_per_l'
+        }
+    }
+};
+
+module.exports = constants;

--- a/src/mmw/js/src/analyze/templates/analyzeResults.html
+++ b/src/mmw/js/src/analyze/templates/analyzeResults.html
@@ -1,3 +1,6 @@
 <div class="desc-region"></div>
 <div class="chart-region"></div>
 <div class="table-region"></div>
+<div class="downloadcsv-link" data-action="download-csv">
+    <i class="fa fa-download"></i> Download this data
+</div>

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -4,7 +4,8 @@ var _ = require('underscore'),
     lodash = require('lodash'),
     md5 = require('blueimp-md5').md5,
     intersect = require('turf-intersect'),
-    centroid = require('turf-centroid');
+    centroid = require('turf-centroid'),
+    papaparse = require('papaparse');
 
 var M2_IN_KM2 = 1000000;
 var noData = 'No Data';
@@ -338,6 +339,31 @@ var utils = {
             geom.type = 'MultiPolygon';
         }
         return geom;
+    },
+
+    downloadDataCSV: function(data, filename) {
+        var csv = papaparse.unparse(JSON.stringify(data)),
+            blob = new Blob([csv], { type: 'text/csv' }),
+            url = window.URL.createObjectURL(blob),
+            tmpLink = document.createElement('a');
+
+        tmpLink.href = url;
+        tmpLink.setAttribute('download', filename + '.csv');
+        tmpLink.setAttribute('target', '_blank');
+        document.body.appendChild(tmpLink);
+        tmpLink.click();
+        document.body.removeChild(tmpLink);
+    },
+
+    renameCSVColumns: function(data, nameMap) {
+        return _.map(data, function(row) {
+            var newRow = {};
+            _.each(row, function(value, key) {
+                var newKey = nameMap[key] || key;
+                newRow[newKey] = value;
+            });
+            return newRow;
+        });
     }
 };
 

--- a/src/mmw/js/src/modeling/gwlfe/quality/constants.js
+++ b/src/mmw/js/src/modeling/gwlfe/quality/constants.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var constants = {
+    waterQualityLoadsCSVColumnMap: {
+        'Source': 'source',
+        'TotalN': 'total_nitrogen_kg',
+        'TotalP': 'total_phosphorus_kg',
+        'Sediment': 'sediment_kg'
+    },
+
+    waterQualitySummaryLoadsCSVColumnMap: {
+        'Source': 'source',
+        'TotalN': 'total_nitrogen',
+        'TotalP': 'total_phosphorus',
+        'Sediment': 'sediment'
+    }
+};
+
+module.exports = constants;

--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
@@ -37,4 +37,10 @@
     Mean Flow: {{ MeanFlow|round(0)|toLocaleString }} (m<sup>3</sup>/year) and {{ MeanFlowPerSecond|round(2)|toLocaleString }} (m<sup>3</sup>/s)
 </div>
 {{ table(landUseColumns, landUseRows, true, renderPrecision.landUseTable, defaultPrecision.landUseTable) }}
+<div class="downloadcsv-link" data-action="download-csv-granular">
+    <i class="fa fa-download"></i> Download this data
+</div>
 {{ table(summaryColumns, summaryRows, false, renderPrecision.summaryTable, defaultPrecision.summaryTable) }}
+<div class="downloadcsv-link" data-action="download-csv-summary">
+    <i class="fa fa-download"></i> Download this data
+</div>

--- a/src/mmw/js/src/modeling/gwlfe/quality/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/quality/views.js
@@ -4,7 +4,9 @@ var $ = require('jquery'),
     _ = require('underscore'),
     Marionette = require('../../../../shim/backbone.marionette'),
     resultTmpl = require('./templates/result.html'),
-    tableTmpl = require('./templates/table.html');
+    tableTmpl = require('./templates/table.html'),
+    utils = require('../../../core/utils.js'),
+    constants = require('./constants');
 
 var ResultView = Marionette.LayoutView.extend({
     className: 'tab-pane',
@@ -40,6 +42,16 @@ var ResultView = Marionette.LayoutView.extend({
 
 var TableView = Marionette.CompositeView.extend({
     template: tableTmpl,
+
+    ui: {
+        downloadLoadsCSV: '[data-action="download-csv-granular"]',
+        downloadSummaryLoadsCSV: '[data-action="download-csv-summary"]'
+    },
+
+    events: {
+        'click @ui.downloadLoadsCSV': 'downloadCSVGranular',
+        'click @ui.downloadSummaryLoadsCSV': 'downloadCSVSummary'
+    },
 
     onAttach: function() {
         $('[data-toggle="table"]').bootstrapTable();
@@ -78,6 +90,27 @@ var TableView = Marionette.CompositeView.extend({
                 landUseTable: 1,
             },
         };
+    },
+
+    downloadCSVGranular: function() {
+        var data = this.model.get('result').Loads,
+            prefix = 'mapshed_water_quality_loads_',
+            nameMap = constants.waterQualityLoadsCSVColumnMap;
+        this.downloadCSV(data, prefix, nameMap);
+    },
+
+    downloadCSVSummary: function() {
+        var data = this.model.get('result').SummaryLoads,
+            prefix = 'mapshed_water_quality_summary_loads_',
+            nameMap = constants.waterQualitySummaryLoadsCSVColumnMap;
+        this.downloadCSV(data, prefix, nameMap);
+    },
+
+    downloadCSV: function(data, filePrefix, nameMap) {
+        var timestamp = new Date().toISOString(),
+            filename = filePrefix + timestamp,
+            renamedData = utils.renameCSVColumns(data, nameMap);
+        utils.downloadDataCSV(renamedData, filename);
     }
 });
 

--- a/src/mmw/js/src/modeling/gwlfe/runoff/constants.js
+++ b/src/mmw/js/src/modeling/gwlfe/runoff/constants.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var constants = {
+    hydrologyCSVColumnMap: {
+        'AvWithdrawal': 'avg_withdrawal_cm',
+        'AvEvapoTrans': 'avg_evapotranspiration_cm',
+        'AvTileDrain': 'avg_tile_drain_cm',
+        'AvPrecipitation': 'avg_precipitation_cm',
+        'AvRunoff': 'avg_runoff_cm',
+        'AvGroundWater': 'avg_groundwater_cm',
+        'AvPtSrcFlow': 'avg_pointsource_flow_cm',
+        'AvStreamFlow': 'avg_stream_flow_cm'
+    }
+};
+
+module.exports = constants;

--- a/src/mmw/js/src/modeling/gwlfe/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/runoff/templates/result.html
@@ -6,3 +6,6 @@
 <div class="runoff-selector-region"></div>
 <div class="runoff-chart-region"></div>
 <div class="runoff-table-region"></div>
+<div class="downloadcsv-link" data-action="download-csv">
+    <i class="fa fa-download"></i> Download this data
+</div>

--- a/src/mmw/js/src/modeling/gwlfe/runoff/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/runoff/views.js
@@ -7,7 +7,9 @@ var $ = require('jquery'),
     barChartTmpl = require('../../../core/templates/barChart.html'),
     selectorTmpl = require('./templates/selector.html'),
     resultTmpl = require('./templates/result.html'),
-    tableTmpl = require('./templates/table.html');
+    tableTmpl = require('./templates/table.html'),
+    utils = require('../../../core/utils.js'),
+    constants = require('./constants');
 
 var runoffVars = [
         { name: 'AvPrecipitation', display: 'Precip' },
@@ -28,6 +30,14 @@ var ResultView = Marionette.LayoutView.extend({
         selectorRegion: '.runoff-selector-region',
         chartRegion: '.runoff-chart-region',
         tableRegion: '.runoff-table-region'
+    },
+
+    ui: {
+        downloadCSV: '[data-action="download-csv"]'
+    },
+
+    events: {
+        'click @ui.downloadCSV': 'downloadCSV'
     },
 
     modelEvents: {
@@ -63,7 +73,18 @@ var ResultView = Marionette.LayoutView.extend({
                 compareMode: this.compareMode
             }));
         }
-    }
+    },
+
+    downloadCSV: function() {
+        var data = this.model.get('result').monthly,
+            prefix = 'mapshed_hydrology_',
+            timestamp = new Date().toISOString(),
+            filename = prefix + timestamp,
+            nameMap = constants.hydrologyCSVColumnMap,
+            renamedData = utils.renameCSVColumns(data, nameMap);
+
+        utils.downloadDataCSV(renamedData, filename);
+    },
 });
 
 var SelectorView = Marionette.ItemView.extend({

--- a/src/mmw/js/src/modeling/tr55/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/result.html
@@ -6,3 +6,6 @@
 {% endif %}
 <div class="quality-chart-region"></div>
 <div class="quality-table-region"></div>
+<div class="downloadcsv-link" data-action="download-csv">
+    <i class="fa fa-download"></i> Download this data
+</div>

--- a/src/mmw/js/src/modeling/tr55/runoff/constants.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/constants.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var constants = {
+    tr55RunoffCSVColumnMap: function(v, k) {
+        switch (k) {
+            case 'et':
+                return ['evapotranspiration_cm', v];
+            case 'inf':
+                return ['infiltration_cm', v];
+            case 'runoff':
+                return ['runoff_cm', v];
+            default:
+                return [k, v];
+        }
+    }
+};
+
+module.exports = constants;

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
@@ -6,3 +6,6 @@
 {% endif %}
 <div class="runoff-chart-region"></div>
 <div class="runoff-table-region"></div>
+<div class="downloadcsv-link" data-action="download-csv">
+    <i class="fa fa-download"></i> Download this data
+</div>

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -9,7 +9,9 @@ var $ = require('jquery'),
     resultTmpl = require('./templates/result.html'),
     AoiVolumeModel = require('../models').AoiVolumeModel,
     tableRowTmpl = require('./templates/tableRow.html'),
-    tableTmpl = require('./templates/table.html');
+    tableTmpl = require('./templates/table.html'),
+    utils = require('../../../core/utils.js'),
+    constants = require('./constants');
 
 var ResultView = Marionette.LayoutView.extend({
     className: 'tab-pane',
@@ -25,6 +27,14 @@ var ResultView = Marionette.LayoutView.extend({
     regions: {
         tableRegion: '.runoff-table-region',
         chartRegion: '.runoff-chart-region'
+    },
+
+    ui: {
+        downloadCSV: '[data-action="download-csv"]'
+    },
+
+    events: {
+        'click @ui.downloadCSV': 'downloadCSV'
     },
 
     modelEvents: {
@@ -59,6 +69,16 @@ var ResultView = Marionette.LayoutView.extend({
                 compareMode: this.compareMode
             }));
         }
+    },
+
+    downloadCSV: function() {
+        var data = this.model.get('result').runoff.modified,
+            prefix = 'tr55_runoff_',
+            timestamp = new Date().toISOString(),
+            filename = prefix + timestamp,
+            renamedData = _.map(_.pick(data, 'et', 'inf', 'runoff'),
+                constants.tr55RunoffCSVColumnMap);
+        utils.downloadDataCSV(renamedData, filename);
     }
 });
 

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -3992,6 +3992,11 @@
         }
       }
     },
+    "papaparse": {
+      "version": "4.2.0",
+      "from": "papaparse@*",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.2.0.tgz"
+    },
     "retina.js": {
       "version": "1.3.0",
       "from": "../../tmp/npm-8086-93d2a729/1490189832167-0.7281006346456707/a70e73639817473bad7bbb33f866b8e060e5f5a7",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -45,6 +45,7 @@
     "node-sass": "3.3.2",
     "nunjucks": "1.3.4",
     "nunjucksify": "0.2.2",
+    "papaparse": "4.2.0",
     "retina.js": "git://github.com/imulus/retinajs#1.3.0",
     "shapefile": "0.6.2",
     "sinon": "1.14.1",

--- a/src/mmw/sass/components/_sidebar.scss
+++ b/src/mmw/sass/components/_sidebar.scss
@@ -55,3 +55,10 @@
     text-align: center;
     width: 100%;
 }
+
+.downloadcsv-link {
+    padding-top: 10px;
+    padding-left: 5px;
+    cursor: pointer;
+    font-size: 0.7rem;
+}


### PR DESCRIPTION
## Overview

This PR enables downloading the data from the analyze and model tabs in CSV format. The first commit here adds the `papaparse` library to handle parsing the CSV; the second adds a utility function to use the library then calls it from a link on each of the analyze tabs plus the TR-55 and MapShed tabs.

Connects #1736 

### Demo

<img width="874" alt="screen shot 2017-03-21 at 5 46 21 pm" src="https://cloud.githubusercontent.com/assets/4165523/24172361/56f26060-0e5e-11e7-85ad-59f81a7b92ee.png">

[nlcd_land_cover_2017-03-21T21-46-25.378Z.csv.txt](https://github.com/WikiWatershed/model-my-watershed/files/859750/nlcd_land_cover_2017-03-21T21-46-25.378Z.csv.txt)

### Notes

I used an `fa-download` icon which was already available in the app for the "Download..." div, but I'll double check the wireframes to ensure that it's the correct style and import a new one from Fontello if not.

## Testing Instructions

 * get this branch, `npm.sh install` and `bundle`
 * visit the site in the browser and choose an AOI
 * for each analysis tab, click the "Download..." link at the bottom and verify that it outputs a CSV file with the data represented on the tab
 * run TR-55 and click the download links on both tabs. Verify that the data in the CSV represents what's displayed in the tab
 * repeat the above step for MapShed
