### PR TITLE
Shorten Analyze Tables to Fit

### DIFF
--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
@@ -1,4 +1,31 @@
 <div class="pageable-table-container">
+{% if totalPages > 1 %}
+<div class="row paging-ctl-row">
+    {% if hasPreviousPage %}
+        <button
+            class="btn-prev-page btn btn-primary col-sm-1 col-sm-offset-3"
+            data-toggle="tooltip"
+            title="Previous Page"
+            data-placement="right"
+        >
+            <span aria-hidden="true">&larr;</span>
+        </button>
+    {% endif %}
+    <p class="col-sm-3 {{ "col-sm-offset-4" if not hasPreviousPage else "" }}">
+        {{currentPage}} of {{totalPages}}
+    </p>
+    {% if hasNextPage %}
+        <button
+            class="btn-next-page btn btn-primary col-sm-1"
+            data-toggle="tooltip"
+            title="Next Page"
+            data-placement="right"
+        >
+            <span aria-hidden="true">&rarr;</span>
+        </button>
+    {% endif %}
+</div>
+{% endif %}
   <table class="table custom-hover catchment-water-quality pageable-table-size" data-toggle="table">
       <thead>
           <tr>
@@ -30,24 +57,3 @@
       </tfoot>
   </table>
 </div>
-{% if totalPages > 1 %}
-    <div class="row paging-ctl-row">
-            <p>
-                {{currentPage}} of {{totalPages}}
-            </p>
-            {% if hasPreviousPage %}
-                <button class="btn-prev-page btn btn-primary"
-                  data-toggle="tooltip" title="Previous Page"
-                  data-placement="right">
-                    <span aria-hidden="true">&larr;</span>
-                </button>
-            {% endif %}
-            {% if hasNextPage %}
-                <button class="btn-next-page btn btn-primary"
-                  data-toggle="tooltip" title="Next Page"
-                  data-placement="right">
-                    <span aria-hidden="true">&rarr;</span>
-                </button>
-            {% endif %}
-    </div>
-{% endif %}

--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -1,4 +1,31 @@
 <div class="pageable-table-container">
+{% if totalPages > 1 %}
+    <div class="row paging-ctl-row">
+        {% if hasPreviousPage %}
+            <button
+                class="btn-prev-page btn btn-primary col-sm-1 col-sm-offset-3"
+                data-toggle="tooltip"
+                title="Previous Page"
+                data-placement="right"
+            >
+                <span aria-hidden="true">&larr;</span>
+            </button>
+        {% endif %}
+        <p class="col-sm-3 {{ "col-sm-offset-4" if not hasPreviousPage else "" }}">
+            {{currentPage}} of {{totalPages}}
+        </p>
+        {% if hasNextPage %}
+            <button
+                class="btn-next-page btn btn-primary col-sm-1"
+                data-toggle="tooltip"
+                title="Next Page"
+                data-placement="right"
+            >
+                <span aria-hidden="true">&rarr;</span>
+            </button>
+        {% endif %}
+    </div>
+{% endif %}
   <table class="table custom-hover point-source pageable-table-size" data-toggle="table">
       <thead>
           <tr>
@@ -35,24 +62,3 @@
       </tfoot>
   </table>
 </div>
