### PR TITLE
Warn Before Leaving Unsaved Project

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -272,15 +272,36 @@ var ProjectMenuView = Marionette.ItemView.extend({
     },
 
     createNewProject: function() {
-        App.map.set({
-            'areaOfInterest': null,
-            'areaOfInterestName': '',
-            'wellKnownAreaOfInterest': null,
-            'zoom': 4,
-        });
-        App.getMapView().fitToDefaultBounds();
-        App.getMapView().setupGeoLocation(true);
-        router.navigate('draw/', { trigger: true });
+        var self = this,
+            project = self.model,
+            showModal = project.isNew() ||
+                        project.get('is_saving') ||
+                        project.get('has_saving_scenarios'),
+            modal = new modalViews.ConfirmView({
+                model: new modalModels.ConfirmModel({
+                    question: 'Leave without saving current project?',
+                    confirmLabel: 'Leave',
+                    cancelLabel: 'Stay'
+                })
+            }),
+            resetAndGoToDraw = function() {
+                App.map.set({
+                    'areaOfInterest': null,
+                    'areaOfInterestName': '',
+                    'wellKnownAreaOfInterest': null,
+                    'zoom': 4,
+                });
+                App.getMapView().fitToDefaultBounds();
+                App.getMapView().setupGeoLocation(true);
+                router.navigate('draw/', { trigger: true });
+            };
+
+        if (showModal) {
+            modal.on('confirmation', resetAndGoToDraw);
+            modal.render();
+        } else {
+            resetAndGoToDraw();
+        }
     }
 });
 


### PR DESCRIPTION
## Overview

When leaving an unsaved project, shows a warning that the project is not saved. Since projects are not auto-saved anymore, it is possible that a user may accidentally leave a page with unsaved useful work. To prevent them from losing that work, we prompt them for saving it.

Connects #1863 

### Notes

I'm not super happy with this solution. @arottersman made a valiant effort in [this commit](https://github.com/WikiWatershed/model-my-watershed/commit/d6976aadbb87dc4bd626fad8bd1745e1e4e870d2), which I tried to further in [this branch](https://github.com/WikiWatershed/model-my-watershed/compare/arr/warn-user-when-they-try-escape...tt+arr/warn-user-when-they-try-escape), but to no avail.

The fundamental difficulty is the lack of a `beforeunload` event on _the route_. Since we're using a custom patched version of a rather old version of Backbone + Marionette Router, the code is a little difficult to reason about, and any additions therein will take us further from the standard. However, without that implementation, there will be edge cases which are not supported, such as:

 * When the user clicks "back" in the browser, there is no warning
 * If the user is logged in, when the click "My Projects" in the top right corner, there is no warning (and adding one may be difficult, because that button and "New Project" are hierarchically very far apart)

One unfortunate side effect of the `beforeunload` warning for the browser is that it pops up if the user tries to sign in with ITSI:

![2017-06-30 16 41 26](https://user-images.githubusercontent.com/1430060/27753282-10299190-5db3-11e7-9d08-bb0d8fef63e3.gif)

I'm not sure if we should merge this and make future cards to fix the breakage, or keep chugging on this until everything works.

## Testing Instructions

 * Check out this branch. Run `bundle`. Go to [:8000/](http://localhost:8000/)
 * Try closing the page in `/`, `/draw`, `/analyze`, and `/projects` routes. Ensure that there is no prompt.
 * Pick an AoI and analyze it and choose a model. Get to the `/project` route.
 * Try to close the tab without saving your work. Ensure you see a message like this:

    ![image](https://user-images.githubusercontent.com/1430060/27752734-8bafdc82-5db0-11e7-85ae-b53a0b9fe258.png)

 * Try to reload the tab without saving your work. Ensure you see a message like this:

    ![image](https://user-images.githubusercontent.com/1430060/27752750-a47a2204-5db0-11e7-859a-22d841f35f83.png)

 * Try and create a new project without saving your work. Ensure you see a message like this:

    ![image](https://user-images.githubusercontent.com/1430060/27752771-b82a425c-5db0-11e7-85cf-2fdba0026ef4.png)

/cc @jfrankl for advice on language in the last modal. The first two are controlled by the browser and cannot be reworded.
