### PR TITLE
Remove search bar when project page is launched

### DIFF
--- a/src/mmw/js/src/projects/controllers.js
+++ b/src/mmw/js/src/projects/controllers.js
@@ -5,6 +5,10 @@ var App = require('../app'),
     coreUtils= require('../core/utils');
 
 var ProjectsController = {
+    projectsPrepare: function() {
+        App.rootView.geocodeSearchRegion.empty();
+    },
+
     projects: function() {
         App.rootView.footerRegion.show(
             new views.ProjectsView()


### PR DESCRIPTION
## Overview

Explicitly remove the search bar when the project page is launched. Some pages remove this element when the page is navigated away from, but this technique does not work for the splash page. I believe this is because it is as the root url and does not have a route name.

Connects #1912

### Demo

![mmw1](https://user-images.githubusercontent.com/1042475/27961792-f8f50126-62fd-11e7-9955-9bf16a93eca6.gif)

## Testing Instructions

- Load the app, and navigate directly to the projects page. Verify the search element does not appear.
- Navigate around the app, and verify that the search element is shown and hidden when appropriate.
