### PR TITLE
Fix JavaScript tests

### DIFF
--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -4,124 +4,124 @@
   "dependencies": {
     "backbone": {
       "version": "1.1.2",
-      "from": "backbone@1.1.2",
+      "from": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz"
     },
     "backbone.marionette": {
       "version": "2.4.1",
-      "from": "backbone.marionette@2.4.1",
+      "from": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.1.tgz",
       "dependencies": {
         "backbone.babysitter": {
-          "version": "0.1.12",
-          "from": "backbone.babysitter@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.12.tgz"
+          "version": "0.1.8",
+          "from": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz"
         },
         "backbone.wreqr": {
-          "version": "1.4.0",
-          "from": "backbone.wreqr@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.4.0.tgz"
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@>=1.4.4 <=1.6.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
     "backbone.paginator": {
       "version": "2.0.5",
-      "from": "backbone.paginator@2.0.5",
+      "from": "https://registry.npmjs.org/backbone.paginator/-/backbone.paginator-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/backbone.paginator/-/backbone.paginator-2.0.5.tgz"
     },
     "blueimp-md5": {
       "version": "1.1.0",
-      "from": "blueimp-md5@1.1.0",
+      "from": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-1.1.0.tgz"
     },
     "bootstrap": {
       "version": "3.3.4",
-      "from": "bootstrap@3.3.4",
+      "from": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz"
     },
     "bootstrap-select": {
       "version": "1.6.4",
-      "from": "../../tmp/npm-6873-f7f6c799/1499449424591-0.02255773078650236/f1755efa102a41e43fc367ba36ce905b8f2b90e1",
+      "from": "../../tmp/npm-25360-e04608df/1472064034158-0.4662157059647143/f1755efa102a41e43fc367ba36ce905b8f2b90e1",
       "resolved": "git://github.com/azavea/bootstrap-select#f1755efa102a41e43fc367ba36ce905b8f2b90e1"
     },
     "bootstrap-table": {
       "version": "1.11.0",
-      "from": "bootstrap-table@1.11.0",
+      "from": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.11.0.tgz",
       "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.11.0.tgz"
     },
     "browserify": {
       "version": "9.0.3",
-      "from": "browserify@9.0.3",
+      "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.10.0",
-          "from": "JSONStream@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
-              "from": "jsonparse@0.0.5",
+              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.2.7 <3.0.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "assert": {
           "version": "1.3.0",
-          "from": "assert@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
           "version": "4.0.4",
-          "from": "browser-pack@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.3.1",
-              "from": "JSONStream@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.3.0",
-                  "from": "jsonparse@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.2.7 <3.0.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "combine-source-map@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.1",
-                  "from": "inline-source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.3.0",
-                      "from": "source-map@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "dependencies": {
                         "amdefine": {
-                          "version": "1.0.1",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                         }
                       }
                     }
@@ -129,18 +129,18 @@
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "convert-source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.31 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.1",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 }
@@ -148,23 +148,23 @@
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.0.34",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
                 }
@@ -172,437 +172,303 @@
             },
             "umd": {
               "version": "3.0.1",
-              "from": "umd@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
             }
           }
         },
         "browser-resolve": {
-          "version": "1.11.2",
-          "from": "browser-resolve@>=1.7.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-          "dependencies": {
-            "resolve": {
-              "version": "1.1.7",
-              "from": "resolve@1.1.7",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-            }
-          }
+          "version": "1.9.0",
+          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "browserify-zlib@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
-              "version": "0.2.9",
-              "from": "pako@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+              "version": "0.2.7",
+              "from": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
             }
           }
         },
         "buffer": {
-          "version": "3.6.0",
-          "from": "buffer@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "version": "3.3.1",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "base64-js@0.0.8",
+              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
-              "version": "1.1.8",
-              "from": "ieee754@>=1.1.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+              "version": "1.1.6",
+              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
             },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            "is-array": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "builtins@>=0.0.3 <0.1.0",
+          "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
           "version": "0.0.1",
-          "from": "commondir@0.0.1",
+          "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
           "version": "1.4.10",
