### PR TITLE
Account for fat borders on touch devices

### DIFF
--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -134,6 +134,9 @@
            font-size: 24px;
            line-height: 38px;
        }
+       .leaflet-touch & {
+           width: 84px;
+       }
     }
 }
 
@@ -156,6 +159,10 @@
         &:hover {
             background-color: #ccc;
         }
+    }
+    .leaflet-touch & {
+        height: 44px;
+        width: 44px;
     }
 }
 


### PR DESCRIPTION
## Overview

Touch devices add a 2px gray border to map controls. Since we use `box-sizing: border-box` for the entire app, these borders eat in to the controls' width rather than expanding out, causing layout and display issues.

By updating the controls to be 4px wider and taller on touch devices, we ensure that the controls are rendered correctly.

:bug: :lipstick:

Connects #1782

### Demo

![image](https://cloud.githubusercontent.com/assets/1430060/25025756/70549d3c-2071-11e7-8489-65630e20a0ac.png)

## Testing Instructions

 * Check out this branch and bundle your scripts `./scripts/bundle.sh --debug`
 * Open `about:config` in Firefox and set `dom.w3c_touch_events.enabled` to `1`
 * Open the site. The map controls should render properly.
 * Test on a regular Firefox / Chrome. There should not be the extra gray border on non-touch devices, and the buttons should look the same as before.
 * Test on an iPad, and ensure that the buttons look and behave correctly