### PR TITLE
Remove Breadcrumbs

### DIFF
--- a/src/mmw/js/src/analyze/controllers.js
+++ b/src/mmw/js/src/analyze/controllers.js
@@ -54,8 +54,6 @@ var AnalyzeController = {
 
         App.state.set({
             'active_page': utils.analyzePageTitle,
-            'was_analyze_visible': true,
-            'was_compare_visible': false,
         });
 
         App.rootView.sidebarRegion.show(analyzeResults);

--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -49,7 +49,6 @@ var CompareController = {
 
         App.state.set({
             'active_page': coreUtils.comparePageTitle,
-            'was_compare_visible': true,
         });
     },
 

--- a/src/mmw/js/src/compare/templates/compareWindow.html
+++ b/src/mmw/js/src/compare/templates/compareWindow.html
@@ -1,7 +1,10 @@
 <div id="compare-scenarios-region"></div>
 <div id="compare-footer">
-    <h3>Navigate Scenarios</h3>
+    <div class="back">
+        <a data-url="/project" class="btn btn-back-compare"><i class="fa fa-arrow-left"></i> Back </a>
+    </div>
     <div id="slide-controls">
+        Navigate Scenarios
         <div class="btn-group">
             <button id="slide-left" type="button" class="btn btn-primary"><i class="fa fa-long-arrow-left"></i></button>
             <button id="slide-right" type="button" class="btn btn-primary"><i class="fa fa-long-arrow-right"></i></button>

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -637,10 +637,6 @@ var AreaOfInterestModel = GeoModel.extend({
 var AppStateModel = Backbone.Model.extend({
     defaults: {
         active_page: 'Select Area Of Interest',
-        was_analyze_visible: false,
-        was_data_catalog_visible: false,
-        was_model_visible: false,
-        was_compare_visible: false,
     }
 });
 

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -1,11 +1,6 @@
 <nav id="app-header" class="navbar-watershed">
     <ul class="global-navigation">
-        <li class="global-navigation-item {{splashNavClasses}}"><button data-url="/">Model My Watershed</button></li>
-        <li class="global-navigation-item {{selectAreaNavClasses}}"><button  data-url="/draw">Select Area</button></li>
-        <li class="global-navigation-item {{analyzeNavClasses}}"><button data-url="/analyze">Analyze</button></li>
-        <li class="global-navigation-item {{dataCatalogNavClasses}}"><button data-url="/search">Search</button></li>
-        <li class="global-navigation-item {{modelNavClasses}}"><button  data-url="/project">Model</button></li>
-        <li class="global-navigation-item {{compareNavClasses}}"><button  data-url="/project/compare">Compare</button></li>
+        <li class="global-navigation-item"><button data-url="/">Model My Watershed</button></li>
     </ul>
     <div class="navigation">
         <ul class="main">

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -5,7 +5,7 @@
     <div class="navigation">
         <ul class="main">
             <li class="header-link"><a target="_blank" href="http://www.stroudcenter.org/"><img src="/static/images/stroud-logo.png" alt="Logo" /></a></li>
-            <li class="header-link"><a target="_blank" href="http://www.wikiwatershed.org">WikiWatershed</a></li>
+            <li class="header-link"><a target="_blank" href="http://www.wikiwatershed.org">About</a></li>
             {% if guest %}
                 <li class="header-link"><a class="show-login" href="javascript:void(0);">Login</a></li>
             {% else %}

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -15,8 +15,7 @@ var $ = require('jquery'),
     models = require('./models'),
     AppRouter = require('../router').AppRouter,
     settings = require('./settings'),
-    testUtils = require('./testUtils'),
-    coreUtils = require('./utils');
+    testUtils = require('./testUtils');
 
 var TEST_SHAPE = {
     'type': 'Feature',
@@ -225,33 +224,6 @@ describe('Core', function() {
                 assert.equal(spy.callCount, 1);
 
                 view.destroy();
-            });
-        });
-
-        describe('HeaderView', function() {
-            it('shows the current page as active', function() {
-                var appState = new models.AppStateModel({
-                        active_page: coreUtils.selectAreaPageTitle,
-                    }),
-                    header = new views.HeaderView({
-                        model: App.user,
-                        appState: appState
-                    }).render();
-
-                assert.include(header.$el.find('.global-navigation-item.active')
-                    .find('button').text(), 'Select Area');
-            });
-            it('shows past active pages as visible', function() {
-                var appState = new models.AppStateModel({
-                        active_page: coreUtils.selectAreaPageTitle,
-                        was_analyze_visible: true,
-                    }),
-                    header = new views.HeaderView({
-                        model: App.user,
-                        appState: appState
-                    }).render();
-                assert.include(header.$el.find('.global-navigation-item.visible').not('.active')
-                    .find('button').text(), 'Analyze');
             });
         });
     });

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -101,68 +101,9 @@ var HeaderView = Marionette.ItemView.extend({
         this.listenTo(this.appState, 'change', this.render);
     },
 
-    makeNavClasses: function(isActive, isVisible) {
-        return (isActive ? 'active' : '') + (isVisible ? ' visible' : '');
-    },
-
-    isProjectsPage: function(currentActive) {
-        return currentActive === coreUtils.projectsPageTitle;
-    },
-
-    makeSplashNavClasses: function() {
-        return this.makeNavClasses(true, true);
-    },
-
-    makeSelectAreaNavClasses: function(currentActive) {
-        var isVisible = !this.isProjectsPage(currentActive),
-            isActive = currentActive === coreUtils.selectAreaPageTitle;
-        return this.makeNavClasses(isActive, isVisible);
-    },
-
-    makeAnalyzeNavClasses: function(currentActive, wasAnalyzeVisible, wasModelVisible) {
-        var isVisible = !this.isProjectsPage(currentActive) && (wasAnalyzeVisible || wasModelVisible),
-            isActive = currentActive === coreUtils.analyzePageTitle;
-        return this.makeNavClasses(isActive, isVisible);
-    },
-
-    makeDataCatalogNavClasses: function(currentActive, wasDataCatalogVisible) {
-        var isVisible = !this.isProjectsPage(currentActive) && wasDataCatalogVisible,
-            isActive = currentActive === coreUtils.dataCatalogPageTitle;
-        return this.makeNavClasses(isActive, isVisible);
-    },
-
-    makeModelNavClasses: function(currentActive) {
-        var modelPackageNames = _.pluck(settings.get('model_packages'), 'display_name'),
-            isCompare = currentActive === coreUtils.comparePageTitle,
-            isActive = _.contains(modelPackageNames, currentActive),
-            isVisible = isActive || isCompare;
-        return this.makeNavClasses(isActive, isVisible);
-    },
-
-    makeCompareNavClasses: function(currentActive, wasCompareVisible) {
-        var modelPackageNames = _.pluck(settings.get('model_packages'), 'display_name'),
-            isModel = _.contains(modelPackageNames, currentActive),
-            isActive = currentActive === coreUtils.comparePageTitle,
-            isVisible = (isModel && wasCompareVisible) || isActive;
-        return this.makeNavClasses(isActive, isVisible);
-    },
-
     templateHelpers: function() {
-        var self = this,
-            currentActive = self.appState.get('active_page'),
-            wasAnalyzeVisible = self.appState.get('was_analyze_visible'),
-            wasDataCatalogVisible = self.appState.get('was_data_catalog_visible'),
-            wasModelVisible = self.appState.get('was_model_visible'),
-            wasCompareVisible = self.appState.get('was_compare_visible');
-
         return {
             'itsi_embed': settings.get('itsi_embed'),
-            'splashNavClasses': this.makeSplashNavClasses(wasAnalyzeVisible, wasModelVisible),
-            'selectAreaNavClasses': this.makeSelectAreaNavClasses(currentActive),
-            'analyzeNavClasses': this.makeAnalyzeNavClasses(currentActive, wasAnalyzeVisible, wasModelVisible),
-            'dataCatalogNavClasses': this.makeDataCatalogNavClasses(currentActive, wasDataCatalogVisible),
-            'modelNavClasses': this.makeModelNavClasses(currentActive),
-            'compareNavClasses': this.makeCompareNavClasses(currentActive, wasCompareVisible),
         };
     },
 

--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -11,7 +11,6 @@ var DataCatalogController = {
 
         App.state.set({
             'active_page': coreUtils.dataCatalogPageTitle,
-            'was_data_catalog_visible': true,
         });
 
         var searchModel = new models.DataCatalogModel();

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -44,7 +44,6 @@ var DrawController = {
         App.map.setDrawSize();
         App.state.set({
             'active_page': utils.splashPageTitle,
-            'was_analyze_visible': false
         });
     }
 };

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -202,11 +202,6 @@ var DrawWindow = Marionette.LayoutView.extend({
         utils.cancelDrawing(App.getLeafletMap());
         clearAoiLayer();
         clearBoundaryLayer(this.model);
-        App.state.set({
-            'was_analyze_visible': false,
-            'was_model_visible': false,
-            'was_compare_visible': false,
-        });
     }
 });
 

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -254,7 +254,6 @@ function setPageTitle() {
 
     App.state.set({
         'active_page': modelPackageDisplayName,
-        'was_model_visible': true,
     });
 }
 

