### PR TITLE
Sync, rather than copy, AWS credentials

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,6 +93,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Path to RWD data (ex. /media/passport/rwd-nhd)
     worker.vm.synced_folder ENV.fetch("RWD_DATA", "/tmp"), "/opt/rwd-data"
 
+    # AWS
+    worker.vm.synced_folder "~/.aws", "/aws"
+
     # Docker
     worker.vm.network "forwarded_port", {
       guest: 2375,

--- a/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.spark-jobserver/tasks/main.yml
@@ -7,12 +7,6 @@
     - "{{ sjs_home }}"
     - "{{ sjs_data_dir }}"
 
-- name: Copy AWS Crendentials
-  copy: src=~/.aws/ dest=/aws
-  when: "['development', 'test'] | some_are_in(group_names)"
-  notify:
-    - Restart Spark Job Server
-
 - name: Configure Spark Job Server
   template: src="{{ item }}.j2"
             dest="/opt/spark-jobserver/{{ item }}"


### PR DESCRIPTION
## Overview

Previously AWS credentials were copied during provisioning. If they were changed, the worker VM would have to be reprovisioned.

Now they can be changed in the host without needing to reprovision the worker VM.

## Testing Instructions

 * Check out this branch
 * Reprovision the `worker` VM to get new folder sync in place
 * Run `debugcelery`
 * Draw a shape and Analyze. Ensure there are no errors in `debugcelery`
 * Change the `mmw-stg` credentials in your host to be incorrect
 * Without reprovisioning the worker VM, restart Spark JobServer: `vagrant ssh worker -c 'sudo restart spark-jobserver'`
 * Run `debugcelery` again, try an Analyze again, ensure it fails
 * Change `mmw-stg` back to correct, restart Spark JobServer, ensure that `debugcelery` works now