### PR TITLE
Move leaflet controls from topright to bottomright

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -188,7 +188,7 @@ var HeaderView = Marionette.ItemView.extend({
 // Init the locate plugin button and add it to the map.
 function addLocateMeButton(map, maxZoom, maxAge) {
     var locateOptions = {
-        position: 'topright',
+        position: 'bottomright',
         metric: false,
         drawCircle: false,
         showPopup: false,
@@ -270,13 +270,21 @@ var MapView = Marionette.ItemView.extend({
             this.setMapToNonInteractive();
         }
 
-        if (options.addZoomControl) {
-            map.addControl(new L.Control.Zoom({position: 'topright'}));
-        }
-
         var maxGeolocationAge = 60000;
+
+        map.addControl(new SidebarToggleControl());
+
         if (options.addLocateMeButton) {
             addLocateMeButton(map, maxGeolocationAge);
+        }
+
+        if (options.addZoomControl) {
+            map.addControl(new L.Control.Zoom({position: 'bottomright'}));
+            // We're overriding css to display the zoom controls horizontally.
+            // Because the zoom-in div usally exists on top, we need to flip it
+            // with the zoom-out div, so when they're horizontal they appear as
+            // [ - | + ]
+            $('.leaflet-control-zoom-out').insertBefore('.leaflet-control-zoom-in');
         }
 
         this.setMapEvents();
@@ -292,7 +300,6 @@ var MapView = Marionette.ItemView.extend({
 
         map.addLayer(this._areaOfInterestLayer);
         map.addLayer(this._modificationsLayer);
-        map.addControl(new SidebarToggleControl());
     },
 
     setupGeoLocation: function(maxAge) {

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -107,6 +107,58 @@
   background-color: transparent;
 }
 
+
+// Override leaflet bottomright controls
+.leaflet-bottom.leaflet-right {
+    text-align: right;
+}
+
+.leaflet-bottom.leaflet-right > .leaflet-control {
+    display: inline-block;
+    float: none;
+    margin: 2px 4px;
+    vertical-align: middle;
+    &:nth-last-child(2), &:last-child {
+        margin-right: 10px;
+    }
+    &.leaflet-control-attribution {
+       display: block;
+    }
+
+    &.leaflet-control-zoom {
+        width: 80px;
+       .leaflet-control-zoom-out {
+           border-right: 2px #ccc solid;
+       }
+       .leaflet-control-zoom-out, .leaflet-control-zoom-in {
+           font-size: 24px;
+           line-height: 38px;
+       }
+    }
+}
+
+.leaflet-bottom.leaflet-right > .leaflet-bar,
+.layer-control-button-container.leaflet-bar {
+    height: 40px;
+    width: 40px;
+    > a {
+        display: inline-block;
+        background-color: $ui-light;
+        color: $ui-secondary;
+        border-radius: 0px;
+        height: 40px;
+        width: 40px;
+        line-height: 40px;
+        border: none;
+        font-size: 18px;
+        box-shadow: none;
+        float: none;
+        &:hover {
+            background-color: #ccc;
+        }
+    }
+}
+
 .leaflet-control {
   .leaflet-control-layers-list {
     display: block;

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -1,7 +1,7 @@
 .layerpicker {
   z-index: 500;
   position: absolute;
-  bottom: 20px;
+  bottom: 22px;
   left: 10px;
   width: 240px;
   background-color: #fff;
@@ -56,7 +56,7 @@
   width: 20%;
   float: left;
   padding: 6px;
-  background-color: #ddd;
+  background-color: $ui-light;
   cursor: pointer;
   &.open {
     background-color: #fff;


### PR DESCRIPTION
## Overview

Moves the map controls to match the wireframes.

#### Wireframe
![image](https://cloud.githubusercontent.com/assets/7633670/24300476/f814f5cc-1082-11e7-8393-675ffca7ec6f.png)

Connects #1743 

### Demo
IE11
<img width="173" alt="screen shot 2017-03-24 at 12 03 34 pm" src="https://cloud.githubusercontent.com/assets/7633670/24303117/34062972-108b-11e7-898c-924bd2707564.png">

Chrome
<img width="323" alt="screen shot 2017-03-24 at 12 10 06 pm" src="https://cloud.githubusercontent.com/assets/7633670/24303120/3647639a-108b-11e7-95f8-5ac449fd7c1c.png">

Firefox
<img width="426" alt="screen shot 2017-03-24 at 12 10 12 pm" src="https://cloud.githubusercontent.com/assets/7633670/24303128/3845f562-108b-11e7-86a3-484a768f1669.png">



## Testing Instructions

 * Bundle
 * Confirm map controls match wireframes in chrome, firefox, safari, ie11 + tablet size.
