### PR TITLE
BiG-CZ Refactor Back-end

### DIFF
--- a/src/mmw/apps/bigcz/clients/__init__.py
+++ b/src/mmw/apps/bigcz/clients/__init__.py
@@ -3,11 +3,22 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from apps.bigcz.clients import hydroshare, cuahsi, cinergi
+from apps.bigcz.clients import cinergi, hydroshare, cuahsi
 
-
-SEARCH_FUNCTIONS = {
-    hydroshare.CATALOG_NAME: hydroshare.search,
-    cuahsi.CATALOG_NAME: cuahsi.search,
-    cinergi.CATALOG_NAME: cinergi.search,
+CATALOGS = {
+    cinergi.CATALOG_NAME: {
+        'model': cinergi.model,
+        'serializer': cinergi.serializer,
+        'search': cinergi.search,
+    },
+    hydroshare.CATALOG_NAME: {
+        'model': hydroshare.model,
+        'serializer': hydroshare.serializer,
+        'search': hydroshare.search,
+    },
+    cuahsi.CATALOG_NAME: {
+        'model': cuahsi.model,
+        'serializer': cuahsi.serializer,
+        'search': cuahsi.search,
+    },
 }

--- a/src/mmw/apps/bigcz/clients/cinergi/__init__.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from apps.bigcz.models import Resource
+from apps.bigcz.serializers import ResourceSerializer
+
+# Import catalog name and search function, so it can be exported from here
+from apps.bigcz.clients.cinergi.search import CATALOG_NAME, search  # NOQA
+
+model = Resource
+serializer = ResourceSerializer

--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -14,7 +14,7 @@ from apps.bigcz.utils import RequestTimedOutError
 
 
 CATALOG_NAME = 'cinergi'
-GEOPORTAL_URL = 'http://132.249.238.169:8080/geoportal/opensearch'
+CATALOG_URL = 'http://132.249.238.169:8080/geoportal/opensearch'
 
 
 def parse_date(value):
@@ -132,7 +132,7 @@ def search(**kwargs):
         })
 
     try:
