### PR TITLE
Fix scenario share links

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -696,7 +696,7 @@ var GwlfeToolbarView = ScenarioModelToolbarView.extend({
 
     ui: {
         thumb: '#gwlfe-modifications-bar .thumb',
-        deleteButton: '.delete-button',
+        deleteButton: '.delete-modification',
         closeButton: 'button.close'
     },
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -378,10 +378,13 @@ var ScenarioDropDownMenuOptionsView = Marionette.ItemView.extend({
     },
 
     showShareModal: function() {
-        var share = new modalViews.ShareView({
+        var link = window.location.origin +
+                   '/project/' + App.currentProject.id +
+                   '/scenario/' + this.model.get('id'),
+            share = new modalViews.ShareView({
                 model: new modalModels.ShareModel({
                     text: 'Scenario',
-                    url: window.location.href,
+                    url: link,
                     guest: App.user.get('guest'),
                     is_private: App.currentProject.get('is_private')
                 }),


### PR DESCRIPTION
## Overview

Previously the scenario share modal would show the current URL of the page. This was okay when the scenarios were tabs, and only the active scenario had a context menu. However, since now any scenario can have context menu, we needed to update the share modal to show the right link, even when the selected scenario is not currently active on the page.

Also fixes modification deletion in GWLF-E.

Connects #2025 
Connects #1982

## Testing Instructions

 * Check out this branch, run `bundle`
 * Go to a TR-55 project. Ensure there are multiple scenarios.
 * Try sharing an active scenario. Ensure the URL is correct.
 * Try sharing an inactive scenario. Ensure the URL is correct.
 * Try pasting the URL in a new tab / window. Ensure the page loads correctly.