### PR TITLE
Support older browsers that lack Intl

### DIFF
--- a/src/mmw/js/src/core/filters.js
+++ b/src/mmw/js/src/core/filters.js
@@ -6,29 +6,44 @@ var _ = require('lodash');
 
 nunjucks.env = new nunjucks.Environment();
 
-var basicFormatter = new Intl.NumberFormat('en');
+if (window.hasOwnProperty('Intl')) {
+    // Intl is available, we should use the faster NumberFormat
+    var basicFormatter = new Intl.NumberFormat('en'),
+        minDigitFormatter = function(n) {
+            return new Intl.NumberFormat('en', { minimumFractionDigits: n });
+        },
+        cachedMinDigitFormatter = _.memoize(minDigitFormatter);
 
-var specificFormatter = function(sigFig) {
-    return new Intl.NumberFormat('en',{minimumFractionDigits: sigFig});
-};
+    var toLocaleStringFormatter = function(val, n) {
+        if (val === undefined || isNaN(val)) {
+            return val;
+        }
 
-var cachedFormatters = _.memoize(specificFormatter);
+        if (n) {
+            return cachedMinDigitFormatter(n).format(val);
+        } else {
+            return basicFormatter.format(val);
+        }
+    };
+} else {
+    // Intl is not available, we should use the more compatible toLocaleString
+    var toLocaleStringFormatter = function(val, n) {
+        if (val === undefined || isNaN(val)) {
+            return val;
+        }
 
-nunjucks.env.addFilter('toLocaleString', function(val, n) {
-    if (val===undefined || isNaN(val)) {
-        return val;
-    }
+        if (n) {
+            return val.toLocaleString('en', { minimumFractionDigits: n });
+        } else {
+            return val.toLocaleString('en');
+        }
+    };
+}
 
-    if (n) {
-        return cachedFormatters(n).format(val);
-    } else {
-        return basicFormatter.format(val);
-    }
-});
+nunjucks.env.addFilter('toLocaleString', toLocaleStringFormatter);
 
 nunjucks.env.addFilter('filterNoData', utils.filterNoData);
 
 nunjucks.env.addFilter('toFriendlyDate', function(date) {
     return new Date(date).toLocaleString();
 });
-


### PR DESCRIPTION
## Overview

While Intl.NumberFormat is a much more performant implementation (see #1566), and is supported by all modern browsers, there are still older browsers in the wild that lack support for it. Most notably, Safari 9 and the Android built-in browser do not support it, leaving many users stuck on older iPads and Macs unable to access the site.

By checking for Intl support before using it, we ensure backwards compatibility, while also using the more performant modern options wherever available.

:bug: :apple: :globe_with_meridians:

Connects #1804
Connects #1668 

### Demo

![img_0092](https://cloud.githubusercontent.com/assets/1430060/25021813/6c3b5dd6-2061-11e7-934b-a796f0a2a76e.PNG)

## Testing Instructions

 * Test in a modern browser
 * Test in a decidedly outdated browser
 * Test on iPad