### PR TITLE
Limit bounding box for CUAHSI searches

### DIFF
--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -1,11 +1,19 @@
 "use strict";
 
 var App = require('../app'),
+    router = require('../router').router,
     coreUtils = require('../core/utils'),
     models = require('./models'),
     views = require('./views');
 
 var DataCatalogController = {
+    dataCatalogPrepare: function() {
+        if (!App.map.get('areaOfInterest')) {
+            router.navigate('', { trigger: true });
+            return false;
+        }
+    },
+
     dataCatalog: function() {
         App.map.setDataCatalogSize();
 

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -2,7 +2,6 @@
 
 var _ = require('underscore'),
     Backbone = require('../../shim/backbone'),
-    App = require('../app'),
     utils = require('./utils');
 
 var DESCRIPTION_MAX_LENGTH = 100;
@@ -18,14 +17,14 @@ var Catalog = Backbone.Model.extend({
         resultCount: 0
     },
 
-    search: function(query) {
-        var bounds = App.getLeafletMap().getBounds(),
-            bbox = utils.formatBounds(bounds),
+    search: function(query, bounds) {
+        var bbox = utils.formatBounds(bounds),
             data = {
                 catalog: this.id,
                 query: query,
                 bbox: bbox
             };
+
         return this.startSearch(data)
             .always(_.bind(this.finishSearch, this));
     },

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -2,6 +2,8 @@
 
 var _ = require('underscore'),
     Backbone = require('../../shim/backbone'),
+    turfIntersect = require('turf-intersect'),
+    App = require('../app'),
     utils = require('./utils');
 
 var DESCRIPTION_MAX_LENGTH = 100;
@@ -83,7 +85,13 @@ var Results = Backbone.Collection.extend({
     url: '/api/bigcz/search',
     model: Result,
     parse: function(response) {
-        return response.results;
+        var aoi = App.map.get('areaOfInterest');
+
+        // Filter results to only include those without geometries (Hydroshare)
+        // and those that intersect the area of interest (CINERGI and CUAHSI).
+        return _.filter(response.results, function(r) {
+            return r.geom === null || turfIntersect(aoi, r.geom) !== undefined;
+        });
     }
 });
 

--- a/src/mmw/js/src/data_catalog/utils.js
+++ b/src/mmw/js/src/data_catalog/utils.js
@@ -1,5 +1,17 @@
 "use strict";
 
+var L = require('leaflet'),
+    turfArea = require('turf-area');
+
+var SQKM_PER_SQM = 0.000001;
+
+// Find area of given LatLngBounds
+function areaOfBounds(bounds) {
+    var area = turfArea(L.rectangle(bounds).toGeoJSON());
+
+    return area * SQKM_PER_SQM;
+}
+
 // Convert LatLngBounds to BBox format
 function formatBounds(bounds) {
     return [
@@ -11,5 +23,6 @@ function formatBounds(bounds) {
 }
 
 module.exports = {
+    areaOfBounds: areaOfBounds,
     formatBounds: formatBounds
 };

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -2,13 +2,17 @@
 
 var Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
+    modalModels = require('../core/modals/models'),
+    modalViews = require('../core/modals/views'),
+    utils = require('./utils'),
     formTmpl = require('./templates/form.html'),
     searchResultTmpl = require('./templates/searchResult.html'),
     tabContentTmpl = require('./templates/tabContent.html'),
     tabPanelTmpl = require('./templates/tabPanel.html'),
     windowTmpl = require('./templates/window.html');
 
-var ENTER_KEYCODE = 13;
+var ENTER_KEYCODE = 13,
+    MAX_AREA_SQKM = 1500;  // Keep in sync with apps/bigcz/clients/cuahsi.py
 
 var DataCatalogWindow = Marionette.LayoutView.extend({
     template: windowTmpl,
@@ -67,7 +71,28 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
     doSearch: function() {
         var catalog = this.getActiveCatalog(),
             query = this.model.get('query'),
-            bounds = App.getLeafletMap().getBounds();
+            bounds = App.getLeafletMap().getBounds(),
+            area = utils.areaOfBounds(bounds);
+
+        // CUAHSI should not be fetched beyond a certain size
+        if (catalog.get('id') === 'cuahsi' && area > MAX_AREA_SQKM) {
+            var alertView = new modalViews.AlertView({
+                model: new modalModels.AlertModel({
+                    alertMessage: "Your query for " + Math.round(area) + " km² " +
+                                  "is larger than the current maximum area of " +
+                                  MAX_AREA_SQKM + " km² supported for WDC.",
+                    alertType: modalModels.AlertTypes.error
+                })
+            });
+            alertView.render();
+
+            // Reset results
+            catalog.get('results').reset();
+            catalog.set({ resultCount: 0 });
+            this.updateMap();
+
+            return;
+        }
 
         // Disable intro text after first search request
         this.ui.introText.addClass('hide');

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var Marionette = require('../../shim/backbone.marionette'),
+var L = require('leaflet'),
+    Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
     modalModels = require('../core/modals/models'),
     modalViews = require('../core/modals/views'),
@@ -71,7 +72,7 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
     doSearch: function() {
         var catalog = this.getActiveCatalog(),
             query = this.model.get('query'),
-            bounds = App.getLeafletMap().getBounds(),
+            bounds = L.geoJson(App.map.get('areaOfInterest')).getBounds(),
             area = utils.areaOfBounds(bounds);
 
         // CUAHSI should not be fetched beyond a certain size

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -65,13 +65,15 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
     },
 
     doSearch: function() {
-        var catalog = this.getActiveCatalog();
+        var catalog = this.getActiveCatalog(),
+            query = this.model.get('query'),
+            bounds = App.getLeafletMap().getBounds();
 
         // Disable intro text after first search request
         this.ui.introText.addClass('hide');
         this.ui.tabs.removeClass('hide');
 
-        catalog.search(this.model.get('query'));
+        catalog.search(query, bounds);
     },
 
     updateMap: function() {

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -79,9 +79,11 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
         if (catalog.get('id') === 'cuahsi' && area > MAX_AREA_SQKM) {
             var alertView = new modalViews.AlertView({
                 model: new modalModels.AlertModel({
-                    alertMessage: "Your query for " + Math.round(area) + " km² " +
-                                  "is larger than the current maximum area of " +
-                                  MAX_AREA_SQKM + " km² supported for WDC.",
+                    alertMessage: "The bounding box of the current area of " +
+                                  "interest is " + Math.round(area) + " km², " +
+                                  "which is larger than the current maximum " +
+                                  "area of " + MAX_AREA_SQKM + " km² supported " +
+                                  "for WDC.",
                     alertType: modalModels.AlertTypes.error
                 })
             });


### PR DESCRIPTION
## Overview

Add bounding box search constraint to CUAHSI results. We don't add this limit to other APIs because they are much faster (CINERGI), and often times don't have results if the bounding box is too narrow (CINERGI), or simply don't take a bounding box parameter (Hydroshare).

I chose a limit of 1,500 km² after some trial and error, but we can change it in the future. This should be in the HUC-10 range, when applied to AoIs. Currently we run the visible map bounds, so if you select a HUC-10 the actual bounds will be much larger.

Connects #1851 

### Demo

![2017-07-06 18 15 12](https://user-images.githubusercontent.com/1430060/27935145-3c8e8696-6277-11e7-9677-ea9658a6ed60.gif)

### Notes

At first I did the server side check, but later did the client side. Not sure if we still need the server side, but since a large search can actually bring our server down we should have some sort of check there. On the other hand, this may be accounted for in #1989 

## Testing Instructions

 * Check out this branch, `bundle`
 * Go to [:8000/search?bigcz](http://localhost:8000/search?bigcz)
 * Ensure that you cannot search for WDC / CUAHSI results if the bounds of the map view exceed 1,500 km².
 * Try zooming in and out. Try switching tabs. Ensure behavior is consistent and sensible.