### PR TITLE
Add tooltip close button and enable opening tooltips when a draw tool is active

### DIFF
--- a/src/mmw/js/src/draw/templates/delineationOptions.html
+++ b/src/mmw/js/src/draw/templates/delineationOptions.html
@@ -20,7 +20,10 @@
          role="button" data-content="Snaps to the nearest downhill point on the Delaware River Basin
          high resolution stream network and calculates the watershed upstream of this point using a
          1/3 arc second (10m) resolution digital elevation model. The stream network was
-         delineated using <a href='http://hydrology.usu.edu/taudem/taudem5/index.html' target='_blank'>TauDEM</a>.">
+         delineated using <a href='http://hydrology.usu.edu/taudem/taudem5/index.html' target='_blank'>TauDEM</a>."
+         data-template="<div class='popover'><div class='pull-right'
+             id='popover-close-button'><i class='fa fa-times' /></div><div
+             class='popover-content'></div><div class='arrow'></div></div>">
          <i class="fa fa-question-circle"></i>
       </a>
     </li>
@@ -34,7 +37,10 @@
          role="button" data-content="Snaps to the nearest downhill point on the medium
          resolution flow lines of the National Hydrography Dataset and calculates the
          watershed upstream of this point using the 30m resolution NHDPlus flow direction grid.
-         Learn more about NHDPlus <a href='http://www.horizon-systems.com/nhdplus/' target='_blank'>here</a>.">
+         Learn more about NHDPlus <a href='http://www.horizon-systems.com/nhdplus/' target='_blank'>here</a>."
+         data-template="<div class='popover'><div class='pull-right'
+             id='popover-close-button'><i class='fa fa-times' /></div><div
+             class='popover-content'></div><div class='arrow'></div></div>">
          <i class="fa fa-question-circle"></i>
       </a>
     </li>

--- a/src/mmw/js/src/draw/templates/draw.html
+++ b/src/mmw/js/src/draw/templates/draw.html
@@ -5,7 +5,10 @@
         <span>Free Draw</span>
     </button>
     <a class="help" data-toggle="popover" tabindex="0"
-       role="button" data-content="Draw a custom area on which you want to perform water quality analysis.">
+       role="button" data-content="Draw a custom area on which you want to perform water quality analysis."
+       data-template="<div class='popover'><div class='pull-right'
+           id='popover-close-button'><i class='fa fa-times' /></div><div
+           class='popover-content'></div><div class='arrow'></div></div>">
        <i class="fa fa-question-circle"></i>
     </a>
   </li>
@@ -15,7 +18,10 @@
         <span>Square Km</span>
     </button>
     <a class="help" data-toggle="popover" tabindex="0"
-       role="button" data-content="Draw a predefined one kilometer square with a center at the point you choose.">
+       role="button" data-content="Draw a predefined one kilometer square with a center at the point you choose."
+       data-template="<div class='popover'><div class='pull-right'
+           id='popover-close-button'><i class='fa fa-times' /></div><div
+           class='popover-content'></div><div class='arrow'></div></div>">
        <i class="fa fa-question-circle"></i>
     </a>
   </li>

--- a/src/mmw/js/src/draw/templates/selectType.html
+++ b/src/mmw/js/src/draw/templates/selectType.html
@@ -13,7 +13,10 @@
           </span>
       </button>
       <a class="help" data-toggle="popover" tabindex="0"
-         role="button" data-content="{{ item.helptext }}">
+         role="button" data-content="{{ item.helptext }}"
+         data-template="<div class='popover'><div class='pull-right'
+             id='popover-close-button'><i class='fa fa-times' /></div><div
+             class='popover-content'></div><div class='arrow'></div></div>">
         <i class="fa fa-question-circle"></i>
       </a>
     </li>

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -634,9 +634,17 @@ var DrawView = Marionette.ItemView.extend({
     },
 
     onShow: function() {
+        this.activatePopovers();
+    },
+
+    onRender: function() {
+        this.activatePopovers();
+    },
+
+    activatePopovers: function() {
         this.ui.helptextIcon.popover({
-            trigger: 'focus',
-            placement: 'top'
+            placement: 'top',
+            trigger: 'focus'
         });
     },
 
@@ -702,13 +710,6 @@ var WatershedDelineationView = Marionette.ItemView.extend({
         'click @ui.items': 'onItemClicked'
     },
 
-    onShow: function() {
-        this.ui.helptextIcon.popover({
-            trigger: 'focus',
-            placement: 'top'
-        });
-    },
-
     modelEvents: {
         'change:toolsEnabled': 'render',
         'change:polling': 'render',
@@ -717,6 +718,21 @@ var WatershedDelineationView = Marionette.ItemView.extend({
 
     initialize: function(options) {
         this.rwdTaskModel = options.rwdTaskModel;
+    },
+
+    onShow: function() {
+        this.activatePopovers();
+    },
+
+    onRender: function() {
+        this.activatePopovers();
+    },
+
+    activatePopovers: function() {
+        this.ui.helptextIcon.popover({
+            placement: 'top',
+            trigger: 'focus'
+        });
     },
 
     onItemClicked: function(e) {

--- a/src/mmw/sass/pages/_draw.scss
+++ b/src/mmw/sass/pages/_draw.scss
@@ -120,3 +120,9 @@
   }
 
 }
+
+#popover-close-button {
+  cursor: pointer;
+  margin-right: 0.5rem;
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Overview

This PR makes two adjustments to the draw window tooltips: it adds a close button in the top right corner, and also enables opening the tooltips when a draw tool is active.

Since the clicking anywhere still closes the popovers, the x to close button works primarily as a highlightable thing to click to close it. It's handled here by adding a string template to the popover including the X to close button which then gets rendered as the markup for the popover div.

Opening the tooltips when a draw tool's active took a big to figure out, but it looks like the tooltips were activated when `onShow` was called for free draw or RWD, but then got deactivated if the `render` method was called again (which happens when the component gets new props from the model). To fix this, I abstracted out an `activatePopovers` function for both free draw and RWD, which is called in `onShow` and then again in `onRender`.

Connects #1793 

### Demo

![mmw-tooltip-interactivity](https://cloud.githubusercontent.com/assets/4165523/25105778/16e8ab96-2394-11e7-9b38-3dee0809af16.gif)

### Notes

Still investigating this part to see if it's common/desirable behavior:

> when clicking anywhere to close the tooltip, you may click on another interactive element of the app. It's not clear if this is desirable.

## Testing Instructions

 * get this branch, then rebundle and view it in the browser
 * click on a draw tool, then open a popover and verify that you see the X button in the top right corner, that the cursor turns into a pointer above the button, and that clicking it closes the popover
 * select free draw, sq km, and the rwd options in series and verify that when each of them is selected the popovers still work as usual in that draw pane slideout