### PR TITLE
Don't show disabled layers in Analyze "Related Layers"

### DIFF
--- a/src/mmw/js/src/analyze/templates/analyzeLayerToggle.html
+++ b/src/mmw/js/src/analyze/templates/analyzeLayerToggle.html
@@ -1,18 +1,20 @@
-{% if message %}
-    <div class="analyze-layermessage">
-        {{ message }}
-    </div>
-{% else %}
-    <button class="analyze-layertoggle">
-            Related Layer: {{ layerDisplay }}
-            <div class="on-off-toggle">
-                {% if isLayerOn %}
-                    <i class="fa fa-times" aria-hidden="true"></i>
-                    Turn off
-                {% else %}
-                    <i class="fa fa-check" aria-hidden="true"></i>
-                    Turn on
-                {% endif %}
-            </div>
-    </button>
+{% if not isDisabled %}
+    {% if message %}
+        <div class="analyze-layermessage">
+            {{ message }}
+        </div>
+    {% else %}
+        <button class="analyze-layertoggle">
+                Related Layer: {{ layerDisplay }}
+                <div class="on-off-toggle">
+                    {% if isLayerOn %}
+                        <i class="fa fa-times" aria-hidden="true"></i>
+                        Turn off
+                    {% else %}
+                        <i class="fa fa-check" aria-hidden="true"></i>
+                        Turn on
+                    {% endif %}
+                </div>
+        </button>
+    {% endif %}
 {% endif %}

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -363,7 +363,7 @@ var AnalyzeLayerToggleView = Marionette.ItemView.extend({
     setLayer: function() {
         this.model = App.getLayerTabCollection().findLayerWhere({ code: this.code });
         if (this.model) {
-            this.model.on('change:active', this.renderIfNotDestroyed, this);
+            this.model.on('change:active change:disabled', this.renderIfNotDestroyed, this);
             this.message = null;
         }
     },
@@ -400,6 +400,7 @@ var AnalyzeLayerToggleView = Marionette.ItemView.extend({
             return {
                 layerDisplay: this.model.get('display'),
                 isLayerOn: this.model.get('active'),
+                isDisabled: this.model.get('disabled')
             };
         }
     },

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -41,6 +41,8 @@ var App = new Marionette.Application({
             App.currentProject.set('needs_reset', needs);
         });
 
+        this.layerTabs.disableLayersOnZoomAndPan(this.getLeafletMap());
+
         this.rootView = new views.RootView({app: this});
         this.user = new userModels.UserModel({});
 

--- a/src/mmw/js/src/core/layerPicker.js
+++ b/src/mmw/js/src/core/layerPicker.js
@@ -120,23 +120,6 @@ var LayerPickerLayerListView = Marionette.CollectionView.extend({
     },
     initialize: function(options) {
         this.leafletMap = options.leafletMap;
-        utils.zoomToggle(this.leafletMap, options.collection.toJSON(),
-            _.bind(this.updateDisabled, this), _.bind(this.clearBgBufferOnLayer, this));
-        utils.perimeterToggle(this.leafletMap, options.collection.toJSON(),
-            _.bind(this.updateDisabled, this), _.bind(this.clearBgBufferOnLayer, this));
-    },
-
-    updateDisabled: function(layer, shouldDisable) {
-        this.collection.findWhere({ display: layer.display })
-            .set('disabled', shouldDisable);
-    },
-
-    clearBgBufferOnLayer: function(layer) {
-        var leafletLayer = this.collection.findWhere({ display: layer.display})
-            .get('leafletLayer');
-        if (leafletLayer) {
-            leafletLayer._clearBgBuffer();
-        }
     },
 
     toggleLayer: function(selectedLayer) {

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -154,6 +154,19 @@ var LayersCollection = Backbone.Collection.extend({
             });
         }
     },
+
+    updateDisabled: function(layer, shouldDisable) {
+        this.findWhere({ display: layer.display })
+            .set('disabled', shouldDisable);
+    },
+
+    clearBgBufferOnLayer: function(layer) {
+        var leafletLayer = this.findWhere({ display: layer.display})
+            .get('leafletLayer');
+        if (leafletLayer) {
+            leafletLayer._clearBgBuffer();
+        }
+    },
 });
 
 var LayerGroupModel = Backbone.Model.extend({
@@ -320,6 +333,22 @@ var LayerTabCollection = Backbone.Collection.extend({
                 ])
             }),
         ]);
+    },
+
+    disableLayersOnZoomAndPan: function(leafletMap) {
+        this.forEach(function(layerTab) {
+            layerTab.get('layerGroups').forEach(function(layerGroup) {
+                var layers = layerGroup.get('layers');
+                if (layers)  {
+                    utils.zoomToggle(leafletMap, layers.toJSON(),
+                        _.bind(layers.updateDisabled, layers),
+                        _.bind(layers.clearBgBufferOnLayer, layers));
+                    utils.perimeterToggle(leafletMap, layers.toJSON(),
+                        _.bind(layers.updateDisabled, layers),
+                        _.bind(layers.clearBgBufferOnLayer, layers));
+                }
+            });
+        });
     },
 
     findLayerWhere: function(attributes) {


### PR DESCRIPTION
## Overview

Certain layers, eg DRB catchments, are only relevant at certain zoom levels or certain places of the country. We disable such layers in the layerpicker, but we were still showing them in the analyze layer toggle views. 

- disable layers via the model instead of the layerpicker
- don't show disabled related layers

Connects #1798 

### Demo
<img width="628" alt="screen shot 2017-04-18 at 4 17 48 pm" src="https://cloud.githubusercontent.com/assets/7633670/25151247/e4fbb06e-2452-11e7-899e-a30710201ae7.png">



## Testing Instructions

 * Pull and `./scripts/bundle.sh`
* Pan and zoom the map around to confirm layers still disable as you'd expect
    - check the coverage grid DRB catchments, philly school district, etc
 * Draw an AoI in philly
      - the water quality tab should show 3 related layers
 * Draw an AoI outside the DRB
      - there should be no related layers listed
