### PR TITLE
Pad AOI name in analyze tab

### DIFF
--- a/src/mmw/sass/components/_sidebar.scss
+++ b/src/mmw/sass/components/_sidebar.scss
@@ -1,6 +1,7 @@
 .results-content.downloadcsv-link,
 .downloadcsv-link {
     margin-top: 14px;
+    margin-bottom: 3rem;
     cursor: pointer;
     font-size: $font-size-h5;
     @extend .btn;

--- a/src/mmw/sass/components/_tabs.scss
+++ b/src/mmw/sass/components/_tabs.scss
@@ -36,7 +36,7 @@
 
 .model-stage-results-tab-pane {
     .nav-tabs {
-        background-color: transparent;
+        background-color: $paper;
     }
     .tab-content {
     // Set a specific height to allow y-scroll:

--- a/src/mmw/sass/components/_tabs.scss
+++ b/src/mmw/sass/components/_tabs.scss
@@ -48,9 +48,6 @@
 
 
 .analyze-stage-results-tab-pane {
-    .nav-tabs {
-        background-color: $black-06;
-    }
     .tab-content {
     // Set a specific height to allow y-scroll:
     // Calc height under the main header (height-lg), aoi region (aoi-header-height),

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -60,6 +60,7 @@
 }
 
 .analyze-message-region {
+  background-color: $paper;
   position: relative;
   height: 100%;
   min-height: 200px;

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -39,10 +39,13 @@
     height: 46px;
 }
 
+.tab-contents-region {
+    background-color: $black-06;
+}
+
 .aoi-region {
-  height: $aoi-header-height;
-  background-color: $black-06;
   padding-top: 20px;
+  padding-bottom: 0px !important;
   h2 {
     font-size: $font-size-h2;
     line-height: $aoi-header-height / 2;


### PR DESCRIPTION
## Overview

This PR makes some adjustments to the Analyze tab to enable showing longer AOI names while keeping the scroll behavior intact. To fix it, we drop the 54px fixed height from the header, make some other adjustments to keep it rendering correctly, add some padding to the download csv button at the bottom to ensure it stays visible on scrolling even when the height of the header changes.

Connects #1897

### Demo

<img width="459" alt="screen shot 2017-07-10 at 3 43 36 pm" src="https://user-images.githubusercontent.com/4165523/28036615-cb60de52-6586-11e7-871d-85aa9efdda25.png">


### Notes

Currently the longest HUC boundary name in the db is 79 char:

```
Little North Fork South Fork Coeur d'Alene River-South Fork Coeur d'Alene River
```

The longest school district is 72 char:

```
Beaufort County School District within Beaufort Marine Corps Air Station
```

Due to some quirks with how the results column's set up the download button will start getting cut off if the title's 160-240+ char long, but since we know the longest current name is just 79, it seems like it makes sense not to adjust the CSS much otherwise

## Testing Instructions

* get branch, then `bundle`, and repeat the following steps in Chrome, FF, Safari, and IE11:
* adjust `aoiHeader.html` to use the 79 char HUC boundary name above as a hard coded name in place of `{{ place }}`, then run analyze and verify that the title no longer overlaps the tab buttons and that the soil and land tabs are fully scrollable & that the download data button's not hidden beneath a div
* model the AOI, then click the analyze tab again and verify that the land and soil tabs are also still fully scrollable