-        response = requests.get(GEOPORTAL_URL,
+        response = requests.get(CATALOG_URL,
                                 timeout=settings.BIGCZ_CLIENT_TIMEOUT,
                                 params=params)
     except requests.Timeout:

--- a/src/mmw/apps/bigcz/clients/cuahsi/__init__.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/__init__.py
@@ -3,11 +3,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from apps.bigcz.models import Resource
-from apps.bigcz.serializers import ResourceSerializer
+from apps.bigcz.clients.cuahsi.models import CuahsiResource
+from apps.bigcz.clients.cuahsi.serializers import CuahsiResourceSerializer
 
 # Import catalog name and search function, so it can be exported from here
 from apps.bigcz.clients.cuahsi.search import CATALOG_NAME, search  # NOQA
 
-model = Resource
-serializer = ResourceSerializer
+model = CuahsiResource
+serializer = CuahsiResourceSerializer

--- a/src/mmw/apps/bigcz/clients/cuahsi/__init__.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from apps.bigcz.models import Resource
+from apps.bigcz.serializers import ResourceSerializer
+
+# Import catalog name and search function, so it can be exported from here
+from apps.bigcz.clients.cuahsi.search import CATALOG_NAME, search  # NOQA
+
+model = Resource
+serializer = ResourceSerializer

--- a/src/mmw/apps/bigcz/clients/cuahsi/models.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/models.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from apps.bigcz.models import Resource
+
+
+class CuahsiResource(Resource):
+    def __init__(self, id, description, author, links, title,
+                 created_at, updated_at, geom, test_field):
+        super(CuahsiResource, self).__init__(id, description, author, links,
+                                             title, created_at, updated_at,
+                                             geom)
+
+        self.test_field = test_field

--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -13,8 +13,10 @@ from django.contrib.gis.geos import Point
 
 from django.conf import settings
 
-from apps.bigcz.models import Resource, ResourceLink, ResourceList, BBox
+from apps.bigcz.models import ResourceLink, ResourceList, BBox
 from apps.bigcz.utils import parse_date, RequestTimedOutError
+
+from apps.bigcz.clients.cuahsi.models import CuahsiResource
 
 
 SQKM_PER_SQM = 0.000001
@@ -65,7 +67,7 @@ def parse_record(record, service):
     if details_url:
         links.append(ResourceLink('details', details_url))
 
-    return Resource(
+    return CuahsiResource(
         id=record['location'],
         title=record['Sitename'],
         description=service['aabstract'],
@@ -73,7 +75,8 @@ def parse_record(record, service):
         links=links,
         created_at=record['beginDate'],
         updated_at=None,
-        geom=geom)
+        geom=geom,
+        test_field="hello world")
 
 
 def find_service(services, service_code):

--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -20,7 +20,7 @@ from apps.bigcz.utils import parse_date, RequestTimedOutError
 SQKM_PER_SQM = 0.000001
 MAX_AREA_SQKM = 1500
 CATALOG_NAME = 'cuahsi'
-SOAP_URL = 'http://hiscentral.cuahsi.org/webservices/hiscentral.asmx?WSDL'
+CATALOG_URL = 'http://hiscentral.cuahsi.org/webservices/hiscentral.asmx?WSDL'
 
 
 DATE_MIN = date(1900, 1, 1)
@@ -28,7 +28,7 @@ DATE_MAX = date(2100, 1, 1)
 DATE_FORMAT = '%m/%d/%Y'
 
 
-client = Client(SOAP_URL, timeout=settings.BIGCZ_CLIENT_TIMEOUT)
+client = Client(CATALOG_URL, timeout=settings.BIGCZ_CLIENT_TIMEOUT)
 
 
 def parse_geom(record):

--- a/src/mmw/apps/bigcz/clients/cuahsi/serializers.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/serializers.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from rest_framework.serializers import CharField
+
+from apps.bigcz.serializers import ResourceSerializer
+
+
+class CuahsiResourceSerializer(ResourceSerializer):
+    test_field = CharField()

--- a/src/mmw/apps/bigcz/clients/hydroshare/__init__.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from apps.bigcz.models import Resource
+from apps.bigcz.serializers import ResourceSerializer
+
+# Import catalog name and search function, so it can be exported from here
+from apps.bigcz.clients.hydroshare.search import CATALOG_NAME, search  # NOQA
+
+model = Resource
+serializer = ResourceSerializer

--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -14,7 +14,7 @@ from apps.bigcz.utils import RequestTimedOutError
 
 
 CATALOG_NAME = 'hydroshare'
-HYDROSHARE_URL = 'https://www.hydroshare.org/hsapi/resource/'
+CATALOG_URL = 'https://www.hydroshare.org/hsapi/resource/'
 
 
 def parse_date(value):
@@ -75,7 +75,7 @@ def search(**kwargs):
         params.update(prepare_bbox(bbox))
 
     try:
-        response = requests.get(HYDROSHARE_URL,
+        response = requests.get(CATALOG_URL,
                                 timeout=settings.BIGCZ_CLIENT_TIMEOUT,
                                 params=params)
     except requests.Timeout:

--- a/src/mmw/apps/bigcz/serializers.py
+++ b/src/mmw/apps/bigcz/serializers.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from rest_framework.serializers import \
-    Serializer, CharField, DateTimeField, IntegerField
+    Serializer, CharField, DateTimeField, IntegerField, SerializerMethodField
 from rest_framework_gis.serializers import GeometryField
 
 
@@ -27,5 +27,9 @@ class ResourceSerializer(Serializer):
 class ResourceListSerializer(Serializer):
     catalog = CharField()
     api_url = CharField()
-    results = ResourceSerializer(many=True)
+    results = SerializerMethodField()
     count = IntegerField()
+
+    def get_results(self, obj):
+        serializer = self.context.get('serializer', ResourceSerializer)
+        return [serializer(r).data for r in obj.results]

--- a/src/mmw/apps/bigcz/views.py
+++ b/src/mmw/apps/bigcz/views.py
@@ -33,9 +33,12 @@ def _do_search(request):
     }
 
     search = CATALOGS[catalog]['search']
+    serializer = CATALOGS[catalog]['serializer']
 
     try:
-        return search(**search_kwargs)
+        result = ResourceListSerializer(search(**search_kwargs),
+                                        context={'serializer': serializer})
+        return result.data
     except ValueError as ex:
         raise ParseError(ex.message)
 
@@ -43,5 +46,4 @@ def _do_search(request):
 @decorators.api_view(['GET'])
 @decorators.permission_classes((AllowAny,))
 def search(request):
-    result = ResourceListSerializer(_do_search(request))
-    return Response(result.data)
+    return Response(_do_search(request))

--- a/src/mmw/apps/bigcz/views.py
+++ b/src/mmw/apps/bigcz/views.py
@@ -8,7 +8,7 @@ from rest_framework.exceptions import ValidationError, ParseError
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
-from apps.bigcz.clients import SEARCH_FUNCTIONS
+from apps.bigcz.clients import CATALOGS
 from apps.bigcz.serializers import ResourceListSerializer
 from apps.bigcz.utils import parse_date
 
@@ -20,6 +20,11 @@ def _do_search(request):
         raise ValidationError({
             'error': 'Required argument: catalog'})
 
+    if catalog not in CATALOGS:
+        raise ValidationError({
+            'error': 'Catalog must be one of: {}'
+                     .format(', '.join(CATALOGS.keys()))})
+
     search_kwargs = {
         'query': request.query_params.get('query'),
         'to_date': parse_date(request.query_params.get('to_date')),
@@ -27,18 +32,12 @@ def _do_search(request):
         'bbox': request.query_params.get('bbox'),
     }
 
-    search = SEARCH_FUNCTIONS.get(catalog)
+    search = CATALOGS[catalog]['search']
 
-    if search:
-        try:
-            return search(**search_kwargs)
-        except ValueError as ex:
-            raise ParseError(ex.message)
-
-    raise ValidationError({
-        'error': 'Catalog must be one of: {}'
-                 .format(', '.join(SEARCH_FUNCTIONS.keys()))
-    })
+    try:
+        return search(**search_kwargs)
+    except ValueError as ex:
+        raise ParseError(ex.message)
 
 
 @decorators.api_view(['GET'])


### PR DESCRIPTION
## Overview

Refactor back-end to support custom fields for each catalog. See commit messages for details.

Our main approach is to define a `model` and `serializer` for each catalog, all of which subclass the generic `Resource` and `ResourceSerializer`. In the general case, CINERGI and Hydroshare so far, we use the generic classes. For CUAHSI, we use a specialized subclass which adds a demo `test_field`. This technique will be used to add other fields, as requested for #1990.

The front-end changes necessary to accommodate these custom fields will be done in #2037.

Connects #2036 

### Demo

For the purpose of demo, I add a `test_field` to CUAHSI results that always have the value "hello world":

```
http :8000/api/bigcz/search catalog==cuahsi query==water bbox=="-75.2585830259156,39.876054698521,-75.159759422944,40.0310812816138" | jq '.results[0]'
```
```json
{
  "id": "NWISGW:395705075135901",
  "title": "PH  1061",
  "description": "The USGS National Water Information System (NWIS) provides access to millions of sites measuring streamflow, groundwater levels, and water quality. This web service provides methods for retrieving Ground Water data from NWIS. For more information about NWIS, see the NWIS home page at http://waterdata.usgs.gov/nwis",
  "author": null,
  "links": [
    {
      "href": "http://hiscentral.cuahsi.org/pub_network.aspx?n=8",
      "type": "service"
    }
  ],
  "created_at": "2015-06-05T00:00:00Z",
  "updated_at": null,
  "geom": {
    "type": "Point",
    "coordinates": [
      -75.2329444,
      39.95130556
    ]
  },
  "test_field": "hello world"
}
```

This field is not present in others, for example CINERGI:

```
http :8000/api/bigcz/search catalog==cinergi query==water bbox=="-75.2585830259156,39.876054698521,-75.159759422944,40.0310812816138" | jq '.results[0]'
```
```json
{
  "id": "4146e0ebc9a441988246314918a0869e",
  "title": "US Water Bodies",
  "description": "U.S. Map Data Water Boundaries represents water feature areas within United States. Water boundaries include the following: basic hydrography, naturally flowing water features, man-made channels to transport water, inland bodies of water, man-made bodies of water, seaward bodies of water, bodies of water in a man-made excavation, and special water features.",
  "author": null,
  "links": [
    {
      "href": "http://www.esri.com/",
      "type": "details"
    }
  ],
  "created_at": "2017-03-14T16:57:59.957000Z",
  "updated_at": "2017-01-14T15:23:24Z",
  "geom": {
    "type": "Polygon",
    "coordinates": [
      [
        [
          -172.4378,
          74.3889
        ],
        [
          -172.4378,
          18.9108
        ],
        [
          -66.9497,
          18.9108
        ],
        [
          -66.9497,
          74.3889
        ],
        [
          -172.4378,
          74.3889
        ]
      ]
    ]
  }
}
```

### Notes

The original issue suggests converting the output to an array. This conversion would require refactoring of the front-end, so I'm leaving that for #2037.

## Testing Instructions

 * Check out this branch
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz), proceed to the search page, and search for "water"
 * Ensure you see results as usual for all three catalogs
 * Inspect the API results of a CUAHSI search: http://localhost:8000/api/bigcz/search?catalog=cuahsi&query=water&bbox=-75.2585830259156%2C39.876054698521%2C-75.159759422944%2C40.0310812816138. Ensure you see a `test_field` in each result, and the fields are otherwise identical to similar results from staging http://staging.portal.bigcz.org/api/bigcz/search?catalog=cuahsi&query=water&bbox=-75.2585830259156%2C39.876054698521%2C-75.159759422944%2C40.0310812816138.
 * Inspect the API results of a CINERGI search: http://localhost:8000/api/bigcz/search?catalog=cinergi&query=water&bbox=-75.2585830259156%2C39.876054698521%2C-75.159759422944%2C40.0310812816138. Ensure you don't see the `test_field` in this.