### PR TITLE
Upgrade tr55 + clear old scenarios

### DIFF
--- a/src/mmw/apps/modeling/migrations/0021_old_scenarios.py
+++ b/src/mmw/apps/modeling/migrations/0021_old_scenarios.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def clear_old_scenario_results(apps, schema_editor):
+    Scenario = apps.get_model('modeling', 'Scenario')
+    old_scenarios = Scenario.objects.filter(
+            project__model_package='tr-55'
+        )
+
+    for scenario in old_scenarios:
+        scenario.results = '[]'
+        scenario.modification_hash = ''
+        scenario.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0020_old_scenarios'),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_old_scenario_results)
+    ]

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -9,7 +9,7 @@ django-registration-redux==1.2
 python-omgeo==2.0.0
 rauth==0.7.1
 djangorestframework-gis==0.8.2
-tr55==1.2.1
+tr55==1.3.0
 gwlf-e==0.6.2
 requests==2.9.1
 rollbar==0.13.8


### PR DESCRIPTION
## Overview

- Upgrade tr-55 to the latest release [`1.3.0`](https://github.com/WikiWatershed/tr-55/releases/tag/1.3.0)
- Add migration to clear out all old tr-55 scenarios so they can re-run for the new results. This incidentally fixes the bug where-by older projects had incorrectly formatted water quality results (#1923)

Connects #2004 
Connects #1923 

## Testing Instructions

 * Pull branch
 * Install the new tr-55 `vagrant ssh worker -c 'sudo pip install -r /vagrant/src/mmw/requirements/base.txt --upgrade'`
* apply the migration `./scripts/manage.sh migrate`
* open an old tr-55 project and confirm it re-runs the model