### PR TITLE
Tweak search box style

### DIFF
--- a/src/mmw/sass/components/_inputs.scss
+++ b/src/mmw/sass/components/_inputs.scss
@@ -10,7 +10,7 @@
   font-size: 0.7rem;
   width: 300px;
   height: 36px;
-  padding: 0 1rem;
+  padding: 0 0.5rem;
   color: $black-54;
   background-color: $paper;
   margin-right: 0.6rem;

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -57,7 +57,7 @@
   position: absolute;
   border-radius: 2px;
   box-shadow: 0 0 6px $black-74;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: $black-54;
   background-color: $paper;
   margin-top: 6px;
@@ -72,10 +72,12 @@
   }
 
   h1 {
-    margin: 0.5rem;
-    border-bottom: 1px solid #bbb;
-    font-size: 0.8rem;
-    color: #bbb;
+    margin: 0.6rem 0.5rem 0.3rem;
+    border-bottom: 1px solid #ccc;
+    font-size: 0.6rem;
+    color: #333;
+    text-transform: uppercase;
+    padding-bottom: 0.3rem;
   }
 
   ul {
@@ -85,11 +87,15 @@
 
     & > li {
       cursor: pointer;
-      padding: 0.3rem 0.5rem;
+      padding: 0.2rem 0.5rem;
 
       &:hover {
         color: $ui-primary;
       }
     }
   }
+}
+
+.boundary-suggestions {
+  padding-bottom: 0.3rem;
 }

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -62,7 +62,14 @@
   background-color: $paper;
   margin-top: 6px;
   min-width: 300px;
+  max-height: 600px;
+  overflow: hidden;
+  overflow-y: auto;
   z-index: 700;
+
+  & .geocode-suggestions {
+    padding-top: 0.3rem;
+  }
 
   h1 {
     margin: 0.5rem;
@@ -78,17 +85,11 @@
 
     & > li {
       cursor: pointer;
-      padding: 0.5rem 1rem;
-      border-bottom: solid 1px $black-12;
-
-      &:last-child {
-        border: none;
-      }
+      padding: 0.3rem 0.5rem;
 
       &:hover {
         color: $ui-primary;
       }
     }
   }
-
 }


### PR DESCRIPTION
## Overview

Reduce padding and make dropdown content scrollable.

Connects #1838

### Demo

![image](https://cloud.githubusercontent.com/assets/43062/25593233/c10fba06-2e89-11e7-9a75-b8414f981707.png)

With reduced `max-height` to demonstrate overflow:

![image](https://cloud.githubusercontent.com/assets/43062/25593237/c2c73fb8-2e89-11e7-9894-766a5ef61fad.png)

### Notes

I considered using `calc(100vh - 200px)` for `max-height` but I'm concerned about cross-browser compatibility issues. As a result, the search results dropdown can be clipped on small resolutions, even though overflow is enabled.

## Testing Instructions

* Checkout PR branch
* Run:
```
./scripts/bundle.sh
```
* Test in browser