### PR TITLE
Update AOI Analyze/Model Size Threshold

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/spark-jobserver.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/templates/spark-jobserver.conf.j2
@@ -38,4 +38,9 @@ spark {
 # spray #
 #########
 
-spray.can.server.parsing.max-content-length = 250m
+spray.can.server {
+  parsing.max-content-length = 250m
+  # Match the backend's timeout set here src/mmw/apps/modeling/tasks.py
+  idle-timeout = 45s
+  request-timeout = 42s
+}

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -7,7 +7,7 @@ var $ = require('jquery'),
     coreUtils = require('../core/utils');
 
 // Keep in sync with src/api/main.py in rapid-watershed-delineation.
-var MAX_AREA = 112700; // About the size of a large state (in km^2)
+var MAX_AREA = 75000; // About the size of West Virginia (in km^2)
 
 var polygonDefaults = {
         fillColor: '#E77471',

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -89,9 +89,9 @@ function validateShape(polygon) {
         d.reject(errorMsg);
     } else if (!utils.isValidForAnalysis(polygon)) {
         var maxArea = utils.MAX_AREA.toLocaleString(),
-            selectedArea = Math.floor(utils.shapeArea(polygon)).toLocaleString(),
-            message = 'Sorry, the area you have delineated is too large ' +
-                      'to analyze or model. ' + selectedArea + ' km² were ' +
+            selectedBoundingBoxArea = Math.floor(utils.shapeBoundingBoxArea(polygon)).toLocaleString(),
+            message = 'Sorry, the bounding box of the area you have delineated is too large ' +
+                      'to analyze or model. ' + selectedBoundingBoxArea + ' km² were ' +
                       'selected, but the maximum supported size is ' +
                       'currently ' + maxArea + ' km².';
         d.reject(message);


### PR DESCRIPTION
## Overview

The continental RWD feature has made shapes that sneak past our AOI size threshold, but are still too large to analyze or run TR55 on more commonplace. To catch these shapes we're adjusting the threshold in three ways:

1. Lower the threshold to `75000 km2`

Testing on staging found this to be closer to the current max we can handle for non-diagonal shapes 

2. Test threshold on shape's extent's area instead of shape's area

While trying to find a more appropriate size threshold we realized the size of an AOI is not the most important factor in determining whether or not the shape will timeout. A more appropriate test is on the AOI's extent because the slowest part of analyze is fetching the land and soil tiles from S3, and the number of tiles fetched is dependent on the extent of the shape ([see this comment on the original issue for examples](https://github.com/WikiWatershed/model-my-watershed/issues/1746#issuecomment-292627146))

3. Set `spray.request-timeout`

We also discovered while timing `mmw-geoprocessing` that shapes would timeout at 40 sec regardless of setting the SJS `timeout` higher. This is because the `spray` timeout params default to 40 sec, and must also be set. This PR sets the `spray``idle-timeout` and `request-timeout` to 42 sec to match the backend.

Connects #1746 

### Demo

![screen shot 2017-04-07 at 2 58 27 pm](https://cloud.githubusercontent.com/assets/7633670/24867219/83790e82-1dda-11e7-887f-0af162540d7c.png)

![screen shot 2017-04-10 at 10 42 36 am](https://cloud.githubusercontent.com/assets/7633670/24867224/86f5f7dc-1dda-11e7-9d19-940469f96398.png)


### Notes

Most shapes that timeout their land and soil analyze tabs succeed on their animal counts, point sources, and water quality measures. With this in mind, should the threshold be set on TR55 only and still allow analyze to complete? 

I have left things as is for now because allowing analyze for shapes that can't do Land/Soil has the disadvantage of showing the user more timeout errors on the first, most prominent tabs. They might not even know the other tabs have succeeded.

## Testing Instructions

 * Pull this branch,  bundle
* Draw a few square AOI's until you've found a box about `75000 km2` large
     * Confirm there is a "Max area exceeded" type message
* Note where two diagonally opposite corners of that AOI lie
     * Draw a skinny snake to connect the two points you noted above and confirm the max area message pops up again noting a similar max area extent as the first AOI you drew (ie the extent of the diagonal line of the square should match the square)
    
To assess the new threshold you can try out these shapes on staging:

Should timeout ~`80,000 km2`
https://staging.app.wikiwatershed.org/project/769/scenario/1462

Should succeed ~`67,000 km2`
https://staging.app.wikiwatershed.org/project/767/scenario/1457
