### PR TITLE
Move draw tools from map to pane

### DIFF
--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -25,7 +25,9 @@ var DrawController = {
 
         App.rootView.geocodeSearchRegion.show(geocodeSearch);
         App.rootView.drawToolsRegion.show(toolbarView);
-        App.rootView.sidebarRegion.show(new views.DrawWindow());
+        App.rootView.sidebarRegion.show(new views.DrawWindow({
+            model: toolbarModel
+        }));
 
         enableSingleProjectModeIfActivity();
 

--- a/src/mmw/js/src/draw/models.js
+++ b/src/mmw/js/src/draw/models.js
@@ -11,7 +11,8 @@ var ToolbarModel = Backbone.Model.extend({
         predefinedShapeTypes: null,
         outlineFeatureGroup: null,
         polling: false,
-        pollError: false
+        pollError: false,
+        selectedDrawTool: null
     },
 
     enableTools: function() {

--- a/src/mmw/js/src/draw/templates/delineationOptions.html
+++ b/src/mmw/js/src/draw/templates/delineationOptions.html
@@ -1,27 +1,30 @@
-<div id="delineate-shape" class="dropdown menu-left">
-  <button class="btn btn-md btn-search-tool dropdown-toggle {{ 'disabled' if not toolsEnabled }}"
-      type="button" data-toggle="dropdown" aria-expanded="true">
-    {% if polling %}
-        <i class="fa fa-circle-o-notch fa-spin"></i>
-    {% endif %}
-    {% if pollError %}
-        <i class="fa fa-exclamation-triangle"></i>
-    {% endif %}
-    Delineate Watershed
-    <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu menu-left" role="menu">
-    <li role="presentation">
-      <a role="menuitem" tabindex="-1" href="#" data-shape-type="stream" data-snapping-on="true" data-data-source={{DRB}}>
+<div class="delineate-watershed-tool">
+  {% if polling %}
+    <div class="delineate-watershed-status-icon pull-right">
+      <i class="fa fa-circle-o-notch fa-spin"></i>
+    </div>
+  {% endif %}
+  {% if pollError %}
+    <div class="delineate-watershed-status-icon pull-right">
+      <i class="fa fa-exclamation-triangle"></i>
+    </div>
+  {% endif %}
+  <ul class="draw-pane-list">
+    <li class="draw-pane-list-item" role="presentation">
+      <button class="draw-pane-list-item-button" role="menuitem" tabindex="-1"
+              href="#" data-shape-type="stream" data-snapping-on="true" data-data-source={{DRB}}
+              {{ 'disabled' if toolsDisabled }}>
         <span>Delaware High Resolution</span> <i class="split fa fa-question-circle"
           data-content="Snaps to the nearest downhill point on the Delaware River Basin high resolution stream network and calculates the watershed upstream of this point using a 1/3 arc second (10m) resolution digital elevation model."></i>
-      </a>
+      </button>
     </li>
-    <li role="presentation">
-      <a role="menuitem" tabindex="-1" href="#" data-shape-type="stream" data-snapping-on="true" data-data-source={{NHD}}>
-        <span style="width: 250px">Continental US Medium Resolution</span> <i class="split fa fa-question-circle"
+    <li class="draw-pane-list-item" role="presentation">
+      <button class="draw-pane-list-item-button" role="button" tabindex="-1"
+              href="#" data-shape-type="stream" data-snapping-on="true" data-data-source={{NHD}}
+              {{ 'disabled' if toolsDisabled }}>
+        <span>Continental US Medium Resolution</span> <i class="split fa fa-question-circle"
           data-content="Snaps to the nearest downhill point on the medium resolution flow lines of the National Hydrography Dataset and calculates the watershed upstream of this point using the 30m resolution NHDPlus flow direction grid."></i>
-      </a>
+      </button>
     </li>
     <!-- Hill Slope is disabled currently
     <li role="presentation">

--- a/src/mmw/js/src/draw/templates/draw.html
+++ b/src/mmw/js/src/draw/templates/draw.html
@@ -1,19 +1,14 @@
-<div id="draw-shape" class="dropdown menu-left">
-  <button class="btn btn-md btn-search-tool dropdown-toggle {{ 'disabled' if not toolsEnabled }}"
-      {{ 'disabled' if not toolsEnabled }} type="button" data-toggle="dropdown" aria-expanded="true">
-      Draw Area
-    <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu menu-left" role="menu">
-    <li role="presentation">
-      <a role="menuitem" tabindex="-1" href="#" id="custom-shape">
-        <span>Free Draw</span> <i class="split fa fa-question-circle" data-content="Draw a custom area on which you want to perform perform water quality analysis."></i>
-      </a>
-    </li>
-    <li role="presentation">
-      <a role="menuitem" tabindex="-1" href="#" id="one-km-stamp">
-        <span>Square Km</span> <i class="split fa fa-question-circle" data-content="Draw a predefined one kilometer square with a center at the point you choose."></i>
-      </a>
-    </li>
-  </ul>
-</div>
+<ul class="draw-pane-list">
+  <li class="draw-pane-list-item" role="presentation">
+    <button class="draw-pane-list-item-button" role="button" tabindex="-1"
+            href="#" id="custom-shape" {{ 'disabled' if toolsDisabled }}>
+      <span>Free Draw</span> <i class="split fa fa-question-circle" data-content="Draw a custom area on which you want to perform perform water quality analysis."></i>
+    </button>
+  </li>
+  <li class="draw-pane-list-item" role="presentation">
+    <button class="draw-pane-list-item-button" role="button" tabindex="-1"
+            href="#" id="one-km-stamp" {{ 'disabled' if toolsDisabled }}>
+      <span>Square Km</span> <i class="split fa fa-question-circle" data-content="Draw a predefined one kilometer square with a center at the point you choose."></i>
+    </button>
+  </li>
+</ul>

--- a/src/mmw/js/src/draw/templates/reset.html
+++ b/src/mmw/js/src/draw/templates/reset.html
@@ -1,1 +1,0 @@
-<button class='btn btn-md btn-active btn-search-tool'>Reset</button>

--- a/src/mmw/js/src/draw/templates/selectType.html
+++ b/src/mmw/js/src/draw/templates/selectType.html
@@ -7,7 +7,7 @@
           data-layer-code="{{ item.code }}"
           data-short-display="{{ item.short_display }}"
           data-min-zoom="{{ item.minZoom }}"
-          {{ 'disabled' if toolsDisabled }}>
+          {{ "disabled" if item.minZoom > currentZoomLevel }}>
           <span>
             {{ item.display }}
           </span> <i class="split fa fa-question-circle"

--- a/src/mmw/js/src/draw/templates/selectType.html
+++ b/src/mmw/js/src/draw/templates/selectType.html
@@ -1,21 +1,18 @@
-<div id="predefined-shape" class="dropdown">
-  <button class="btn btn-md btn-search-tool dropdown-toggle {{ 'disabled' if not toolsEnabled }}"
-      type="button" data-toggle="dropdown" aria-expanded="true">
-    Select by Boundary
-    <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu menu-left" role="menu" id="wrapper">
-  {% for item in predefinedShapeTypes %}
-      <li role="presentation">
-        <a role="menuitem" tabindex="-1" href="#"
-           data-tile-url="{{ item.url }}"
-           data-layer-code="{{ item.code }}"
-           data-short-display="{{ item.short_display }}"
-           data-min-zoom="{{ item.minZoom }}">
-          <span>{{ item.display }}</span> <i class="split fa fa-question-circle"
-                                             data-content="{{ item.helptext }}"></i>
-        </a>
-      </li>
-  {% endfor %}
-  </ul>
-</div>
+<ul class="draw-pane-list">
+{% for item in predefinedShapeTypes %}
+    <li class="draw-pane-list-item" role="presentation">
+      <button class="draw-pane-list-item-button" role="button"
+          tabindex="-1" href="#"
+          data-tile-url="{{ item.url }}"
+          data-layer-code="{{ item.code }}"
+          data-short-display="{{ item.short_display }}"
+          data-min-zoom="{{ item.minZoom }}"
+          {{ 'disabled' if toolsDisabled }}>
+          <span>
+            {{ item.display }}
+          </span> <i class="split fa fa-question-circle"
+                     data-content="{{ item.helptext }}"></i>
+      </button>
+    </li>
+{% endfor %}
+</ul>

--- a/src/mmw/js/src/draw/templates/toolbar.html
+++ b/src/mmw/js/src/draw/templates/toolbar.html
@@ -1,5 +1,1 @@
-<div id="select-area-region"></div>
-<div id="draw-region"></div>
-<div id="place-marker-region"></div>
 <div id="dropbox-region"></div>
-<div id="reset-draw-region"></div>

--- a/src/mmw/js/src/draw/templates/uploadFile.html
+++ b/src/mmw/js/src/draw/templates/uploadFile.html
@@ -1,0 +1,15 @@
+<ul class="draw-pane-list">
+  <li class="draw-pane-list-item" role="presentation">
+    <div>
+        <span class="draw-button-title pull-left"
+              id="file-upload-title">
+            Drag and drop a file (shp, geojson, what?)
+        </span>
+        <br />
+        <button class="btn btn-success pull-left"
+                id="draw-tool-file-upload-button">
+            Select a file
+        </button>
+    </div>
+  </li>
+</ul>

--- a/src/mmw/js/src/draw/templates/window.html
+++ b/src/mmw/js/src/draw/templates/window.html
@@ -1,2 +1,28 @@
 <h1>Select Area</h1>
-<p>Draw tools go here</p>
+<p id="draw-pane-header-description">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Duis ac pharetra nibh. Nullam gravida massa non egestas
+    pellentesque.
+</p>
+<div id="draw-pane-buttons">
+    {% for drawTool in drawTools %}
+        <div class="btn btn-lg btn-block draw-tool-button" type="button"
+            data-toggle="dropdown" aria-expanded="true"
+            id={{ drawTool.button }}>
+            <p class="draw-button-title pull-left">
+                {{ drawTool.name }}
+            </p>
+            <span class="draw-button-icon caret pull-right"></span>
+            <br />
+            <p class="draw-button-subtitle pull-left">
+                Lorem ipsum dolor sit amet, consectetur
+            </p>
+        </div>
+        {% if activeDrawTool == drawTool.id %}
+            <div class="draw-tool-button-slideout" aria-expanded="true">
+                <i class="fa fa-times pull-right reset-draw-button"></i>
+                <div id={{ drawTool.region }}></div>
+            </div>
+        {% endif %}
+    {% endfor %}
+</div>

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -46,9 +46,9 @@ function actOnUI(datum, bool) {
         $el = $('[data-layer-code="' + code + '"]');
 
     if (bool) {
-        $el.addClass('disabled');
+        $el.prop('disabled', true);
     } else {
-        $el.removeClass('disabled');
+        $el.prop('disabled', false);
     }
 }
 
@@ -531,7 +531,7 @@ var SelectAreaView = Marionette.ItemView.extend({
             shortDisplay = $el.data('short-display'),
             minZoom = $el.data('min-zoom');
 
-        if (!$el.hasClass('disabled')) {
+        if (!$el.prop('disabled')) {
             clearAoiLayer();
             this.changeOutlineLayer(tileUrl, layerCode, shortDisplay, minZoom);
             e.preventDefault();

--- a/src/mmw/sass/pages/_draw.scss
+++ b/src/mmw/sass/pages/_draw.scss
@@ -20,3 +20,86 @@
     margin-left: 30px;
   }
 }
+
+#draw-pane-header-description {
+  margin-top: 0.8rem;
+}
+
+#draw-pane-buttons {
+  margin-top: 1rem;
+
+  & .draw-tool-button {
+    background-color: #d4d7d8;
+  }
+
+  & .draw-tool-button-slideout {
+    margin-top: 0px;
+    margin-bottom: 5px;
+    background-color: #eceff1;
+    line-height: 0.5rem;
+
+    & .reset-draw-button {
+      margin-top: 1rem;
+      margin-right: 0.9rem;
+      cursor: pointer;
+    }
+  }
+
+  & .draw-button-title {
+    font-size: 1rem;
+    font-weight: 400;
+    color: black;
+    line-height: 1.4;
+    margin-top: 0.4rem;
+  }
+
+  & .draw-button-subtitle {
+    font-size: 0.8rem;
+    margin-bottom: 0.4rem;
+  }
+
+  & .draw-button-icon {
+    margin-top: 1rem;
+  }
+
+  & #upload-file-region {
+    height: 5.5rem;
+
+    & #file-upload-title {
+      margin-top: 0;
+    }
+  }
+
+  & #draw-tool-file-upload-button {
+    margin-top: 0.4rem;
+    margin-bottom: 0.4rem;
+  }
+
+  & .draw-pane-list {
+    text-align: left;
+    font-size: 1rem;
+    display: inline;
+
+    & .draw-pane-list-item {
+      list-style-type: none;
+      margin-top: 0.5rem;
+      margin-bottom: 0.5rem;
+      margin-left: 0.8rem;
+      font-size: 0.8rem;
+
+      & .draw-pane-list-item-button {
+        background: transparent;
+        border: none;
+      }
+
+      & .draw-pane-list-item-button:disabled {
+        color: #7f8181;
+      }
+    }
+  }
+
+  & .delineate-watershed-status-icon {
+    margin-top: 1rem;
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR moves the draw tools from the map onto a sidebar as displayed in the wireframes linked from #1735 

The styling currently roughly matches what's in the wireframes, and the image below shows the behavior. 

Succinctly: clicking to toggle a draw tool active de-activates and closes any others which are open, and clicking again on an active draw tool deactivates it. The x/close buttons call the reset action.

Connects #1735 

### Demo

![mmw-draw-pane](https://cloud.githubusercontent.com/assets/4165523/24477598/9cb4be48-14a5-11e7-83a7-8a7b0a0c68c1.gif)

### Notes

The new DrawWindow view mostly supplants the old ToolbarView; the only reason that view has been kept around now is so that we can keep the shapefile upload button there. #1735 suggested not bothering to change it, but if we'd like I can move it -- and thereby remove the rest of the ToolbarView.

Tagging @jfrankl for answers to the following Qs:

* should we keep the tooltips for each item in the lists?
* how should these lists be styled?

## Testing Instructions

 * get this branch, then `./scripts/bundle.sh --vendor` and `./scripts/bundle.sh`
 * visit localhost:8000 and hard refresh
 * when the draw pane loads verify that all the controls still work (note: the Shapefile upload section's currently not active per note in #1735, and I left the old toolbar version on the map).
 * move back and forth between modeling, analyze, and draw, and verify that the tools continue to work
 * verify that the x/ reset button resets the drawing state
 * verify that the rest of the app still works as expected