### PR TITLE
Adjust left margin for analyze tabs

### DIFF
--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -136,7 +136,7 @@ function renderHorizontalBarChart(chartEl, data, options) {
 
     options = options || {};
     _.defaults(options, {
-        margin: {top: 30, right: 30, bottom: 40, left: 200},
+        margin: {top: 30, right: 30, bottom: 40, left: 210},
         maxBarHeight: 150
     });
 


### PR DESCRIPTION
## Overview

This PR fixes a styling bug whereby the soil results analysis tab had its labels lopped off. The fix is to give it some additional space on the left margin via the nvd3 config options.

Connects #1998 

### Demo

![screen shot 2017-07-10 at 1 45 19 pm](https://user-images.githubusercontent.com/4165523/28031681-101b449e-6576-11e7-9a7b-63eef7fb3e54.png)

## Testing Instructions

* get this branch, then bundle & use Firefox, Safari, Chrome, and IE11 on both Retina and non-Retina screens to...
    * select an aoi
    * click the soil results tab and verify that the bar chart labels aren't cut off
    * check the land results tab and verify that its bar chart & labels are still visible too


