### PR TITLE
BiGCZ: Add Initial `/search` Sidebar View

### DIFF
--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -22,6 +22,7 @@ urlpatterns = patterns(
     url(r'^project/compare/$', project, name='project'),
     url(r'^project/(?P<proj_id>[0-9]+)/compare/$', project, name='project'),
     url(r'^analyze$', home_page, name='analyze'),
+    url(r'^search$', home_page, name='search'),
     url(r'^error', home_page, name='error'),
     url(r'^sign-up', home_page, name='sign_up'),
 )

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -132,7 +132,7 @@ def get_client_settings(request):
             'vizer_names': settings.VIZER_NAMES,
             'model_packages': get_model_packages(),
             'mapshed_max_area': settings.GWLFE_CONFIG['MaxAoIArea'],
-            'analyze_enabled': settings.ANALYZE_ENABLED,
+            'data_catalog_enabled': settings.DATA_CATALOG_ENABLED,
             'itsi_enabled': settings.ITSI_ENABLED,
         }),
         'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,

--- a/src/mmw/js/src/analyze/templates/dataSourceButton.html
+++ b/src/mmw/js/src/analyze/templates/dataSourceButton.html
@@ -1,0 +1,4 @@
+<button id="data-source-button" class="btn btn-model btn-lg btn-active btn-go-to-data-catalog" type="button">
+    Search data sources
+    <i class="fa fa-arrow-right"></i>
+</button>

--- a/src/mmw/js/src/analyze/templates/modelSelectionDropdown.html
+++ b/src/mmw/js/src/analyze/templates/modelSelectionDropdown.html
@@ -1,0 +1,19 @@
+<div class="dropdown">
+  <button class="btn btn-model btn-lg btn-active dropdown-toggle" type="button" data-toggle="dropdown">Model this area
+  <span class="caret"></span></button>
+  <ul class="dropdown-menu dropdown-menu-right">
+    {% for modelPackage in modelPackages %}
+        <li>
+            {% if modelPackage.disabled %}
+                <a class="disabled" class="model-package" href="#" data-id="{{ modelPackage.name }}">
+                    {{ modelPackage.display_name }} (Coming Soon)
+                </a>
+            {% else %}
+                <a href="#" class="model-package" data-id="{{ modelPackage.name }}">
+                    {{ modelPackage.display_name }}
+                </a>
+            {% endif %}
+        </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/src/mmw/js/src/analyze/templates/resultsWindow.html
+++ b/src/mmw/js/src/analyze/templates/resultsWindow.html
@@ -7,25 +7,7 @@
             </a>
         </li>
         <li>
-            <div class="dropdown">
-              <button class="btn btn-model btn-lg btn-active dropdown-toggle" type="button" data-toggle="dropdown">Model this area
-              <span class="caret"></span></button>
-              <ul class="dropdown-menu dropdown-menu-right">
-                {% for modelPackage in modelPackages %}
-                    <li>
-                        {% if modelPackage.disabled %}
-                            <a class="disabled" class="model-package" href="#" data-id="{{ modelPackage.name }}">
-                                {{ modelPackage.display_name }} (Coming Soon)
-                            </a>
-                        {% else %}
-                            <a href="#" class="model-package" data-id="{{ modelPackage.name }}">
-                                {{ modelPackage.display_name }}
-                            </a>
-                        {% endif %}
-                    </li>
-                {% endfor %}
-              </ul>
-            </div>
+            <div id="next-stage-navigation-region"></div>
         </li>
     </ul>
 </div>

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -78,8 +78,21 @@ var MapModel = Backbone.Model.extend({
         this._setSizeOptions({ single: true  }, { large: true }, fit);
     },
 
-    _setSizeOptions: function(top, bottom, fit, noHeader) {
-        this.set('size', { top: top, bottom: bottom, fit: !!fit, noHeader: noHeader });
+    setDataCatalogSize: function(fit) {
+        var wideSidebar = true,
+            noHeader = true;
+        this._setSizeOptions({ sidebar: true  }, { sidebar: true }, fit, noHeader,
+            wideSidebar);
+    },
+
+    _setSizeOptions: function(top, bottom, fit, noHeader, wideSidebar) {
+        this.set('size', {
+            top: top,
+            bottom: bottom,
+            fit: !!fit,
+            noHeader: noHeader,
+            wideSidebar: wideSidebar
+        });
     }
 
 });
