### PR TITLE
Add flag to disable geoprocessing caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ Spark Job Server       | 8090 | [http://localhost:8090](http://localhost:8090)
 
 In order to speed up things up, you may want to consider leveraging the `vagrant-cachier` plugin. If installed, it is automatically used by Vagrant.
 
+To speed up geoprocessing, those requests are cached in Redis. To disable this caching for development purposes, set the value of `MMW_GEOPROCESSING_CACHE` to `0`:
+
+```bash
+$ vagrant ssh worker -c 'echo "0" | sudo tee /etc/mmw.d/env/MMW_GEOPROCESSING_CACHE'
+$ vagrant ssh worker -c 'sudo service celeryd restart'
+```
+
+To enable the geoprocessing cache simply set it to `1` and restart the `celeryd` service.
+
 ### Test Mode
 
 In order to run the app in test mode, which simulates the production static asset bundle, reprovision with `VAGRANT_ENV=TEST vagrant provision`.

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -47,6 +47,7 @@ sjs_port: 8090
 sjs_container_image: "quay.io/azavea/spark-jobserver:0.6.1"
 
 geop_version: "1.2.0"
+geop_cache_enabled: 1
 
 nginx_cache_dir: "/var/cache/nginx"
 observation_api_url: "http://www.wikiwatershed-vs.org/"

--- a/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
@@ -10,6 +10,7 @@ envdir_config:
   MMW_CACHE_HOST: "{{ redis_host }}"
   MMW_CACHE_PORT: "{{ redis_port }}"
   MMW_TILER_HOST: "{{ tiler_host }}"
+  MMW_GEOPROCESSING_CACHE: "{{ geop_cache_enabled }}"
   MMW_GEOPROCESSING_HOST: "{{ sjs_host }}"
   MMW_GEOPROCESSING_PORT: "{{ sjs_port }}"
   MMW_GEOPROCESSING_VERSION: "{{ geop_version }}"

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -58,7 +58,7 @@ def start(self, opname, input_data, wkaoi=None):
     outgoing = {}
 
     if wkaoi and settings.GEOP['cache']:
-        key = '{}__{}'.format(wkaoi, opname)
+        key = 'geop_{}__{}'.format(wkaoi, opname)
         outgoing['key'] = key
         cached = cache.get(key)
         if cached:

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -57,7 +57,7 @@ def start(self, opname, input_data, wkaoi=None):
 
     outgoing = {}
 
-    if wkaoi:
+    if wkaoi and settings.GEOP['cache']:
         key = '{}__{}'.format(wkaoi, opname)
         outgoing['key'] = key
         cached = cache.get(key)

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -379,6 +379,7 @@ ITSI = {
 
 # Geoprocessing Settings
 GEOP = {
+    'cache': bool(int(environ.get('MMW_GEOPROCESSING_CACHE', 1))),
     'host': environ.get('MMW_GEOPROCESSING_HOST', 'localhost'),
     'port': environ.get('MMW_GEOPROCESSING_PORT', '8090'),
     'args': 'context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA


### PR DESCRIPTION
## Overview

Adds flag to disable geoprocessing caching. This is useful when exercising that part of the code during development.

Connects #1906

## Testing Instructions

 * Check out this branch. Reprovision `app` and `worker`
 * Download and apply this patch [caching-test.patch.txt](https://github.com/WikiWatershed/model-my-watershed/files/1014416/caching-test.patch.txt)

       git apply caching-test.patch.txt

 * Debug Celery

       ./scripts/debugcelery.sh

 * In a new terminal window, fire off an Analyze / Land request

       curl 'http://localhost:8000/api/modeling/start/analyze/land/' --data 'analyze_input=%7B%22wkaoi%22%3A%22huc12__55174%22%7D'

 * Observe the Celery output. Ensure you see the `==> geoprocessing caching is enabled` message.
 * In case this shape hadn't been cached before, it should be cached now. Run the same request again to ensure that the geoprocessing service doesn't run the second time.
 * Update `MMW_GEOPROCESSING_CACHE` to be 0, and restart the Django and Celery

       vagrant ssh app -c 'echo "0" | sudo tee /etc/mmw.d/env/MMW_GEOPROCESSING_CACHE'
       vagrant ssh app -c 'sudo restart mmw-app'
       ./scripts/debugcelery.sh

 * Send the above `curl` request again. Ensure that caching is not used this time, and that you see the `==> geoprocessing caching is disabled` message in Celery.
 * Delete the `MMW_GEOPROCESSING_CACHE` file and restart the services

       vagrant ssh app -c 'sudo rm /etc/mmw.d/env/MMW_GEOPROCESSING_CACHE'
       vagrant ssh app -c 'sudo restart mmw-app'
       ./scripts/debugcelery.sh

 * Run the `curl` request again. Ensure that caching is enabled.