### PR TITLE
Update JVM and geoprocessing service versions

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -32,7 +32,7 @@ nodejs_npm_version: 2.1.17
 
 apache_version: "2.4.7-*"
 
-java_version: "7u121-*"
+java_version: "7u131-*"
 
 graphite_carbon_version: "0.9.13-pre1"
 graphite_whisper_version: "0.9.13-pre1"
@@ -46,7 +46,7 @@ sjs_host: "localhost"
 sjs_port: 8090
 sjs_container_image: "quay.io/azavea/spark-jobserver:0.6.1"
 
-geop_version: "1.2.0"
+geop_version: "2.0.1"
 geop_cache_enabled: 1
 
 nginx_cache_dir: "/var/cache/nginx"


### PR DESCRIPTION
## Overview

The OpenJDK package for 7u121 is no longer available.

The mmw-geoprocessing Spark Job Server job was updated to interact with the Datahub GeoTrellis catalog vs. the one in the GeoTrellis AWS account.

Fixes https://github.com/WikiWatershed/model-my-watershed/issues/1955

### Notes

See `CHANGELOG` and notes in the following dependent PRs for details:

- https://github.com/WikiWatershed/mmw-geoprocessing/blob/develop/CHANGELOG.md
- https://github.com/WikiWatershed/mmw-geoprocessing/pull/45
- https://github.com/azavea/azavea-data-hub/pull/49

## Testing Instructions

Provision the `worker` virtual machine so that the 2.0.1 geoprocessing JAR gets put into place:

```bash
$ vagrant provision worker
```

From there, interact with the MMW UI to trigger any and all geoprocessing related asynchronous tasks you know about. Review the Spark Job Server logs to ensure that the correct catalog is being used (`datahub-catalogs-us-east-1`):

```bash
$ vagrant ssh worker
vagrant@worker:~$ sudo grep "datahub-catalogs-us-east-1" /var/log/upstart/spark-jobserver.log 
```
