### PR TITLE
Keep map within post-render bounds on load

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -5,7 +5,8 @@
     {% block header %}
     {% endblock header %}
 
-    <div class="map-container">
+    <div class="map-container map-container-top-sidebar map-container-bottom-sidebar
+                {% if not project %} map-container-top-sidebar-no-header {% endif %}">
         {% block map %}
         {% endblock map %}
 

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -44,7 +44,10 @@ def project(request, proj_id=None, scenario_id=None):
         if project.user != request.user and project.is_private:
             raise Http404
 
-        return render_to_response('home/home.html', get_context(request))
+        context = get_context(request)
+        context.update({'project': True})
+
+        return render_to_response('home/home.html', context)
     else:
         return redirect('/projects/')
 


### PR DESCRIPTION
## Overview

On load, the map would expand to the full page width, and transition to a reduced width after the application finishes loading. This led to a jarring transition, especially when the application loaded slowly.

By adding the classes that would be applied post-load to the `.map-container` before it loads, we ensure it stays within the bounds of actual rendering.

The project view uses a smaller map than the home view, but since it is a transition of the top of the map it isn't as jarring. No buttons move around, and there is no overlapping content.

Connects #1773 [:lipstick:](https://gitmoji.carloscuesta.me/)

### Demo

Loading the home page:

![2017-04-12 15 15 00](https://cloud.githubusercontent.com/assets/1430060/24975203/e4bce8a8-1f92-11e7-8170-9f5350759888.gif)

Loading a project page:

![2017-04-12 15 44 53](https://cloud.githubusercontent.com/assets/1430060/24976344/121f607e-1f97-11e7-8ef0-6314d2524f1b.gif)

## Testing Instructions

 * Check out this branch and rebundle the scripts `./scripts/bundle.sh --debug`
 * Reload the app in various configurations and ensure that you don't see the flash of transition as described in the original issue.