### PR TITLE
Feature gate ITSI and Analyze mode for BiG CZ

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -50,3 +50,5 @@ geop_version: "1.2.0"
 
 nginx_cache_dir: "/var/cache/nginx"
 observation_api_url: "http://www.wikiwatershed-vs.org/"
+
+bigcz_mode: "{{ lookup('env', 'MMW_BIGCZ_MODE') }}"

--- a/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
@@ -19,4 +19,6 @@ envdir_config:
   MMW_STACK_COLOR: "{{ stack_color }}"
   MMW_TILECACHE_BUCKET: "{{ tilecache_bucket_name }}"
   MMW_STACK_TYPE: "{{ stack_type }}"
+  MMW_BIGCZ_MODE: "{{ bigcz_mode }}"
+
   ROLLBAR_SERVER_SIDE_ACCESS_TOKEN: "Unknown"

--- a/scripts/mode.sh
+++ b/scripts/mode.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Switch between MMW and BiG CZ modes
+
+set -e
+set -u
+set -x
+
+usage() {
+    set +x
+    echo -n "$(basename "${0}") [OPTION]
+
+Set development mode to MMW or BiG CZ.
+
+Options:
+    mmw     Model My Watershed
+    bigcz   BiG Critical Zone
+"
+}
+
+
+case $1 in
+    mmw)
+        vagrant ssh app -c 'echo "" | sudo tee /etc/mmw.d/env/MMW_BIGCZ_MODE'
+        vagrant ssh app -c 'sudo restart mmw-app'
+        ;;
+    bigcz)
+        vagrant ssh app -c 'echo "1" | sudo tee /etc/mmw.d/env/MMW_BIGCZ_MODE'
+        vagrant ssh app -c 'sudo restart mmw-app'
+        ;;
+    help)
+        usage
+        exit 0
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -128,7 +128,9 @@ def get_client_settings(request):
             'vizer_ignore': settings.VIZER_IGNORE,
             'vizer_names': settings.VIZER_NAMES,
             'model_packages': get_model_packages(),
-            'mapshed_max_area': settings.GWLFE_CONFIG['MaxAoIArea']
+            'mapshed_max_area': settings.GWLFE_CONFIG['MaxAoIArea'],
+            'analyze_enabled': settings.ANALYZE_ENABLED,
+            'itsi_enabled': settings.ITSI_ENABLED,
         }),
         'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,
     }

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -20,7 +20,8 @@ var App = new Marionette.Application({
         this.state = new models.AppStateModel();
 
         // If in embed mode we are by default in activity mode.
-        var activityMode = settings.get('itsi_embed');
+        var activityMode = settings.get('itsi_enabled') &&
+                settings.get('itsi_embed');
         settings.set('activityMode', activityMode);
 
         // Initialize embed interface if in activity mode
@@ -123,6 +124,7 @@ var App = new Marionette.Application({
     showLoginModal: function(onSuccess) {
         new userViews.LoginModalView({
             model: new userModels.LoginFormModel({
+                showItsiButton: settings.get('itsi_enabled'),
                 successCallback: onSuccess
             }),
             app: this

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -4,6 +4,8 @@ var _ = require('lodash');
 
 var defaultSettings = {
     itsi_embed: false,
+    itsi_enabled: true,
+    analyze_enabled: true,
     base_layers: {},
     stream_layers: {},
     coverage_layers: {},

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -984,7 +984,9 @@ function addLayer(shape, name, label) {
 }
 
 function navigateToAnalyze() {
-    router.navigate('analyze', { trigger: true });
+    if (settings.get('analyze_enabled')) {
+        router.navigate('analyze', { trigger: true });
+    }
 }
 
 module.exports = {

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -110,7 +110,8 @@ var SignUpFormModel = ModalBaseModel.extend({
         username: null,
         password1: null,
         password2: null,
-        email: null
+        email: null,
+        showItsiButton: true
     },
 
     url: '/user/sign_up',

--- a/src/mmw/js/src/user/templates/loginModal.html
+++ b/src/mmw/js/src/user/templates/loginModal.html
@@ -24,8 +24,10 @@
     <div class="text-muted" id="continue-as-divider">
         Or continue as
     </div>
-    <div class="row" id="guest-buttons">
+    <div class="row{% if showItsiButton %} half-width{% endif %}" id="guest-buttons">
         <button type="button" class="btn btn-lg btn-primary" data-dismiss="modal" id="dismiss-button">Guest</button>
+        {% if showItsiButton %}
         <button type="button" class="btn btn-lg btn-primary itsi-login">ITSI</button>
+        {% endif %}
     </div>
 {% endblock %}

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -355,6 +355,15 @@ OMGEO_SETTINGS = [[
     }
 ]]
 
+# Feature flags
+MMW_BIGCZ_MODE = bool(environ.get('MMW_BIGCZ_MODE', False))
+if MMW_BIGCZ_MODE:
+    ANALYZE_ENABLED = False
+    ITSI_ENABLED = False
+else:
+    ANALYZE_ENABLED = True
+    ITSI_ENABLED = True
+
 # ITSI Portal Settings
 ITSI = {
     'client_id': environ.get('MMW_ITSI_CLIENT_ID', 'model-my-watershed'),

--- a/src/mmw/sass/base/_login.scss
+++ b/src/mmw/sass/base/_login.scss
@@ -7,10 +7,16 @@
 #guest-buttons {
   .btn {
     float: left;
-    width: 48%;
+    width: 100%;
   }
 
-  .btn + .btn {
-    margin-left: 4%;
+  &.half-width {
+    .btn {
+      width: 48%;
+    }
+
+    .btn + .btn {
+      margin-left: 4%;
+    }
   }
 }


### PR DESCRIPTION
## Overview

Adds the `MMW_BIGCZ_MODE` environment variable to enable/disable certain
MMW features when enabled.

Connects #1763

### Demo

The ITSI login button should not be visible when BiG CZ mode is enabled.

BiG CZ:

![screenshot 2017-03-28 at 14 09 56](https://cloud.githubusercontent.com/assets/43062/24420261/402d4c2a-13c0-11e7-891b-acbeac9b6836.png)

Drawing a shape should not redirect to Analyze mode in BiG CZ mode:

![screenshot 2017-03-28 at 14 21 28](https://cloud.githubusercontent.com/assets/43062/24420762/edd2be7c-13c1-11e7-8c8e-a237aa6603ea.png)

## Testing Instructions

* Enable BiG CZ:
```
MMW_BIGCZ_MODE=1 vagrant provision app
```
* Verify that the ITSI login button is not visible
* Verfy that Draw mode doesn't navigate to Analyze mode after producing a shape
* Disable BiGCZ:
```
MMW_BIGCZ_MODE= vagrant provision app
```