### PR TITLE
Boundary layer search endpoint

### DIFF
--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -36,6 +36,8 @@ urlpatterns = patterns(
     url(r'start/gwlfe/$', views.start_gwlfe, name='start_gwlfe'),
     url(r'boundary-layers/(?P<table_code>\w+)/(?P<obj_id>[0-9]+)/$',
         views.boundary_layer_detail, name='boundary_layer_detail'),
+    url(r'boundary-layers-search/$',
+        views.boundary_layer_search, name='boundary_layer_search'),
     url(r'export/gms/?$', views.export_gms, name='export_gms'),
     url(r'point-source/$', views.drb_point_sources, name='drb_point_sources'),
 )

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -197,6 +197,8 @@ LAYER_GROUPS = {
                         'HUC-8 to analyze.',
             'minZoom': 7,
             'selectable': True,
+            'searchable': True,
+            'search_priority': 100,
         },
         {
             'code': 'huc10',
@@ -212,6 +214,8 @@ LAYER_GROUPS = {
                         'HUC-10 to analyze.',
             'minZoom': 8,
             'selectable': True,
+            'searchable': True,
+            'search_priority': 90,
         },
         {
             'code': 'huc12',
@@ -228,6 +232,8 @@ LAYER_GROUPS = {
                         'HUC-12 to analyze.',
             'minZoom': 9,
             'selectable': True,
+            'searchable': True,
+            'search_priority': 80,
         },
         {
             'code': 'county',


### PR DESCRIPTION
## Overview

Create a new API endpoint which performs a full text search against HUC boundary layers.

Connects #1765

### Demo

![image](https://cloud.githubusercontent.com/assets/43062/24514098/15bd9418-1541-11e7-8b73-a64b9ab58c7a.png)

### Notes

You need HUC boundary layers loaded locally to test this. This can take a long time. I recommend updating `layer_settings.py` to test searching against school boundary layers instead. These don't take much time to load.

## Testing Instructions

* Download boundary layers
```
vagrant ssh app
/vagrant/scripts/aws/setupdb.sh -b
```
* Update `layer_settings.py` (if you are missing any HUC boundaries)
* Exercise search endpoint:
```
http://localhost:8000/api/modeling/boundary-layers-search/?text=penn
```