### PR TITLE
Add layer toggles to analyze sidebar

### DIFF
--- a/src/mmw/js/src/analyze/templates/analyzeLayerToggle.html
+++ b/src/mmw/js/src/analyze/templates/analyzeLayerToggle.html
@@ -1,0 +1,18 @@
+{% if message %}
+    <div class="analyze-layermessage">
+        {{ message }}
+    </div>
+{% else %}
+    <button class="analyze-layertoggle">
+            Related Layer: {{ layerDisplay }}
+            <div class="on-off-toggle">
+                {% if isLayerOn %}
+                    <i class="fa fa-times" aria-hidden="true"></i>
+                    Turn off
+                {% else %}
+                    <i class="fa fa-check" aria-hidden="true"></i>
+                    Turn on
+                {% endif %}
+            </div>
+    </button>
+{% endif %}

--- a/src/mmw/js/src/analyze/templates/analyzeResults.html
+++ b/src/mmw/js/src/analyze/templates/analyzeResults.html
@@ -1,6 +1,9 @@
-<div class="desc-region"></div>
-<div class="chart-region"></div>
-<div class="table-region"></div>
-<div class="downloadcsv-link" data-action="download-csv">
-    <i class="fa fa-download"></i> Download this data
+<div class="layer-region"></div>
+<div class="results-content">
+    <div class="desc-region"></div>
+    <div class="chart-region"></div>
+    <div class="table-region"></div>
+    <div class="downloadcsv-link" data-action="download-csv">
+        <i class="fa fa-download"></i> Download this data
+    </div>
 </div>

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -16,7 +16,7 @@ var App = new Marionette.Application({
     initialize: function() {
         this.restApi = new RestAPI();
         this.map = new models.MapModel();
-        this.layers = new models.LayersModel();
+        this.layerTabs = new models.LayerTabCollection(null);
         this.state = new models.AppStateModel();
 
         // If in embed mode we are by default in activity mode.
@@ -32,7 +32,7 @@ var App = new Marionette.Application({
         // This view is intentionally not attached to any region.
         this._mapView = new views.MapView({
             model: this.map,
-            layersModel: this.layers,
+            layerTabCollection: this.layerTabs,
             el: '#map'
         });
 
@@ -74,13 +74,13 @@ var App = new Marionette.Application({
         }
     },
 
-    getLayersModel: function() {
-        return this.layers;
+    getLayerTabCollection: function() {
+        return this.layerTabs;
     },
 
     showLayerPicker: function() {
         this.layerPickerView = new LayerPickerView({
-            model: this.layers,
+            collection: this.layerTabs,
             leafletMap: this.getLeafletMap(),
         });
         this.rootView.layerPickerRegion.show(this.layerPickerView);
@@ -152,7 +152,7 @@ function initializeShutterbug() {
                 'width': window.innerWidth
             });
 
-            var activeBaseLayer = App.getLayersModel().getCurrentActiveBaseLayer(),
+            var activeBaseLayer = App.getLayerTabCollection().getCurrentActiveBaseLayer(),
                 googleLayerVisible = !!activeBaseLayer.get('leafletLayer')._google;
 
             if (googleLayerVisible) {
@@ -181,7 +181,7 @@ function initializeShutterbug() {
                 'width': ''
             });
 
-            var activeBaseLayer = App.getLayersModel().getCurrentActiveBaseLayer(),
+            var activeBaseLayer = App.getLayerTabCollection().getCurrentActiveBaseLayer(),
                 googleLayerVisible = !!activeBaseLayer.get('leafletLayer')._google;
 
             if (googleLayerVisible) {

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -119,7 +119,7 @@ var CompareScenarioView = Marionette.LayoutView.extend({
 
     onShow: function() {
         this.mapModel = new coreModels.MapModel({});
-        this.layersModel = new coreModels.LayersModel();
+        this.LayerTabCollection = new coreModels.LayerTabCollection();
         this.mapModel.set({
             'areaOfInterest': this.projectModel.get('area_of_interest'),
             'areaOfInterestName': this.projectModel.get('area_of_interest_name')
@@ -131,8 +131,8 @@ var CompareScenarioView = Marionette.LayoutView.extend({
             addLocateMeButton: false,
             addLayerSelector: false,
             showLayerAttribution: false,
-            initialLayerName: App.getLayersModel().getCurrentActiveBaseLayerName(),
-            layersModel: this.layersModel,
+            initialLayerName: App.getLayerTabCollection().getCurrentActiveBaseLayerName(),
+            LayerTabCollection: this.LayerTabCollection,
             interactiveMode: false
         });
 

--- a/src/mmw/js/src/core/layerPicker.js
+++ b/src/mmw/js/src/core/layerPicker.js
@@ -242,7 +242,7 @@ var LayerPickerView = Marionette.LayoutView.extend({
 
     collectionEvents: {
         'change': 'render',
-        'change:layer': 'render'
+        'toggle:layer': 'render'
     },
 
     initialize: function (options) {

--- a/src/mmw/js/src/core/layerPicker.js
+++ b/src/mmw/js/src/core/layerPicker.js
@@ -273,9 +273,10 @@ var LayerPickerView = Marionette.LayoutView.extend({
                         if (layers) {
                             return layers.findWhere({ active : true });
                         }
-                    }));
-                layerTab.navButtonClass = showTabAsActive ?
-                    'layerpicker-navbutton active' : 'layerpicker-navbutton';
+                    })),
+                    activeClass = showTabAsActive ? 'active ' : '',
+                    openClass = layerTab.active ? 'open ' : '';
+                layerTab.navButtonClass = 'layerpicker-navbutton ' +  openClass + activeClass;
             })
         };
     },

--- a/src/mmw/js/src/core/templates/layerPicker.html
+++ b/src/mmw/js/src/core/templates/layerPicker.html
@@ -1,11 +1,2 @@
 <div id="layerpicker-tab"></div>
-<div class="layerpicker-nav">
-    {% for layerTab in layerTabs %}
-        <div
-            class="{{ layerTab.navButtonClass }}"
-            data-layer-tab="{{ layerTab.name }}"
-        >
-            <i class="{{ layerTab.iconClass }}" title="{{ layerTab.name }}"></i>
-        </div>
-    {% endfor %}
-</div>
+<div class="layerpicker-nav"></div>

--- a/src/mmw/js/src/core/templates/layerPickerNav.html
+++ b/src/mmw/js/src/core/templates/layerPickerNav.html
@@ -1,0 +1,8 @@
+{% for layerTab in layerTabs %}
+    <div
+        class="{{ layerTab.navButtonClass }}"
+        data-layer-tab="{{ layerTab.name }}"
+    >
+        <i class="{{ layerTab.iconClass }}" title="{{ layerTab.name }}"></i>
+    </div>
+{% endfor %}

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -76,10 +76,10 @@ describe('Core', function() {
 
             it('adds layers to the map when the map model attribute areaOfInterest is set', function() {
                 var model = new models.MapModel(),
-                    layersModel = new models.LayersModel(),
+                    layerTabCollection = new models.LayerTabCollection(null),
                     view = new views.MapView({
                         model: model,
-                        layersModel: layersModel,
+                        layerTabCollection: layerTabCollection,
                         el: sandboxSelector
                     }),
                     featureGroup = view._areaOfInterestLayer;
@@ -95,10 +95,10 @@ describe('Core', function() {
 
             it('updates the position of the map when the map model location attributes are set', function() {
                 var model = new models.MapModel(),
-                    layersModel = new models.LayersModel(),
+                    layerTabCollection = new models.LayerTabCollection(null),
                     view = new views.MapView({
                         model: model,
-                        layersModel: layersModel,
+                        layerTabCollection: layerTabCollection,
                         el: sandboxSelector
                     }),
                     latLng = [40, -75],
@@ -117,10 +117,10 @@ describe('Core', function() {
 
             it('silently sets the map model location attributes when the map position is updated', function() {
                 var model = new models.MapModel(),
-                    layersModel = new models.LayersModel(),
+                    layerTabCollection = new models.LayerTabCollection(null),
                     view = new views.MapView({
                         model: model,
-                        layersModel: layersModel,
+                        layerTabCollection: layerTabCollection,
                         el: sandboxSelector
                     }),
                     latLng = [40, -75],
@@ -137,10 +137,10 @@ describe('Core', function() {
 
             it('adds the map-container top & bottom classes to the map container for DoubleHeader and Small Footer', function(){
                 var model = new models.MapModel(),
-                    layersModel = new models.LayersModel(),
+                    layerTabCollection = new models.LayerTabCollection(null),
                     view = new views.MapView({
                         model: model,
-                        layersModel: layersModel,
+                        layerTabCollection: layerTabCollection,
                         el: sandboxSelector
                     }),
                     $container = $(sandboxSelector).parent();
@@ -154,10 +154,10 @@ describe('Core', function() {
 
             it('adds the map-container sidebar top & bottom classes to the map container for Draw screen', function(){
                 var model = new models.MapModel(),
-                    layersModel = new models.LayersModel(),
+                    layerTabCollection = new models.LayerTabCollection(null),
                     view = new views.MapView({
                         model: model,
-                        layersModel: layersModel,
+                        layerTabCollection: layerTabCollection,
                         el: sandboxSelector
                     }),
                     $container = $(sandboxSelector).parent();
@@ -185,9 +185,9 @@ describe('Core', function() {
                 ];
                 settings.set('base_layers', baseLayers);
 
-                var model = new models.LayersModel(),
+                var collection = new models.LayerTabCollection(null),
                     view = new LayerPickerView({
-                        model: model,
+                        collection: collection,
                         leafletMap: App.getLeafletMap(),
                         // The basemaps are currently the 5th tab in the
                         // layerpicker

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -84,6 +84,7 @@ var utils = {
         if (layerGroup.get('name') === "Basemaps") {
             map.fireEvent('baselayerchange', selectedLayer.get('leafletLayer'));
         }
+        layerGroup.trigger('toggle:layer');
     },
 
     // A function for enabling/disabling modal buttons.  In additiion

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var _ = require('underscore'),
+var L = require('leaflet'),
+    _ = require('underscore'),
     lodash = require('lodash'),
     md5 = require('blueimp-md5').md5,
     intersect = require('turf-intersect'),
@@ -33,6 +34,55 @@ var utils = {
             return data.toFixed(3);
         } else {
             return noData;
+        }
+    },
+
+    // If the google layer wasn't ready to set up when the model was initialized,
+    // initialize it
+    loadGoogleLayer: function(layer) {
+        if (window.google) {
+            layer.set('leafletLayer', new L.Google(layer.get('googleType'), {
+                maxZoom: layer.get('maxZoom')
+            }));
+        }
+    },
+
+    toggleLayer: function(selectedLayer, map, layerGroup) {
+        var layers = layerGroup.get('layers');
+        if (!selectedLayer.get('leafletLayer') && selectedLayer.get('googleType')) {
+            this.loadGoogleLayer(selectedLayer);
+        }
+        var currentActiveLayers = layers.where({ active: true });
+        var isInCurrentActive = _.includes(currentActiveLayers, selectedLayer);
+        if (currentActiveLayers.length > 0) {
+            // Works like a checkbox
+            if (layerGroup.get('canSelectMultiple')) {
+                if (isInCurrentActive) {
+                    selectedLayer.set('active', false);
+                    map.removeLayer(selectedLayer.get('leafletLayer'));
+                } else {
+                    selectedLayer.set('active', true);
+                    map.addLayer(selectedLayer.get('leafletLayer'));
+                }
+            // Works like radio buttons
+            } else {
+                if (isInCurrentActive && !layerGroup.get('mustHaveActive')) {
+                    selectedLayer.set('active', false);
+                    map.removeLayer(selectedLayer.get('leafletLayer'));
+                } else {
+                    var currentActiveLayer = currentActiveLayers[0];
+                    currentActiveLayer.set('active', false);
+                    map.removeLayer(currentActiveLayer.get('leafletLayer'));
+                    selectedLayer.set('active', true);
+                    map.addLayer(selectedLayer.get('leafletLayer'));
+                }
+            }
+        } else {
+            selectedLayer.set('active', true);
+            map.addLayer(selectedLayer.get('leafletLayer'));
+        }
+        if (layerGroup.get('name') === "Basemaps") {
+            map.fireEvent('baselayerchange', selectedLayer.get('leafletLayer'));
         }
     },
 

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -243,7 +243,7 @@ var MapView = Marionette.ItemView.extend({
     initialize: function(options) {
         var map_controls = settings.get('map_controls');
 
-        this.layersModel = options.layersModel;
+        this.layerTabCollection = options.layerTabCollection;
 
         _.defaults(options, {
             addZoomControl: _.contains(map_controls, 'ZoomControl'),
@@ -291,8 +291,8 @@ var MapView = Marionette.ItemView.extend({
         this.setupGeoLocation(maxGeolocationAge);
 
         var initialLayer = options.initialLayerName ?
-            this.layersModel.baseLayers.findWhere({ display: options.initialLayerName }) :
-            this.layersModel.baseLayers.findWhere({active: true});
+            this.layerTabCollection.findLayerWhere({ display: options.initialLayerName }) :
+            this.layerTabCollection.getBaseLayerTab().findLayerWhere({ active: true });
 
         if (initialLayer) {
             map.addLayer(initialLayer.get('leafletLayer'));
@@ -638,7 +638,7 @@ var MapView = Marionette.ItemView.extend({
 
     updateDrbLayerZoomLevel: function(layer) {
         var layerMaxZoom = layer.options.maxZoom;
-        var drbStreamLayer = this.layersModel.streamLayers.findWhere({ code: 'drb_streams_v2'});
+        var drbStreamLayer = this.layerTabCollection.findLayerWhere({ code: 'drb_streams_v2' });
         drbStreamLayer.get('leafletLayer').options.maxZoom = layerMaxZoom;
     },
 
@@ -656,7 +656,8 @@ var MapView = Marionette.ItemView.extend({
                 return;
             } else {
                 // Set layer zoom level to the max for the current area
-                self.layersModel.baseLayers.forEach(function(layer) {
+                self.layerTabCollection.getBaseLayerTab().get('layerGroups').forEach(function(layerGroup) {
+                    layerGroup.get('layers').forEach(function(layer) {
                         if (layer.get('googleType')) {
                             var leafletLayer = layer.get('leafletLayer');
                             if (leafletLayer) {
@@ -666,6 +667,7 @@ var MapView = Marionette.ItemView.extend({
                             }
                         }
                     });
+                });
             }
         });
     },

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -79,6 +79,7 @@ LAYER_GROUPS = {
     'coverage': [
         {
             'display': 'National Land Cover Database',
+            'code': 'nlcd',
             'css_class_prefix': 'nlcd',
             'short_display': 'NLCD',
             'helptext': 'National Land Cover Database defines'
@@ -92,6 +93,7 @@ LAYER_GROUPS = {
         },
         {
             'display': 'Hydrologic Soil Groups From gSSURGO',
+            'code': 'soil',
             'short_display': 'SSURGO',
             'css_class_prefix': 'soil',
             'helptext': 'Soils are classified by the Natural Resource Conservation '

--- a/src/mmw/sass/components/_sidebar.scss
+++ b/src/mmw/sass/components/_sidebar.scss
@@ -56,6 +56,7 @@
     width: 100%;
 }
 
+.results-content.downloadcsv-link,
 .downloadcsv-link {
     padding-top: 10px;
     padding-left: 5px;

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -1,5 +1,9 @@
 // Analyze
 
+.tab-content.analyze {
+    padding: 0 !important;
+}
+
 #analyze-output-wrapper {
   position: absolute;
   left: 0;
@@ -10,6 +14,14 @@
   z-index: 100;
   width: 100%;
 }
+
+.results-content,
+.analyze-layertoggle,
+.analyze-layermessage,
+.aoi-region {
+    padding: 1rem;
+}
+
 
 .analyze-message-region {
   position: relative;
@@ -29,6 +41,24 @@
 .analyze-description {
   font-size: 0.8rem;
   padding-top: 5px;
+}
+
+.layer-region {
+    border-bottom: 2px solid $ui-light;
+    .analyze-layertoggle, .analyze-layermessage {
+        padding-bottom: 0.5rem;
+        border: none;
+        font-size: 0.7rem;
+        background: none;
+        display: inline;
+        text-align: left;
+        width: 100%;
+        > .on-off-toggle {
+            color: #337ab7; // bootstrap brand-primary used for anchor tags
+            display: inline;
+            margin-left: 1rem;
+        }
+    }
 }
 
 .paging-ctl-row {


### PR DESCRIPTION
## Overview

The MMW experience is greatly enhanced when you use the overlays. To call them out, we're adding related overlay toggles to each analyze tab (except animals).

#### Wireframe
![screen shot 2017-03-29 at 2 52 01 pm](https://cloud.githubusercontent.com/assets/7633670/24471397/0152b73a-1490-11e7-8d53-145243338e9f.png)

(Note in the above, Jeff gave sign off that the Turn On blue should actually match the link color in the rest of the app)

Connects #1745 
Connects #1776 

### Demo

![suj3f3azty](https://cloud.githubusercontent.com/assets/7633670/24471435/1ab87ef8-1490-11e7-96e9-ad74b0619c8e.gif)

### Notes

- The "Total Area" info at the top of each tab will move eventually, so don't worry about that not matching the wireframe

- For the water quality tab @jfrankl is working on a mockup of a collapsable list of layers (there are three: TP, TSS, TN). Will add a commit to style them accordingly once that's ready 

## Testing Instructions

 * Bundle
 * Test the layerpicker as its model has been refactored
     - DRB layers should be disabled when outside their extent
      - Go through each tab
 * Draw an AOI
 * Go through each tab analyze view and confirm you see the relevant layers for each
* The main layerpicker should be synced with the toggles
 * Pointsource should have a loading message while loading

