### PR TITLE
On draw error, keep draw tools enabled

### DIFF
--- a/src/mmw/js/src/draw/models.js
+++ b/src/mmw/js/src/draw/models.js
@@ -13,7 +13,8 @@ var ToolbarModel = Backbone.Model.extend({
         pollError: false,
         activeDrawTool: null,
         activeDrawToolItem: null,
-        openDrawTool: null
+        openDrawTool: null,
+        leafletDrawTool: null,
     },
 
     reset: function() {
@@ -45,6 +46,13 @@ var ToolbarModel = Backbone.Model.extend({
         if (map && this.has('rwd-original-point')) {
             map.removeLayer(this.get('rwd-original-point'));
             this.unset('rwd-original-point');
+        }
+    },
+
+    disableLeafletDrawTool: function() {
+        var leafletDrawTool = this.get('leafletDrawTool');
+        if (leafletDrawTool) {
+            leafletDrawTool.disable();
         }
     }
 });

--- a/src/mmw/js/src/draw/tests.js
+++ b/src/mmw/js/src/draw/tests.js
@@ -6,7 +6,6 @@ var $ = require('jquery'),
     _ = require('underscore'),
     L = require('leaflet'),
     assert = require('chai').assert,
-    sinon = require('sinon'),
     Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
     models = require('./models'),
@@ -172,13 +171,12 @@ describe('Draw', function() {
         });
 
         it('removes in progress drawing on Reset', function() {
-            var setup = setupResetTestObject(),
-                spy = sinon.spy(utils, 'cancelDrawing');
+            var setup = setupResetTestObject();
 
-            utils.drawPolygon(setup.map);
+            utils.drawPolygon(setup.map, setup.view.model);
             setup.view.resetDrawingState();
 
-            assert.equal(spy.callCount, 1);
+            assert.equal(setup.view.model.get('leafletDrawTool')._enabled, false);
         });
     });
 });

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -18,28 +18,23 @@ var polygonDefaults = {
         color: '#E77471'
     };
 
-function drawPolygon(map, drawOpts) {
+function drawPolygon(map, drawModel, drawOpts) {
     var defer = $.Deferred(),
         tool = new L.Draw.Polygon(map, {
             allowIntersection: false,
             shapeOptions: _.defaults(drawOpts || {}, polygonDefaults)
         }),
-        clearEvents = function() {
-            map.off('draw:created');
-            map.off('draw:drawstop');
-        },
         drawCreated = function(e) {
             var layer = e.layer,
                 shape = layer.toGeoJSON();
-            clearEvents();
             defer.resolve(shape);
         },
         drawStop = function() {
             tool.disable();
-            clearEvents();
             defer.reject(CANCEL_DRAWING);
         };
 
+    drawModel.set('leafletDrawTool', tool);
     cancelDrawing(map);
 
     map.on('draw:created', drawCreated);
@@ -49,7 +44,7 @@ function drawPolygon(map, drawOpts) {
     return defer.promise();
 }
 
-function placeMarker(map, drawOpts) {
+function placeMarker(map, drawModel, drawOpts) {
     var defer = $.Deferred(),
         tool = new L.Draw.Marker(map, { shapeOptions: drawOpts || {}}),
         clearEvents = function() {
@@ -67,6 +62,7 @@ function placeMarker(map, drawOpts) {
             defer.reject(CANCEL_DRAWING);
         };
 
+    drawModel.set('leafletDrawTool', tool);
     cancelDrawing(map);
 
     map.on('draw:created', drawCreated);
@@ -86,6 +82,11 @@ function createRwdMarkerIcon(iconName) {
 // Cancel any previous draw action in progress.
 function cancelDrawing(map) {
     map.fire('draw:drawstop');
+}
+
+function removeDrawEventListeners(map) {
+    map.off('draw:created');
+    map.off('draw:drawstop');
 }
 
 function getGeoJsonLatLngs(shape) {
@@ -164,6 +165,7 @@ module.exports = {
     placeMarker: placeMarker,
     createRwdMarkerIcon: createRwdMarkerIcon,
     cancelDrawing: cancelDrawing,
+    removeDrawEventListeners: removeDrawEventListeners,
     polygonDefaults: polygonDefaults,
     shapeBoundingBoxArea: shapeBoundingBoxArea,
     isValidForAnalysis: isValidForAnalysis,


### PR DESCRIPTION
## Overview

When canceling a draw session (pressing ESC or drawing an invalid AoI) the map would end up in a bad state where the draw tool view was still open, but the tool was no longer enabled. Now when we cancel the draw, we re-enable the same draw tool, and don't clear the event listeners. 

Connects #2031 

### Demo

![e7zqz4t7mf](https://user-images.githubusercontent.com/7633670/28227345-8877ce6a-68a7-11e7-996c-04976d34e033.gif)

## Testing Instructions

 * Try to draw a shape the size of the states
    * Confirm you can try to draw again after you cancel the Too Big AoI Modal
 * Start to draw a shape but before finished it, press the escape key
    * Confirm you can go right back to drawing a shape
 * Press the escape key while using the Select square km tool — confirm it does nothing
 * Confirm canceling the draw tool with the "x", drawing valid AoIs, and selecting boundaryies still work
