### PR TITLE
Start Model Stage With Only Current Conditions Scenario

### DIFF
--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -332,10 +332,6 @@ function setupNewProjectScenarios(project) {
         new models.ScenarioModel({
             name: 'Current Conditions',
             is_current_conditions: true,
-            aoi_census: aoiCensus
-        }),
-        new models.ScenarioModel({
-            name: 'New Scenario',
             active: true,
             aoi_census: aoiCensus
         })

--- a/src/mmw/js/src/modeling/templates/scenarioToolbarTabContents.html
+++ b/src/mmw/js/src/modeling/templates/scenarioToolbarTabContents.html
@@ -1,0 +1,5 @@
+{% if hasNoScenarios %}
+    <button id="add-changes" class="btn btn-sm btn-primary dropdown-button" type="button" aria-expanded="true">
+        <i class="fa fa-plus-circle"></i> Add changes to this area
+    </button>
+{% endif %}

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -26,6 +26,7 @@ var _ = require('lodash'),
     scenarioMenuTmpl = require('./templates/scenarioMenu.html'),
     scenarioMenuItemTmpl = require('./templates/scenarioMenuItem.html'),
     projectMenuTmpl = require('./templates/projectMenu.html'),
+    scenarioToolbarTabContentsTmpl = require('./templates/scenarioToolbarTabContents.html'),
     tr55ScenarioToolbarTabContentTmpl = require('./templates/tr55ScenarioToolbarTabContent.html'),
     gwlfeScenarioToolbarTabContentTmpl = require('./templates/gwlfeScenarioToolbarTabContent.html'),
     tr55RunoffViews = require('./tr55/runoff/views.js'),
@@ -794,9 +795,23 @@ var GwlfeToolbarTabContentView = ToolbarTabContentView.extend({
 
 // The collection of modification and input toolbars for each
 // scenario.
-var ToolbarTabContentsView = Marionette.CollectionView.extend({
+var ToolbarTabContentsView = Marionette.CompositeView.extend({
+    template: scenarioToolbarTabContentsTmpl,
     collection: models.ScenariosCollection,
     className: 'tab-content',
+
+    ui: {
+        addChangesButton: '#add-changes',
+    },
+
+    events: {
+        'click @ui.addChangesButton': 'onAddChangesClick',
+    },
+
+    collectionEvents: {
+        'change:active': 'render',
+    },
+
     getChildView: function() {
         var isGwlfe = App.currentProject.get('model_package') === 'gwlfe';
         if (isGwlfe) {
@@ -818,6 +833,17 @@ var ToolbarTabContentsView = Marionette.CollectionView.extend({
 
     initialize: function(options) {
         this.mergeOptions(options, ['model_package']);
+    },
+
+    onAddChangesClick: function() {
+        this.collection.createNewScenario();
+    },
+
+    templateHelpers: function() {
+        return {
+            hasNoScenarios: this.collection.length === 1 &&
+                this.collection.first().get('is_current_conditions'),
+        };
     }
 });
 

--- a/src/mmw/sass/bootstrap/_navs.scss
+++ b/src/mmw/sass/bootstrap/_navs.scss
@@ -222,7 +222,7 @@
     display: none;
   }
   > .active {
-    display: block;
+    display: initial;
   }
 }
 


### PR DESCRIPTION
## Overview
- Start each project off with Current Conditions as the only scenario
- Add button "+ Add changes to this area" to create new scenario

Eventually on model start we wont show any hint of scenarios at all, but I'll leave that work for #1865 which will have to rework the scenario views anyway.

**Wireframes**
![screen shot 2017-05-08 at 1 08 15 pm](https://cloud.githubusercontent.com/assets/7633670/25815660/754244c0-33ef-11e7-91c7-a881caa5feb6.png)

Connects #1866 

### Demo

![tbjf5qlhli](https://cloud.githubusercontent.com/assets/7633670/25815636/59d23db2-33ef-11e7-8923-ba55cbff71ad.gif)

## Testing Instructions

 * Pull this branch  and `./scripts/bundle.sh`
 * Create new projects with both models
    * Confirm both start with "Current Conditions" and there's a "Add changes to this area" button that on click creates a new scenario
    * Ensure the button does not appear when there are already multiple scenarios