### PR TITLE
Add collapsable header to layerpicker

### DIFF
--- a/src/mmw/js/src/core/templates/layerPicker.html
+++ b/src/mmw/js/src/core/templates/layerPicker.html
@@ -1,2 +1,10 @@
+<div class="layerpicker-header">
+    Layers
+    {% if isOpen %}
+        <i class="fa fa-chevron-down"></i>
+    {% else %}
+        <i class="fa fa-chevron-up"></i>
+    {% endif %}
+</div>
 <div id="layerpicker-tab"></div>
 <div class="layerpicker-nav"></div>

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -13,6 +13,19 @@
   }
 }
 
+.layerpicker-header {
+    background-color: $ui-primary;
+    color: $paper;
+    cursor: pointer;
+    font-size: 15px;
+    font-weight: bold;
+    padding: 4px 12px;
+    i {
+        float: right;
+        margin-top: 2px;
+    }
+}
+
 .layerpicker-layers {
   max-height: 104px;
   overflow: auto;
@@ -45,7 +58,7 @@
 }
 
 .layerpicker-heading {
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 700;
   padding: 6px;
   display: flex;


### PR DESCRIPTION

## Overview

It's not obvious that re-clicking the active tab button on the layerpicker collapses the view. Add a header with an "expand/collapse" icon to collapse the view instead.

**Wireframes**

![screen shot 2017-04-11 at 12 12 05 pm](https://cloud.githubusercontent.com/assets/7633670/24921237/28349788-1eb8-11e7-97af-22044b6ad081.png)


Connects #1748 

### Demo

![screen shot 2017-04-11 at 12 52 52 pm](https://cloud.githubusercontent.com/assets/7633670/24921252/33c66cd4-1eb8-11e7-831c-692a5a55beb1.png)

<img width="300" alt="screen shot 2017-04-11 at 12 52 48 pm" src="https://cloud.githubusercontent.com/assets/7633670/24921251/33c62b16-1eb8-11e7-9b77-e931ccbe053f.png">

## Testing Instructions

 * Pull and `./scripts/bundle.sh`
 * Play around with the layerpicker:
        - You should be able to collapse/expand it by clicking the header, or the tabs
        - State should be maintained (if you collapse, and then expand the same tab should be open unless you clicked a different one)
