### PR TITLE
Fix compare view layerpicker errors

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -129,11 +129,10 @@ var CompareScenarioView = Marionette.LayoutView.extend({
             el: $(this.el).find('.map-container').get(),
             addZoomControl: false,
             addLocateMeButton: false,
-            addLayerSelector: false,
             addSidebarToggleControl: false,
             showLayerAttribution: false,
             initialLayerName: App.getLayerTabCollection().getCurrentActiveBaseLayerName(),
-            LayerTabCollection: this.LayerTabCollection,
+            layerTabCollection: this.LayerTabCollection,
             interactiveMode: false
         });
 

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -350,7 +350,7 @@ var LayerTabCollection = Backbone.Collection.extend({
     },
 
     getCurrentActiveBaseLayer: function() {
-        return this.getBaseLayerTab.findLayerWhere({ 'active': true });
+        return this.getBaseLayerTab().findLayerWhere({ 'active': true });
     },
 
     getCurrentActiveBaseLayerName: function() {


### PR DESCRIPTION
## Overview

- Some typos were made when refactoring the layerpicker in https://github.com/WikiWatershed/model-my-watershed/pull/1777
- They resulted in empty compare views and the layerpicker never getting removed from the page

This commit corrects the typos

Connects #1788 
Connects #1745

## Testing Instructions

 * Pull this PR, `./scripts/bundle.sh`
 * Navigate to compare view
 * Confirm it works, there are no errors in the console and the layerpicker isn't visible
