### PR TITLE
Allow sign in while model is running

### DIFF
--- a/src/mmw/apps/core/tasks.py
+++ b/src/mmw/apps/core/tasks.py
@@ -3,9 +3,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-from rest_framework.response import Response
-from django.shortcuts import get_object_or_404
-
 from django.utils.timezone import now
 from celery import shared_task
 from apps.core.models import Job
@@ -15,27 +12,6 @@ import logging
 
 
 logger = logging.getLogger(__name__)
-
-
-def get_job(request, job_uuid, format=None):
-    """ A generic view to get a job by id. Used
-    in apps with Celery tasks"""
-    # TODO consider if we should have some sort of session id check to ensure
-    # you can only view your own jobs.
-    job = get_object_or_404(Job, uuid=job_uuid, user=request.user)
-
-    # TODO Should we return the error? Might leak info about the internal
-    # workings that we don't want exposed.
-    return Response(
-        {
-            'job_uuid': job.uuid,
-            'status': job.status,
-            'result': job.result,
-            'error': job.error,
-            'started': job.created_at,
-            'finished': job.delivered_at,
-        }
-    )
 
 
 @shared_task(bind=True)


### PR DESCRIPTION
## Overview

We were querying for jobs with the job's `uuid` and the user, if there was one:
```py
job = get_object_or_404(Job, uuid=job_uuid, user=user)
```

When a user logged-in in the middle of task's polling, we wouldn't be able to find the job anymore because its user didn't match (the job was created without a user).

This PR queries the `Job` model by the `uuid` alone, then, if the found job has a user, confirms the user matches. This way users can't read other users' jobs, but can read anonymous jobs. Before anonymous requests could read any anonymous jobs, so it seems acceptable that users should be able to read them, too. 

Thanks @rajadain for talking this through with me!

Connects #1967 

### Demo

![fus0zizq65](https://user-images.githubusercontent.com/7633670/28037886-fb7117b6-658a-11e7-90c0-7033e0aaca18.gif)

## Testing Instructions

 * Pull branch
 * While logged out, model an AoI, and while it's still polling log in. Confirm the task still completes without error and you're able to save the project
 * Try some bad uuid like `curl localhost:8000/api/modeling/jobs/432e2f6b-9bc8-4813-bd58-67fbe8b74b73/` and confirm the response is `Not found`