-{% if totalPages > 1 %}
-    <div class="row paging-ctl-row">
-            <p>
-                {{currentPage}} of {{totalPages}}
-            </p>
-            {% if hasPreviousPage %}
-                <button class="btn-prev-page btn btn-primary"
-                  data-toggle="tooltip" title="Previous Page"
-                  data-placement="right">
-                    <span aria-hidden="true">&larr;</span>
-                </button>
-            {% endif %}
-            {% if hasNextPage %}
-                <button class="btn-next-page btn btn-primary"
-                  data-toggle="tooltip" title="Next Page"
-                  data-placement="right">
-                    <span aria-hidden="true">&rarr;</span>
-                </button>
-            {% endif %}
-    </div>
-{% endif %}

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -889,11 +889,15 @@ var AnalyzeResultView = Marionette.LayoutView.extend({
     },
 
     showAnalyzeResults: function(CategoriesToCensus, AnalyzeTableView,
-        AnalyzeChartView, description, associatedLayerCodes) {
+        AnalyzeChartView, description, associatedLayerCodes, pageSize) {
         var categories = this.model.get('categories'),
             largestArea = lodash.max(lodash.pluck(categories, 'area')),
             units = utils.magnitudeOfArea(largestArea),
             census = new CategoriesToCensus(categories);
+
+        if (pageSize) {
+            census.setPageSize(pageSize);
+        }
 
         this.tableRegion.show(new AnalyzeTableView({
             units: units,
@@ -962,9 +966,12 @@ var PointSourceResultView = AnalyzeResultView.extend({
     onShow: function() {
         var desc = 'Discharge Monitoring Report annual averages from EPA NPDES',
             associatedLayerCodes = ['pointsource'],
+            avgRowHeight = 30,  // Most rows are between 2-3 lines, 12px per line
+            minScreenHeight = 768 + 45, // height of landscape iPad + extra content below the table
+            pageSize = utils.calculateVisibleRows(minScreenHeight, avgRowHeight, 3),
             chart = null;
         this.showAnalyzeResults(coreModels.PointSourceCensusCollection,
-            PointSourceTableView, chart, desc, associatedLayerCodes);
+            PointSourceTableView, chart, desc, associatedLayerCodes, pageSize);
     }
 });
 
@@ -978,9 +985,12 @@ var CatchmentWaterQualityResultView = AnalyzeResultView.extend({
                 'drb_catchment_water_quality_tp',
                 'drb_catchment_water_quality_tss',
             ],
+            avgRowHeight = 18,  // Most rows are between 1-2 lines, 12px per line
+            minScreenHeight = 768 + 45, // height of landscape iPad + extra content below the table
+            pageSize = utils.calculateVisibleRows(minScreenHeight, avgRowHeight, 5),
             chart = null;
         this.showAnalyzeResults(coreModels.CatchmentWaterQualityCensusCollection,
-            CatchmentWaterQualityTableView, chart, desc, associatedLayerCodes);
+            CatchmentWaterQualityTableView, chart, desc, associatedLayerCodes, pageSize);
     }
 });
 

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -14,7 +14,6 @@ var $ = require('jquery'),
     modalViews = require('../core/modals/views'),
     coreModels = require('../core/models'),
     coreViews = require('../core/views'),
-    coreUtils = require('../core/utils'),
     chart = require('../core/chart'),
     utils = require('../core/utils'),
     constants = require('./constants'),
@@ -73,9 +72,9 @@ var ModelSelectionDropdownView = Marionette.ItemView.extend({
             });
 
         if (modelPackageName === 'gwlfe' && settings.get('mapshed_max_area')) {
-            var areaInSqKm = coreUtils.changeOfAreaUnits(aoiModel.get('area'),
-                                                         aoiModel.get('units'),
-                                                         'km<sup>2</sup>');
+            var areaInSqKm = utils.changeOfAreaUnits(aoiModel.get('area'),
+                                                     aoiModel.get('units'),
+                                                     'km<sup>2</sup>');
 
             if (areaInSqKm > settings.get('mapshed_max_area')) {
                 alertView = new modalViews.AlertView({

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -559,13 +559,13 @@ var AnimalCensusCollection = Backbone.Collection.extend({
 var PointSourceCensusCollection = Backbone.PageableCollection.extend({
     comparator: 'city',
     mode: 'client',
-    state: { pageSize: 50, firstPage: 1 }
+    state: { pageSize: 3, firstPage: 1 }
 });
 
 var CatchmentWaterQualityCensusCollection = Backbone.PageableCollection.extend({
     comparator: 'nord',
     mode: 'client',
-    state: { pageSize: 50, firstPage: 1 }
+    state: { pageSize: 5, firstPage: 1 }
 });
 
 var GeoModel = Backbone.Model.extend({

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -435,6 +435,15 @@ var utils = {
             });
             return newRow;
         });
+    },
+
+    calculateVisibleRows: function(minScreenHeight, avgRowHeight, minRows) {
+        var screenHeight = document.documentElement.clientHeight;
+        if (screenHeight <= minScreenHeight) {
+            return minRows;
+        }
+
+        return minRows + Math.floor((screenHeight - minScreenHeight) / avgRowHeight);
     }
 };
 

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -76,13 +76,7 @@
 
 .paging-ctl-row {
   text-align: center;
-  bottom:0rem;
-  position:fixed;
-  background-color: $paper;
-  @media (max-height: 884px) {
-    top:0.2rem;
-    position:relative;
-  }
+  margin-top: 20px !important;
 }
 
 .pageable-table-container {


### PR DESCRIPTION
## Overview

Previously, long tables would hijack scroll events on touch devices, making it impossible to scroll the sidebar. Since the tables are pretty wide, we _do_ need them to scroll horizontally, thus disabling scroll with something like `pointer-events: none` was not an option.

This solution sets the table's `pageSize` based on hard-coded characteristics for each kind of table. The resulting tables are much shorter and easier to manage on touch devices.

Also tagging @ajrobbins and @jfrankl for visual review.

Connects #1815 

### Demo

Portrait iPad:

![image](https://cloud.githubusercontent.com/assets/1430060/25595051/5ab611da-2e91-11e7-83c2-efd6537a5914.png)

![image](https://cloud.githubusercontent.com/assets/1430060/25595078/7207d8dc-2e91-11e7-84de-9bb1e32c699d.png)

Landscape iPad:

![image](https://cloud.githubusercontent.com/assets/1430060/25595112/961a89ea-2e91-11e7-87ba-0d86ceaf8c07.png)

![image](https://cloud.githubusercontent.com/assets/1430060/25595121/9c10be78-2e91-11e7-82ae-828a714c94fc.png)

### Notes

The number of rows is not calculated truly dynamically: we give the function some educated guesses for the characteristics of each type of table. The results are not _perfect_, but good enough for now.

Now that we're relying more on the pagination, we might have to really fix #1594. /cc @ajrobbins 

## Testing Instructions

 * Pull down this branch and bundle `./scripts/bundle.sh --debug`
 * Select a shape within the DRB (I go with a HUC-12 in Philadelphia as shown in the screenshots) so it has a lot of point sources of contamination and water quality polygon overlaps.
 * Go to the Analyze view. Open the Point Source tab. Ensure that the table length does not exceed the page. Ensure that pagination works as expected.
 * Open the Water Quality tab. Ensure the same as above.
 * Try on a touch device and ensure that all functionality in the sidebar (downloading CSV, paginating, etc) is easily available