-          "from": "concat-stream@>=1.4.1 <1.5.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "constants-browserify@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
-          "version": "3.11.0",
-          "from": "crypto-browserify@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+          "version": "3.9.14",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
           "dependencies": {
-            "browserify-cipher": {
-              "version": "1.0.0",
-              "from": "browserify-cipher@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-              "dependencies": {
-                "browserify-aes": {
-                  "version": "1.0.6",
-                  "from": "browserify-aes@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
-                  "dependencies": {
-                    "buffer-xor": {
-                      "version": "1.0.3",
-                      "from": "buffer-xor@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
-                    },
-                    "cipher-base": {
-                      "version": "1.0.3",
-                      "from": "cipher-base@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
-                    }
-                  }
-                },
-                "browserify-des": {
-                  "version": "1.0.0",
-                  "from": "browserify-des@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-                  "dependencies": {
-                    "cipher-base": {
-                      "version": "1.0.3",
-                      "from": "cipher-base@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
-                    },
-                    "des.js": {
-                      "version": "1.0.0",
-                      "from": "des.js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-                      "dependencies": {
-                        "minimalistic-assert": {
-                          "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "evp_bytestokey": {
-                  "version": "1.0.0",
-                  "from": "evp_bytestokey@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
-                }
-              }
+            "browserify-aes": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz"
             },
             "browserify-sign": {
-              "version": "4.0.0",
-              "from": "browserify-sign@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
+              "version": "3.0.2",
+              "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "4.11.6",
-                  "from": "bn.js@>=4.1.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "4.0.1",
-                  "from": "browserify-rsa@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "elliptic": {
-                  "version": "6.4.0",
-                  "from": "elliptic@>=6.0.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
                   "dependencies": {
                     "brorand": {
-                      "version": "1.1.0",
-                      "from": "brorand@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
                       "version": "1.0.3",
-                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
-                    },
-                    "hmac-drbg": {
-                      "version": "1.0.0",
-                      "from": "hmac-drbg@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz"
-                    },
-                    "minimalistic-assert": {
-                      "version": "1.0.0",
-                      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-                    },
-                    "minimalistic-crypto-utils": {
-                      "version": "1.0.1",
-                      "from": "minimalistic-crypto-utils@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
                     }
                   }
                 },
                 "parse-asn1": {
-                  "version": "5.1.0",
-                  "from": "parse-asn1@>=5.0.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "4.9.1",
-                      "from": "asn1.js@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+                      "version": "2.1.2",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
-                    },
-                    "browserify-aes": {
-                      "version": "1.0.6",
-                      "from": "browserify-aes@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
-                      "dependencies": {
-                        "buffer-xor": {
-                          "version": "1.0.3",
-                          "from": "buffer-xor@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
-                        },
-                        "cipher-base": {
-                          "version": "1.0.3",
-                          "from": "cipher-base@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
-                        }
-                      }
-                    },
-                    "evp_bytestokey": {
-                      "version": "1.0.0",
-                      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                     }
                   }
                 }
               }
             },
             "create-ecdh": {
-              "version": "4.0.0",
-              "from": "create-ecdh@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "4.11.6",
-                  "from": "bn.js@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "elliptic": {
-                  "version": "6.4.0",
-                  "from": "elliptic@>=6.0.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
                   "dependencies": {
                     "brorand": {
-                      "version": "1.1.0",
-                      "from": "brorand@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
                       "version": "1.0.3",
-                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
-                    },
-                    "hmac-drbg": {
-                      "version": "1.0.0",
-                      "from": "hmac-drbg@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz"
-                    },
-                    "minimalistic-assert": {
-                      "version": "1.0.0",
-                      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-                    },
-                    "minimalistic-crypto-utils": {
-                      "version": "1.0.1",
-                      "from": "minimalistic-crypto-utils@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "create-hash": {
-              "version": "1.1.2",
-              "from": "create-hash@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "dependencies": {
-                "cipher-base": {
-                  "version": "1.0.3",
-                  "from": "cipher-base@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
-                },
                 "ripemd160": {
                   "version": "1.0.1",
-                  "from": "ripemd160@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
                 },
                 "sha.js": {
-                  "version": "2.4.8",
-                  "from": "sha.js@>=2.3.6 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+                  "version": "2.4.2",
+                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz"
                 }
               }
             },
             "create-hmac": {
-              "version": "1.1.4",
-              "from": "create-hmac@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
-              "version": "5.0.2",
-              "from": "diffie-hellman@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+              "version": "3.0.2",
+              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "4.11.6",
-                  "from": "bn.js@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "miller-rabin": {
-                  "version": "4.0.0",
-                  "from": "miller-rabin@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
                   "dependencies": {
                     "brorand": {
-                      "version": "1.1.0",
-                      "from": "brorand@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     }
                   }
                 }
               }
             },
             "pbkdf2": {
-              "version": "3.0.9",
-              "from": "pbkdf2@>=3.0.3 <4.0.0",
-              "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
             },
             "public-encrypt": {
-              "version": "4.0.0",
-              "from": "public-encrypt@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "4.11.6",
-                  "from": "bn.js@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "4.0.1",
-                  "from": "browserify-rsa@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "parse-asn1": {
-                  "version": "5.1.0",
-                  "from": "parse-asn1@>=5.0.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "4.9.1",
-                      "from": "asn1.js@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+                      "version": "2.1.2",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
-                    },
-                    "browserify-aes": {
-                      "version": "1.0.6",
-                      "from": "browserify-aes@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
-                      "dependencies": {
-                        "buffer-xor": {
-                          "version": "1.0.3",
-                          "from": "buffer-xor@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
-                        },
-                        "cipher-base": {
-                          "version": "1.0.3",
-                          "from": "cipher-base@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
-                        }
-                      }
-                    },
-                    "evp_bytestokey": {
-                      "version": "1.0.0",
-                      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                     }
                   }
                 }
               }
             },
             "randombytes": {
-              "version": "2.0.3",
-              "from": "randombytes@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             }
           }
         },
         "deep-equal": {
-          "version": "1.0.1",
-          "from": "deep-equal@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
           "version": "1.3.9",
-          "from": "deps-sort@>=1.3.5 <2.0.0",
+          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.3.1",
-              "from": "JSONStream@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.3.0",
-                  "from": "jsonparse@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.2.7 <3.0.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
@@ -610,55 +476,55 @@
           }
         },
         "domain-browser": {
-          "version": "1.1.7",
-          "from": "domain-browser@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+          "version": "1.1.4",
+          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
         },
         "duplexer2": {
           "version": "0.0.2",
-          "from": "duplexer2@>=0.0.2 <0.1.0",
+          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "events": {
           "version": "1.0.2",
-          "from": "events@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
           "version": "4.5.3",
-          "from": "glob@>=4.0.5 <5.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
-              "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "version": "2.0.8",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.6",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "balanced-match@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -666,168 +532,156 @@
               }
             },
             "once": {
-              "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             }
           }
         },
         "has": {
-          "version": "1.0.1",
-          "from": "has@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-          "dependencies": {
-            "function-bind": {
-              "version": "1.1.0",
-              "from": "function-bind@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-            }
-          }
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/has/-/has-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "http-browserify@>=1.4.0 <2.0.0",
+          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
-          "version": "0.0.1",
-          "from": "https-browserify@>=0.0.0 <0.1.0",
-          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+          "version": "0.0.0",
+          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "inherits": {
-          "version": "2.0.3",
-          "from": "inherits@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
-          "version": "6.6.3",
-          "from": "insert-module-globals@>=6.2.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+          "version": "6.5.2",
+          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.3.1",
-              "from": "JSONStream@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.3.0",
-                  "from": "jsonparse@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.2.7 <3.0.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "combine-source-map": {
               "version": "0.6.1",
-              "from": "combine-source-map@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
               "dependencies": {
                 "convert-source-map": {
-                  "version": "1.1.3",
-                  "from": "convert-source-map@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
                 },
                 "inline-source-map": {
                   "version": "0.5.0",
-                  "from": "inline-source-map@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
                 },
                 "lodash.memoize": {
                   "version": "3.0.4",
-                  "from": "lodash.memoize@>=3.0.3 <3.1.0",
+                  "from": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
                 },
                 "source-map": {
-                  "version": "0.4.4",
-                  "from": "source-map@>=0.4.2 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "version": "0.4.3",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.1",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 }
               }
             },
-            "is-buffer": {
-              "version": "1.1.5",
-              "from": "is-buffer@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-            },
             "lexical-scope": {
-              "version": "1.2.0",
-              "from": "lexical-scope@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
               "dependencies": {
                 "astw": {
-                  "version": "2.2.0",
-                  "from": "astw@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                   "dependencies": {
                     "acorn": {
-                      "version": "4.0.11",
-                      "from": "acorn@>=4.0.3 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
+                      "version": "1.2.2",
+                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     }
                   }
                 }
               }
             },
             "process": {
-              "version": "0.11.9",
-              "from": "process@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
+              "version": "0.11.1",
+              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
             },
             "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
-          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
               "version": "1.3.2",
-              "from": "stream-splicer@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
               "dependencies": {
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "readable-wrap@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
@@ -835,69 +689,140 @@
           }
         },
         "module-deps": {
-          "version": "3.9.1",
-          "from": "module-deps@>=3.7.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+          "version": "3.8.1",
+          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.3.1",
-              "from": "JSONStream@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.3.0",
-                  "from": "jsonparse@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz"
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.2.7 <3.0.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "detective": {
-              "version": "4.5.0",
-              "from": "detective@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+              "version": "4.1.1",
+              "from": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "4.0.11",
-                  "from": "acorn@>=4.0.3 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
+                  "version": "1.2.2",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                },
+                "escodegen": {
+                  "version": "1.6.1",
+                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "1.9.3",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                    },
+                    "esutils": {
+                      "version": "1.1.6",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                    },
+                    "esprima": {
+                      "version": "1.2.5",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                    },
+                    "optionator": {
+                      "version": "0.5.0",
+                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                      "dependencies": {
+                        "prelude-ls": {
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                        },
+                        "deep-is": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                        },
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                        },
+                        "type-check": {
+                          "version": "0.3.1",
+                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                        },
+                        "levn": {
+                          "version": "0.2.5",
+                          "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                        },
+                        "fast-levenshtein": {
+                          "version": "1.0.6",
+                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "stream-combiner2@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.17 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                      "version": "1.0.33",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "3.0.0",
-                      "from": "xtend@>=3.0.0 <3.1.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                     }
                   }
@@ -905,236 +830,222 @@
               }
             },
             "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "os-browserify@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "1.0.1",
-          "from": "parents@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.11.15",
-              "from": "path-platform@>=0.11.15 <0.12.0",
+              "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "path-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.10.1",
-          "from": "process@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
           "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "punycode@>=1.2.3 <1.3.0",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@>=1.1.13 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "1.1.13",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
