### PR TITLE
Promise polyfill for shapefile parsing

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -2,6 +2,7 @@
 
 var $ = require('jquery'),
     _ = require('lodash'),
+    JSZip = require('jszip'),
     L = require('leaflet'),
     Marionette = require('../../shim/backbone.marionette'),
     turfBboxPolygon = require('turf-bbox-polygon'),
@@ -28,6 +29,12 @@ var $ = require('jquery'),
     modalViews = require('../core/modals/views');
 
 var codeToLayer = {}; // code to layer mapping
+
+// The shapefile library relies on a native Promise implementation,
+// a polyfill for which is available in the JSZip library
+if (!window.Promise) {
+    window.Promise = JSZip.external.Promise;
+}
 
 function displayAlert(message, alertType) {
     var alertView = new modalViews.AlertView({


### PR DESCRIPTION
## Overview

The shapefile library used in this project relies on native Promise
objects to be defined, which aren't in IE. Since the JSZip library
already included in the project contains a Promise polyfill, we assign
the global Promise to that type if one is otherwise not defined. This
allows shapefiles to be opened in IE.

Additionally breaks out file processing code to separate functions to reduce
 the level of nesting within the various Promise chains.

Connects #1820 

### Notes

I'm not completely satisfied with the wisdom of coupling the JSZip and Shapefile libraries this way, but I think it's preferable to duplicating the polyfill code by including a 3rd library.

The original PR #1758 was tested in IE, as per the notes, so I'm not sure why it isn't working now.  It may be that the GeoJSON portion of that PR was tested in IE, but not shapefile.

## Testing Instructions

 * Upload a shapefile zip in IE and verify it succeeds as it does on Chrome & Firefox
