### PR TITLE
Display alert when shapefile has multiple features

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -400,6 +400,13 @@ var AoIUploadView = Marionette.ItemView.extend({
                         if (result.done) { return; }
                         var geom = reproject.toWgs84(result.value, prj);
                         self.addPolygonToMap(geom);
+                        return source.read();
+                    })
+                    .then(function hasMore(result) {
+                        if (!result.done) {
+                            var msg = "This shapefile has multiple features and we've used just the first one.  If you'd like to use a different feature, please create a shapefile containing just that single one.";
+                            displayAlert(msg, modalModels.AlertTypes.warn);
+                        }
                     })
                     .catch(self.handleShapefileError);
             })


### PR DESCRIPTION
## Overview

If the shapefile contains additional records after the first is read
in, alert the user that the first feature was used. Their only recourse
is to create a new shapefile with a more strategically selected feature.

Connects #1889 

### Demo

![screenshot from 2017-05-26 12 54 35](https://cloud.githubusercontent.com/assets/1014341/26504513/dddee39a-4212-11e7-82df-401e133a992c.png)

## Testing Instructions

* Add a shapefile with [multiple features](https://github.com/WikiWatershed/model-my-watershed/files/1032520/cty_animals.zip) and see the new warning modal.
* Add a shapefile with a [single feature](https://github.com/WikiWatershed/model-my-watershed/files/1032521/single.zip) and receive no such information.


