### PR TITLE
Don't show error modal on canceling draw

### DIFF
--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -8,6 +8,8 @@ var $ = require('jquery'),
     turfBboxPolygon = require('turf-bbox-polygon'),
     coreUtils = require('../core/utils');
 
+var CANCEL_DRAWING = 'CANCEL_DRAWING';
+
 // Keep in sync with src/api/main.py in rapid-watershed-delineation.
 var MAX_AREA = 75000; // About the size of West Virginia (in km^2)
 
@@ -35,7 +37,7 @@ function drawPolygon(map, drawOpts) {
         drawStop = function() {
             tool.disable();
             clearEvents();
-            defer.reject();
+            defer.reject(CANCEL_DRAWING);
         };
 
     cancelDrawing(map);
@@ -62,7 +64,7 @@ function placeMarker(map, drawOpts) {
         drawStop = function() {
             tool.disable();
             clearEvents();
-            defer.reject();
+            defer.reject(CANCEL_DRAWING);
         };
 
     cancelDrawing(map);
@@ -168,5 +170,6 @@ module.exports = {
     loadAsyncShpFilesFromZip: loadAsyncShpFilesFromZip,
     NHD: 'nhd',
     DRB: 'drb',
+    CANCEL_DRAWING: CANCEL_DRAWING,
     MAX_AREA: MAX_AREA
 };

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -41,6 +41,10 @@ if (!window.Promise) {
 }
 
 function displayAlert(message, alertType) {
+    if (message === drawUtils.CANCEL_DRAWING) {
+        return;
+    }
+
     var alertView = new modalViews.AlertView({
         model: new modalModels.AlertModel({
             alertMessage: message,


### PR DESCRIPTION
## Overview

This PR remedies a bug whereby canceling a draw tool would lead to an error message display. To fix it, I added a guard to the `displayAlert` function in `draw/views` which checks whether there's a legit error message along with the alert.

If so, we display it -- as in the case where RWD starts and fails.
If not, we don't display anything -- as in the case where a draw tool or RWD is cancelled.

Connects #1827 

### Notes

An error message will still display if RWD is canceled after it has been started. This happens because canceling there doesn't actually stop the job from running, so it fails with an actual error message a few seconds later. Going to look into whether we might sort or ignore these messages, but we've got #1716 to handle rejecting the RWD task.

## Testing Instructions

 * get this branch then `bundle`, view it in the browser, and hard refresh
 * click on each draw tool, then click cancel after each and verify that you don't see the error modal
 * click on an RWD option then click cancel and verify that you don't see the warning modal