-              "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
-          "version": "1.3.2",
-          "from": "resolve@>=1.1.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-          "dependencies": {
-            "path-parse": {
-              "version": "1.0.5",
-              "from": "path-parse@>=1.0.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
-            }
-          }
+          "version": "1.1.6",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
-          "from": "shallow-copy@0.0.1",
+          "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
-          "version": "1.0.2",
-          "from": "shasum@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
             },
             "sha.js": {
-              "version": "2.4.8",
-              "from": "sha.js@>=2.4.4 <2.5.0",
-              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+              "version": "2.3.6",
+              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
             }
           }
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "shell-quote@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "subarg@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
             }
           }
         },
         "syntax-error": {
-          "version": "1.3.0",
-          "from": "syntax-error@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+          "version": "1.1.4",
+          "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
           "dependencies": {
             "acorn": {
-              "version": "4.0.11",
-              "from": "acorn@>=4.0.3 <5.0.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "through2@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "timers-browserify": {
-          "version": "1.4.2",
-          "from": "timers-browserify@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+          "version": "1.4.1",
+          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
           "dependencies": {
             "process": {
-              "version": "0.11.9",
-              "from": "process@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
+              "version": "0.11.1",
+              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
             }
           }
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "tty-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
           "version": "0.10.3",
-          "from": "url@>=0.10.1 <0.11.0",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             },
             "querystring": {
               "version": "0.2.0",
-              "from": "querystring@0.2.0",
+              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.1 <0.11.0",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "vm-browserify@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "indexof@0.0.1",
+              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "xtend@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
     },
     "chai": {
       "version": "1.10.0",
-      "from": "chai@1.10.0",
+      "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
       "dependencies": {
         "assertion-error": {
           "version": "1.0.0",
-          "from": "assertion-error@1.0.0",
+          "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
         },
         "deep-eql": {
           "version": "0.1.3",
-          "from": "deep-eql@0.1.3",
+          "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
-              "from": "type-detect@0.1.1",
+              "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
             }
           }
@@ -1172,27 +1083,27 @@
     },
     "d3": {
       "version": "3.5.5",
-      "from": "d3@3.5.5",
+      "from": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz"
     },
     "font-awesome": {
       "version": "4.3.0",
-      "from": "font-awesome@4.3.0",
+      "from": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz"
     },
     "iframe-phone": {
       "version": "1.1.3",
-      "from": "../../tmp/npm-6873-f7f6c799/1499449424428-0.8736400809139013/200f47f43ee32d640868072c17de4a675e16d96a",
+      "from": "../../tmp/npm-25360-e04608df/1472064033714-0.5331821811851114/200f47f43ee32d640868072c17de4a675e16d96a",
       "resolved": "git://github.com/concord-consortium/iframe-phone#200f47f43ee32d640868072c17de4a675e16d96a"
     },
     "jquery": {
       "version": "2.1.3",
-      "from": "jquery@2.1.3",
+      "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz"
     },
     "jshint": {
       "version": "2.8.0",
-      "from": "jshint@2.8.0",
+      "from": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
       "dependencies": {
         "cli": {
@@ -1364,136 +1275,136 @@
     },
     "jstify": {
       "version": "0.9.0",
-      "from": "jstify@0.9.0",
+      "from": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
       "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.9.0.tgz",
       "dependencies": {
         "html-minifier": {
           "version": "0.6.9",
-          "from": "html-minifier@>=0.6.8 <0.7.0",
+          "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
           "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
           "dependencies": {
             "change-case": {
               "version": "2.1.6",
-              "from": "change-case@>=2.1.0 <2.2.0",
+              "from": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
               "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
               "dependencies": {
                 "camel-case": {
-                  "version": "1.2.2",
-                  "from": "camel-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz"
                 },
                 "constant-case": {
-                  "version": "1.1.2",
-                  "from": "constant-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.1.tgz"
                 },
                 "dot-case": {
-                  "version": "1.1.2",
-                  "from": "dot-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
                 },
                 "is-lower-case": {
-                  "version": "1.1.3",
-                  "from": "is-lower-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
                 },
                 "is-upper-case": {
-                  "version": "1.1.2",
-                  "from": "is-upper-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
                 },
                 "lower-case": {
-                  "version": "1.1.4",
-                  "from": "lower-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz"
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
                 },
                 "param-case": {
-                  "version": "1.1.2",
-                  "from": "param-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
                 },
                 "pascal-case": {
-                  "version": "1.1.2",
-                  "from": "pascal-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz"
                 },
                 "path-case": {
-                  "version": "1.1.2",
-                  "from": "path-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
                 },
                 "sentence-case": {
-                  "version": "1.1.3",
-                  "from": "sentence-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
                 },
                 "snake-case": {
-                  "version": "1.1.2",
-                  "from": "snake-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
                 },
                 "swap-case": {
-                  "version": "1.1.2",
-                  "from": "swap-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.1.tgz"
                 },
                 "title-case": {
-                  "version": "1.1.2",
-                  "from": "title-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.1.tgz"
                 },
                 "upper-case": {
-                  "version": "1.1.3",
-                  "from": "upper-case@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
                 },
                 "upper-case-first": {
-                  "version": "1.1.2",
-                  "from": "upper-case-first@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz"
                 }
               }
             },
             "clean-css": {
               "version": "2.2.23",
-              "from": "clean-css@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
               "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.2.0",
-                  "from": "commander@>=2.2.0 <2.3.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
                 }
               }
             },
             "cli": {
               "version": "0.6.6",
-              "from": "cli@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.1 <3.3.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.7.3",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                          "version": "2.6.5",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
@@ -1502,61 +1413,61 @@
                 },
                 "exit": {
                   "version": "0.1.2",
-                  "from": "exit@0.1.2",
+                  "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
                 }
               }
             },
             "uglify-js": {
-              "version": "2.4.24",
-              "from": "uglify-js@>=2.4.0 <2.5.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+              "version": "2.4.23",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.34",
-                  "from": "source-map@0.1.34",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.1",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.5.4",
-                  "from": "yargs@>=3.5.4 <3.6.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "decamelize": {
-                      "version": "1.2.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "window-size@0.1.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
@@ -1564,59 +1475,59 @@
               }
             },
             "relateurl": {
-              "version": "0.2.7",
-              "from": "relateurl@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
+              "version": "0.2.6",
+              "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
             }
           }
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "1.0.34",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "version": "1.0.33",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "lodash.escape": {
           "version": "3.0.0",
-          "from": "lodash.escape@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
           "dependencies": {
             "lodash._basetostring": {
               "version": "3.0.1",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
             }
           }
@@ -1625,69 +1536,69 @@
     },
     "jszip": {
       "version": "3.1.3",
-      "from": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
+      "from": "jszip@*",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+          "from": "core-js@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz"
         },
         "es6-promise": {
           "version": "3.0.2",
-          "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "from": "es6-promise@>=3.0.2 <3.1.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
         },
         "lie": {
           "version": "3.1.1",
-          "from": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+          "from": "lie@>=3.1.0 <3.2.0",
           "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
           "dependencies": {
             "immediate": {
               "version": "3.0.6",
-              "from": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+              "from": "immediate@>=3.0.5 <3.1.0",
               "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz"
             }
           }
         },
         "pako": {
           "version": "1.0.5",
-          "from": "https://registry.npmjs.org/pako/-/pako-1.0.5.tgz",
+          "from": "pako@>=1.0.2 <1.1.0",
           "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.5.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "from": "readable-stream@>=2.0.6 <2.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "from": "isarray@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "from": "process-nextick-args@>=1.0.6 <1.1.0",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "from": "util-deprecate@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
@@ -1696,69 +1607,69 @@
     },
     "leaflet": {
       "version": "0.7.3",
-      "from": "leaflet@0.7.3",
+      "from": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
     },
     "leaflet-draw": {
       "version": "0.3.2",
-      "from": "../../tmp/npm-6873-f7f6c799/1499449423894-0.7228874808643013/35f0df26bb8e403b1395a684f8d8a7fa0fae775e",
+      "from": "../../../tmp/npm-18905-e89b6279/1473350151307-0.03946083621121943/35f0df26bb8e403b1395a684f8d8a7fa0fae775e",
       "resolved": "git://github.com/azavea/Leaflet.draw#35f0df26bb8e403b1395a684f8d8a7fa0fae775e"
     },
     "leaflet-plugins": {
       "version": "1.3.8",
-      "from": "../../tmp/npm-6873-f7f6c799/1499449424462-0.2565404491033405/4d077a6f2e8a12ac26955bc80a15148777192530",
+      "from": "../../tmp/npm-5416-4ad39d54/1490301357046-0.16352414642460644/4d077a6f2e8a12ac26955bc80a15148777192530",
       "resolved": "git://github.com/azavea/leaflet-plugins#4d077a6f2e8a12ac26955bc80a15148777192530"
     },
     "leaflet.locatecontrol": {
       "version": "0.43.0",
-      "from": "leaflet.locatecontrol@0.43.0",
+      "from": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz",
       "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz"
     },
     "livereload": {
       "version": "0.3.7",
-      "from": "livereload@0.3.7",
+      "from": "https://registry.npmjs.org/livereload/-/livereload-0.3.7.tgz",
       "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.3.7.tgz",
       "dependencies": {
         "opts": {
-          "version": "1.2.6",
-          "from": "opts@>=1.2.0",
-          "resolved": "https://registry.npmjs.org/opts/-/opts-1.2.6.tgz"
+          "version": "1.2.2",
+          "from": "https://registry.npmjs.org/opts/-/opts-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/opts/-/opts-1.2.2.tgz"
         },
         "websocket.io": {
           "version": "0.2.1",
-          "from": "websocket.io@>=0.1.0",
+          "from": "https://registry.npmjs.org/websocket.io/-/websocket.io-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/websocket.io/-/websocket.io-0.2.1.tgz",
           "dependencies": {
             "debug": {
-              "version": "2.6.3",
-              "from": "debug@*",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.7.2",
-                  "from": "ms@0.7.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "ws": {
               "version": "0.4.20",
-              "from": "ws@0.4.20",
+              "from": "https://registry.npmjs.org/ws/-/ws-0.4.20.tgz",
               "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.20.tgz",
               "dependencies": {
                 "commander": {
                   "version": "0.6.1",
-                  "from": "commander@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                 },
                 "tinycolor": {
                   "version": "0.0.1",
-                  "from": "tinycolor@>=0.0.0 <1.0.0",
+                  "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                 },
                 "options": {
                   "version": "0.0.6",
-                  "from": "options@latest",
+                  "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                 }
               }
@@ -1769,17 +1680,1722 @@
     },
     "lodash": {
       "version": "3.6.0",
-      "from": "lodash@3.6.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
     },
     "minifyify": {
       "version": "7.0.0",
-      "from": "minifyify@7.0.0",
+      "from": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
       "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
       "dependencies": {
         "concat-stream": {
+          "version": "1.5.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+        },
+        "lodash.bind": {
+          "version": "3.1.0",
+          "from": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
+          "dependencies": {
+            "lodash._createwrapper": {
+              "version": "3.0.7",
+              "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                },
+                "lodash._basecreate": {
+                  "version": "3.0.3",
+                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
+                }
+              }
+            },
+            "lodash._replaceholders": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz"
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            }
+          }
+        },
+        "lodash.defaults": {
+          "version": "3.1.2",
+          "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash._createassigner": {
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.9",
+                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            }
+          }
+        },
+        "lodash.foreach": {
+          "version": "3.0.3",
+          "from": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
+          "dependencies": {
+            "lodash._arrayeach": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+            },
+            "lodash._baseeach": {
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+              "dependencies": {
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+            },
+            "lodash.isarray": {
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.4.3",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        },
+        "tmp": {
+          "version": "0.0.25",
+          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz"
+        },
+        "transform-filter": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/transform-filter/-/transform-filter-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/transform-filter/-/transform-filter-0.1.1.tgz",
+          "dependencies": {
+            "multimatch": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+              "dependencies": {
+                "array-differ": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                },
+                "array-union": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.4.23",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.5.4",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                },
+                "decamelize": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "mocha": {
+      "version": "2.0.1",
+      "from": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+        },
+        "debug": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.0.8",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+        },
+        "glob": {
+          "version": "3.2.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "growl": {
+          "version": "1.8.1",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+        },
+        "jade": {
+          "version": "0.26.3",
+          "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        }
+      }
+    },
+    "moment": {
+      "version": "2.10.6",
+      "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+    },
+    "node-sass": {
+      "version": "3.3.2",
+      "from": "https://registry.npmjs.org/node-sass/-/node-sass-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.3.2.tgz",
+      "dependencies": {
+        "async-foreach": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "gaze": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+          "dependencies": {
+            "globule": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                },
+                "glob": {
+                  "version": "3.1.21",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                    },
+                    "inherits": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+        },
+        "glob": {
+          "version": "5.0.14",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            }
+          }
+        },
+        "meow": {
+          "version": "3.3.0",
+          "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "map-obj": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                }
+              }
+            },
+            "indent-string": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+              "dependencies": {
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "nan": {
+          "version": "2.0.9",
+          "from": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
+        },
+        "npmconf": {
+          "version": "2.1.2",
+          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+          "dependencies": {
+            "config-chain": {
+              "version": "1.1.9",
+              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.4",
+                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "ini": {
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+            },
+            "nopt": {
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            },
+            "uid-number": {
+              "version": "0.0.5",
+              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+            }
+          }
+        },
+        "pangyp": {
+          "version": "2.3.2",
+          "from": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.2.tgz",
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.8",
+              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.2",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "4.3.5",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.8",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                }
+              }
+            },
+            "npmlog": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
+              "dependencies": {
+                "ansi": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                },
+                "are-we-there-yet": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "gauge": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
+                  "dependencies": {
+                    "has-unicode": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
+            },
+            "request": {
+              "version": "2.51.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.0.14",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.12.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "semver": {
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            },
+            "tar": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            }
+          }
+        },
+        "request": {
+          "version": "2.62.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.62.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.62.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "1.4.2",
+                  "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.6",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.6.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.18.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.18.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.18.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "5.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+            },
+            "http-signature": {
+              "version": "0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+            },
+            "hawk": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.2",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.2.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.2.tgz"
+                },
+                "boom": {
+                  "version": "2.8.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "har-validator": {
+              "version": "1.8.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+              "dependencies": {
+                "bluebird": {
+                  "version": "2.10.0",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.0.tgz"
+                },
+                "commander": {
+                  "version": "2.8.1",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.12.2",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "sass-graph": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "3.10.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "yargs": {
+              "version": "3.25.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.25.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.0.2",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.0.2",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                },
+                "os-locale": {
+                  "version": "1.4.0",
+                  "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                  "dependencies": {
+                    "lcid": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "window-size": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
+                },
+                "y18n": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/y18n/-/y18n-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "nunjucks": {
+      "version": "1.3.4",
+      "from": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.3.4.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "chokidar": {
+          "version": "0.12.6",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
+          "dependencies": {
+            "readdirp": {
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "nunjucksify": {
+      "version": "0.2.2",
+      "from": "https://registry.npmjs.org/nunjucksify/-/nunjucksify-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/nunjucksify/-/nunjucksify-0.2.2.tgz",
+      "dependencies": {
+        "through": {
+          "version": "2.3.8",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        }
+      }
+    },
+    "papaparse": {
+      "version": "4.2.0",
+      "from": "https://registry.npmjs.org/papaparse/-/papaparse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.2.0.tgz"
+    },
+    "reproject": {
+      "version": "1.1.1",
+      "from": "reproject@*",
+      "resolved": "https://registry.npmjs.org/reproject/-/reproject-1.1.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
+        "concat-stream": {
           "version": "1.6.0",
-          "from": "concat-stream@>=1.4.7 <2.0.0",
+          "from": "concat-stream@>=1.5.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "dependencies": {
             "inherits": {
@@ -1793,13 +3409,13 @@
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
-              "version": "2.2.6",
+              "version": "2.2.9",
               "from": "readable-stream@>=2.2.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
               "dependencies": {
                 "buffer-shims": {
                   "version": "1.0.0",
-                  "from": "buffer-shims@>=1.0.0 <2.0.0",
+                  "from": "buffer-shims@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                 },
                 "core-util-is": {
@@ -1818,9 +3434,9 @@
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "version": "1.0.0",
+                  "from": "string_decoder@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
@@ -1831,2349 +3447,19 @@
             }
           }
         },
-        "convert-source-map": {
-          "version": "1.4.0",
-          "from": "convert-source-map@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz"
-        },
-        "lodash.bind": {
-          "version": "3.1.0",
-          "from": "lodash.bind@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
-          "dependencies": {
-            "lodash._createwrapper": {
-              "version": "3.2.0",
-              "from": "lodash._createwrapper@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.2.0.tgz",
-              "dependencies": {
-                "lodash._root": {
-                  "version": "3.0.1",
-                  "from": "lodash._root@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-                }
-              }
-            },
-            "lodash._replaceholders": {
-              "version": "3.0.0",
-              "from": "lodash._replaceholders@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz"
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-            }
-          }
-        },
-        "lodash.defaults": {
-          "version": "3.1.2",
-          "from": "lodash.defaults@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-          "dependencies": {
-            "lodash.assign": {
-              "version": "3.2.0",
-              "from": "lodash.assign@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-              "dependencies": {
-                "lodash._baseassign": {
-                  "version": "3.2.0",
-                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                    }
-                  }
-                },
-                "lodash._createassigner": {
-                  "version": "3.1.1",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                  "dependencies": {
-                    "lodash._bindcallback": {
-                      "version": "3.0.1",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-                    },
-                    "lodash._isiterateecall": {
-                      "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                    }
-                  }
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1",
-                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.1.0",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-            }
-          }
-        },
-        "lodash.foreach": {
-          "version": "3.0.3",
-          "from": "lodash.foreach@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
-          "dependencies": {
-            "lodash._arrayeach": {
-              "version": "3.0.0",
-              "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
-            },
-            "lodash._baseeach": {
-              "version": "3.0.4",
-              "from": "lodash._baseeach@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
-              "dependencies": {
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1",
-                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.1.0",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1",
-              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-            },
-            "lodash.isarray": {
-              "version": "3.0.4",
-              "from": "lodash.isarray@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.1",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-            }
-          }
-        },
-        "through": {
-          "version": "2.3.8",
-          "from": "through@>=2.3.6 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-        },
-        "tmp": {
-          "version": "0.0.25",
-          "from": "tmp@>=0.0.25 <0.0.26",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz"
-        },
-        "transform-filter": {
-          "version": "0.1.1",
-          "from": "transform-filter@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/transform-filter/-/transform-filter-0.1.1.tgz",
-          "dependencies": {
-            "multimatch": {
-              "version": "2.1.0",
-              "from": "multimatch@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-              "dependencies": {
-                "array-differ": {
-                  "version": "1.0.0",
-                  "from": "array-differ@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-                },
-                "array-union": {
-                  "version": "1.0.2",
-                  "from": "array-union@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-                  "dependencies": {
-                    "array-uniq": {
-                      "version": "1.0.3",
-                      "from": "array-uniq@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
-                    }
-                  }
-                },
-                "arrify": {
-                  "version": "1.0.1",
-                  "from": "arrify@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.3",
-                  "from": "minimatch@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "from": "balanced-match@>=0.4.1 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.14",
-          "from": "uglify-js@>=2.4.16 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.14.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.6",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-            },
-            "yargs": {
-              "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "cliui": {
-                  "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "dependencies": {
-                    "center-align": {
-                      "version": "0.1.3",
-                      "from": "center-align@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "3.1.0",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.5",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.6.1",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                            }
-                          }
-                        },
-                        "lazy-cache": {
-                          "version": "1.0.4",
-                          "from": "lazy-cache@>=1.0.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-                        }
-                      }
-                    },
-                    "right-align": {
-                      "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "3.1.0",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.5",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.6.1",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                },
-                "window-size": {
-                  "version": "0.1.0",
-                  "from": "window-size@0.1.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "mocha": {
-      "version": "2.0.1",
-      "from": "mocha@2.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
-      "dependencies": {
-        "commander": {
-          "version": "2.3.0",
-          "from": "commander@2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-        },
-        "debug": {
-          "version": "2.0.0",
-          "from": "debug@2.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.6.2",
-              "from": "ms@0.6.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-            }
-          }
-        },
-        "diff": {
-          "version": "1.0.8",
-          "from": "diff@1.0.8",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.2",
-          "from": "escape-string-regexp@1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-        },
-        "glob": {
-          "version": "3.2.3",
-          "from": "glob@3.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-          "dependencies": {
-            "minimatch": {
-              "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            }
-          }
-        },
-        "growl": {
-          "version": "1.8.1",
-          "from": "growl@1.8.1",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
-        },
-        "jade": {
-          "version": "0.26.3",
-          "from": "jade@0.26.3",
-          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-          "dependencies": {
-            "commander": {
-              "version": "0.6.1",
-              "from": "commander@0.6.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-            },
-            "mkdirp": {
-              "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        }
-      }
-    },
-    "moment": {
-      "version": "2.10.6",
-      "from": "moment@2.10.6",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
-    },
-    "node-sass": {
-      "version": "3.3.2",
-      "from": "node-sass@3.3.2",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.3.2.tgz",
-      "dependencies": {
-        "async-foreach": {
-          "version": "0.1.3",
-          "from": "async-foreach@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "gaze": {
-          "version": "0.5.2",
-          "from": "gaze@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-          "dependencies": {
-            "globule": {
-              "version": "0.1.0",
-              "from": "globule@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "1.0.2",
-                  "from": "lodash@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                },
-                "glob": {
-                  "version": "3.1.21",
-                  "from": "glob@>=3.1.21 <3.2.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "graceful-fs@>=1.2.0 <1.3.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "1.0.2",
-                      "from": "inherits@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-        },
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.14 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.3",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.6",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "balanced-match@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-            }
-          }
-        },
-        "meow": {
-          "version": "3.7.0",
-          "from": "meow@>=3.3.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "dependencies": {
-            "camelcase-keys": {
-              "version": "2.1.0",
-              "from": "camelcase-keys@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "2.1.1",
-                  "from": "camelcase@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "from": "decamelize@>=1.1.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-            },
-            "loud-rejection": {
-              "version": "1.6.0",
-              "from": "loud-rejection@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-              "dependencies": {
-                "currently-unhandled": {
-                  "version": "0.4.1",
-                  "from": "currently-unhandled@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-                  "dependencies": {
-                    "array-find-index": {
-                      "version": "1.0.2",
-                      "from": "array-find-index@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
-                    }
-                  }
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "from": "signal-exit@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-                }
-              }
-            },
-            "map-obj": {
-              "version": "1.0.1",
-              "from": "map-obj@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-            },
-            "normalize-package-data": {
-              "version": "2.3.6",
-              "from": "normalize-package-data@>=2.3.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-              "dependencies": {
-                "hosted-git-info": {
-                  "version": "2.4.1",
-                  "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz"
-                },
-                "is-builtin-module": {
-                  "version": "1.0.0",
-                  "from": "is-builtin-module@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                  "dependencies": {
-                    "builtin-modules": {
-                      "version": "1.1.1",
-                      "from": "builtin-modules@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "5.3.0",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-                },
-                "validate-npm-package-license": {
-                  "version": "3.0.1",
-                  "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                  "dependencies": {
-                    "spdx-correct": {
-                      "version": "1.0.2",
-                      "from": "spdx-correct@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                      "dependencies": {
-                        "spdx-license-ids": {
-                          "version": "1.2.2",
-                          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-                        }
-                      }
-                    },
-                    "spdx-expression-parse": {
-                      "version": "1.0.4",
-                      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "from": "read-pkg-up@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "dependencies": {
-                "find-up": {
-                  "version": "1.1.2",
-                  "from": "find-up@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                  "dependencies": {
-                    "path-exists": {
-                      "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg": {
-                  "version": "1.1.0",
-                  "from": "read-pkg@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                  "dependencies": {
-                    "load-json-file": {
-                      "version": "1.1.0",
-                      "from": "load-json-file@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.11",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "from": "parse-json@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.1",
-                              "from": "error-ex@>=1.2.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        },
-                        "strip-bom": {
-                          "version": "2.0.0",
-                          "from": "strip-bom@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                          "dependencies": {
-                            "is-utf8": {
-                              "version": "0.2.1",
-                              "from": "is-utf8@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "path-type": {
-                      "version": "1.1.0",
-                      "from": "path-type@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.11",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "redent": {
-              "version": "1.0.0",
-              "from": "redent@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-              "dependencies": {
-                "indent-string": {
-                  "version": "2.1.0",
-                  "from": "indent-string@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                  "dependencies": {
-                    "repeating": {
-                      "version": "2.0.1",
-                      "from": "repeating@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.2",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-indent": {
-                  "version": "1.0.1",
-                  "from": "strip-indent@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                }
-              }
-            },
-            "trim-newlines": {
-              "version": "1.0.0",
-              "from": "trim-newlines@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "nan": {
-          "version": "2.5.1",
-          "from": "nan@>=2.0.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz"
-        },
-        "npmconf": {
-          "version": "2.1.2",
-          "from": "npmconf@>=2.1.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
-          "dependencies": {
-            "config-chain": {
-              "version": "1.1.11",
-              "from": "config-chain@>=1.1.8 <1.2.0",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-              "dependencies": {
-                "proto-list": {
-                  "version": "1.2.4",
-                  "from": "proto-list@>=1.2.1 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "ini": {
-              "version": "1.3.4",
-              "from": "ini@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "from": "nopt@>=3.0.1 <3.1.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.1.0",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "from": "once@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "from": "osenv@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                }
-              }
-            },
-            "semver": {
-              "version": "4.3.6",
-              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-            },
-            "uid-number": {
-              "version": "0.0.5",
-              "from": "uid-number@0.0.5",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
-            }
-          }
-        },
-        "pangyp": {
-          "version": "2.3.3",
-          "from": "pangyp@>=2.3.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.3.tgz",
-          "dependencies": {
-            "fstream": {
-              "version": "1.0.11",
-              "from": "fstream@>=1.0.3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.11",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                }
-              }
-            },
-            "glob": {
-              "version": "4.3.5",
-              "from": "glob@>=4.3.5 <4.4.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.6",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "3.0.11",
-              "from": "graceful-fs@>=3.0.5 <3.1.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-              "dependencies": {
-                "natives": {
-                  "version": "1.1.0",
-                  "from": "natives@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.6",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "balanced-match@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "from": "nopt@>=3.0.1 <3.1.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.1.0",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
-                }
-              }
-            },
-            "npmlog": {
-              "version": "1.0.0",
-              "from": "npmlog@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
-              "dependencies": {
-                "ansi": {
-                  "version": "0.3.1",
-                  "from": "ansi@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
-                },
-                "are-we-there-yet": {
-                  "version": "1.0.6",
-                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "from": "delegates@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "2.2.6",
-                      "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-                      "dependencies": {
-                        "buffer-shims": {
-                          "version": "1.0.0",
-                          "from": "buffer-shims@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                        },
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "from": "isarray@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "gauge": {
-                  "version": "1.0.2",
-                  "from": "gauge@>=1.0.2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
-                  "dependencies": {
-                    "has-unicode": {
-                      "version": "1.0.1",
-                      "from": "has-unicode@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "from": "osenv@>=0.0.0 <1.0.0",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                }
-              }
-            },
-            "request": {
-              "version": "2.51.0",
-              "from": "request@>=2.51.0 <2.52.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-              "dependencies": {
-                "bl": {
-                  "version": "0.9.5",
-                  "from": "bl@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.8.0",
-                  "from": "caseless@>=0.8.0 <0.9.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-                },
-                "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-                },
-                "form-data": {
-                  "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.0.14",
-                      "from": "mime-types@>=2.0.3 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                },
-                "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                },
-                "node-uuid": {
-                  "version": "1.4.8",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
-                },
-                "qs": {
-                  "version": "2.3.3",
-                  "from": "qs@>=2.3.1 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.3",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.4.1",
-                      "from": "punycode@>=1.4.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.5.0",
-                  "from": "oauth-sign@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-                },
-                "hawk": {
-                  "version": "1.1.1",
-                  "from": "hawk@1.1.1",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "0.9.1",
-                      "from": "hoek@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                    },
-                    "boom": {
-                      "version": "0.4.2",
-                      "from": "boom@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "0.2.2",
-                      "from": "cryptiles@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                    },
-                    "sntp": {
-                      "version": "0.2.4",
-                      "from": "sntp@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "rimraf@>=2.2.8 <2.3.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-            },
-            "semver": {
-              "version": "4.3.6",
-              "from": "semver@>=4.3.6 <4.4.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-            },
-            "tar": {
-              "version": "1.0.3",
-              "from": "tar@>=1.0.3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                }
-              }
-            },
-            "which": {
-              "version": "1.0.9",
-              "from": "which@>=1.0.8 <1.1.0",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
-            }
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "from": "request@>=2.61.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "from": "caseless@>=0.12.0 <0.13.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "2.1.2",
-              "from": "form-data@>=2.1.1 <2.2.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "from": "asynckit@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-                }
-              }
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "from": "har-validator@>=4.2.1 <4.3.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-              "dependencies": {
-                "ajv": {
-                  "version": "4.11.5",
-                  "from": "ajv@>=4.9.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "from": "co@>=4.6.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                    },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "from": "jsonify@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "1.0.5",
-                  "from": "har-schema@>=1.0.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                },
-                "jsprim": {
-                  "version": "1.4.0",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.11.0",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-                    },
-                    "getpass": {
-                      "version": "0.1.6",
-                      "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "from": "tweetnacl@>=0.14.0 <0.15.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.14",
-              "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.26.0",
-                  "from": "mime-db@>=1.26.0 <1.27.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "from": "performance-now@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-            },
-            "qs": {
-              "version": "6.4.0",
-              "from": "qs@>=6.4.0 <6.5.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
-              "from": "safe-buffer@>=5.0.1 <6.0.0",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "from": "tough-cookie@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "from": "punycode@>=1.4.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "from": "tunnel-agent@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "from": "uuid@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-            }
-          }
-        },
-        "sass-graph": {
-          "version": "2.1.2",
-          "from": "sass-graph@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "7.1.1",
-              "from": "glob@>=7.0.0 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "from": "fs.realpath@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.3",
-                  "from": "minimatch@>=3.0.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "from": "balanced-match@>=0.4.1 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                }
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "from": "lodash@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-            },
-            "yargs": {
-              "version": "4.8.1",
-              "from": "yargs@>=4.7.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-              "dependencies": {
-                "cliui": {
-                  "version": "3.2.0",
-                  "from": "cliui@>=3.2.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                  "dependencies": {
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                        }
-                      }
-                    },
-                    "wrap-ansi": {
-                      "version": "2.1.0",
-                      "from": "wrap-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "from": "decamelize@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                },
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "from": "get-caller-file@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
-                },
-                "lodash.assign": {
-                  "version": "4.2.0",
-                  "from": "lodash.assign@>=4.0.3 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
-                },
-                "os-locale": {
-                  "version": "1.4.0",
-                  "from": "os-locale@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                  "dependencies": {
-                    "lcid": {
-                      "version": "1.0.0",
-                      "from": "lcid@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                      "dependencies": {
-                        "invert-kv": {
-                          "version": "1.0.0",
-                          "from": "invert-kv@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.2",
-                      "from": "find-up@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.1.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.1.0",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.11",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.1",
-                                  "from": "error-ex@>=1.2.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.1",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.1",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "normalize-package-data": {
-                          "version": "2.3.6",
-                          "from": "normalize-package-data@>=2.3.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-                          "dependencies": {
-                            "hosted-git-info": {
-                              "version": "2.4.1",
-                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz"
-                            },
-                            "is-builtin-module": {
-                              "version": "1.0.0",
-                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                              "dependencies": {
-                                "builtin-modules": {
-                                  "version": "1.1.1",
-                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-                                }
-                              }
-                            },
-                            "semver": {
-                              "version": "5.3.0",
-                              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-                            },
-                            "validate-npm-package-license": {
-                              "version": "3.0.1",
-                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                              "dependencies": {
-                                "spdx-correct": {
-                                  "version": "1.0.2",
-                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                                  "dependencies": {
-                                    "spdx-license-ids": {
-                                      "version": "1.2.2",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-                                    }
-                                  }
-                                },
-                                "spdx-expression-parse": {
-                                  "version": "1.0.4",
-                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.1.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.11",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.1",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "from": "require-directory@>=2.1.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "from": "require-main-filename@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "from": "set-blocking@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "from": "string-width@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "which-module": {
-                  "version": "1.0.0",
-                  "from": "which-module@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
-                },
-                "window-size": {
-                  "version": "0.2.0",
-                  "from": "window-size@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "from": "y18n@>=3.2.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
-                },
-                "yargs-parser": {
-                  "version": "2.4.1",
-                  "from": "yargs-parser@>=2.4.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "3.0.0",
-                      "from": "camelcase@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "nunjucks": {
-      "version": "1.3.4",
-      "from": "nunjucks@1.3.4",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.3.4.tgz",
-      "dependencies": {
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@*",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
-            "minimist": {
-              "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
-          }
-        },
-        "chokidar": {
-          "version": "0.12.6",
-          "from": "chokidar@>=0.12.5 <0.13.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
-          "dependencies": {
-            "readdirp": {
-              "version": "1.3.0",
-              "from": "readdirp@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@>=0.2.12 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "1.0.34",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "async-each": {
-              "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
-            }
-          }
-        }
-      }
-    },
-    "nunjucksify": {
-      "version": "0.2.2",
-      "from": "nunjucksify@0.2.2",
-      "resolved": "https://registry.npmjs.org/nunjucksify/-/nunjucksify-0.2.2.tgz",
-      "dependencies": {
-        "through": {
-          "version": "2.3.8",
-          "from": "through@>=2.3.4 <2.4.0",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-        }
-      }
-    },
-    "papaparse": {
-      "version": "4.2.0",
-      "from": "https://registry.npmjs.org/papaparse/-/papaparse-4.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.2.0.tgz"
-    },
-    "reproject": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/reproject/-/reproject-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/reproject/-/reproject-1.1.1.tgz",
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            },
-            "readable-stream": {
-              "version": "2.2.9",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-              "dependencies": {
-                "buffer-shims": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                },
-                "string_decoder": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
         "proj4": {
           "version": "2.4.3",
-          "from": "https://registry.npmjs.org/proj4/-/proj4-2.4.3.tgz",
+          "from": "proj4@>=2.3.12 <3.0.0",
           "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.4.3.tgz",
           "dependencies": {
             "mgrs": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+              "from": "mgrs@1.0.0",
               "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz"
             },
             "wkt-parser": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.1.3.tgz",
+              "from": "wkt-parser@>=1.1.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.1.3.tgz"
             }
           }
@@ -4182,99 +3468,99 @@
     },
     "retina.js": {
       "version": "1.3.0",
-      "from": "../../tmp/npm-6873-f7f6c799/1499449428774-0.8246659983415157/a70e73639817473bad7bbb33f866b8e060e5f5a7",
+      "from": "../../tmp/npm-25360-e04608df/1472064034211-0.10679260268807411/a70e73639817473bad7bbb33f866b8e060e5f5a7",
       "resolved": "git://github.com/imulus/retinajs#a70e73639817473bad7bbb33f866b8e060e5f5a7"
     },
     "shapefile": {
       "version": "0.6.2",
-      "from": "shapefile@0.6.2",
+      "from": "https://registry.npmjs.org/shapefile/-/shapefile-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/shapefile/-/shapefile-0.6.2.tgz",
       "dependencies": {
         "array-source": {
           "version": "0.0.3",
-          "from": "array-source@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/array-source/-/array-source-0.0.3.tgz",
           "resolved": "https://registry.npmjs.org/array-source/-/array-source-0.0.3.tgz"
         },
         "commander": {
           "version": "2.9.0",
-          "from": "commander@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
+              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "path-source": {
           "version": "0.1.2",
-          "from": "path-source@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/path-source/-/path-source-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/path-source/-/path-source-0.1.2.tgz",
           "dependencies": {
             "file-source": {
               "version": "0.6.1",
-              "from": "file-source@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/file-source/-/file-source-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/file-source/-/file-source-0.6.1.tgz"
             }
           }
         },
         "slice-source": {
           "version": "0.4.1",
-          "from": "slice-source@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz"
         },
         "stream-source": {
           "version": "0.3.4",
-          "from": "stream-source@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/stream-source/-/stream-source-0.3.4.tgz",
           "resolved": "https://registry.npmjs.org/stream-source/-/stream-source-0.3.4.tgz"
         },
         "text-encoding": {
           "version": "0.6.1",
-          "from": "text-encoding@0.6.1",
+          "from": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.1.tgz"
         }
       }
     },
     "sinon": {
       "version": "1.14.1",
-      "from": "sinon@1.14.1",
+      "from": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
-          "from": "formatio@1.1.1",
+          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "dependencies": {
             "samsam": {
-              "version": "1.1.3",
-              "from": "samsam@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.3.tgz"
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.3 <1.0.0",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "lolex": {
           "version": "1.1.0",
-          "from": "lolex@1.1.0",
+          "from": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
         }
       }
     },
     "testem": {
       "version": "0.5.15",
-      "from": "testem@0.5.15",
+      "from": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
       "resolved": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
       "dependencies": {
         "express": {
@@ -4353,64 +3639,64 @@
         },
         "mustache": {
           "version": "0.4.0",
-          "from": "mustache@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz"
         },
         "socket.io": {
           "version": "0.9.17",
-          "from": "socket.io@>=0.9.13 <0.10.0",
+          "from": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
-              "from": "socket.io-client@0.9.16",
+              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.5",
-                  "from": "uglify-js@1.2.5",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "ws@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "commander@>=2.1.0 <2.2.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "nan@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
+                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     }
                   }
                 },
                 "xmlhttprequest": {
                   "version": "1.4.2",
-                  "from": "xmlhttprequest@1.4.2",
+                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
-                  "from": "active-x-obfuscator@0.0.1",
+                  "from": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
-                      "from": "zeparser@0.0.5",
+                      "from": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
@@ -4419,59 +3705,59 @@
             },
             "policyfile": {
               "version": "0.0.4",
-              "from": "policyfile@0.0.4",
+              "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
             },
             "base64id": {
               "version": "0.1.0",
-              "from": "base64id@0.1.0",
+              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
-              "from": "redis@0.7.3",
+              "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
               "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
         "winston": {
           "version": "0.7.3",
-          "from": "winston@>=0.7.1 <0.8.0",
+          "from": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "dependencies": {
             "cycle": {
               "version": "1.0.3",
-              "from": "cycle@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "pkginfo": {
-              "version": "0.3.1",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "request": {
               "version": "2.16.6",
-              "from": "request@>=2.16.0 <2.17.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "dependencies": {
                 "form-data": {
                   "version": "0.0.10",
-                  "from": "form-data@>=0.0.3 <0.1.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
@@ -4480,174 +3766,174 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.7 <1.3.0",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "hawk": {
                   "version": "0.10.2",
-                  "from": "hawk@>=0.10.2 <0.11.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.7.6",
-                      "from": "hoek@>=0.7.0 <0.8.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
                     },
                     "boom": {
                       "version": "0.3.8",
-                      "from": "boom@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
                     },
                     "cryptiles": {
                       "version": "0.1.3",
-                      "from": "cryptiles@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
                     },
                     "sntp": {
                       "version": "0.1.4",
-                      "from": "sntp@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
                     }
                   }
                 },
                 "node-uuid": {
-                  "version": "1.4.8",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
+                  "version": "1.4.3",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.2.0",
-                  "from": "cookie-jar@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
                 },
                 "aws-sign": {
                   "version": "0.2.0",
-                  "from": "aws-sign@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.2.0",
-                  "from": "oauth-sign@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.2.0",
-                  "from": "forever-agent@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.2.0",
-                  "from": "tunnel-agent@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "3.0.0",
-                  "from": "json-stringify-safe@>=3.0.0 <3.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
                 },
                 "qs": {
                   "version": "0.5.6",
-                  "from": "qs@>=0.5.4 <0.6.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
                 }
               }
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
         },
         "charm": {
           "version": "0.0.8",
-          "from": "charm@>=0.0.5 <0.1.0",
+          "from": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "js-yaml@>=2.1.0 <2.2.0",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "tap": {
           "version": "0.4.13",
-          "from": "tap@>=0.4.4 <0.5.0",
+          "from": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
           "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
           "dependencies": {
             "buffer-equal": {
-              "version": "0.0.2",
-              "from": "buffer-equal@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.2.tgz"
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
             },
             "deep-equal": {
               "version": "0.0.0",
-              "from": "deep-equal@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
             },
             "difflet": {
               "version": "0.2.6",
-              "from": "difflet@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
               "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
               "dependencies": {
                 "traverse": {
                   "version": "0.6.6",
-                  "from": "traverse@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
                   "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
                 },
                 "charm": {
                   "version": "0.1.2",
-                  "from": "charm@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -4655,57 +3941,57 @@
               }
             },
             "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@*",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nopt": {
               "version": "2.2.1",
-              "from": "nopt@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.1.0",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "runforcover": {
               "version": "0.0.2",
-              "from": "runforcover@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
               "dependencies": {
                 "bunker": {
                   "version": "0.1.2",
-                  "from": "bunker@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                   "dependencies": {
                     "burrito": {
                       "version": "0.2.12",
-                      "from": "burrito@>=0.2.5 <0.3.0",
+                      "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                       "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.5.2",
-                          "from": "traverse@>=0.5.1 <0.6.0",
+                          "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                         },
                         "uglify-js": {
                           "version": "1.1.1",
-                          "from": "uglify-js@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                         }
                       }
@@ -4716,105 +4002,105 @@
             },
             "slide": {
               "version": "1.1.6",
-              "from": "slide@*",
+              "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
             },
             "yamlish": {
               "version": "0.0.7",
-              "from": "yamlish@*",
+              "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz"
             }
           }
         },
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@*",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "2.8.1",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
+              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
-              "version": "1.0.2",
-              "from": "inherits@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "backbone": {
           "version": "1.0.0",
-          "from": "backbone@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz"
         },
         "styled_string": {
           "version": "0.0.1",
-          "from": "styled_string@*",
+          "from": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "fileset": {
           "version": "0.1.8",
-          "from": "fileset@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
           "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.4.0",
-              "from": "minimatch@>=0.0.0 <1.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -4823,37 +4109,37 @@
         },
         "growl": {
           "version": "1.7.0",
-          "from": "growl@>=1.7.0 <1.8.0",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
         },
         "consolidate": {
           "version": "0.8.0",
-          "from": "consolidate@>=0.8.0 <0.9.0",
+          "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz",
           "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz"
         },
         "did_it_work": {
           "version": "0.0.6",
-          "from": "did_it_work@>=0.0.5 <0.1.0",
+          "from": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz"
         },
         "fireworm": {
           "version": "0.4.4",
-          "from": "fireworm@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.9 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -4864,17 +4150,17 @@
     },
     "turf-area": {
       "version": "1.1.1",
-      "from": "turf-area@1.1.1",
+      "from": "https://registry.npmjs.org/turf-area/-/turf-area-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/turf-area/-/turf-area-1.1.1.tgz",
       "dependencies": {
         "geojson-area": {
-          "version": "0.2.1",
-          "from": "geojson-area@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.2.1.tgz",
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.2.0.tgz",
           "dependencies": {
             "wgs84": {
               "version": "0.0.0",
-              "from": "wgs84@0.0.0",
+              "from": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz"
             }
           }
@@ -4883,19 +4169,19 @@
     },
     "turf-bbox-polygon": {
       "version": "1.0.1",
-      "from": "turf-bbox-polygon@1.0.1",
+      "from": "https://registry.npmjs.org/turf-bbox-polygon/-/turf-bbox-polygon-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/turf-bbox-polygon/-/turf-bbox-polygon-1.0.1.tgz",
       "dependencies": {
         "turf-polygon": {
           "version": "1.0.3",
-          "from": "turf-polygon@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz"
         }
       }
     },
     "turf-centroid": {
       "version": "3.0.12",
-      "from": "turf-centroid@3.0.12",
+      "from": "turf-centroid@*",
       "resolved": "https://registry.npmjs.org/turf-centroid/-/turf-centroid-3.0.12.tgz",
       "dependencies": {
         "turf-meta": {
@@ -4912,18 +4198,18 @@
     },
     "turf-destination": {
       "version": "1.2.1",
-      "from": "turf-destination@1.2.1",
+      "from": "https://registry.npmjs.org/turf-destination/-/turf-destination-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/turf-destination/-/turf-destination-1.2.1.tgz",
       "dependencies": {
         "turf-point": {
           "version": "2.0.1",
-          "from": "turf-point@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/turf-point/-/turf-point-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/turf-point/-/turf-point-2.0.1.tgz",
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
             }
           }
         }
@@ -4931,7 +4217,7 @@
     },
     "turf-erase": {
       "version": "1.3.2",
-      "from": "turf-erase@1.3.2",
+      "from": "https://registry.npmjs.org/turf-erase/-/turf-erase-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/turf-erase/-/turf-erase-1.3.2.tgz",
       "dependencies": {
         "jsts": {
@@ -4948,14 +4234,14 @@
         },
         "turf-featurecollection": {
           "version": "1.0.1",
-          "from": "turf-featurecollection@1.0.1",
+          "from": "https://registry.npmjs.org/turf-featurecollection/-/turf-featurecollection-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/turf-featurecollection/-/turf-featurecollection-1.0.1.tgz"
         }
       }
     },
     "turf-intersect": {
       "version": "1.4.2",
-      "from": "turf-intersect@1.4.2",
+      "from": "https://registry.npmjs.org/turf-intersect/-/turf-intersect-1.4.2.tgz",
       "resolved": "https://registry.npmjs.org/turf-intersect/-/turf-intersect-1.4.2.tgz",
       "dependencies": {
         "jsts": {
@@ -4974,104 +4260,87 @@
     },
     "turf-kinks": {
       "version": "3.0.12",
-      "from": "turf-kinks@3.0.12",
+      "from": "https://registry.npmjs.org/turf-kinks/-/turf-kinks-3.0.12.tgz",
       "resolved": "https://registry.npmjs.org/turf-kinks/-/turf-kinks-3.0.12.tgz",
       "dependencies": {
         "turf-helpers": {
           "version": "3.0.12",
-          "from": "turf-helpers@>=3.0.12 <4.0.0",
+          "from": "https://registry.npmjs.org/turf-helpers/-/turf-helpers-3.0.12.tgz",
           "resolved": "https://registry.npmjs.org/turf-helpers/-/turf-helpers-3.0.12.tgz"
         }
       }
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "underscore@1.8.3",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "watchify": {
       "version": "3.1.0",
-      "from": "watchify@3.1.0",
+      "from": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
       "dependencies": {
         "chokidar": {
-          "version": "1.6.1",
-          "from": "chokidar@>=1.0.0-rc4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
-                "arrify": {
-                  "version": "1.0.1",
-                  "from": "arrify@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-                },
                 "micromatch": {
-                  "version": "2.3.11",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                  "version": "2.1.6",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
                   "dependencies": {
                     "arr-diff": {
-                      "version": "2.0.0",
-                      "from": "arr-diff@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
-                        "arr-flatten": {
-                          "version": "1.0.1",
-                          "from": "arr-flatten@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                        "array-slice": {
+                          "version": "0.2.3",
+                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
-                    "array-unique": {
-                      "version": "0.2.1",
-                      "from": "array-unique@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-                    },
                     "braces": {
-                      "version": "1.8.5",
-                      "from": "braces@>=1.8.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                      "version": "1.8.0",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
-                          "version": "1.8.2",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                          "version": "1.8.1",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
-                              "version": "2.2.3",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                              "version": "2.2.2",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
-                                  "version": "2.1.0",
-                                  "from": "is-number@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                  "version": "1.1.2",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
-                                  "version": "2.1.0",
-                                  "from": "isobject@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                                  "dependencies": {
-                                    "isarray": {
-                                      "version": "1.0.0",
-                                      "from": "isarray@1.0.0",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                                    }
-                                  }
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.1.tgz"
                                 },
                                 "randomatic": {
-                                  "version": "1.1.6",
-                                  "from": "randomatic@>=1.1.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz"
+                                  "version": "1.1.0",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
-                                  "version": "1.6.1",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                  "version": "1.5.2",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
                             }
@@ -5079,114 +4348,102 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
-                    "expand-brackets": {
-                      "version": "0.1.5",
-                      "from": "expand-brackets@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
-                        "is-posix-bracket": {
-                          "version": "0.1.1",
-                          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
-                    "extglob": {
-                      "version": "0.3.2",
-                      "from": "extglob@>=0.3.1 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                    "expand-brackets": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    },
                     "kind-of": {
-                      "version": "3.1.0",
-                      "from": "kind-of@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                      "dependencies": {
-                        "is-buffer": {
-                          "version": "1.1.5",
-                          "from": "is-buffer@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                        }
-                      }
-                    },
-                    "normalize-path": {
-                      "version": "2.0.1",
-                      "from": "normalize-path@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
-                      "version": "2.0.1",
-                      "from": "object.omit@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                      "version": "0.2.1",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "dependencies": {
                         "for-own": {
-                          "version": "0.1.5",
-                          "from": "for-own@>=0.1.4 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
-                              "version": "1.0.2",
-                              "from": "for-in@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+                              "version": "0.1.4",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
-                        "is-extendable": {
-                          "version": "0.1.1",
-                          "from": "is-extendable@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                        "isobject": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                         }
                       }
                     },
                     "parse-glob": {
-                      "version": "3.0.4",
-                      "from": "parse-glob@>=3.0.4 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
-                          "version": "0.3.0",
-                          "from": "glob-base@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
-                          "version": "1.0.2",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
-                      "version": "0.4.3",
-                      "from": "regex-cache@>=0.4.2 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -5195,125 +4452,96 @@
                 }
               }
             },
+            "arrify": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+            },
             "async-each": {
-              "version": "1.0.1",
-              "from": "async-each@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+              "version": "0.1.6",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
-              "version": "2.0.0",
-              "from": "glob-parent@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
-                  "version": "1.8.0",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
-              "version": "2.0.1",
-              "from": "is-glob@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "dependencies": {
-                "is-extglob": {
-                  "version": "1.0.0",
-                  "from": "is-extglob@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                }
-              }
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             },
             "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
-              "version": "2.1.0",
-              "from": "readdirp@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "4.1.11",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
-                  "version": "3.0.3",
-                  "from": "minimatch@>=3.0.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "version": "0.2.14",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "from": "balanced-match@>=0.4.1 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
+                    "lru-cache": {
+                      "version": "2.6.5",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-stream": {
-                  "version": "2.2.6",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "from": "buffer-shims@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                    },
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
-                },
-                "set-immediate-shim": {
-                  "version": "1.0.1",
-                  "from": "set-immediate-shim@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
                 }
               }
             }
@@ -5321,37 +4549,37 @@
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "outpipe": {
           "version": "1.1.1",
-          "from": "outpipe@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
           "dependencies": {
             "shell-quote": {
-              "version": "1.6.1",
-              "from": "shell-quote@>=1.4.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+              "version": "1.4.3",
+              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "array-filter": {
                   "version": "0.0.1",
-                  "from": "array-filter@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                 },
                 "array-reduce": {
                   "version": "0.0.0",
-                  "from": "array-reduce@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
                 },
                 "array-map": {
                   "version": "0.0.0",
-                  "from": "array-map@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                 }
               }
@@ -5360,42 +4588,42 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "1.0.34",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "version": "1.0.33",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
           }
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "version": "4.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }
     }


### PR DESCRIPTION
## Overview

Partially reverts 91e7c54 and selectively applies changes. The NPM shrinkwrap update had been overly aggressive and changed libraries unrelated to Clipboard copying. Specifically, [`updateModificationHash`](https://github.com/WikiWatershed/model-my-watershed/blob/7c81929273fcb5878999092cc3b1fcb29abff36e/src/mmw/js/src/modeling/models.js#L846) was generating a different hash because the rounding of numbers had subtly changed:

```diff
--- 
+++ 
@@ -1,13 +1,13 @@
 [
   [
     {
-      "area": 44.42257988387458
+      "area": 44.422579883894436
     },
     {
-      "effectiveArea": 44.42257988387458
+      "effectiveArea": 44.422579883894436
     },
     {
       "effectiveShape": [
         {
           "geometry": [
             {
```

which led to a different hash being generated in Jenkins http://civicci01.internal.azavea.com/job/model-my-watershed-develop/750/console:

```
not ok 97 Firefox 54.0 - Modeling Models ScenarioModel #updateModificationHash generates and sets modification_hash based on the scenario's modifications
    ---
        message: >
            expected 'ca1872c7647c7cb9a7f0a00b683407df' to equal '582b6178186440159bd4ea25f0260892'
    ...
```

By hand picking the updated libraries and keeping the rest the same, we ensure that the calculation integrity is maintained.

The diff might not be readable in GitHub, but if we look at changes in this file from before it was updated and this branch, we see it is much more specific and manageable:

```bash
git diff 2902441..63434d6 src/mmw/npm-shrinkwrap.json
```

```diff
diff --git a/src/mmw/npm-shrinkwrap.json b/src/mmw/npm-shrinkwrap.json
index 3eaf69e..7e42a7e 100644
--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -1052,6 +1052,35 @@
         }
       }
     },
+    "clipboard": {
+      "version": "1.7.1",
+      "from": "clipboard@*",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+      "dependencies": {
+        "good-listener": {
+          "version": "1.2.2",
+          "from": "good-listener@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+          "dependencies": {
+            "delegate": {
+              "version": "3.1.3",
+              "from": "delegate@>=3.1.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.3.tgz"
+            }
+          }
+        },
+        "select": {
+          "version": "1.1.2",
+          "from": "select@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz"
+        },
+        "tiny-emitter": {
+          "version": "2.0.1",
+          "from": "tiny-emitter@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.1.tgz"
+        }
+      }
+    },
     "d3": {
       "version": "3.5.5",
       "from": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz",
@@ -4597,11 +4626,6 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }
-    },
-    "zeroclipboard": {
-      "version": "2.2.0",
-      "from": "https://registry.npmjs.org/zeroclipboard/-/zeroclipboard-2.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/zeroclipboard/-/zeroclipboard-2.2.0.tgz"
     }
   }
 }
```

### Notes

There is a further failing test in Testem in Chrome that doesn't fail in other environments. That has not been fixed here.

## Testing Instructions

 * Check out this branch
 * Delete your `node_modules` folder: `vagrant ssh app -c 'cd /opt/app && rm -rf node_modules'`
 * Install new npm modules: `./scripts/npm.sh install`
 * Bundle: `./scripts/bundle.sh --tests --vendor`
 * Run Testem `./scripts/testem.sh` and ensure that [this test](http://localhost:7357/test.html?grep=Modeling%20Models%20ScenarioModel%20%23updateModificationHash%20generates%20and%20sets%20modification_hash%20based%20on%20the%20scenario%27s%20modifications) passes
 * Run `./scripts/test.sh` and ensure that everything passes