### PR TITLE
Don't show expand control in compare view

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -130,6 +130,7 @@ var CompareScenarioView = Marionette.LayoutView.extend({
             addZoomControl: false,
             addLocateMeButton: false,
             addLayerSelector: false,
+            addSidebarToggleControl: false,
             showLayerAttribution: false,
             initialLayerName: App.getLayersModel().getCurrentActiveBaseLayerName(),
             layersModel: this.layersModel,

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -247,6 +247,7 @@ var MapView = Marionette.ItemView.extend({
 
         _.defaults(options, {
             addZoomControl: _.contains(map_controls, 'ZoomControl'),
+            addSidebarToggleControl: _.contains(map_controls, 'SidebarToggleControl'),
             addLocateMeButton: _.contains(map_controls, 'LocateMeButton'),
             showLayerAttribution: _.contains(map_controls, 'LayerAttribution'),
             interactiveMode: true // True if clicking on map does stuff
@@ -272,7 +273,9 @@ var MapView = Marionette.ItemView.extend({
 
         var maxGeolocationAge = 60000;
 
-        map.addControl(new SidebarToggleControl());
+        if (options.addSidebarToggleControl) {
+            map.addControl(new SidebarToggleControl());
+        }
 
         if (options.addLocateMeButton) {
             addLocateMeButton(map, maxGeolocationAge);
@@ -668,18 +671,6 @@ var MapView = Marionette.ItemView.extend({
                     });
             }
         });
-    },
-
-    addSidebarToggleControl: function() {
-        this._sidebarToggleControl = new SidebarToggleControl();
-        this._leafletMap.addControl(this._sidebarToggleControl);
-    },
-
-    removeSidebarToggleControl: function() {
-        if (this._sidebarToggleControl) {
-            this._leafletMap.removeControl(this._sidebarToggleControl);
-            delete this._sidebarToggleControl;
-        }
     },
 });
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -495,6 +495,7 @@ MAP_CONTROLS = [
     'LayerSelector',
     'LocateMeButton',
     'ZoomControl',
+    'SidebarToggleControl',
 ]
 
 GWLFE = 'gwlfe'

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -106,6 +106,7 @@ MAP_CONTROLS = [
     'LayerSelector',
     'LocateMeButton',
     'ZoomControl',
+    'SidebarToggleControl',
 ]
 
 DISABLED_MODEL_PACKAGES = []


### PR DESCRIPTION

## Overview

The compare view tiny maps had the expand controls. Add a flag to adding the control like we do with zoom and locate.

Connects #1747 

### Demo

<img width="903" alt="screen shot 2017-03-30 at 1 31 35 pm" src="https://cloud.githubusercontent.com/assets/7633670/24526328/c7060780-156b-11e7-92a7-117ec5ccbf49.png">

## Testing Instructions

 * Bundle
 * Expand control on main map should look the same
 * Compare view shouldn't have any expand control