@@ -610,6 +623,7 @@ var AppStateModel = Backbone.Model.extend({
     defaults: {
         active_page: 'Select Area Of Interest',
         was_analyze_visible: false,
+        was_data_catalog_visible: false,
         was_model_visible: false,
         was_compare_visible: false,
     }

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 var defaultSettings = {
     itsi_embed: false,
     itsi_enabled: true,
-    analyze_enabled: true,
+    data_catalog_enabled: false,
     base_layers: {},
     stream_layers: {},
     coverage_layers: {},

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -3,6 +3,7 @@
         <li class="global-navigation-item {{splashNavClasses}}"><button data-url="/">Model My Watershed</button></li>
         <li class="global-navigation-item {{selectAreaNavClasses}}"><button  data-url="/draw">Select Area</button></li>
         <li class="global-navigation-item {{analyzeNavClasses}}"><button data-url="/analyze">Analyze</button></li>
+        <li class="global-navigation-item {{dataCatalogNavClasses}}"><button data-url="/search">Search</button></li>
         <li class="global-navigation-item {{modelNavClasses}}"><button  data-url="/project">Model</button></li>
         <li class="global-navigation-item {{compareNavClasses}}"><button  data-url="/project/compare">Compare</button></li>
     </ul>

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -25,6 +25,8 @@ var utils = {
 
     analyzePageTitle: 'Geospatial Analysis',
 
+    dataCatalogPageTitle: 'Search Data Sources',
+
     comparePageTitle: 'Compare',
 
     projectsPageTitle: 'Projects',

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -102,6 +102,12 @@ var HeaderView = Marionette.ItemView.extend({
         return this.makeNavClasses(isActive, isVisible);
     },
 
+    makeDataCatalogNavClasses: function(currentActive, wasDataCatalogVisible) {
+        var isVisible = !this.isProjectsPage(currentActive) && wasDataCatalogVisible,
+            isActive = currentActive === coreUtils.dataCatalogPageTitle;
+        return this.makeNavClasses(isActive, isVisible);
+    },
+
     makeModelNavClasses: function(currentActive) {
         var modelPackageNames = _.pluck(settings.get('model_packages'), 'display_name'),
             isCompare = currentActive === coreUtils.comparePageTitle,
@@ -122,6 +128,7 @@ var HeaderView = Marionette.ItemView.extend({
         var self = this,
             currentActive = self.appState.get('active_page'),
             wasAnalyzeVisible = self.appState.get('was_analyze_visible'),
+            wasDataCatalogVisible = self.appState.get('was_data_catalog_visible'),
             wasModelVisible = self.appState.get('was_model_visible'),
             wasCompareVisible = self.appState.get('was_compare_visible');
 
@@ -130,6 +137,7 @@ var HeaderView = Marionette.ItemView.extend({
             'splashNavClasses': this.makeSplashNavClasses(wasAnalyzeVisible, wasModelVisible),
             'selectAreaNavClasses': this.makeSelectAreaNavClasses(currentActive),
             'analyzeNavClasses': this.makeAnalyzeNavClasses(currentActive, wasAnalyzeVisible, wasModelVisible),
+            'dataCatalogNavClasses': this.makeDataCatalogNavClasses(currentActive, wasDataCatalogVisible),
             'modelNavClasses': this.makeModelNavClasses(currentActive),
             'compareNavClasses': this.makeCompareNavClasses(currentActive, wasCompareVisible),
         };
@@ -598,6 +606,7 @@ var MapView = Marionette.ItemView.extend({
         $container.toggleClass('map-container-bottom-sidebar', !!size.top.sidebar);
 
         $container.toggleClass('map-container-top-sidebar-no-header', !!size.noHeader);
+        $container.toggleClass('-widesidebar', !!size.wideSidebar);
 
         _.delay(function() {
             self._leafletMap.invalidateSize();

--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -1,0 +1,43 @@
+"use strict";
+
+var App = require('../app'),
+    router = require('../router').router,
+    utils = require('../core/utils'),
+    views = require('./views');
+
+var DataCatalogController = {
+    dataCatalogPrepare: function() {
+        if (!App.map.get('areaOfInterest')) {
+            router.navigate('', { trigger: true });
+            return false;
+        }
+
+        // The mask layer should always be applied to the map when entering
+        // data catalog mode
+        if (!App.map.get('maskLayerApplied')) {
+            App.map.set('maskLayerApplied', true);
+        }
+
+    },
+
+    dataCatalog: function() {
+        App.map.setDataCatalogSize();
+
+        App.state.set({
+            'active_page': utils.dataCatalogPageTitle,
+            'was_data_catalog_visible': true,
+        });
+
+        var dataCatalogWindow = new views.DataCatalogWindow();
+
+        App.rootView.sidebarRegion.show(dataCatalogWindow);
+    },
+
+    dataCatalogCleanUp: function() {
+        App.rootView.sidebarRegion.empty();
+    }
+};
+
+module.exports = {
+    DataCatalogController: DataCatalogController,
+};

--- a/src/mmw/js/src/data_catalog/templates/searchbar.html
+++ b/src/mmw/js/src/data_catalog/templates/searchbar.html
@@ -1,0 +1,11 @@
+<div class="data-catalog-search">
+    <i class="data-catalog-search-icon fa fa-search"></i>
+    <input
+        class="data-catalog-search-input"
+        type="text"
+        placeholder="Search data sources"
+    />
+    <div class="data-catalog-search-description">
+        eg: Turbidity, Fixed Shore, USGS, more stuff
+    </div>
+</div>

--- a/src/mmw/js/src/data_catalog/templates/window.html
+++ b/src/mmw/js/src/data_catalog/templates/window.html
@@ -1,0 +1,6 @@
+<div class="data-catalog-window">
+    <div class="data-catalog-title">
+        Data sources
+    </div>
+    <div id="data-catalog-searchbar-region"></div>
+</div>

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -1,0 +1,26 @@
+"use strict";
+
+var Marionette = require('../../shim/backbone.marionette'),
+    dataCatalogWindowTmpl = require('./templates/window.html'),
+    searchbarTmpl = require('./templates/searchbar.html');
+
+var DataCatalogWindow = Marionette.LayoutView.extend({
+    template: dataCatalogWindowTmpl,
+
+    regions: {
+        'searchBar': '#data-catalog-searchbar-region',
+    },
+
+    onShow: function() {
+        this.searchBar.show(new SearchBarView());
+    },
+
+});
+
+var SearchBarView = Marionette.LayoutView.extend({
+    template: searchbarTmpl,
+});
+
+module.exports = {
+    DataCatalogWindow: DataCatalogWindow,
+};

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -1017,9 +1017,7 @@ function addLayer(shape, name, label) {
 }
 
 function navigateToAnalyze() {
-    if (settings.get('analyze_enabled')) {
-        router.navigate('analyze', { trigger: true });
-    }
+    router.navigate('analyze', { trigger: true });
 }
 
 module.exports = {

--- a/src/mmw/js/src/routes.js
+++ b/src/mmw/js/src/routes.js
@@ -1,8 +1,10 @@
 'use strict';
 
 var router = require('./router').router,
+    settings = require('./core/settings'),
     DrawController = require('./draw/controllers').DrawController,
     AnalyzeController = require('./analyze/controllers').AnalyzeController,
+    DataCatalogController = require('./data_catalog/controllers').DataCatalogController,
     ModelingController = require('./modeling/controllers').ModelingController,
     CompareController = require('./compare/controllers').CompareController,
     ProjectsController = require('./projects/controllers').ProjectsController,
@@ -21,6 +23,10 @@ router.addRoute('projects(/)', ProjectsController, 'projects');
 router.addRoute('error(/:type)(/)', ErrorController, 'error');
 router.addRoute('sign-up(/)', SignUpController, 'signUp');
 router.addRoute('sign-up/itsi(/:username)(/:first_name)(/:last_name)(/)', SignUpController, 'itsiSignUp');
+
+if (settings.get('data_catalog_enabled')) {
+    router.addRoute(/^search/, DataCatalogController, 'dataCatalog');
+}
 
 router.on('route', function() {
     // Allow Google Analytics to track virtual pageloads following approach in

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -358,10 +358,10 @@ OMGEO_SETTINGS = [[
 # Feature flags
 MMW_BIGCZ_MODE = bool(environ.get('MMW_BIGCZ_MODE', False))
 if MMW_BIGCZ_MODE:
-    ANALYZE_ENABLED = False
+    DATA_CATALOG_ENABLED = True
     ITSI_ENABLED = False
 else:
-    ANALYZE_ENABLED = True
+    DATA_CATALOG_ENABLED = False
     ITSI_ENABLED = True
 
 # ITSI Portal Settings

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -52,6 +52,11 @@
       right: 485px !important;
     }
   }
+  &.-widesidebar {
+      @media(min-width: 1040px) {
+        right: 600px !important;
+      }
+  }
   // Sets map to correct container size for sidebar.
   &.map-container-bottom-sidebar {
     bottom: 0 !important;

--- a/src/mmw/sass/components/_buttons.scss
+++ b/src/mmw/sass/components/_buttons.scss
@@ -188,3 +188,7 @@
   background-color: darken($ui-light, 5%);
   border: solid 1px darken($ui-light, 10%);
 }
+
+.btn-go-to-data-catalog > .fa-arrow-right {
+    margin-left: 0.25rem;
+}

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -76,4 +76,5 @@
   "pages/compare",
   "pages/projects",
   "pages/water-balance",
-  "pages/registration";
+  "pages/registration",
+  "pages/data-catalog";

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -1,0 +1,44 @@
+.data-catalog-window {
+    width: 600px;
+    padding: 1rem;
+    position: absolute;
+    right: 0;
+    transition: all 200ms;
+    top: 44px;
+    bottom: 0px;
+    overflow-y: auto;
+    background-color: $ui-light;
+}
+
+.data-catalog-title {
+    font-weight: 900;
+    display: inline;
+    margin-right: 1rem;
+    font-size: 1.2rem;
+}
+
+.data-catalog-search {
+    position: relative;
+    top: 0;
+    margin-top: 1rem;
+    > .data-catalog-search-input {
+        width: 100%;
+        height: 38px;
+        border: none;
+        padding-left: 38px;
+        margin-bottom: 0.5rem;
+        font-size: 0.8rem;
+    }
+    > .data-catalog-search-icon {
+        color: $ui-grey;
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        font-size: 18px;
+    }
+    > .data-catalog-search-description {
+        color: $ui-grey;
+        font-size: 0.7rem;
+        margin-left: 0.5rem;
+    }
+}


### PR DESCRIPTION
## Overview

Add the initial data catalog search ui:
- When in BiG CZ mode, ~route to `/search` after draw~ replace the model selection dropdown in analyze with navigation to `/search`
- Add dummy search bar to `/search` sidebar view

*Possibly outdated wireframe I used for inspiration*
![screen shot 2017-04-24 at 5 04 09 pm](https://cloud.githubusercontent.com/assets/7633670/25358731/8ab0edf0-2910-11e7-8c9f-0c50167eb7ae.png)

Connects #1840 

### Demo

![screen shot 2017-04-25 at 2 55 40 pm](https://cloud.githubusercontent.com/assets/7633670/25402806/e849abfc-29c7-11e7-9e49-1656aeb7e759.png)

![screen shot 2017-04-24 at 5 06 18 pm](https://cloud.githubusercontent.com/assets/7633670/25358748/97f5611c-2910-11e7-8797-a69bc7c0e90f.png)

### Notes
 ~This assumes the setting `analyze_enabled=False` is equivalent to "show data catalog"
@kdeloach How did you envision this? Should there be an additional flag `data_catalog_enabled`?~

Replaced `analyze_enabled` with `data_catalog_enabled` as now both apps will have some sort of analyze step

## Testing Instructions
 * `./scripts/mode.sh mmw`: check that analyze and model still work and you can't access the data catalog
 * `./scripts/mode.sh bigcz`: check that there's a button in analyze to "Search data sources", and you are routed to `/search`. You should see filler UI
 * Going direct to `/search` directs you back to the home page