--- a/src/mmw/sass/components/_buttons.scss
+++ b/src/mmw/sass/components/_buttons.scss
@@ -61,7 +61,7 @@
   &:hover, &:focus {
     color: $black-74;
     background-color: darken($ui-light, 5%);
-    border: solid 0 darken($ui-light, 10%);
+    border: solid 1px darken($ui-light, 10%);
   }
 
   //For precip control
@@ -153,6 +153,13 @@
       color: $paper;
     }
   }
+}
+
+.btn-back-compare {
+    i {
+      margin-right: 4px;
+    }
+    font-size: $font-size-h3;
 }
 
 .btn-search-tool {

--- a/src/mmw/sass/components/_global-navigation.scss
+++ b/src/mmw/sass/components/_global-navigation.scss
@@ -14,17 +14,8 @@
 .global-navigation-item {
   float: left;
   position: relative;
-  &:after {
-    position: absolute;
-    content: '';
-    height: 16px;
-    width: 6px;
-    background-image: url(/static/images/global-navigation-arrow.svg);
-    top: 14px;
-    opacity: 0.5;
-    left: -11px;
-  }
   button {
+    font-weight: 800;
     background: none;
     background-color: transparent;
     color: #fff;
@@ -35,19 +26,6 @@
     &::-moz-focus-inner {
       border: 0;
       padding: 0;
-    }
-  }
-  &:not(.visible) {
-    display: none;
-  }
-  &:not(.active) {
-    button {
-      opacity: 0.5;
-    }
-  }
-  &.active {
-    button {
-      font-weight: 800;
     }
   }
 }

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -255,9 +255,12 @@
     padding: 8px;
   }
 
-  h3 {
-    display: inline-block;
-    padding: 1rem;
+  .back {
+      line-height: 50px;
+      height: 100%;
+      display: inline-block;
+      position: relative;
+      vertical-align: top;
   }
 }
 
@@ -271,4 +274,3 @@
     color: $black-74;
   }
 }
-


### PR DESCRIPTION
## Overview

- Redesign makes the breadcrumbs unnecessary for navigation, so we remove them
- WikiWatershed in header simplifies to "About"
- Redesign also moves the stroud logo into the splash page. I've left this work for #1869, when we'll presumably have the colored logo assets

Connects #1870 

### Demo

![screen shot 2017-06-12 at 10 30 21 am](https://user-images.githubusercontent.com/7633670/27042213-4e24c134-4f64-11e7-8e4f-c7f5e27a1d83.png)

![screen shot 2017-06-12 at 11 41 17 am](https://user-images.githubusercontent.com/7633670/27042204-4672d070-4f64-11e7-9fef-cad3753f884c.png)

## Testing Instructions

 * Pull and bundle
 * Navigate around the app and confirm the header matches[ the wireframes](https://marvelapp.com/gji4cg6/screen/27712920) for the most part and there are no errors in the console
 * Confirm the compare view has working back button
