### PR TITLE
Limit Search to Area of Interest

### DIFF
--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -1,11 +1,19 @@
 "use strict";
 
 var App = require('../app'),
+    router = require('../router').router,
     coreUtils = require('../core/utils'),
     models = require('./models'),
     views = require('./views');
 
 var DataCatalogController = {
+    dataCatalogPrepare: function() {
+        if (!App.map.get('areaOfInterest')) {
+            router.navigate('', { trigger: true });
+            return false;
+        }
+    },
+
     dataCatalog: function() {
         App.map.setDataCatalogSize();
 

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -2,6 +2,8 @@
 
 var _ = require('underscore'),
     Backbone = require('../../shim/backbone'),
+    turfIntersect = require('turf-intersect'),
+    App = require('../app'),
     utils = require('./utils');
 
 var DESCRIPTION_MAX_LENGTH = 100;
@@ -83,7 +85,13 @@ var Results = Backbone.Collection.extend({
     url: '/api/bigcz/search',
     model: Result,
     parse: function(response) {
-        return response.results;
+        var aoi = App.map.get('areaOfInterest');
+
+        // Filter results to only include those without geometries (Hydroshare)
+        // and those that intersect the area of interest (CINERGI and CUAHSI).
+        return _.filter(response.results, function(r) {
+            return r.geom === null || turfIntersect(aoi, r.geom) !== undefined;
+        });
     }
 });
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var Marionette = require('../../shim/backbone.marionette'),
+var L = require('leaflet'),
+    Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
     modalModels = require('../core/modals/models'),
     modalViews = require('../core/modals/views'),
@@ -71,7 +72,7 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
     doSearch: function() {
         var catalog = this.getActiveCatalog(),
             query = this.model.get('query'),
-            bounds = App.getLeafletMap().getBounds(),
+            bounds = L.geoJson(App.map.get('areaOfInterest')).getBounds(),
             area = utils.areaOfBounds(bounds);
 
         // CUAHSI should not be fetched beyond a certain size


### PR DESCRIPTION
## Overview

Limits "Search" functionality to the area of interest. The results will now be limited and filtered to the area of interest drawn. The Search page is now no longer directly accessible, only via home → draw → analyze → search.

Builds on top of #2003 
Connects #1947 

### Demo

Current Behavior (Search extent of Map View):

![image](https://user-images.githubusercontent.com/1430060/27964870-b62749d0-6307-11e7-8da7-6ed0098c035c.png)

Step 1 Limit to Bounding Box of Area of Interest:

![image](https://user-images.githubusercontent.com/1430060/27964894-d4bd1cee-6307-11e7-8047-be7f5df7644b.png)

Step 2 Limit to Results Intersecting Area of Interest:

![image](https://user-images.githubusercontent.com/1430060/27964910-e64183b0-6307-11e7-8079-e4f02f851480.png)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/search?bigcz](http://localhost:8000/search?bigcz). Ensure you are redirected to home
 * Select an area of interest. Proceed to Analyze and Search. Search for "water". Ensure that the search results of CINERGI are limited to those that intersect the area of interest.
 * Switch to the Hydroshare tab. Ensure that the results are same as before, since Hydroshare does not accept bounding box as a search parameter and has no geometries in the results.
 * Switch to WDC tab. Ensure that the results are those that intersect the area of interest.
 * Move the map around and play with zoom. Re-run the searches by clicking their tabs. Ensure that the results are the same every time.