### PR TITLE
Add sidebar splash and draw placeholder

### DIFF
--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -10,6 +10,7 @@ from apps.home.views import home_page, projects, project, project_clone
 urlpatterns = patterns(
     '',
     url(r'^$', home_page, name='home_page'),
+    url(r'^draw/?$', home_page, name='home_page'),
     url(r'^projects/$', projects, name='projects'),
     url(r'^project/$', project, name='project'),
     url(r'^project/new/', project, name='project'),

--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -45,7 +45,6 @@ var AnalyzeController = {
             // Modelling Controller.
             App.currentProject = null;
         }
-        App.getMapView().addSidebarToggleControl();
     },
 
     analyze: function() {
@@ -66,7 +65,6 @@ var AnalyzeController = {
 
     analyzeCleanUp: function() {
         App.rootView.sidebarRegion.empty();
-        App.getMapView().removeSidebarToggleControl();
     }
 };
 

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -70,7 +70,7 @@ var MapModel = Backbone.Model.extend({
     },
 
     setDrawSize: function(fit) {
-        this._setSizeOptions({ single: true }, { min: true }, fit);
+        this.setNoHeaderSidebarSize(fit);
     },
 
     setAnalyzeSize: function(fit) {

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -1,9 +1,7 @@
 <nav id="app-header" class="navbar-watershed">
-    <div class="brand">
-        <a href="#">Model My Watershed</a>
-    </div>
     <ul class="global-navigation">
-        <li class="global-navigation-item {{selectAreaNavClasses}}"><button  data-url="/">Select Area</button></li>
+        <li class="global-navigation-item {{splashNavClasses}}"><button data-url="/">Model My Watershed</button></li>
+        <li class="global-navigation-item {{selectAreaNavClasses}}"><button  data-url="/draw">Select Area</button></li>
         <li class="global-navigation-item {{analyzeNavClasses}}"><button data-url="/analyze">Analyze</button></li>
         <li class="global-navigation-item {{modelNavClasses}}"><button  data-url="/project">Model</button></li>
         <li class="global-navigation-item {{compareNavClasses}}"><button  data-url="/project/compare">Compare</button></li>

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -152,7 +152,7 @@ describe('Core', function() {
                 view.destroy();
             });
 
-            it('adds the map-container top & bottom classes to the map container for Draw screen', function(){
+            it('adds the map-container sidebar top & bottom classes to the map container for Draw screen', function(){
                 var model = new models.MapModel(),
                     layersModel = new models.LayersModel(),
                     view = new views.MapView({
@@ -163,8 +163,8 @@ describe('Core', function() {
                     $container = $(sandboxSelector).parent();
 
                 model.setDrawSize();
-                assert.isTrue($container.hasClass('map-container-top-1'));
-                assert.isTrue($container.hasClass('map-container-bottom-1'));
+                assert.isTrue($container.hasClass('map-container-top-sidebar'));
+                assert.isTrue($container.hasClass('map-container-bottom-sidebar'));
 
                 view.destroy();
             });

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -17,6 +17,8 @@ var utils = {
         boundary_layers: 2
     },
 
+    splashPageTitle: 'Model My Watershed',
+
     selectAreaPageTitle: 'Choose Area of Interest',
 
     analyzePageTitle: 'Geospatial Analysis',

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -287,6 +287,7 @@ var MapView = Marionette.ItemView.extend({
 
         map.addLayer(this._areaOfInterestLayer);
         map.addLayer(this._modificationsLayer);
+        map.addControl(new SidebarToggleControl());
     },
 
     setupGeoLocation: function(maxAge) {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -86,6 +86,10 @@ var HeaderView = Marionette.ItemView.extend({
         return currentActive === coreUtils.projectsPageTitle;
     },
 
+    makeSplashNavClasses: function() {
+        return this.makeNavClasses(true, true);
+    },
+
     makeSelectAreaNavClasses: function(currentActive) {
         var isVisible = !this.isProjectsPage(currentActive),
             isActive = currentActive === coreUtils.selectAreaPageTitle;
@@ -123,6 +127,7 @@ var HeaderView = Marionette.ItemView.extend({
 
         return {
             'itsi_embed': settings.get('itsi_embed'),
+            'splashNavClasses': this.makeSplashNavClasses(wasAnalyzeVisible, wasModelVisible),
             'selectAreaNavClasses': this.makeSelectAreaNavClasses(currentActive),
             'analyzeNavClasses': this.makeAnalyzeNavClasses(currentActive, wasAnalyzeVisible, wasModelVisible),
             'modelNavClasses': this.makeModelNavClasses(currentActive),

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -11,12 +11,7 @@ var App = require('../app'),
     models = require('./models');
 
 var DrawController = {
-    drawPrepare: function() {
-        App.map.revertMaskLayer();
-        if (!App.map.get('areaOfInterest')) {
-            App.map.setDrawSize(true);
-        }
-    },
+    drawPrepare: prepareView,
 
     draw: function() {
         var geocodeSearch = new geocoder.GeocoderView(),
@@ -30,6 +25,7 @@ var DrawController = {
 
         App.rootView.geocodeSearchRegion.show(geocodeSearch);
         App.rootView.drawToolsRegion.show(toolbarView);
+        App.rootView.sidebarRegion.show(new views.DrawWindow());
 
         enableSingleProjectModeIfActivity();
 
@@ -42,8 +38,20 @@ var DrawController = {
         App.rootView.geocodeSearchRegion.empty();
         App.rootView.drawToolsRegion.empty();
         App.rootView.footerRegion.empty();
+    },
+
+    splashPrepare: prepareView,
+
+    splash: function() {
+        App.rootView.geocodeSearchRegion.show(new geocoder.GeocoderView());
+        App.rootView.sidebarRegion.show(new views.SplashWindow());
+        App.map.setDrawSize();
     }
 };
+
+function prepareView() {
+    App.map.revertMaskLayer();
+}
 
 /**
  * If we are in embed mode then the project is an activity and we want to keep

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -30,7 +30,6 @@ var DrawController = {
         enableSingleProjectModeIfActivity();
 
         App.map.setDrawSize();
-
         App.state.set('active_page', utils.selectAreaPageTitle);
     },
 
@@ -46,6 +45,10 @@ var DrawController = {
         App.rootView.geocodeSearchRegion.show(new geocoder.GeocoderView());
         App.rootView.sidebarRegion.show(new views.SplashWindow());
         App.map.setDrawSize();
+        App.state.set({
+            'active_page': utils.splashPageTitle,
+            'was_analyze_visible': false
+        });
     }
 };
 

--- a/src/mmw/js/src/draw/templates/splash.html
+++ b/src/mmw/js/src/draw/templates/splash.html
@@ -1,0 +1,34 @@
+<h1>
+    Model stormwater and its impact on an area
+</h1>
+
+<p>
+    Analyze real geo-data, model storms, and compare conservation or development scenarios in a watershed.
+</p>
+
+<div class="splash-step">
+    <h2><span class="badge">1</span>Select Area</h2>
+    <p>
+        Select an area to analyze on model...
+    </p>
+</div>
+<div class="splash-step">
+    <h2><span class="badge">2</span>Analyze</h2>
+    <p>
+        See summary statistics of the area you selected...
+    </p>
+</div>
+<div class="splash-step">
+    <h2><span class="badge">3</span>Model</h2>
+    <p>
+        Simulate how that area behaves under different scenarios...
+    </p>
+</div>
+
+<hr/>
+
+<button id="get-started" class="btn btn-active btn-lg btn-block" type="button">
+    Get started <i class="fa fa-arrow-right"></i>
+</button>
+
+<button id="splash-open-project" class="btn btn-link btn-block">Open Project</button>

--- a/src/mmw/js/src/draw/templates/window.html
+++ b/src/mmw/js/src/draw/templates/window.html
@@ -1,0 +1,2 @@
+<h1>Select Area</h1>
+<p>Draw tools go here</p>

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -145,6 +145,10 @@ var SplashWindow = Marionette.ItemView.extend({
         'openProject': '#splash-open-project',
     },
 
+    initialize: function() {
+        clearAoiLayer();
+    },
+
     events: {
         'click @ui.start': 'moveToDraw',
         'click @ui.openProject': 'openOrLogin',

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -17,6 +17,8 @@ var $ = require('jquery'),
     toolbarTmpl = require('./templates/toolbar.html'),
     loadingTmpl = require('./templates/loading.html'),
     selectTypeTmpl = require('./templates/selectType.html'),
+    splashTmpl = require('./templates/splash.html'),
+    windowTmpl = require('./templates/window.html'),
     drawTmpl = require('./templates/draw.html'),
     resetDrawTmpl = require('./templates/reset.html'),
     delineationOptionsTmpl = require('./templates/delineationOptions.html'),
@@ -125,6 +127,37 @@ function validatePointWithinDataSourceBounds(latlng, dataSource) {
     }
     return d.promise();
 }
+
+var DrawWindow = Marionette.ItemView.extend({
+    template: windowTmpl,
+
+    id: 'draw-window',
+
+});
+
+var SplashWindow = Marionette.ItemView.extend({
+    template: splashTmpl,
+
+    id: 'splash-window',
+
+    ui: {
+        'start': '#get-started',
+        'openProject': '#splash-open-project',
+    },
+
+    events: {
+        'click @ui.start': 'moveToDraw',
+        'click @ui.openProject': 'openOrLogin',
+    },
+
+    moveToDraw: function() {
+        router.navigate('/draw', {trigger: true});
+    },
+
+    openOrLogin: function() {
+        router.navigate('/projects', {trigger: true});
+    }
+});
 
 // Responsible for loading and displaying tools for selecting and drawing
 // shapes on the map.
@@ -703,5 +736,7 @@ function navigateToAnalyze() {
 
 module.exports = {
     ToolbarView: ToolbarView,
+    SplashWindow: SplashWindow,
+    DrawWindow: DrawWindow,
     getShapeAndAnalyze: getShapeAndAnalyze
 };

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -15,7 +15,6 @@ var ModelingController = {
             router.navigate('', { trigger: true });
             return false;
         }
-        App.getMapView().addSidebarToggleControl();
     },
 
     project: function(projectId, scenarioParam) {
@@ -114,7 +113,6 @@ var ModelingController = {
             project = App.currentProject;
             project.set('model_package', modelPackage);
             itsiResetProject(project);
-            App.getMapView().addSidebarToggleControl();
             setPageTitle();
         } else {
             var lock = $.Deferred();
@@ -149,7 +147,6 @@ var ModelingController = {
             setupNewProjectScenarios(project);
             finishProjectSetup(project, lock);
             updateUrl();
-            App.getMapView().addSidebarToggleControl();
             setPageTitle();
         }
     },
@@ -291,7 +288,6 @@ function projectCleanUp() {
         App.projectNumber = scenarios.at(0).get('project');
     }
 
-    App.getMapView().removeSidebarToggleControl();
     App.getMapView().updateModifications(null);
     App.rootView.subHeaderRegion.empty();
     App.rootView.sidebarRegion.empty();

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -9,7 +9,8 @@ var router = require('./router').router,
     ErrorController = require('./core/error/controllers').ErrorController,
     SignUpController = require('./user/controllers').SignUpController;
 
-router.addRoute(/^/, DrawController, 'draw');
+router.addRoute(/^/, DrawController, 'splash');
+router.addRoute(/^draw/, DrawController, 'draw');
 router.addRoute(/^analyze/, AnalyzeController, 'analyze');
 router.addRoute('project/new/:modelPackage(/)', ModelingController, 'makeNewProject');
 router.addRoute('project(/:projectId)(/scenario/:scenarioId)(/)', ModelingController, 'project');

--- a/src/mmw/sass/_bootstrap.scss
+++ b/src/mmw/sass/_bootstrap.scss
@@ -27,7 +27,7 @@
 @import "bootstrap/pagination";
 @import "bootstrap/pager";
 @import "bootstrap/labels";
-// @import "bootstrap/badges";
+@import "bootstrap/badges";
 // @import "bootstrap/jumbotron";
 // @import "bootstrap/thumbnails";
 // @import "bootstrap/alerts";

--- a/src/mmw/sass/components/_global-navigation.scss
+++ b/src/mmw/sass/components/_global-navigation.scss
@@ -5,6 +5,10 @@
   margin-left: 18px;
   margin-bottom: 0px;
   @include clearfix;
+
+  &>li:first-child:after {
+    content: none;
+  }
 }
 
 .global-navigation-item {

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -70,6 +70,7 @@
  */
 @import
   "pages/search-map",
+  "pages/draw",
   "pages/analyze",
   "pages/model",
   "pages/compare",

--- a/src/mmw/sass/pages/_draw.scss
+++ b/src/mmw/sass/pages/_draw.scss
@@ -1,0 +1,22 @@
+#draw-window,
+#splash-window {
+    width: 460px;
+    padding: 15px;
+    position: absolute;
+    right: 0;
+    transition: all 200ms;
+    top: 44px;
+    overflow-y: auto;
+}
+
+.splash-step {
+  padding: 8px;
+
+  & .badge {
+    margin-right: 10px;
+  }
+
+  & p {
+    margin-left: 30px;
+  }
+}


### PR DESCRIPTION
## Overview

The sidebar now is a permanent fixture in the app, including the splash
page. This approximates the style laid forth in the wireframes, but is
not meant to be comprehensive. The draw panel exists only to sort out
the navigation and will be completed in a subsequent card.  The map 
expand button is now also permanent and the breadcrumb navigation is updated.
The "Home" link is now a route and now a hard refresh via a `href`.

The implementation strongly mimics that of https://github.com/project-icp/bee-pollinator-app/pull/29 
to keep consistency between the development of each project.

Tested in Chrome & IE.

Connects #1734 

cc/ @jfrankl heads up that this will need refinement, eventually.

### Demo
![screenshot from 2017-03-22 15 06 36](https://cloud.githubusercontent.com/assets/1014341/24216059/3a1d2e4e-0f11-11e7-93c2-b9da9bfb3117.png)

![screenshot from 2017-03-22 15 06 47](https://cloud.githubusercontent.com/assets/1014341/24216060/3a394958-0f11-11e7-83a6-051c411e6c59.png)

![screenshot from 2017-03-22 15 12 26](https://cloud.githubusercontent.com/assets/1014341/24216275/ff0efec6-0f11-11e7-8f1c-0a02b686cae5.png)

### Notes

* The `Open Project` link will route to `/projects` which works if you're logged in, but doesn't prompt for login if not.  To be concluded in #1741
* The breadcrumb/global nav is likely to be removed altogether in subsequent designs, so don't spend much time on that review portion.

## Testing Instructions

* Bundle
* Verify `/` brings a splash screen
* `/draw` brings the draw tools panel (but leaves tools on the map, for now)
* Navigating back and forth generally works
