### PR TITLE
Add Timeout To BiGCZ Client Requests

### DIFF
--- a/src/mmw/apps/bigcz/clients/cinergi.py
+++ b/src/mmw/apps/bigcz/clients/cinergi.py
@@ -7,7 +7,10 @@ import requests
 import dateutil.parser
 from django.contrib.gis.geos import Polygon
 
+from django.conf import settings
+
 from apps.bigcz.models import Resource, ResourceLink, ResourceList, BBox
+from apps.bigcz.utils import RequestTimedOutError
 
 
 CATALOG_NAME = 'cinergi'
@@ -128,7 +131,13 @@ def search(**kwargs):
             'bbox': prepare_bbox(bbox)
         })
 
-    response = requests.get(GEOPORTAL_URL, params=params)
+    try:
+        response = requests.get(GEOPORTAL_URL,
+                                timeout=settings.BIGCZ_CLIENT_TIMEOUT,
+                                params=params)
+    except requests.Timeout:
+        raise RequestTimedOutError()
+
     data = response.json()
 
     if 'hits' not in data:

--- a/src/mmw/apps/bigcz/clients/cuahsi.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi.py
@@ -9,7 +9,7 @@ from socket import timeout
 
 from suds.client import Client
 from rest_framework.exceptions import ValidationError
-from django.contrib.gis.geos import Point, Polygon
+from django.contrib.gis.geos import Point
 
 from django.conf import settings
 
@@ -134,10 +134,10 @@ def make_request(request, **kwargs):
 
 def get_services_in_box(box):
     result = make_request(client.service.GetServicesInBox2,
-            xmin=box.xmin,
-            xmax=box.xmax,
-            ymin=box.ymin,
-            ymax=box.ymax)
+                          xmin=box.xmin,
+                          xmax=box.xmax,
+                          ymin=box.ymin,
+                          ymax=box.ymax)
 
     try:
         return result['ServiceInfo']
@@ -154,14 +154,14 @@ def get_series_catalog_in_box(box, from_date, to_date):
     to_date = to_date or DATE_MAX
 
     result = make_request(client.service.GetSeriesCatalogForBox2,
-        xmin=box.xmin,
-        xmax=box.xmax,
-        ymin=box.ymin,
-        ymax=box.ymax,
-        conceptKeyword='',
-        networkIDs='',
-        beginDate=from_date.strftime(DATE_FORMAT),
-        endDate=to_date.strftime(DATE_FORMAT))
+                          xmin=box.xmin,
+                          xmax=box.xmax,
+                          ymin=box.ymin,
+                          ymax=box.ymax,
+                          conceptKeyword='',
+                          networkIDs='',
+                          beginDate=from_date.strftime(DATE_FORMAT),
+                          endDate=to_date.strftime(DATE_FORMAT))
 
     try:
         return result['SeriesRecord']

--- a/src/mmw/apps/bigcz/clients/cuahsi.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi.py
@@ -4,13 +4,17 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from datetime import date
+from urllib2 import URLError
+from socket import timeout
 
 from suds.client import Client
 from rest_framework.exceptions import ValidationError
 from django.contrib.gis.geos import Point, Polygon
 
+from django.conf import settings
+
 from apps.bigcz.models import Resource, ResourceLink, ResourceList, BBox
-from apps.bigcz.utils import parse_date
+from apps.bigcz.utils import parse_date, RequestTimedOutError
 
 
 SQKM_PER_SQM = 0.000001
@@ -24,7 +28,7 @@ DATE_MAX = date(2100, 1, 1)
 DATE_FORMAT = '%m/%d/%Y'
 
 
-client = Client(SOAP_URL)
+client = Client(SOAP_URL, timeout=settings.BIGCZ_CLIENT_TIMEOUT)
 
 
 def parse_geom(record):
@@ -116,12 +120,25 @@ def group_series_by_location(series):
     return result.values()
 
 
+def make_request(request, **kwargs):
+    try:
+        return request(**kwargs)
+    except URLError, e:
+        if isinstance(e.reason, timeout):
+            raise RequestTimedOutError()
+        else:
+            raise
+    except timeout:
+        raise RequestTimedOutError()
+
+
 def get_services_in_box(box):
-    result = client.service.GetServicesInBox2(
-        xmin=box.xmin,
-        xmax=box.xmax,
-        ymin=box.ymin,
-        ymax=box.ymax)
+    result = make_request(client.service.GetServicesInBox2,
+            xmin=box.xmin,
+            xmax=box.xmax,
+            ymin=box.ymin,
+            ymax=box.ymax)
+
     try:
         return result['ServiceInfo']
     except KeyError:
@@ -135,7 +152,8 @@ def get_services_in_box(box):
 def get_series_catalog_in_box(box, from_date, to_date):
     from_date = from_date or DATE_MIN
     to_date = to_date or DATE_MAX
