### PR TITLE
Use Lodash's assign rather than Object's

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -922,7 +922,7 @@ var ScenarioModel = Backbone.Model.extend({
                     mergedGisData = JSON.parse(project.get('gis_data'));
 
                 modifications.forEach(function(mod) {
-                    Object.assign(mergedGisData, mod.get('output'));
+                    _.assign(mergedGisData, mod.get('output'));
                 });
 
                 return {


### PR DESCRIPTION
## Overview

Lodash provides a shim that works in IE11, which does not support Object.assign natively.

Connects #1911 

## Testing Instructions

 * Check out this branch and `bundle`
 * View the app in IE11. Create a MapShed project. Add a conservation practice. Inspect that there are no errors in the console.