### PR TITLE
Fix precipitation slider input width

### DIFF
--- a/src/mmw/js/src/core/templates/opacityControl.html
+++ b/src/mmw/js/src/core/templates/opacityControl.html
@@ -3,6 +3,6 @@
    min="0"
    max="99"
    step="3"
-   class="layerpicker-slider slider-leaflet"
+   class="layerpicker-slider slider-leaflet custom-slider"
    value="{{ sliderValue }}"
 >

--- a/src/mmw/js/src/modeling/templates/controls/precipitation.html
+++ b/src/mmw/js/src/modeling/templates/controls/precipitation.html
@@ -1,7 +1,7 @@
 <div>
     <label>
         <span class="name">Precipitation</span>
-        <input type="range" min="0" max="25" step="0.25" />
+        <input type="range" min="0" max="25" step="0.25" class="precipitation-slider" />
         <span class="value"></span>
     </label>
 </div>

--- a/src/mmw/js/src/modeling/templates/controls/precipitation.html
+++ b/src/mmw/js/src/modeling/templates/controls/precipitation.html
@@ -1,7 +1,7 @@
 <div>
     <label>
         <span class="name">Precipitation</span>
-        <input type="range" min="0" max="25" step="0.25" class="precipitation-slider" />
+        <input type="range" min="0" max="25" step="0.25" class="precipitation-slider custom-slider" />
         <span class="value"></span>
     </label>
 </div>

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -229,17 +229,91 @@ header {
             }
         }
 
-      // Precipitation slider
-      .precipitation {
-        // Undo bootstrap input[type="range"] syling
-        input {
-          display: inline-block;
-          width: 120px;
-          margin: 0 0.7rem;
-          padding: 0;
-          vertical-align: bottom;
-        }
-      }
+    }
+  }
+}
+
+// Precipitation slider
+.precipitation {
+  width: 285px;
+  .precipitation-slider {
+    -webkit-appearance: none;
+    background-color: transparent;
+    display: inline-block;
+    width: 120px;
+    margin: 0 0.7rem;
+    padding: 0;
+    vertical-align: middle;
+
+    &:focus {
+      outline: none;
+    }
+
+    &::-webkit-slider-thumb {
+      background: $brand-primary;
+      width: 12px;
+      height: 12px;
+      border: 1px solid $brand-primary;
+      border-radius: 50px;
+      margin-top: -5px;
+      -webkit-appearance: none;
+    }
+
+    &:focus::-webkit-slider-thumb {
+      background: $brand-primary;
+    }
+
+    &::-webkit-slider-runnable-track {
+      width: 100%;
+      height: 2.2px;
+      cursor: pointer;
+      background: #999;
+    }
+
+    &::-moz-range-track {
+      background: #999;
+    }
+    &::-moz-range-thumb {
+      background: $brand-primary;
+      width: 12px;
+      height: 12px;
+      border: 1px solid $brand-primary;
+      border-radius: 50px;
+    }
+
+    &::-ms-track {
+      background: transparent;
+      border-color: transparent;
+      width: 100%;
+      height: 2.2px;
+      cursor: pointer;
+      border-width: 6px 0;
+      color: transparent;
+    }
+    &::-ms-thumb {
+      background: $brand-primary;
+      width: 12px;
+      height: 12px;
+      border: 1px solid $brand-primary;
+      border-radius: 50px;
+    }
+    &::-ms-fill-lower {
+      background:#999;
+      border: #999;
+    }
+    &::-ms-fill-upper {
+      background: #999;
+      border: #999;
+    }
+    &:focus::-ms-fill-lower {
+      background:  #999;
+      border:  #999;
+      border-radius: 7px;
+    }
+    &:focus::-ms-fill-upper {
+      background: #999;
+      border:  #999;
+      border-radius: 7px;
     }
   }
 }

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -237,84 +237,11 @@ header {
 .precipitation {
   width: 285px;
   .precipitation-slider {
-    -webkit-appearance: none;
-    background-color: transparent;
     display: inline-block;
     width: 120px;
     margin: 0 0.7rem;
     padding: 0;
     vertical-align: middle;
-
-    &:focus {
-      outline: none;
-    }
-
-    &::-webkit-slider-thumb {
-      background: $brand-primary;
-      width: 12px;
-      height: 12px;
-      border: 1px solid $brand-primary;
-      border-radius: 50px;
-      margin-top: -5px;
-      -webkit-appearance: none;
-    }
-
-    &:focus::-webkit-slider-thumb {
-      background: $brand-primary;
-    }
-
-    &::-webkit-slider-runnable-track {
-      width: 100%;
-      height: 2.2px;
-      cursor: pointer;
-      background: #999;
-    }
-
-    &::-moz-range-track {
-      background: #999;
-    }
-    &::-moz-range-thumb {
-      background: $brand-primary;
-      width: 12px;
-      height: 12px;
-      border: 1px solid $brand-primary;
-      border-radius: 50px;
-    }
-
-    &::-ms-track {
-      background: transparent;
-      border-color: transparent;
-      width: 100%;
-      height: 2.2px;
-      cursor: pointer;
-      border-width: 6px 0;
-      color: transparent;
-    }
-    &::-ms-thumb {
-      background: $brand-primary;
-      width: 12px;
-      height: 12px;
-      border: 1px solid $brand-primary;
-      border-radius: 50px;
-    }
-    &::-ms-fill-lower {
-      background:#999;
-      border: #999;
-    }
-    &::-ms-fill-upper {
-      background: #999;
-      border: #999;
-    }
-    &:focus::-ms-fill-lower {
-      background:  #999;
-      border:  #999;
-      border-radius: 7px;
-    }
-    &:focus::-ms-fill-upper {
-      background: #999;
-      border:  #999;
-      border-radius: 7px;
-    }
   }
 }
 

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -151,7 +151,6 @@
     margin-right: 5px;
 }
 
