### PR TITLE
Reproject uploaded shapefiles

### DIFF
--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -129,6 +129,7 @@ JS_DEPS=(backbone
          moment
          papaparse
          nunjucks
+         reproject
          shapefile
          turf-area
          turf-bbox-polygon

--- a/src/mmw/js/src/draw/templates/aoiUpload.html
+++ b/src/mmw/js/src/draw/templates/aoiUpload.html
@@ -5,7 +5,7 @@
               id="dropbox">
             Drag and drop a file
             <ul class="draw-pane-description-list">
-                <li>Must be a shapefile (.zip) or geojson</li>
+                <li>Must be a shapefile (zip containing shp and prj files) or geojson</li>
                 <li>Only the first feature is used</li>
             </ul>
         <button

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -374,6 +374,11 @@ var AoIUploadView = Marionette.ItemView.extend({
         } else {
             displayAlert(validationInfo.message, modalModels.AlertTypes.error);
         }
+
+        // If the upload fails, the user may choose to upload another file.
+        // Clear the current file input so that the `change` event will fire
+        // on the second time.
+        this.ui.selectFileInput.val(null);
     },
 
     validateFile: function(file) {

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -9,6 +9,7 @@ var $ = require('jquery'),
     turfIntersect = require('turf-intersect'),
     turfKinks = require('turf-kinks'),
     shapefile = require('shapefile'),
+    reproject = require('reproject'),
     router = require('../router').router,
     App = require('../app'),
     utils = require('./utils'),
@@ -435,23 +436,33 @@ var AoIUploadView = Marionette.ItemView.extend({
 
     handleShp: function(zipfile) {
         var self = this,
-            errorMsg = 'Unable to parse shapefile. Please try a different file.';
+            errorMsg = 'Unable to parse shapefile. Please ensure it is a valid shapefile with projection information.';
 
-        drawUtils.loadAsyncShpFileFromZip(zipfile)
-            .then(function(file) {
-                shapefile.open(file)
+        drawUtils.loadAsyncShpFilesFromZip(zipfile)
+            .then(function(shpAndPrj) {
+                var shp = shpAndPrj[0],
+                    prj = shpAndPrj[1];
+
+                shapefile.open(shp)
                     .then(function(source) {
                         source.read()
                             .then(function parse(result) {
                                 if (result.done) { return; }
                                 // Add the first feature to the map
-                                self.addPolygonToMap(result.value);
+                                var geom = reproject.toWgs84(result.value, prj);
+                                self.addPolygonToMap(geom);
+                            }).catch(function() {
+                                displayAlert(errorMsg, modalModels.AlertTypes.error);
                             });
                     }).catch(function() {
                         displayAlert(errorMsg, modalModels.AlertTypes.error);
                     });
-            }).catch(function() {
-                displayAlert(errorMsg, modalModels.AlertTypes.error);
+            }).catch(function(err) {
+                var msg = errorMsg;
+                if (typeof err === "string") {
+                    msg = err;
+                }
+                displayAlert(msg, modalModels.AlertTypes.error);
             });
     },
 

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -3354,6 +3354,89 @@
       "from": "https://registry.npmjs.org/papaparse/-/papaparse-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.2.0.tgz"
     },
+    "reproject": {
+      "version": "1.1.1",
+      "from": "reproject@*",
+      "resolved": "https://registry.npmjs.org/reproject/-/reproject-1.1.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
+        "concat-stream": {
+          "version": "1.6.0",
+          "from": "concat-stream@>=1.5.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.3 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.6 <0.0.7",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "from": "readable-stream@>=2.2.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "from": "buffer-shims@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "string_decoder": {
+                  "version": "1.0.0",
+                  "from": "string_decoder@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "proj4": {
+          "version": "2.4.3",
+          "from": "proj4@>=2.3.12 <3.0.0",
+          "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.4.3.tgz",
+          "dependencies": {
+            "mgrs": {
+              "version": "1.0.0",
+              "from": "mgrs@1.0.0",
+              "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz"
+            },
+            "wkt-parser": {
+              "version": "1.1.3",
+              "from": "wkt-parser@>=1.1.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.1.3.tgz"
+            }
+          }
+        }
+      }
+    },
     "retina.js": {
       "version": "1.3.0",
       "from": "../../tmp/npm-25360-e04608df/1472064034211-0.10679260268807411/a70e73639817473bad7bbb33f866b8e060e5f5a7",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -47,6 +47,7 @@
     "nunjucks": "1.3.4",
     "nunjucksify": "0.2.2",
     "papaparse": "4.2.0",
+    "reproject": "1.1.1",
     "retina.js": "git://github.com/imulus/retinajs#1.3.0",
     "shapefile": "0.6.2",
     "sinon": "1.14.1",


### PR DESCRIPTION
## Overview

Shapefile collections typically contain a .prj file which defines a Proj4, OGC or ESRI WKT representation of the coordinate system the shapefile uses. I've added a `reproject` library that wraps the `proj4js` library to allow easy transformations to wsg84 geographic coordinates from a variety of projections.  The original issue recommends projecting to web mercator, but that is unnecessary as Leaflet can read geographic coordinates natively and further transforms them internally, this is similar to how we are handling GeoJSON files.

Additionally fixes a bug which prevented subsequent attempts at uploading a file via the file input after an initial failure.

Connects #1800 

### Notes

The prj file spec is not uniformly implemented by the software which creates them, it is very likely that we will encounter shapefiles that cannot be reprojected.

Due to the existing issue #1820, this PR will not succeed on IE.

## Testing Instructions
* A new library has been added; install and rebundle
* `./scripts/npm.sh install && ./scripts/bundle.sh --debug --vendor`
* The attached states ([states.zip](https://github.com/WikiWatershed/model-my-watershed/files/925664/states.zip)) shapefile zip is in `epsg:4269` and the neighborhood ([Neighborhoods_Philadelphia.zip](https://github.com/WikiWatershed/model-my-watershed/files/925666/Neighborhoods_Philadelphia.zip)) zip is in PA state plane.
* Upload the attached zips and confirm that the correctly projected shapes are added to the map.
* Remove or rename the prj file from either zip and confirm that an error indicates it is required.
* Adulterate the _contents_ of one prj file and confirm the error is handled.
