### PR TITLE
Add a custom ElastiCache parameter group with maxmemory-policy

### DIFF
--- a/deployment/cfn/data_plane.py
+++ b/deployment/cfn/data_plane.py
@@ -433,11 +433,19 @@ class DataPlane(StackNode):
             SubnetIds=Ref(self.private_subnets)
         ))
 
+        elasticache_parameter_group = self.add_resource(ec.ParameterGroup(
+            'ecpgCacheCluster',
+            CacheParameterGroupFamily='redis2.8',
+            Description='Parameter group for the ElastiCache instances',
+            Properties={'maxmemory-policy': 'allkeys-lru'}
+        ))
+
         return self.add_resource(ec.ReplicationGroup(
             'CacheReplicationGroup',
             AutomaticFailoverEnabled=True,
             AutoMinorVersionUpgrade=True,
             CacheNodeType=Ref(self.elasticache_instance_type),
+            CacheParameterGroupName=Ref(elasticache_parameter_group),
             CacheSubnetGroupName=Ref(elasticache_subnet_group),
             Engine='redis',
             EngineVersion='2.8.19',


### PR DESCRIPTION
## Overview

Define a custom ElastiCache parameter group with the `maxmemory-policy` set to `allkeys-lru`. This ensures that all keys (regardless of `expire set`) are evicted from the cache based on a LRU (less recently used) policy.

Closes #1898 

### Demo

<img width="1182" alt="screen shot 2017-05-31 at 14 51 50" src="https://cloud.githubusercontent.com/assets/43639/26648514/b7c7d2c8-4610-11e7-8def-cac237180f66.png">

## Testing Instructions

Login to the staging AWS account and navigate to the ElastiCache [parameter groups listing](https://console.aws.amazon.com/elasticache/home?region=us-east-1#param-groups:). From there, select the `datap-ecpgc-kkegl1bqv074` parameter group and confirm that `maxmemory-policy` is set to `allkeys-lru`.