### PR TITLE
Add TR-55 Pre-Columbian Water Quality Results

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -213,15 +213,19 @@ def format_quality(model_output):
                 'Total Phosphorus']
     codes = ['tss', 'tn', 'tp']
 
-    def fn(input):
-        measure, code = input
-        return {
-            'measure': measure,
-            'load': model_output['modified'][code] * KG_PER_POUND,
-            'runoff': model_output['modified']['runoff']  # Already CM
-        }
+    quality = {}
+    for key in model_output:
+        def map_and_convert_units(input):
+            measure, code = input
+            return {
+                'measure': measure,
+                'load': model_output[key][code] * KG_PER_POUND,
+                'runoff': model_output[key]['runoff']  # Already CM
+            }
 
-    return map(fn, zip(measures, codes))
+        quality[key] = map(map_and_convert_units, zip(measures, codes))
+
+    return quality
 
 
 def format_runoff(model_output):

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -335,6 +335,24 @@ var utils = {
         return element.measure !== "Biochemical Oxygen Demand";
     },
 
+
+    // TR-55 runoff and water quality results are in the format:
+    // {
+    //     modified: ...,
+    //     unmodified: ...,
+    //     pc_unmodified: ...,
+    // }
+    // Use the scenario attributes to figure out which subresult should be
+    // accessed.
+    getTR55ResultKey: function(scenario) {
+        if (scenario.get('is_current_conditions')) {
+            return 'unmodified';
+        } else if (scenario.get('is_pre_columbian')) {
+            return 'pc_unmodified';
+        }
+        return 'modified';
+    },
+
     // Reverse sorting of a Backbone Collection.
     // Taken from http://stackoverflow.com/a/12220415/2053314
     reverseSortBy: function(sortByFunction) {

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -50,6 +50,8 @@ var ResultView = Marionette.LayoutView.extend({
 
     initialize: function(options) {
         this.compareMode = options.compareMode;
+        this.scenario = options.scenario;
+
         this.aoiVolumeModel = new AoiVolumeModel({
             areaOfInterest: this.options.areaOfInterest
         });
@@ -62,11 +64,12 @@ var ResultView = Marionette.LayoutView.extend({
             if (this.compareMode) {
                 this.chartRegion.show(new CompareChartView({
                     model: this.model,
-                    aoiVolumeModel: this.aoiVolumeModel
+                    aoiVolumeModel: this.aoiVolumeModel,
+                    scenario: this.scenario,
                 }));
             } else {
                 var dataCollection = new Backbone.Collection(
-                    this.model.get('result').quality.filter(
+                    this.model.get('result').quality['modified'].filter(
                         utils.filterOutOxygenDemand
                 ));
 
@@ -210,7 +213,7 @@ var CompareChartView = Marionette.ItemView.extend({
         }
 
         var chartEl = this.$el.find('.bar-chart').get(0),
-            result = this.model.get('result').quality.filter(utils.filterOutOxygenDemand),
+            result = this.model.get('result').quality,
             aoiVolumeModel = this.options.aoiVolumeModel,
             seriesDisplayNames = ['Suspended Solids',
                                   'Nitrogen',
@@ -220,7 +223,9 @@ var CompareChartView = Marionette.ItemView.extend({
 
         $(chartEl).empty();
         if (result) {
-            data = getData(result, seriesDisplayNames);
+            var resultKey = utils.getTR55ResultKey(this.scenario);
+
+            data = getData(result[resultKey].filter(utils.filterOutOxygenDemand), seriesDisplayNames);
             chartOptions = {
                 seriesColors: ['#4aeab3', '#4ebaea', '#329b9c'],
                 yAxisLabel: 'Loading Rate (kg/ha)',

--- a/src/mmw/js/src/modeling/tr55/runoff/views.js
+++ b/src/mmw/js/src/modeling/tr55/runoff/views.js
@@ -125,22 +125,14 @@ var ChartView = Marionette.ItemView.extend({
         $(chartEl).empty();
 
         if (result) {
+            var resultKey = utils.getTR55ResultKey(this.scenario);
+            labelNames = [resultKey];
             if (this.compareMode) {
-                var target_result = 'modified';
-                if (this.scenario.get('is_current_conditions')) {
-                    target_result = 'unmodified';
-                }
-                if (this.scenario.get('is_pre_columbian')) {
-                    target_result = 'pc_unmodified';
-                }
-                labelNames = [target_result];
                 labelDisplayNames = [''];
                 this.$el.addClass('current-conditions');
             } else if (this.scenario.get('is_current_conditions')) {
-                labelNames = ['unmodified'];
                 labelDisplayNames = ['Current Conditions'];
             } else {
-                labelNames = ['modified'];
                 labelDisplayNames = ['Modified'];
             }
 


### PR DESCRIPTION
## Overview

- The TR-55 model output is composed of the model run with pre-columbian `false` and pre-columbian `true`
- The 100% forest cover scenario in the compare view corresponds to the pre-columbian `true` model run
- We were only returning the water-quality results from the pre-columbian `false` model run 
- This PR corrects this and makes the water quality result format match the runoff result format:
`{ modified: ..., unmodified: ..., pc_unmodified: ... }`

Connects #1786 

### Demo

![screen shot 2017-04-10 at 4 36 52 pm](https://cloud.githubusercontent.com/assets/7633670/24881687/a70ea866-1e0c-11e7-8c4b-45c44f8d64ae.png)

## Testing Instructions

 * Pull this branch, `./scripts/bundle.sh`
 * Draw an AOI over an urban area
 * Run Site Storm Model
      * Confirm both model tabs look all right
 * Go to Compare
      * Confirm Runoff and Water Quality charts appear
      * Confirm 100% forest cover is different than Current Conditions under water quality
