### PR TITLE
Move Layerpicker Right --> Left and Style Model Result Titles

### DIFF
--- a/src/mmw/js/src/core/latLngControl.js
+++ b/src/mmw/js/src/core/latLngControl.js
@@ -6,7 +6,7 @@ var PRECISION = 5;
 
 module.exports = L.Control.extend({
     options: {
-        position: 'bottomleft'
+        position: 'bottomright'
     },
 
     onAdd: function(map) {

--- a/src/mmw/js/src/core/sidebarToggleControl.js
+++ b/src/mmw/js/src/core/sidebarToggleControl.js
@@ -7,7 +7,7 @@ var L = require('leaflet'),
 
 module.exports = L.Control.extend({
     options: {
-        position: 'bottomleft'
+        position: 'bottomright'
     },
 
     initialize: function(options) {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -160,7 +160,7 @@ var HeaderView = Marionette.ItemView.extend({
 // Init the locate plugin button and add it to the map.
 function addLocateMeButton(map, maxZoom, maxAge) {
     var locateOptions = {
-        position: 'bottomleft',
+        position: 'bottomright',
         metric: false,
         drawCircle: false,
         showPopup: false,
@@ -248,7 +248,7 @@ var MapView = Marionette.ItemView.extend({
         }
 
         if (options.addZoomControl) {
-            map.addControl(new L.Control.Zoom({position: 'bottomleft'}));
+            map.addControl(new L.Control.Zoom({position: 'bottomright'}));
             // We're overriding css to display the zoom controls horizontally.
             // Because the zoom-in div usally exists on top, we need to flip it
             // with the zoom-out div, so when they're horizontal they appear as

--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
@@ -1,6 +1,8 @@
-<p class="result-text text-muted">
+<div class="result-title">
     Average annual loads
     from 30-years of daily fluxes
-    simulated by the GWLF-E (MapShed) model.
+</div>
+<p class="result-description text-muted">
+    Simulated by the GWLF-E (MapShed) model
 </p>
 <div class="quality-table-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/runoff/templates/result.html
@@ -1,7 +1,9 @@
-<p class="result-text text-muted">
-    Average monthly water fluxes in centimeters
+<div class="result-title">
+    Average monthly water fluxes (cm)
     from 30-years of daily water balance
-    simulated by the GWLF-E (MapShed) model.
+</div>
+<p class="result-description text-muted">
+    Simulated by the GWLF-E (MapShed) model
 </p>
 <div class="runoff-selector-region"></div>
 <div class="runoff-chart-region"></div>

--- a/src/mmw/js/src/modeling/tr55/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/result.html
@@ -1,8 +1,10 @@
 {% if showModelDescription %}
-<p class="result-text text-muted">
-    Total loads delivered in a 24-hour hypothetical storm event
-    as simulated by EPA's STEP-L model algorithms.
-</p>
+    <div class="result-title">
+        Total loads delivered in a 24-hour hypothetical storm event
+    </div>
+    <p class="result-description text-muted">
+        Simulated by EPA's STEP-L model algorithms
+    </p>
 {% endif %}
 <div class="quality-chart-region"></div>
 <div class="quality-table-region"></div>

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
@@ -1,8 +1,10 @@
 {% if showModelDescription %}
-<p class="result-text text-muted">
-    Results of a 24-hour hypothetical storm event
-    as simulated by SLAMM and TR-55 model algorithms.
-</p>
+    <div class="result-title">
+        24-hour hypothetical storm event
+    </div>
+    <p class="result-description text-muted">
+        Simulated by SLAMM and TR-55 model algorithms
+    </p>
 {% endif %}
 <div class="runoff-chart-region"></div>
 <div class="runoff-table-region"></div>

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -62,21 +62,23 @@
 }
 
 
-// Override leaflet bottomleft controls
-.leaflet-bottom.leaflet-left {
+// Override leaflet bottomright controls
+.leaflet-bottom.leaflet-right {
     text-align: right;
 }
 
-.leaflet-bottom.leaflet-left > .leaflet-control {
+.leaflet-bottom.leaflet-right > .leaflet-control {
     display: inline-block;
     float: none;
-    margin: 18px 4px;
     vertical-align: middle;
+    margin-bottom: 6px;
+
     &:first-child {
-        margin-left: 10px;
+        margin-right: 10px;
     }
     &.leaflet-control-attribution {
        display: block;
+       margin-bottom: 0px;
     }
 
     &.leaflet-control-zoom {
@@ -98,7 +100,7 @@
     }
 }
 
-.leaflet-bottom.leaflet-left > .leaflet-bar,
+.leaflet-bottom.leaflet-right > .leaflet-bar,
 .layer-control-button-container.leaflet-bar {
     height: 34px;
     width: 34px;

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -2,7 +2,7 @@
   z-index: 500;
   position: absolute;
   bottom: 22px;
-  right: $right-controls-margin;
+  left: $map-controls-margin;
   width: $layerpicker-width;
   background-color: #fff;
   border-radius: 2px;

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -28,11 +28,17 @@
     height: 100%;
     width: 100%;
 
-    .result-text {
-        margin-bottom: $font-size-h4;
+    .result-title {
+        padding-top: 5px;
         font-size: $font-size-h4;
-        font-weight: 600;
-        color: #333333;
+        font-weight: 800;
+    }
+
+    .result-description {
+        font-size: $font-size-h5;
+        font-weight: 400;
+        color: $black-54;
+        margin-bottom: 4px;
     }
 
     .mean-flow {

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -5,7 +5,7 @@
   right: 0;
   z-index: 600;
   padding: 0.7rem;
-  padding-right: $right-controls-margin;
+  padding-right: $map-controls-margin;
 
   @media(max-width: 1200px) {
     max-width: 595px;
@@ -57,7 +57,7 @@
 
 #geocode-search-results-region {
   position: absolute;
-  right: $right-controls-margin;
+  right: $map-controls-margin;
   border-radius: 2px;
   box-shadow: 0 0 6px $black-74;
   font-size: $font-size-h4;

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -47,7 +47,7 @@ $search-width: 300px;
 //Border-radius
 $radius-sm: 2px;
 
-$right-controls-margin: 12px;
+$map-controls-margin: 12px;
 
 $nlcdColors: (
     11: #5475A8,


### PR DESCRIPTION
## Overview
- The layerpicker legend tooltips got cut off when the layerpicker was on the right side of the map, so we move it back to the left side, and put the map controls to the right
- Break the model results titles down into a proper bold title/light subtitle style

Connects #1916 
Connects #1872 

### Demo
![screen shot 2017-06-22 at 11 28 48 am](https://user-images.githubusercontent.com/7633670/27442364-fd7e2126-573d-11e7-85d7-d7de7bbf18f4.png)



![screen shot 2017-06-22 at 11 19 23 am](https://user-images.githubusercontent.com/7633670/27442346-efdad082-573d-11e7-9fe9-e0d8a40c6563.png)
![screen shot 2017-06-22 at 11 19 32 am](https://user-images.githubusercontent.com/7633670/27442343-efaa63b6-573d-11e7-9980-f429065545aa.png)
![screen shot 2017-06-22 at 11 23 13 am](https://user-images.githubusercontent.com/7633670/27442348-efec159a-573d-11e7-8c8f-ff31a54d9311.png)
![screen shot 2017-06-22 at 11 23 19 am](https://user-images.githubusercontent.com/7633670/27442345-efb031ce-573d-11e7-8728-7ef71291611a.png)

## Testing Instructions

 * Pull, bundle
 * Inspect the various map controls (search, zoom, layerpicker, etc)
 * Run both models and checkout the titles on each of their tabs