-    result = client.service.GetSeriesCatalogForBox2(
+
+    result = make_request(client.service.GetSeriesCatalogForBox2,
         xmin=box.xmin,
         xmax=box.xmax,
         ymin=box.ymin,
@@ -144,6 +162,7 @@ def get_series_catalog_in_box(box, from_date, to_date):
         networkIDs='',
         beginDate=from_date.strftime(DATE_FORMAT),
         endDate=to_date.strftime(DATE_FORMAT))
+
     try:
         return result['SeriesRecord']
     except KeyError:
@@ -162,15 +181,6 @@ def search(**kwargs):
     if not bbox:
         raise ValidationError({
             'error': 'Required argument: bbox'})
-
-    bbox_polygon = Polygon.from_bbox([float(i) for i in bbox.split(',')])
-    bbox_polygon.set_srid(4326)
-    bbox_area = bbox_polygon.transform(5070, clone=True).area * SQKM_PER_SQM
-    if bbox_area > MAX_AREA_SQKM:
-        raise ValidationError({
-            'error': 'bbox area of {} km² is too large. '
-                     'Current max limit is {} km²'
-                     .format(bbox_area, MAX_AREA_SQKM)})
 
     box = BBox(bbox)
     world = BBox('-180,-90,180,90')

--- a/src/mmw/apps/bigcz/clients/hydroshare.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare.py
@@ -7,7 +7,10 @@ import requests
 import dateutil.parser
 from rest_framework.exceptions import ValidationError
 
+from django.conf import settings
+
 from apps.bigcz.models import Resource, ResourceLink, ResourceList, BBox
+from apps.bigcz.utils import RequestTimedOutError
 
 
 CATALOG_NAME = 'hydroshare'
@@ -71,7 +74,13 @@ def search(**kwargs):
     if bbox:
         params.update(prepare_bbox(bbox))
 
-    response = requests.get(HYDROSHARE_URL, params=params)
+    try:
+        response = requests.get(HYDROSHARE_URL,
+                                timeout=settings.BIGCZ_CLIENT_TIMEOUT,
+                                params=params)
+    except requests.Timeout:
+        raise RequestTimedOutError()
+
     data = response.json()
 
     if 'results' not in data:

--- a/src/mmw/apps/bigcz/utils.py
+++ b/src/mmw/apps/bigcz/utils.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from rest_framework.exceptions import APIException
 import dateutil.parser
 
 
@@ -10,3 +11,9 @@ def parse_date(value):
     if not value:
         return None
     return dateutil.parser.parse(value)
+
+
+class RequestTimedOutError(APIException):
+    status_code = 408
+    default_detail = 'Requested resource timed out.'
+    default_code = 'request_timeout'

--- a/src/mmw/apps/core/tasks.py
+++ b/src/mmw/apps/core/tasks.py
@@ -3,9 +3,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-from rest_framework.response import Response
-from django.shortcuts import get_object_or_404
-
 from django.utils.timezone import now
 from celery import shared_task
 from apps.core.models import Job
@@ -15,27 +12,6 @@ import logging
 
 
 logger = logging.getLogger(__name__)
-
-
-def get_job(request, job_uuid, format=None):
-    """ A generic view to get a job by id. Used
-    in apps with Celery tasks"""
-    # TODO consider if we should have some sort of session id check to ensure
-    # you can only view your own jobs.
-    job = get_object_or_404(Job, uuid=job_uuid, user=request.user)
-
-    # TODO Should we return the error? Might leak info about the internal
-    # workings that we don't want exposed.
-    return Response(
-        {
-            'job_uuid': job.uuid,
-            'status': job.status,
-            'result': job.result,
-            'error': job.error,
-            'started': job.created_at,
-            'finished': job.delivered_at,
-        }
-    )
 
 
 @shared_task(bind=True)

--- a/src/mmw/js/src/data_catalog/templates/error.html
+++ b/src/mmw/js/src/data_catalog/templates/error.html
@@ -1,0 +1,8 @@
+{% if error %}
+    <div class="no-results-panel">
+        <div>
+            <i class="fa fa-exclamation-triangle"></i>
+        </div>
+        <p> {{ error }} </p>
+    </div>
+{% endif %}

--- a/src/mmw/js/src/data_catalog/templates/tabContent.html
+++ b/src/mmw/js/src/data_catalog/templates/tabContent.html
@@ -8,4 +8,6 @@
     No results
 </div>
 
+<div class="error-region"></div>
+
 <div class="result-region"></div>

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -358,6 +358,7 @@ OMGEO_SETTINGS = [[
 
 # BiG-CZ Host, for enabling custom behavior.
 BIGCZ_HOST = 'portal.bigcz.org'
+BIGCZ_CLIENT_TIMEOUT = 5  # timeout in seconds
 
 # ITSI Portal Settings
 ITSI = {


### PR DESCRIPTION
## Overview

We shouldn't tie up the app web workers making them wait indefinitely for large bigcz api client searches to complete. This PR adds a 5 second timeout to their requests.

Connects #1989 

### Demo

<img width="466" alt="screen shot 2017-07-11 at 5 22 56 pm" src="https://user-images.githubusercontent.com/7633670/28092361-10946f90-6661-11e7-828e-becef173f1d1.png">

### Notes
608bbc2 and 	4c6ae45 are sort of tangential to this issue. Open to dropping them.

## Testing Instructions
 * Search as normal and confirm each tab works at a reasonable scale
 * update the timeout in `src/mmw/mmw/settings/bigcz_settings.py` to `0.0001`
* Try each tab again and confirm the service times out appropriately
