### PR TITLE
Clear prior AOI on opening new project

### DIFF
--- a/src/mmw/js/src/projects/views.js
+++ b/src/mmw/js/src/projects/views.js
@@ -168,6 +168,10 @@ var ProjectRowView = Marionette.ItemView.extend({
 
     openProject: function() {
         App.clearAnalyzeCollection();
+        App.map.set({
+            'areaOfInterest': null,
+            'areaOfInterestName': ''
+        });
         router.navigate('/project/' + this.model.id, { trigger: true });
     }
 });


### PR DESCRIPTION
## Overview

This PR fixes a bug described in #1767 whereby loading a previously saved project immediately after creating an RWD project would not remove the markers placed to designate the RWD clicked point and RWD outlet point

Connects #1767 

## Testing Instructions

 * get and bundle this branch, then view it in the browser
 * login, then create and save new non-RWD project as described in #1767
 * start over and create and save new RWD project, verifying that you see the clicked points
 * click on "My Projects" to open the project menu, then select the first saved non-RWD project
 * when that project loads, verify that the new AOI appears and everything loads as normal & that the RWD points from the previous RWD project are saved on the map
 * verify that you can switch back and forth between projects as before and that you don't see any errors in the console