### PR TITLE
Activate tooltips on click instead of hover

### DIFF
--- a/src/mmw/js/src/core/layerPicker.js
+++ b/src/mmw/js/src/core/layerPicker.js
@@ -80,7 +80,7 @@ var LayerPickerLayerView = Marionette.ItemView.extend({
 
     onRender: function() {
         this.ui.layerHelpIcon.popover({
-            trigger: 'hover',
+            trigger: 'focus',
             viewport: {
                 'selector': '.map-container',
                 'padding': 10

--- a/src/mmw/js/src/core/templates/layerPickerLayer.html
+++ b/src/mmw/js/src/core/templates/layerPickerLayer.html
@@ -8,10 +8,9 @@
     {% if not isDisabled and legendMapping %}
         <a
             tabindex="-1"
-            role="presentation"
+            role="button"
             data-html="true"
             data-toggle="popover"
-            data-trigger="focus"
             class="layerpicker-info"
             data-layer-help-icon="{{layerDisplay}}"
         >

--- a/src/mmw/js/src/draw/templates/delineationOptions.html
+++ b/src/mmw/js/src/draw/templates/delineationOptions.html
@@ -14,17 +14,29 @@
       <button class="draw-pane-list-item-button" role="menuitem" tabindex="-1"
               href="#" data-shape-type="stream" data-snapping-on="true" data-data-source={{DRB}}
               {{ 'disabled' if toolsDisabled }}>
-        <span>Delaware High Resolution</span> <i class="split fa fa-question-circle"
-          data-content="Snaps to the nearest downhill point on the Delaware River Basin high resolution stream network and calculates the watershed upstream of this point using a 1/3 arc second (10m) resolution digital elevation model."></i>
+        <span>Delaware High Resolution</span>
       </button>
+      <a class="help" data-toggle="popover" tabindex="0" data-html="true"
+         role="button" data-content="Snaps to the nearest downhill point on the Delaware River Basin
+         high resolution stream network and calculates the watershed upstream of this point using a
+         1/3 arc second (10m) resolution digital elevation model. The stream network was
+         delineated using <a href='http://hydrology.usu.edu/taudem/taudem5/index.html' target='_blank'>TauDEM</a>.">
+         <i class="fa fa-question-circle"></i>
+      </a>
     </li>
     <li class="draw-pane-list-item" role="presentation">
       <button class="draw-pane-list-item-button" role="button" tabindex="-1"
               href="#" data-shape-type="stream" data-snapping-on="true" data-data-source={{NHD}}
               {{ 'disabled' if toolsDisabled }}>
-        <span>Continental US Medium Resolution</span> <i class="split fa fa-question-circle"
-          data-content="Snaps to the nearest downhill point on the medium resolution flow lines of the National Hydrography Dataset and calculates the watershed upstream of this point using the 30m resolution NHDPlus flow direction grid."></i>
+        <span>Continental US Medium Resolution</span>
       </button>
+      <a class="help" data-toggle="popover" tabindex="0" data-html="true"
+         role="button" data-content="Snaps to the nearest downhill point on the medium
+         resolution flow lines of the National Hydrography Dataset and calculates the
+         watershed upstream of this point using the 30m resolution NHDPlus flow direction grid.
+         Learn more about NHDPlus <a href='http://www.horizon-systems.com/nhdplus/' target='_blank'>here</a>.">
+         <i class="fa fa-question-circle"></i>
+      </a>
     </li>
     <!-- Hill Slope is disabled currently
     <li role="presentation">

--- a/src/mmw/js/src/draw/templates/draw.html
+++ b/src/mmw/js/src/draw/templates/draw.html
@@ -2,13 +2,21 @@
   <li class="draw-pane-list-item" role="presentation">
     <button class="draw-pane-list-item-button" role="button" tabindex="-1"
             href="#" id="custom-shape" {{ 'disabled' if toolsDisabled }}>
-      <span>Free Draw</span> <i class="split fa fa-question-circle" data-content="Draw a custom area on which you want to perform perform water quality analysis."></i>
+        <span>Free Draw</span>
     </button>
+    <a class="help" data-toggle="popover" tabindex="0"
+       role="button" data-content="Draw a custom area on which you want to perform water quality analysis.">
+       <i class="fa fa-question-circle"></i>
+    </a>
   </li>
   <li class="draw-pane-list-item" role="presentation">
     <button class="draw-pane-list-item-button" role="button" tabindex="-1"
             href="#" id="one-km-stamp" {{ 'disabled' if toolsDisabled }}>
-      <span>Square Km</span> <i class="split fa fa-question-circle" data-content="Draw a predefined one kilometer square with a center at the point you choose."></i>
+        <span>Square Km</span>
     </button>
+    <a class="help" data-toggle="popover" tabindex="0"
+       role="button" data-content="Draw a predefined one kilometer square with a center at the point you choose.">
+       <i class="fa fa-question-circle"></i>
+    </a>
   </li>
 </ul>

--- a/src/mmw/js/src/draw/templates/selectType.html
+++ b/src/mmw/js/src/draw/templates/selectType.html
@@ -10,9 +10,12 @@
           {{ "disabled" if item.minZoom > currentZoomLevel }}>
           <span>
             {{ item.display }}
-          </span> <i class="split fa fa-question-circle"
-                     data-content="{{ item.helptext }}"></i>
+          </span>
       </button>
+      <a class="help" data-toggle="popover" tabindex="0"
+         role="button" data-content="{{ item.helptext }}">
+        <i class="fa fa-question-circle"></i>
+      </a>
     </li>
 {% endfor %}
 </ul>

--- a/src/mmw/js/src/draw/templates/window.html
+++ b/src/mmw/js/src/draw/templates/window.html
@@ -2,7 +2,9 @@
 <p id="draw-pane-header-description">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     Duis ac pharetra nibh. Nullam gravida massa non egestas
-    pellentesque.
+    pellentesque. More information and help for these tools
+    is available <a href="http://wikiwatershed.org/model/" target="_blank">
+    here</a>.
 </p>
 <div id="draw-pane-buttons">
     {% for drawTool in drawTools %}

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -489,7 +489,7 @@ var SelectAreaView = Marionette.ItemView.extend({
     ui: {
         items: '[data-tile-url]',
         button: '#predefined-shape',
-        helptextIcon: 'i.split'
+        helptextIcon: 'a.help'
     },
 
     events: {
@@ -519,8 +519,8 @@ var SelectAreaView = Marionette.ItemView.extend({
 
     onRender: function() {
         this.ui.helptextIcon.popover({
-            trigger: 'hover',
-            viewport: '.map-container'
+            trigger: 'focus',
+            placement: 'top'
         });
     },
 
@@ -610,7 +610,7 @@ var DrawView = Marionette.ItemView.extend({
     ui: {
         drawArea: '#custom-shape',
         drawStamp: '#one-km-stamp',
-        helptextIcon: 'i.split'
+        helptextIcon: 'a.help'
     },
 
     events: {
@@ -649,8 +649,8 @@ var DrawView = Marionette.ItemView.extend({
 
     onShow: function() {
         this.ui.helptextIcon.popover({
-            trigger: 'hover',
-            viewport: '.map-container'
+            trigger: 'focus',
+            placement: 'top'
         });
     },
 
@@ -709,7 +709,7 @@ var WatershedDelineationView = Marionette.ItemView.extend({
     ui: {
         items: '[data-shape-type]',
         button: '#delineate-shape',
-        helptextIcon: 'i.split'
+        helptextIcon: 'a.help'
     },
 
     events: {
@@ -718,8 +718,8 @@ var WatershedDelineationView = Marionette.ItemView.extend({
 
     onShow: function() {
         this.ui.helptextIcon.popover({
-            trigger: 'hover',
-            viewport: '.map-container'
+            trigger: 'focus',
+            placement: 'top'
         });
     },
 

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -125,3 +125,8 @@ p.info {
   z-index: 1;
   opacity: 0.8;
 }
+
+a:focus {
+    outline: none;
+    outline-offset: 0;
+}

--- a/src/mmw/sass/base/_base.scss
+++ b/src/mmw/sass/base/_base.scss
@@ -111,18 +111,6 @@ p.info {
         span {
           display:inline-block;
         }
-
-        i.split {
-          display:inline-block;
-          position: absolute;
-          right: 5%;
-          top:30%;
-        }
-        .popover {
-          min-width: 400px;
-          max-width: 450px;
-          line-height: 200%;
-        }
       }
     }
   }

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -77,6 +77,7 @@
   margin: -4px;
   &:hover {
     color: inherit;
+    text-decoration: none;
   }
   &:after {
     content: "\f05a";

--- a/src/mmw/sass/pages/_draw.scss
+++ b/src/mmw/sass/pages/_draw.scss
@@ -6,7 +6,7 @@
     right: 0;
     transition: all 200ms;
     top: 44px;
-    overflow-y: auto;
+    overflow: visible;
 }
 
 .splash-step {
@@ -94,6 +94,14 @@
 
       & .draw-pane-list-item-button:disabled {
         color: #7f8181;
+      }
+
+      & a.help {
+        color: #999;
+
+        &:hover {
+          color: inherit;
+        }
       }
     }
   }


### PR DESCRIPTION
## Overview

Tooltips are now activated on click instead of hover so that links in the tooltip text are now clickable. Previously, the tooltip closed as the pointer was moved from the tooltip icon to the tooltip text, preventing the user from clicking on any links in the text.

To better unify the UI/UX of the app, the tooltips in the legend were updated to behave in the same way. Additionally, the style of both tooltips was made consistent.

Links were added to the RWD tools. Also, a general link to documentation about the various draw tools was added to the sidebar instead of each draw tooltip (as previously requested). This seemed like a more appropriate solution now that there is a space for explanatory text near the tools.

Connects to #1749
Connects to #1233 

### Demo

![mmw7](https://cloud.githubusercontent.com/assets/1042475/24759922/01d08ec8-1ab5-11e7-87d0-e8a17cb5b2e1.gif)

## Testing Instructions

- View the tooltips for various draw tools, and verify that they open on click and not hover.
- Try to click the links in the RWD tooltips.
- Verify the legend tooltips behave in the same way as the draw tool tooltips.