### PR TITLE
Make sidebar scrollable

### DIFF
--- a/src/mmw/sass/pages/_draw.scss
+++ b/src/mmw/sass/pages/_draw.scss
@@ -6,7 +6,8 @@
     right: 0;
     transition: all 200ms;
     top: 44px;
-    overflow: visible;
+    bottom: 0px;
+    overflow-y: auto;
 }
 
 .splash-step {


### PR DESCRIPTION
## Overview

Makes the sidebar scrollable so that when there is a lot of content, or the screen is really short, the app remains accessible. This change applies to the sidebar in splash and draw views.

:bug: :lipstick:

Connects #1792 

### Demo

![2017-04-20 12 44 58](https://cloud.githubusercontent.com/assets/1430060/25242759/ccb36944-25c8-11e7-80d0-c1cdc9856178.gif)

## Testing Instructions

 * Check out this branch
 * Download this patch file: [long-sidebar-text.patch.txt](https://github.com/WikiWatershed/model-my-watershed/files/944709/long-sidebar-text.patch.txt)
 * Apply the patch to add long text to your local

       $ git apply long-sidebar-text.patch.txt

 * Bundle the new stuff `./scripts/bundle.sh --debug`
 * Open the app in your local and ensure that it is workable even though main action buttons are pushed below the fold