### PR TITLE
Use MapshedJob for Analyze and TR-55

### DIFF
--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -192,7 +192,9 @@ def data_to_census(data):
             elif soil_str == 'cd':
                 soil_str = 'd'
             key_str = '%s:%s' % (soil_str, nlcd_str)
-            dist[key_str] = {'cell_count': count}
+            dist[key_str] = {'cell_count': (
+                count + (dist[key_str]['cell_count'] if key_str in dist else 0)
+            )}
 
     def after_rule(count, census):
         census['cell_count'] = count

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -51,20 +51,12 @@ NO_LAND_COVER = 'NO_LAND_COVER'
 
 @shared_task(bind=True, default_retry_delay=1, max_retries=42)
 def mapshed_start(self, opname, input_data):
-    host = settings.GEOP['host']
-    port = settings.GEOP['port']
-    args = settings.GEOP['args']['MapshedJob']
-
     data = settings.GEOP['json'][opname].copy()
     data['input'].update(input_data)
 
     try:
-        job_id = sjs_submit(host, port, args, data, retry=self.retry)
-
         return {
-            'host': host,
-            'port': port,
-            'job_id': job_id
+            'job_id': sjs_submit(data, retry=self.retry)
         }
     except Retry as r:
         raise r

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -15,7 +15,7 @@ from sys import path
 from layer_settings import (LAYER_GROUPS, VIZER_URLS, VIZER_IGNORE, VIZER_NAMES,
                             NHD_REGION2_PERIMETER, DRB_PERIMETER)  # NOQA
 from gwlfe_settings import (GWLFE_DEFAULTS, GWLFE_CONFIG, SOIL_GROUP, # NOQA
-                            SOILP, CURVE_NUMBER)  # NOQA
+                            SOILP, CURVE_NUMBER, NODATA)  # NOQA
 from tr55_settings import (NLCD_MAPPING, SOIL_MAPPING)
 
 # Normally you should not import ANYTHING from Django directly
@@ -395,6 +395,19 @@ GEOP = {
                 'soilLayer': 'ssurgo-hydro-groups-30m-epsg5070-0.10.0',
                 'zoom': 0
             },
+        },
+        'nlcd_soil_census': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'nlcd-2011-30m-epsg5070-0.10.0',
+                    'ssurgo-hydro-groups-30m-epsg5070-0.10.0'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterGroupedCount',
+                'zoom': 0
+            }
         },
         'nlcd_streams': {
             'input': {

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -382,20 +382,9 @@ GEOP = {
     'host': environ.get('MMW_GEOPROCESSING_HOST', 'localhost'),
     'port': environ.get('MMW_GEOPROCESSING_PORT', '8090'),
     'args': {
-        'SummaryJob': 'context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.SummaryJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
         'MapshedJob': 'context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
     },
     'json': {
-        'nlcdSoilCensus': {
-            'input': {
-                'geometry': None,
-                'tileCRS': 'ConusAlbers',
-                'polyCRS': 'LatLng',
-                'nlcdLayer': 'nlcd-2011-30m-epsg5070-0.10.0',
-                'soilLayer': 'ssurgo-hydro-groups-30m-epsg5070-0.10.0',
-                'zoom': 0
-            },
-        },
         'nlcd_soil_census': {
             'input': {
                 'polygon': [],

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -381,9 +381,7 @@ ITSI = {
 GEOP = {
     'host': environ.get('MMW_GEOPROCESSING_HOST', 'localhost'),
     'port': environ.get('MMW_GEOPROCESSING_PORT', '8090'),
-    'args': {
-        'MapshedJob': 'context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
-    },
+    'args': 'context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
     'json': {
         'nlcd_soil_census': {
             'input': {


### PR DESCRIPTION
## Overview

This PR switches Analyze and TR-55 jobs to use the more configurable [MapshedJob](https://github.com/WikiWatershed/mmw-geoprocessing/blob/develop/summary/src/main/scala/MapshedJob.scala) instead of the older [SummaryJob](https://github.com/WikiWatershed/mmw-geoprocessing/blob/develop/summary/src/main/scala/SummaryJob.scala).

It also fixes a bug in how the results of NLCD / Soil histogram aggregation that would overwrite values instead of summing them.

Connects #1876 

### Notes

A deployment strategy will have to be devised since the bug fix in the first commit changes calculation of saved values in projects.

The final two commits remove and refactor unused code. If we would like to not remove that code at this time, those commits can be dropped.

## Testing Instructions

 * Checkout the first commit of this branch (which includes a fix for aggregating GeoTrellis histogram into a census, but excludes the switch to MapshedJob), and reload the Celery service

       vagrant ssh worker -c 'sudo service celeryd restart'

 * Open the network tab of developer tools, and run an Analyze job on a WKAoI (so it is easy to reproduce). Find the server response and save the JSON response.
 * Checkout the rest of this branch (which includes the switch to MapshedJob), and reload the Celery service

       vagrant ssh worker -c 'sudo service celeryd restart'

 * Run an Analyze job on the same shape. Save the JSON response.
 * Compare the two responses and ensure they are identical.
 * Try out Analyze, TR-55, and Mapshed jobs and ensure they all still work.