### PR TITLE
Increase number of results limit on boundary layer search

### DIFF
--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -544,7 +544,7 @@ def _get_boundary_search_query(search_term):
         (SELECT id, '{code}' AS code, name, {rank} AS rank,
             ST_Centroid(geom) as center
         FROM {table}
-        WHERE name ILIKE %(term)s
+        WHERE UPPER(name) LIKE UPPER(%(term)s)
         LIMIT 3)
     """.strip()
 

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -200,7 +200,7 @@ LAYER_GROUPS = {
             'minZoom': 7,
             'selectable': True,
             'searchable': True,
-            'search_priority': 100,
+            'search_rank': 30,
         },
         {
             'code': 'huc10',
@@ -217,7 +217,7 @@ LAYER_GROUPS = {
             'minZoom': 8,
             'selectable': True,
             'searchable': True,
-            'search_priority': 90,
+            'search_rank': 20,
         },
         {
             'code': 'huc12',
@@ -235,7 +235,7 @@ LAYER_GROUPS = {
             'minZoom': 9,
             'selectable': True,
             'searchable': True,
-            'search_priority': 80,
+            'search_rank': 10,
         },
         {
             'code': 'county',


### PR DESCRIPTION
## Overview

Instead of displaying 5 total results for all boundary layers, we now
show up to 3 results for each boundary layer.

Also, priority was renamed to rank. Since we now show results for each
boundary layer regardless of priority/rank, the only thing this number
does is determine the sort order for results on the frontend.

The goal of this is to show more results and hopefully improve performance
before we spend any more time researching #1826.

### Demo

See how there are 3 results for each boundary layer. If I had HUC12s on my workstation you might see an additional 3 results.

![image](https://cloud.githubusercontent.com/assets/43062/25196979/530a0868-2510-11e7-8d14-0875fc449d70.png)