### PR TITLE
Fix IE11 Analyze/Model Views

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -24,7 +24,7 @@ var ControlView = Marionette.LayoutView.extend({
     model: models.ModelPackageControlModel,
 
     className: function() {
-        return 'inline ' + this.getControlName();
+        return 'inline control-item ' + this.getControlName();
     },
 
     initialize: function(options) {

--- a/src/mmw/js/src/modeling/templates/controls/modDropdown.html
+++ b/src/mmw/js/src/modeling/templates/controls/modDropdown.html
@@ -2,7 +2,7 @@
     <button class="btn btn-sm btn-primary dropdown-button" type="button" aria-expanded="true">
         <i class="fa fa-plus-circle"></i> {{ controlDisplayName }}
     </button>
-    <div class="dropdown-menu draw-tools menu-left" role="menu"> <!-- Dropdown -->
+    <div class="dropdown-menu menu-right" role="menu"> <!-- Dropdown -->
         <div class="mod-content-region"></div>
     </div> <!-- End Dropdown -->
 </div> <!-- End Conservation Practice Tools -->

--- a/src/mmw/js/src/modeling/templates/controls/precipitation.html
+++ b/src/mmw/js/src/modeling/templates/controls/precipitation.html
@@ -1,4 +1,4 @@
-<div class="btn-sm btn-primary">
+<div class="btn btn-sm btn-primary">
 <label>
     <span class="name">Precipitation</span>
     <input type="range" min="0" max="25" step="0.25" />

--- a/src/mmw/js/src/modeling/templates/gwlfeScenarioToolbar.html
+++ b/src/mmw/js/src/modeling/templates/gwlfeScenarioToolbar.html
@@ -1,15 +1,15 @@
-<div class="inline controls"></div>
+<div class="controls"></div>
 
 {% if not compareMode and modifications.length > 0 %}
     <div id="gwlfe-modifications-bar">
         <div class="title-icon">
             <i class="fa fa-database" data-toggle="tooltip" title="Applied Conservation Practices"
-                data-placement="right"></i>
+                data-placement="left"></i>
         </div>
         {% for mod in modifications %}
             <div class="thumb" data-value="{{ mod.modKey }}"
                 data-toggle="tooltip" title="{{ mod.modKey|modShortName }}"
-                data-placement="right">
+                data-placement="left">
                 <svg height="{{ 36 }}" width="{{ 36 }}">
                     <rect height="{{ 36 }}" width="{{ 36 }}" fill="{{ mod.modKey|modFill }}"></rect>
                 </svg>
@@ -18,7 +18,7 @@
     </div>
 
     {% if activeMod %}
-        <div id="gwlfe-modifications-popup" class="popover right" style="top">
+        <div id="gwlfe-modifications-popup" class="popover left" style="top">
             <div class="arrow" style="top: 50%;"></div>
             <div class="popover-content">
                 <h5>

--- a/src/mmw/js/src/modeling/templates/modelingHeader.html
+++ b/src/mmw/js/src/modeling/templates/modelingHeader.html
@@ -4,7 +4,7 @@
     </div>
 
     <div class="toolbar">
-        <div class="inline" id="scenarios-region"></div>
-        <div class="inline" id="toolbar-region"></div>
+        <div id="scenarios-region"></div>
+        <div id="toolbar-region"></div>
     </div>
 </header>

--- a/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
+++ b/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
@@ -1,3 +1,4 @@
+<div class="tab-content scenario-toolbar-tab-content"></div>
 {% if isOnlyCurrentConditions %}
     <button id="add-changes" class="btn btn-sm btn-primary dropdown-button" type="button" aria-expanded="true">
         <i class="fa fa-plus-circle"></i> Add changes to this area

--- a/src/mmw/js/src/modeling/templates/tr55ScenarioToolbar.html
+++ b/src/mmw/js/src/modeling/templates/tr55ScenarioToolbar.html
@@ -12,7 +12,7 @@
                 <span id="modification-number"><strong>{{ shapes|length }}</strong></span> Modifications
                 </button>
             {% endif %}
-            <div id="modifications" class="dropdown-menu menu-right" role="menu"> <!-- DropdownContent -->
+            <div id="modifications" class="dropdown-menu modification-dropdown menu-right" role="menu"> <!-- DropdownContent -->
                 {% for controlName, models in groupedShapes %}
                     <div class="pad-1 brd-bottom">
                         <table id="mod-{{ controlName|lower|replace(' ', '') }}" class="table modifications custom-hover">

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -608,7 +608,7 @@ var ScenarioModelToolbarView = Marionette.CompositeView.extend({
     childViewContainer: '.controls',
 
     tagName: 'div',
-    className: 'tab-pane',
+    className: 'tab-pane scenario-toolbar-tab-pane',
 
     childViewOptions: function(modelPackageControl) {
         var controlModel = this.getInputControlModel(modelPackageControl),
@@ -813,7 +813,7 @@ var GwlfeToolbarView = ScenarioModelToolbarView.extend({
 var ScenarioToolbarView = Marionette.CompositeView.extend({
     template: scenarioAddChangesButtonTmpl,
     collection: models.ScenariosCollection,
-    className: 'tab-content',
+    childViewContainer: '.tab-content.scenario-toolbar-tab-content',
 
     ui: {
         addChangesButton: '#add-changes',

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -75,26 +75,6 @@ header {
       }
     }
   }
-
-  .toolbar {
-    position: absolute;
-    top: $height-xl;
-    left: 0;
-    right: 0;
-    padding: 0.7rem 0.15rem;
-    background-color: $paper;
-    height: $height-xl;
-
-    #modification-btn-wrapper {
-      float: right;
-    }
-
-    #advanced {
-      position: absolute;
-      top: 0;
-      right: 0;
-    }
-  }
 }
 
 //Model Header
@@ -116,21 +96,6 @@ header {
         vertical-align: top;
       }
     }
-
-    .top-bar {
-      position: absolute;
-      top: 0;
-      left: 240px;
-      right: 0;
-      padding: 8px 0 8px 8px;
-      height: inherit;
-
-      #scenarios-drop-down-region {
-        .dropdown-menu {
-          z-index: ($zindex-dropdown + 10);
-        }
-      }
-    }
   }
 
   .toolbar {
@@ -138,9 +103,20 @@ header {
     top: $height-xl;
     left: 0;
     right: 0;
-    padding: 0.15rem 0.7rem;
+    padding: 0rem $right-controls-margin 0 1rem;
     background-color: $ui-light;
     height: $height-xl;
+    line-height: $height-xl;
+    display: flex;
+    flex: 0 0 100%;
+    flex-direction: row;
+    flex-wrap: nowrap;
+
+    .tooltip-inner {
+        white-space: initial;
+        max-width: 100px;
+        width: 100px;
+    }
 
     #gwlfe-modifications-bar, #gwlfe-modifications-popup {
       padding: 5px;
@@ -160,9 +136,9 @@ header {
     }
 
     #gwlfe-modifications-bar {
-      top: 60px;
-      left: 0;
-      background-color: #D0D0D0;
+      top: $height-xl;
+      right: 0;
+      background-color: $ui-light;
       z-index: 1001;
 
       .title-icon {
@@ -172,7 +148,8 @@ header {
     }
 
     #gwlfe-modifications-popup {
-      left: 46px;
+      right: 56px;
+      left: auto;
       z-index: 1003;
 
       .popover-content {
@@ -191,7 +168,8 @@ header {
     }
 
     #modification-btn-wrapper {
-      float: right;
+      display: inline-block;
+      white-space: initial;
     }
 
     #modifications {
@@ -206,10 +184,29 @@ header {
 
     .inline {
       display: inline-block;
-      margin-right: 5px;
     }
 
+    #scenarios-region {
+        white-space: nowrap;
+    }
+
+    #toolbar-region {
+        margin-right: 0;
+        margin-left: auto;
+    }
+
+    .scenario-toolbar-tab-content,
+    .active.scenario-toolbar-tab-pane {
+        display: inline-block;
+        white-space: nowrap;
+    }
+
+
     .controls {
+        .control-item {
+            margin-left: 5px;
+        }
+
       // Precipitation slider
       .precipitation {
         // Undo bootstrap input[type="range"] syling

--- a/src/mmw/sass/bootstrap/_navs.scss
+++ b/src/mmw/sass/bootstrap/_navs.scss
@@ -222,7 +222,7 @@
     display: none;
   }
   > .active {
-    display: initial;
+    display: block;
   }
 }
 

--- a/src/mmw/sass/components/_dropdowns.scss
+++ b/src/mmw/sass/components/_dropdowns.scss
@@ -107,6 +107,7 @@
 
 //Drawing Tools Dropdown
 .thumb-select {
+  white-space: normal;
   padding: 0!important;
   min-width: 200px;
 
@@ -168,6 +169,7 @@
 
 .modification-dropdown {
   z-index: 1002;
+  white-space: normal;
 }
 
 .project-dropdown,


### PR DESCRIPTION
## Overview

The analyze and model sidebars were blank in IE11, because of [this change to the bootstrap stylesheets](https://github.com/WikiWatershed/model-my-watershed/commit/a100f08183d2b7083455013dd8fd83204305317d#diff-4e8e01e9df294745f58db61a059a2a4fR225). This PR reverts the change, and fixes the model toolbar styling which broke without it. 

Connects #1886 

### Demo

_Analyze no longer blank on ie11_
![screen shot 2017-05-19 at 1 41 15 pm](https://cloud.githubusercontent.com/assets/7633670/26261114/f7a739d2-3c9d-11e7-9185-7c1862b9e2d6.png)

_put this thing on the right so it doesn't overlap with sidebar_
<img width="260" alt="screen shot 2017-05-19 at 1 48 49 pm" src="https://cloud.githubusercontent.com/assets/7633670/26261119/fda60ef8-3c9d-11e7-9886-2ef465ff248f.png">

_put everything on the right like they are in wireframes_
![screen shot 2017-05-19 at 1 41 26 pm](https://cloud.githubusercontent.com/assets/7633670/26261132/0826ee7e-3c9e-11e7-8136-3bafb3985682.png)

_make sure elements don't wrap; while  #1914 is open_
<img width="1042" alt="screen shot 2017-05-19 at 1 11 13 pm" src="https://cloud.githubusercontent.com/assets/7633670/26261136/0c48e8cc-3c9e-11e7-9b00-b45cb8ecf5a5.png">

## Notes
-  #1867 will handle actual control styling

## Testing Instructions

 * On all major browsers, test both model stages in their "Current Conditions" view and "Scenario" view
     - Confirm all dropdowns, popovers, and tooltips are styled correctly


