### PR TITLE
Allow action after login success

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -120,9 +120,11 @@ var App = new Marionette.Application({
         });
     },
 
-    showLoginModal: function() {
+    showLoginModal: function(onSuccess) {
         new userViews.LoginModalView({
-            model: new userModels.LoginFormModel({}),
+            model: new userModels.LoginFormModel({
+                successCallback: onSuccess
+            }),
             app: this
         }).render();
     }

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -159,7 +159,13 @@ var SplashWindow = Marionette.ItemView.extend({
     },
 
     openOrLogin: function() {
-        router.navigate('/projects', {trigger: true});
+        if (App.user.get('guest')) {
+            App.showLoginModal(function() {
+                router.navigate('/projects', {trigger: true});
+            });
+        } else {
+            router.navigate('/projects', {trigger: true});
+        }
     }
 });
 

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var Backbone = require('../../shim/backbone');
+var Backbone = require('../../shim/backbone'),
+    _ = require('underscore');
 
 var UserModel = Backbone.Model.extend({
     defaults: {
@@ -65,7 +66,8 @@ var ModalBaseModel = Backbone.Model.extend({
 var LoginFormModel = ModalBaseModel.extend({
     defaults: {
         username: null,
-        password: null
+        password: null,
+        successCallback: null
     },
 
     url: '/user/login',
@@ -92,6 +94,13 @@ var LoginFormModel = ModalBaseModel.extend({
                 'client_errors': null,
                 'server_errors': null
             });
+        }
+    },
+
+    onSuccess: function() {
+        var callback = this.get('successCallback');
+        if (callback && _.isFunction(callback)) {
+            callback();
         }
     }
 });

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -192,6 +192,7 @@ var LoginModalView = ModalBaseView.extend({
     handleSuccess: function() {
         this.$el.modal('hide');
         this.app.user.set('guest', false);
+        this.model.onSuccess();
     },
 
     handleFailure: function(response) {


### PR DESCRIPTION
## Overview

Allow a callback to be provided with a request for login. Used to
ensure that navigating to `/project` will succeed from splash page.

Connects #1741 

## Testing Instructions
* Bundle
* While logged out, try to use the splash page link "Open Project"
  * Confirm you are prompted for log in
     * "Guest" or canceling the modal should revert you to splash
     * Success on login should route to `/projects`
* Refresh or return to splash (can click on "Model My Watershed" link for fast route now)
    * Use link again, while signed in.
    * Confirm directly routed to `/projects`