### PR TITLE
Scenario Dropdown Updates

### DIFF
--- a/src/mmw/js/src/core/modals/models.js
+++ b/src/mmw/js/src/core/modals/models.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var Backbone = require('../../../shim/backbone');
+var Backbone = require('../../../shim/backbone'),
+    _ = require('lodash');
 
 var ConfirmModel = Backbone.Model.extend({
     defaults: {
@@ -14,7 +15,17 @@ var InputModel = Backbone.Model.extend({
     defaults: {
         initial: '',
         title: 'Input Value',
-        fieldLabel: ''
+        fieldLabel: '',
+        validationFunction: null, // a function that returns an error message string if the value
+                                  // isn't valid, and null if it is
+    },
+
+    validate: function(val) {
+        var validationFunction = this.get('validationFunction');
+        if (validationFunction && _.isFunction(validationFunction)) {
+            return validationFunction(val);
+        }
+        return null;
     }
 });
 

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -129,13 +129,17 @@ var InputView = ModalBaseView.extend({
             return;
         }
 
-        var val = this.ui.input.val().trim();
+        var val = this.ui.input.val().trim(),
+            validationMessage = this.model.validate(val);
 
-        if (val) {
+        if (val && !validationMessage) {
             this.triggerMethod('update', val);
             this.hide();
         } else {
-            this.ui.error.text('Please enter a valid project name');
+            var inputType = this.model.get('fieldLabel').toLowerCase(),
+                errorText = validationMessage || ('Please enter a valid ' + inputType);
+            this.ui.error.text(errorText);
+            coreUtils.modalButtonToggle(this.model, this.ui.save, true);
         }
     }
 });

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -643,7 +643,8 @@ var ScenarioModel = Backbone.Model.extend({
         aoi_census: null, // JSON blob
         modification_censuses: null, // JSON blob
         allow_save: true, // Is allowed to save to the server - false in compare mode
-        is_saving: false // Is in the process of saving
+        is_saving: false, // Is in the process of saving
+        options_menu_is_open: false // The sub-dropdown options menu for this scenario is open
     },
 
     initialize: function(attrs) {
@@ -1046,6 +1047,22 @@ var ScenariosCollection = Backbone.Collection.extend({
 
     getActiveScenario: function() {
         return this.findWhere({active: true});
+    },
+
+    toggleScenarioOptionsMenu: function(model) {
+        // Close all open scenarios
+        var openScenarios = this.where({ options_menu_is_open: true });
+        _.forEach(openScenarios, function(scenario) {
+            scenario.set('options_menu_is_open', false);
+        });
+
+        // Open the selected scenario if it was not open already
+        var wasModelAlreadyOpen = _.some(openScenarios, function(scenario) {
+            return scenario.cid === model.cid;
+        });
+        if (!wasModelAlreadyOpen) {
+            model.set('options_menu_is_open', true);
+        }
     }
 });
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1050,19 +1050,26 @@ var ScenariosCollection = Backbone.Collection.extend({
     },
 
     toggleScenarioOptionsMenu: function(model) {
-        // Close all open scenarios
-        var openScenarios = this.where({ options_menu_is_open: true });
-        _.forEach(openScenarios, function(scenario) {
-            scenario.set('options_menu_is_open', false);
-        });
+        var prevOpenScenarios = this.closeAllOpenOptionMenus();
 
         // Open the selected scenario if it was not open already
-        var wasModelAlreadyOpen = _.some(openScenarios, function(scenario) {
+        var wasModelAlreadyOpen = _.some(prevOpenScenarios, function(scenario) {
             return scenario.cid === model.cid;
         });
         if (!wasModelAlreadyOpen) {
             model.set('options_menu_is_open', true);
         }
+    },
+
+    /** Closes all open scenario option menus
+        @return an array of all the scenarios that had open menus
+    **/
+    closeAllOpenOptionMenus: function() {
+        var openScenarios = this.where({ options_menu_is_open: true });
+        _.forEach(openScenarios, function(scenario) {
+            scenario.set('options_menu_is_open', false);
+        });
+        return openScenarios;
     }
 });
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -993,23 +993,36 @@ var ScenariosCollection = Backbone.Collection.extend({
         this.setActiveScenarioByCid(scenario.cid);
     },
 
-    updateScenarioName: function(model, newName) {
-        newName = newName.trim();
+    /** Validate the new scenario name
+    @param model - the model your trying to rename
+    @param newName the new name string
+    @returns If valid, null
+             If invalid, a string with the error
+    **/
+    validateNewScenarioName: function(model, newName) {
+        var trimmedNewName = newName.trim();
 
         // Bail early if the name actually didn't change.
-        if (model.get('name') === newName) {
-            return true;
+        if (model.get('name') === trimmedNewName) {
+            return null;
         }
 
         var match = this.find(function(model) {
-            return model.get('name').toLowerCase() === newName.toLowerCase();
+            return model.get('name').toLowerCase() === trimmedNewName.toLowerCase();
         });
 
         if (match) {
-            console.log('This name is already in use.');
-            return false;
-        } else if (model.get('name') !== newName) {
-            return model.set('name', newName);
+            return 'This name is already in use';
+        }
+
+        return null;
+    },
+
+    updateScenarioName: function(model, newName) {
+        var trimmedNewName = newName.trim();
+
+        if (model.get('name') !== trimmedNewName) {
+            return model.set('name', trimmedNewName);
         }
     },
 

--- a/src/mmw/js/src/modeling/templates/scenarioMenuItem.html
+++ b/src/mmw/js/src/modeling/templates/scenarioMenuItem.html
@@ -1,7 +1,7 @@
 <div class="dropdown-submenu scenario-dropdown-menu-item">
 <!-- elements appear in the reverse order in the ui -->
     {% if editable and (gwlfe or not is_current_conditions or not is_new) %}
-        <div class="scenario-dropdown-actions">
+        <div class="scenario-dropdown-actions {% if options_menu_is_open -%} -open {% endif -%}">
             <div class="dropdown options-dropdown-region"></div>
             <i data-action="show-options-dropdown" class="fa fa-ellipsis-h" title="Options..."></i>
         </div>

--- a/src/mmw/js/src/modeling/templates/scenarioMenuItem.html
+++ b/src/mmw/js/src/modeling/templates/scenarioMenuItem.html
@@ -1,23 +1,9 @@
-<div class="scenario-dropdown-menu-item">
+<div class="dropdown-submenu scenario-dropdown-menu-item">
 <!-- elements appear in the reverse order in the ui -->
     {% if editable and (gwlfe or not is_current_conditions or not is_new) %}
         <div class="scenario-dropdown-actions">
-            <div class="more-options-region"></div>
-            <i data-action="show-more" class="fa fa-ellipsis-h" title="More..."></i>
-            {% if not is_current_conditions %}
-                <i data-action="delete" class="fa fa-trash" title="Delete"></i>
-            {% endif %}
-            {% if is_gwlfe %}
-                <form id="export-gms-form" method="post" action="/api/modeling/export/gms/" target="_blank">
-                    <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrftoken }}">
-                    <input type="hidden" name="filename" class="gms-filename" value="export.gms">
-                    <input type="hidden" name="mapshed_data" value='{{ gis_data }}'>
-                </form>
-                <i data-action="export-gms" class="fa fa-download" title="Export GMS"></i>
-            {% endif %}
-            {% if not is_current_conditions %}
-                <i data-action="rename" class="fa fa-pencil-square-o" title="Rename"></i>
-            {% endif %}
+            <div class="dropdown options-dropdown-region"></div>
+            <i data-action="show-options-dropdown" class="fa fa-ellipsis-h" title="Options..."></i>
         </div>
     {% endif %}
     <span id="scenario-name" data-action="select">

--- a/src/mmw/js/src/modeling/templates/scenarioMenuItemMoreOptions.html
+++ b/src/mmw/js/src/modeling/templates/scenarioMenuItemMoreOptions.html
@@ -1,6 +1,0 @@
-{% if not is_new %}
-    <i data-action="share" class="fa fa-share-alt" title="Share"></i>
-{% endif %}
-{% if not is_current_conditions %}
-    <i data-action="duplicate" class="fa fa-copy" title="Duplicate"></i>
-{% endif %}

--- a/src/mmw/js/src/modeling/templates/scenarioMenuItemOptions.html
+++ b/src/mmw/js/src/modeling/templates/scenarioMenuItemOptions.html
@@ -1,0 +1,31 @@
+{% if not is_new %}
+    <li class="scenario-options-dropdown-menu-item" role="presentation" role="presentation" data-action="share">
+        <i  class="fa fa-share-alt" title="Share"></i> Share
+    </li>
+{% endif %}
+{% if not is_current_conditions %}
+    <li class="scenario-options-dropdown-menu-item" role="presentation" li data-action="duplicate">
+        <i class="fa fa-copy" title="Duplicate"></i> Duplicate
+    </li>
+{% endif %}
+{% if not is_current_conditions %}
+    <li class="scenario-options-dropdown-menu-item" role="presentation" data-action="delete">
+        <i class="fa fa-trash" title="Delete"></i> Delete
+    </li>
+{% endif %}
+{% if is_gwlfe %}
+    <li class="scenario-options-dropdown-menu-item" role="presentation" data-action="export-gms">
+        <form id="export-gms-form" method="post" action="/api/modeling/export/gms/" target="_blank">
+            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrftoken }}">
+            <input type="hidden" name="filename" class="gms-filename" value="export.gms">
+            <!-- Put `gis_data` in single quotes, to keep any unescaped chars from breaking the template -->
+            <input type="hidden" name="mapshed_data" value='{{ gis_data }}'>
+        </form>
+        <i class="fa fa-download" title="Export GMS"></i> Export GMS
+    </li>
+{% endif %}
+{% if not is_current_conditions %}
+    <li class="scenario-options-dropdown-menu-item" role="presentation" data-action="rename">
+        <i class="fa fa-pencil-square-o" title="Rename"></i> Rename
+    </li>
+{% endif %}

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1087,6 +1087,7 @@ module.exports = {
     ScenarioButtonsView: ScenarioButtonsView,
     ScenarioDropDownMenuView: ScenarioDropDownMenuView,
     ScenarioDropDownMenuItemView: ScenarioDropDownMenuItemView,
+    ScenarioDropDownMenuOptionsView: ScenarioDropDownMenuOptionsView,
     ScenarioToolbarView: ScenarioToolbarView,
     Tr55ToolbarView: Tr55ToolbarView,
     ProjectMenuView: ProjectMenuView,

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -613,6 +613,14 @@ var ScenarioDropDownMenuView = Marionette.CompositeView.extend({
     childView: ScenarioDropDownMenuItemView,
     childViewContainer: 'ul',
 
+    ui: {
+        toggleDropdown: '[data-toggle="dropdown"]',
+    },
+
+    events: {
+        'click @ui.toggleDropdown': 'toggleDropdown',
+    },
+
     collectionEvents: {
         'change:active change:name': 'render',
         'remove': 'onChildRemoved',
@@ -625,6 +633,10 @@ var ScenarioDropDownMenuView = Marionette.CompositeView.extend({
         }
         model.destroy();
         this.render();
+   },
+
+   toggleDropdown: function() {
+       this.collection.closeAllOpenOptionMenus();
    },
 
     templateHelpers: function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -484,6 +484,9 @@ var ScenarioDropDownMenuItemView = Marionette.LayoutView.extend({
     },
 
     toggleOptionsDropdown: function() {
+        // Render to show the "dropdown open" styling on the toggle icon
+        this.render();
+
         if (this.optionsDropdown.hasView() && !this.model.get('options_menu_is_open')) {
             this.optionsDropdown.empty();
         } else if (this.model.get('options_menu_is_open')) {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -553,7 +553,7 @@ var ScenarioDropDownMenuItemView = Marionette.LayoutView.extend({
     },
 
     modelEvents: {
-        'change': 'render',
+        'change:options_menu_is_open': 'toggleOptionsDropdown',
     },
 
     ui: {
@@ -563,15 +563,20 @@ var ScenarioDropDownMenuItemView = Marionette.LayoutView.extend({
 
     events: {
         'click @ui.selectScenario': 'selectScenario',
-        'click @ui.showOptionsDropdown': 'toggleOptionsDropdown',
+        'click @ui.showOptionsDropdown': 'onOptionsDropdownClick',
     },
 
-    toggleOptionsDropdown: function(e) {
+    onOptionsDropdownClick: function(e) {
         e.preventDefault();
         e.stopPropagation();
-        if (this.optionsDropdown.hasView()) {
+
+        this.model.collection.toggleScenarioOptionsMenu(this.model);
+    },
+
+    toggleOptionsDropdown: function() {
+        if (this.optionsDropdown.hasView() && !this.model.get('options_menu_is_open')) {
             this.optionsDropdown.empty();
-        } else {
+        } else if (this.model.get('options_menu_is_open')) {
             this.optionsDropdown.show(new ScenarioDropDownMenuOptionsView({
                 model: this.model,
             }));

--- a/src/mmw/sass/components/_dropdowns.scss
+++ b/src/mmw/sass/components/_dropdowns.scss
@@ -24,7 +24,9 @@
 
     li {
 
-      a, .scenario-dropdown-menu-item {
+      a,
+      .scenario-dropdown-menu-item,
+      .scenario-options-dropdown-menu-item {
         color: $black-74;
         line-height: $height-md;
         padding: 0 0.5rem;
@@ -223,7 +225,7 @@
     float: right;
     clear: right;
     > i,
-    > .more-options-region > .more-options > i {
+    .scenario-options-dropdown .i {
         float: right;
         font-size: $font-size-h4;
         line-height: 35px;
@@ -243,9 +245,14 @@
     #export-gms-form {
         display: none;
     }
-    .more-options-region, .more-options {
+
+    .scenario-options-dropdown {
         float: right;
         display: inline;
+        // Bootstrap lines this sub dropdown up under the more-options icon
+        // Push it to the side of the dropdown item
+        left: 25px;
+        top: -25px;
     }
 }
 

--- a/src/mmw/sass/components/_dropdowns.scss
+++ b/src/mmw/sass/components/_dropdowns.scss
@@ -224,17 +224,24 @@
 .scenario-dropdown-menu-item > .scenario-dropdown-actions {
     float: right;
     clear: right;
-    > i,
-    .scenario-options-dropdown .i {
-        float: right;
+    > i {
         font-size: $font-size-h4;
         line-height: 35px;
         margin-left: 2px;
         margin-right: 0px !important;
-        padding: 0rem 0.15rem;
+        padding: 0rem 5px;
         &:hover {
             color: $ui-primary !important;
         }
+    }
+
+    &.-open > i {
+        background: $black-12;
+        margin-top: 7px;
+        margin-bottom: 0px;
+        height: 22px;
+        padding: 0px 5px;
+        line-height: 22px;
     }
 
     // This icon doesn't look in line with the other at the same line-height
@@ -251,7 +258,7 @@
         display: inline;
         // Bootstrap lines this sub dropdown up under the more-options icon
         // Push it to the side of the dropdown item
-        left: 25px;
+        left: 31px;
         top: -25px;
     }
 }


### PR DESCRIPTION
## Overview
- Consolidate all the scenario actions into a sub-dropdown menu to the right of the Scenario dropdown menu (removes hiding extra icons behind the ellipses)
- This initially broke the rename action because the button was no longer part of the same view as the editable text. While we could trigger a backbone event for the parent view, and then do the rename there in the same way, it seemed cleaner/faster to just implement #1887 and show a rename popup like the rest of the actions

(Ignore the typo in the branch name 😨 )

Connects #1909 
Connects #1887 

### Demo

![c22evlaoj2](https://user-images.githubusercontent.com/7633670/27401121-5ac2db96-5690-11e7-987c-4eb816a085c8.gif)

## Testing Instructions
 * Pull and `./scripts/bundle.sh`
 * For both models, open a project and confirm all the various scenario actions work
 * Confirm renaming a project works as before