-// Generated and considerably refined from http://danielstern.ca/range.css/
 .layerpicker-slider {
     -webkit-appearance: none;
     width: 90px !important;
@@ -171,72 +170,5 @@
         position: absolute;
         right: 12px;
         top: 6px;
-
-        &::-webkit-slider-thumb {
-            background: $brand-primary;
-            width: 12px;
-            height: 12px;
-            border: 1px solid $brand-primary;
-            border-radius: 50px;
-            margin-top: -5px;
-            -webkit-appearance: none;
-        }
-
-        &:focus::-webkit-slider-thumb {
-            background: $brand-primary;
-        }
-
-        &::-webkit-slider-runnable-track {
-            width: 100%;
-            height: 2.2px;
-            cursor: pointer;
-            background: #999;
-        }
-
-        &::-moz-range-track {
-            background: #999;
-        }
-        &::-moz-range-thumb {
-            background: $brand-primary;
-            width: 12px;
-            height: 12px;
-            border: 1px solid $brand-primary;
-            border-radius: 50px;
-        }
-
-        &::-ms-track {
-            background: transparent;
-            border-color: transparent;
-            width: 100%;
-            height: 2.2px;
-            cursor: pointer;
-            border-width: 6px 0;
-            color: transparent;
-        }
-        &::-ms-thumb {
-            background: $brand-primary;
-            width: 12px;
-            height: 12px;
-            border: 1px solid $brand-primary;
-            border-radius: 50px;
-        }
-        &::-ms-fill-lower {
-            background:#999;
-            border: #999;
-        }
-        &::-ms-fill-upper {
-            background: #999;
-            border: #999;
-        }
-        &:focus::-ms-fill-lower {
-            background:  #999;
-            border:  #999;
-            border-radius: 7px;
-        }
-        &:focus::-ms-fill-upper {
-            background: #999;
-            border:  #999;
-            border-radius: 7px;
-        }
     }
 }

--- a/src/mmw/sass/components/_slider.scss
+++ b/src/mmw/sass/components/_slider.scss
@@ -1,28 +1,82 @@
-.slider {
-  width: 200px;
-  margin-left: 12px!important;
-  display: inline-block!important;
-  padding: 12px 0;
-
-  .dragger {
-    background-color: $active;
-    -webkit-border-radius: 12px;
-    -moz-border-radius: 12px;
-    border-radius: 12px;
-    border: 3px solid $paper;
-    width: 24px;
-    height: 24px;
+// Generated and considerably refined from http://danielstern.ca/range.css/
+.custom-slider {
+  -webkit-appearance: none;
+  background-color: transparent;
+  cursor: pointer;
+  &:focus {
+    outline: none;
   }
 
-  .track, .highlight-track {
-    background-color: $black-12;
-    height: 4px;
+  &::-webkit-slider-thumb {
+    background: $brand-primary;
+    width: 12px;
+    height: 12px;
+    border: 1px solid $brand-primary;
+    border-radius: 50px;
+    margin-top: -5px;
+    -webkit-appearance: none;
   }
 
-  .highlight-track {
-    background-color: $water;
-    height: 4px;
+  &:focus::-webkit-slider-thumb {
+    background: $brand-primary;
+  }
+
+  &::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 2.2px;
+    cursor: pointer;
+    background: #999;
+  }
+
+  &::-moz-range-track {
+    background: #999;
+  }
+
+  &::-moz-range-thumb {
+    background: $brand-primary;
+    width: 12px;
+    height: 12px;
+    border: 1px solid $brand-primary;
+    border-radius: 50px;
+  }
+
+  &::-ms-track {
+    background: transparent;
+    border-color: transparent;
+    width: 100%;
+    height: 2.2px;
+    cursor: pointer;
+    border-width: 6px 0;
+    color: transparent;
+  }
+
+  &::-ms-thumb {
+    background: $brand-primary;
+    width: 12px;
+    height: 12px;
+    border: 1px solid $brand-primary;
+    border-radius: 50px;
+  }
+
+  &::-ms-fill-lower {
+    background:#999;
+    border: #999;
+  }
+
+  &::-ms-fill-upper {
+    background: #999;
+    border: #999;
+  }
+
+  &:focus::-ms-fill-lower {
+    background:  #999;
+    border:  #999;
+    border-radius: 7px;
+  }
+
+  &:focus::-ms-fill-upper {
+    background: #999;
+    border:  #999;
+    border-radius: 7px;
   }
 }
-
-

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -63,7 +63,8 @@
   "components/observations",
   "components/sidebar",
   "components/global-navigation",
-  "components/layerpicker";
+  "components/layerpicker",
+  "components/slider";
 
 /**
  * Pages


### PR DESCRIPTION
## Overview

This PR smooths the precipitation slider input on FF & Safari by giving the whole control a fixed width, which prevents it from resizing dynamically when the numeric value changes.

Connects #2013 

## Testing Instructions

 * get this branch, then `bundle`
 * test the precipitation slider in FF, Chrome, Safari, and IE11 to verify that it still works and is doesn't resize on changes
