### PR TITLE
Display boundary layer search results

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -898,7 +898,7 @@ var PointSourceResultView = AnalyzeResultView.extend({
 var CatchmentWaterQualityResultView = AnalyzeResultView.extend({
     onShow: function() {
         var desc = 'Delaware River Basin only: <a target="_blank" ' +
-                   'href="https://www.arcgis.com/home/item.html?id=260d7e17039d48a6beee0f0b640eb754"​>' +
+                   'href="https://www.arcgis.com/home/item.html?id=260d7e17039d48a6beee0f0b640eb754">' +
                    'Stream Reach Assessment Tool</a> model estimates',
             associatedLayerCodes = [
                 'drb_catchment_water_quality_tn',

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -994,5 +994,7 @@ function navigateToAnalyze() {
 module.exports = {
     SplashWindow: SplashWindow,
     DrawWindow: DrawWindow,
-    getShapeAndAnalyze: getShapeAndAnalyze
+    getShapeAndAnalyze: getShapeAndAnalyze,
+    addLayer: addLayer,
+    clearAoiLayer: clearAoiLayer
 };

--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -9,29 +9,20 @@ var GeocoderModel = Backbone.Model.extend({
     }
 });
 
-var LocationModel = Backbone.Model.extend({
+var SuggestionModel = Backbone.Model.extend({
     url: '/api/geocode/',
 
-    parse: function(response) {
-        if (response.length) {
-            return response[0];
-        } else {
-            return {};
-        }
-    }
-});
-
-var SuggestionModel = Backbone.Model.extend({
     defaults: {
         zoom: 18
     },
 
     setMapViewToLocation: function(zoom) {
-        var location = this.get('location');
-        if (location) {
+        var lat = this.get('y'),
+            lng = this.get('x');
+        if (lat && lng) {
             App.map.set({
-                lat: location.get('y'),
-                lng: location.get('x'),
+                lat: lat,
+                lng: lng,
                 zoom: zoom || this.get('zoom')
             });
         }
@@ -42,10 +33,16 @@ var SuggestionModel = Backbone.Model.extend({
             key: this.get('magicKey'),
             search: this.get('text')
         };
+        return this.fetch({ data: data });
+    },
 
-        this.set('location', new LocationModel(data));
-
-        return this.get('location').fetch({ data: data });
+    parse: function(data) {
+        // Parse from API request
+        if (data.length) {
+            return data[0];
+        }
+        // Parse from initialization
+        return data;
     }
 });
 
@@ -69,6 +66,5 @@ var SuggestionsCollection = Backbone.Collection.extend({
 module.exports = {
     GeocoderModel: GeocoderModel,
     SuggestionModel: SuggestionModel,
-    LocationModel: LocationModel,
     SuggestionsCollection: SuggestionsCollection
 };

--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var Backbone = require('../../shim/backbone'),
+var _ = require('underscore'),
+    $ = require('jquery'),
+    Backbone = require('../../shim/backbone'),
     App = require('../app');
 
 var GeocoderModel = Backbone.Model.extend({
@@ -11,9 +13,11 @@ var GeocoderModel = Backbone.Model.extend({
 
 var SuggestionModel = Backbone.Model.extend({
     url: '/api/geocode/',
+    idAttribute: 'magicKey',
 
     defaults: {
-        zoom: 18
+        zoom: 18,
+        isBoundaryLayer: false
     },
 
     setMapViewToLocation: function(zoom) {
@@ -46,7 +50,21 @@ var SuggestionModel = Backbone.Model.extend({
     }
 });
 
-var SuggestionsCollection = Backbone.Collection.extend({
+var BoundarySuggestionModel = SuggestionModel.extend({
+    idAttribute: 'id',
+
+    defaults: {
+        isBoundaryLayer: true
+    },
+
+    select: function() {
+        // We don't need to make a separate request for lat/lng
+        var xhr = new $.Deferred();
+        return xhr.resolve();
+    }
+});
+
+var GeocodeSuggestions = Backbone.Collection.extend({
     model: SuggestionModel,
     url: function() {
         return 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?f=json' +
@@ -60,6 +78,43 @@ var SuggestionsCollection = Backbone.Collection.extend({
 
     parse: function(response) {
         return response.suggestions;
+    }
+});
+
+var BoundarySuggestions = GeocodeSuggestions.extend({
+    model: BoundarySuggestionModel,
+    url: '/api/modeling/boundary-layers-search'
+});
+
+// Composite collection which merges the results from
+// GeocodeSuggestions and BoundarySuggestions.
+var SuggestionsCollection = Backbone.Collection.extend({
+    initialize: function() {
+        this.geocodeSuggestions = new GeocodeSuggestions();
+        this.boundarySuggestions = new BoundarySuggestions();
+    },
+
+    fetch: function(options) {
+        var xhr = new $.Deferred();
+
+        var requests = $.when(
+            this.geocodeSuggestions.fetch(options)
+                .then(_.bind(this.combineSuggestions, this)),
+            this.boundarySuggestions.fetch(options)
+                .then(_.bind(this.combineSuggestions, this)));
+
+        requests
+            .done(xhr.resolve)
+            .fail(xhr.reject);
+
+        return xhr.promise();
+    },
+
+    combineSuggestions: function() {
+        var models = [].concat(
+            this.geocodeSuggestions.models,
+            this.boundarySuggestions.models);
+        this.set(models);
     }
 });
 

--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -142,7 +142,11 @@ var SuggestionsCollection = Backbone.Collection.extend({
         this.requests.push(fetch(this.geocodeSuggestions));
         this.requests.push(fetch(this.boundarySuggestions));
 
-        return xhr.promise();
+        var promise = xhr.promise();
+        promise.cancel = function() {
+            xhr.reject({ cancelled: true });
+        };
+        return promise;
     },
 
     combineSuggestions: function() {

--- a/src/mmw/js/src/geocode/templates/suggestion.html
+++ b/src/mmw/js/src/geocode/templates/suggestion.html
@@ -1,6 +1,0 @@
-<span>
-    {% if label %}
-    <strong>{{ label }}:</strong>
-    {% endif %}
-    {{ text }}
-</span>

--- a/src/mmw/js/src/geocode/templates/suggestion.html
+++ b/src/mmw/js/src/geocode/templates/suggestion.html
@@ -1,1 +1,6 @@
-<span>{{ text }}</span>
+<span>
+    {% if label %}
+    <strong>{{ label }}:</strong>
+    {% endif %}
+    {{ text }}
+</span>

--- a/src/mmw/js/src/geocode/templates/suggestions.html
+++ b/src/mmw/js/src/geocode/templates/suggestions.html
@@ -1,0 +1,19 @@
+{% if geocodeSuggestions.size() %}
+<div class="geocode-suggestions">
+<ul>
+{% for model in geocodeSuggestions.models %}
+  <li data-cid="{{ model.cid }}">{{ model.get('text') }}</li>
+{% endfor %}
+</ul>
+</div>
+{% endif %}
+<div class="boundary-suggestions">
+{% for label, models in boundarySuggestions %}
+<h1>{{ label }}</h1>
+<ul>
+  {% for model in models %}
+  <li data-cid="{{ model.cid }}">{{ model.get('text') }}</li>
+  {% endfor %}
+</ul>
+{% endfor %}
+</div>

--- a/src/mmw/js/src/geocode/tests.js
+++ b/src/mmw/js/src/geocode/tests.js
@@ -15,8 +15,7 @@ var sandboxId = 'sandbox',
     sandboxSelector = '#' + sandboxId;
 
 describe('Geocoder', function() {
-    var MSG_EMPTY = 'No results found.',
-        MSG_ERROR = 'Oops! Something went wrong.';
+    var MSG_ERROR = 'Oops! Something went wrong.';
 
     before(function() {
         if ($(sandboxSelector).length === 0) {
@@ -56,17 +55,6 @@ describe('Geocoder', function() {
             this.server.respondWith([200, { 'Content-Type': 'application/json' }, responseData]);
 
             testNumberOfResults(testData.length * 2, done);
-        });
-
-        it('renders no list items and an error message if there are no suggestions', function(done) {
-            this.server.respondWith([200, { 'Content-Type': 'application/json' }, '[]']);
-            var view = createView();
-
-            view.handleSearch('a query').then(function() {
-                assert.equal($('#sandbox li').length, 0);
-                assert.include($('.message').text().trim(), MSG_EMPTY);
-                done();
-            }());
         });
 
         it('renders an error message if there was a problem getting suggestions', function(done) {

--- a/src/mmw/js/src/geocode/tests.js
+++ b/src/mmw/js/src/geocode/tests.js
@@ -184,25 +184,31 @@ describe('Geocoder', function() {
                     testGeocode = getTestGeocodes(1),
                     zoomLevel = 15;
 
-                model.set('location', new models.LocationModel(testGeocode[0]));
+                model.fetch = function() {
+                    model.set(testGeocode[0]);
+                };
+
+                model.select();
                 model.setMapViewToLocation(zoomLevel);
 
-                assert.equal(App.map.get('lat'), model.get('location').get('y'));
-                assert.equal(App.map.get('lng'), model.get('location').get('x'));
+                assert.equal(App.map.get('lat'), model.get('y'));
+                assert.equal(App.map.get('lng'), model.get('x'));
                 assert.equal(App.map.get('zoom'), zoomLevel);
             });
         });
 
         describe('#select', function() {
-            it('fetchs location information for the selected model', function(done) {
+            it('fetches location information for the selected model', function(done) {
                 var testSuggestion = getTestSuggestions(1),
-                    model = new models.SuggestionModel(testSuggestion[0]),
-                    testGeocode = JSON.stringify(getTestGeocodes(1));
+                    testGeocode = getTestGeocodes(1),
+                    model = new models.SuggestionModel(testSuggestion[0]);
 
-                this.server.respondWith([200, { 'Content-Type': 'application/json' }, testGeocode]);
+                this.server.respondWith([200, { 'Content-Type': 'application/json' },
+                    JSON.stringify(testGeocode)]);
 
                 model.select().done(function() {
-                    assert.instanceOf(model.get('location'), Backbone.Model);
+                    assert.equal(model.get('y'), testGeocode[0].y);
+                    assert.equal(model.get('x'), testGeocode[0].x);
                     done();
                 });
             });

--- a/src/mmw/js/src/geocode/tests.js
+++ b/src/mmw/js/src/geocode/tests.js
@@ -5,7 +5,6 @@ require('../core/setup');
 var _ = require('lodash'),
     $ = require('jquery'),
     assert = require('chai').assert,
-    Backbone = require('../../shim/backbone'),
     sinon = require('sinon'),
     App = require('../app'),
     views = require('./views'),
@@ -47,7 +46,7 @@ describe('Geocoder', function() {
 
             this.server.respondWith([200, { 'Content-Type': 'application/json' }, responseData]);
 
-            testNumberOfResults(testData.length, done);
+            testNumberOfResults(testData.length * 2, done);
         });
 
         it('renders multiple list items if there are multiple suggestions', function(done) {
@@ -56,7 +55,7 @@ describe('Geocoder', function() {
 
             this.server.respondWith([200, { 'Content-Type': 'application/json' }, responseData]);
 
-            testNumberOfResults(testData.length, done);
+            testNumberOfResults(testData.length * 2, done);
         });
 
         it('renders no list items and an error message if there are no suggestions', function(done) {
@@ -86,7 +85,8 @@ describe('Geocoder', function() {
                 responseData = JSON.stringify({ suggestions: testData }),
                 view = createView();
 
-            this.server.respondWith([200, { 'Content-Type': 'application/json' }, responseData]);
+            this.server.respondWith(/geocode.arcgis.com/,
+                [200, { 'Content-Type': 'application/json' }, responseData]);
 
             var self = this;
             view.handleSearch('a query').done(function() {

--- a/src/mmw/js/src/geocode/views.js
+++ b/src/mmw/js/src/geocode/views.js
@@ -163,6 +163,12 @@ var SearchBoxView = Marionette.LayoutView.extend({
         var self = this,
             defer = $.Deferred();
 
+        if (this.collection.size() === 0) {
+            this.setStateError();
+            defer.reject();
+            return defer.promise();
+        }
+
         this.setStateWorking();
 
         this.collection

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -2,7 +2,7 @@
 #search-map {
   position: absolute;
   top: 0;
-  z-index: 100;
+  z-index: 600;
   padding: 1rem;
 
   @media(max-width: 1200px) {
@@ -55,19 +55,27 @@
 
 #geocode-search-results-region {
   position: absolute;
+  border-radius: 2px;
+  box-shadow: 0 0 6px $black-74;
+  font-size: 0.8rem;
+  color: $black-54;
+  background-color: $paper;
+  margin-top: 6px;
+  min-width: 300px;
+  z-index: 700;
+
+  h1 {
+    margin: 0.5rem;
+    border-bottom: 1px solid #bbb;
+    font-size: 0.8rem;
+    color: #bbb;
+  }
 
   ul {
     list-style-type: none;
-    position: absolute;
-    border-radius: 2px;
-    box-shadow: 0 0 6px $black-74;
-    font-size: 0.8rem;
-    padding: 0.5rem 0;
-    color: $black-54;
-    background-color: $paper;
-    margin-top: 6px;
-    min-width: 300px;
-    z-index: 10;
+    margin: 0;
+    padding: 0;
+
     & > li {
       cursor: pointer;
       padding: 0.5rem 1rem;


### PR DESCRIPTION
## Overview

Display boundary layer search results in the geocoder autocomplete and the map.

Connects #1762

### Demo

![image](https://cloud.githubusercontent.com/assets/43062/25094694/5788c8f8-2366-11e7-80d8-393411a3df44.png)

## Testing Instructions

 * Configure searchable boundary layers in `layer_settings.py` depending on which boundary layers you have on your workstation
 * Run `./scripts/bundle.sh`
 * Verify that boundary layers and geocoded results show up in the autocomplete
 * Verify that picking geocoded suggestions still work
 * Verify that picking boundary layer suggestions adds the layer to the map