### PR TITLE
Show custom fields per catalog

### DIFF
--- a/src/mmw/apps/bigcz/views.py
+++ b/src/mmw/apps/bigcz/views.py
@@ -38,7 +38,7 @@ def _do_search(request):
     try:
         result = ResourceListSerializer(search(**search_kwargs),
                                         context={'serializer': serializer})
-        return result.data
+        return [result.data]
     except ValueError as ex:
         raise ParseError(ex.message)
 

--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -28,18 +28,18 @@ var DataCatalogController = {
                 id: 'cinergi',
                 name: 'CINERGI',
                 active: true,
-                results: new models.Results()
+                results: new models.Results(null, { catalog: 'cinergi' }),
             }),
             new models.Catalog({
                 id: 'hydroshare',
                 name: 'HydroShare',
-                results: new models.Results()
+                results: new models.Results(null, { catalog: 'hydroshare' }),
             }),
             new models.Catalog({
                 id: 'cuahsi',
                 name: 'WDC',
                 description: 'Optional catalog description here...',
-                results: new models.Results()
+                results: new models.Results(null, { catalog: 'cuahsi' }),
             })
         ]);
 

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -98,12 +98,18 @@ var Result = Backbone.Model.extend({
 var Results = Backbone.Collection.extend({
     url: '/api/bigcz/search',
     model: Result,
+
+    initialize: function(models, options) {
+        this.catalog = options.catalog;
+    },
+
     parse: function(response) {
-        var aoi = App.map.get('areaOfInterest');
+        var aoi = App.map.get('areaOfInterest'),
+            data = _.findWhere(response, { catalog: this.catalog });
 
         // Filter results to only include those without geometries (Hydroshare)
         // and those that intersect the area of interest (CINERGI and CUAHSI).
-        return _.filter(response.results, function(r) {
+        return _.filter(data.results, function(r) {
             return r.geom === null || turfIntersect(aoi, r.geom) !== undefined;
         });
     }

--- a/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
+++ b/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
@@ -1,0 +1,19 @@
+<h3 class="resource-title">
+    {{ title }}
+</h3>
+<div class="resource-description">
+    {{ summary }}
+</div>
+{% if created_at %}
+    <div class="resource-date">
+        {{ created_at|toDateFullYear }}
+    </div>
+{% endif %}
+{% if author %}
+    <div class="resource-author">
+        {{ author }}
+    </div>
+{% endif %}
+<div class="resource-test-field">
+    {{ test_field }}
+</div>

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -9,12 +9,18 @@ var L = require('leaflet'),
     errorTmpl = require('./templates/error.html'),
     formTmpl = require('./templates/form.html'),
     searchResultTmpl = require('./templates/searchResult.html'),
+    cuahsiSearchResultTmpl = require('./templates/cuahsiSearchResult.html'),
     tabContentTmpl = require('./templates/tabContent.html'),
     tabPanelTmpl = require('./templates/tabPanel.html'),
     windowTmpl = require('./templates/window.html');
 
 var ENTER_KEYCODE = 13,
-    MAX_AREA_SQKM = 1500;  // Keep in sync with apps/bigcz/clients/cuahsi.py
+    MAX_AREA_SQKM = 1500,
+    CATALOG_RESULT_TEMPLATE = {
+        cinergi: searchResultTmpl,
+        hydroshare: searchResultTmpl,
+        cuahsi: cuahsiSearchResultTmpl,
+    };
 
 var DataCatalogWindow = Marionette.LayoutView.extend({
     template: windowTmpl,
@@ -201,7 +207,8 @@ var TabContentView = Marionette.LayoutView.extend({
 
     onShow: function() {
         this.resultRegion.show(new ResultsView({
-            collection: this.model.get('results')
+            collection: this.model.get('results'),
+            catalog: this.model.id,
         }));
 
         this.errorRegion.show(new ErrorView({
@@ -235,7 +242,10 @@ var TabContentsView = Marionette.CollectionView.extend({
 });
 
 var ResultView = Marionette.ItemView.extend({
-    template: searchResultTmpl,
+    getTemplate: function() {
+        return CATALOG_RESULT_TEMPLATE[this.options.catalog];
+    },
+
     className: 'resource',
 
     events: {
@@ -249,6 +259,12 @@ var ResultView = Marionette.ItemView.extend({
 
 var ResultsView = Marionette.CollectionView.extend({
     childView: ResultView,
+
+    childViewOptions: function() {
+        return {
+            catalog: this.options.catalog,
+        };
+    },
 
     modelEvents: {
         'sync error': 'render'


### PR DESCRIPTION
## Overview

Following up from #2036, adds ability to show custom fields per catalog to the front-end. Also adds ability to work with an array of results, instead of the singleton previously delivered.

Connects #2037 

### Demo

![image](https://user-images.githubusercontent.com/1430060/28279090-63016a36-6aed-11e7-9f1f-e0bcaaf41b96.png)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and proceed to the search page
 * Search for `water`. Try all three tabs. Ensure they all render correctly and there are no errors in the console.
 * Ensure you see the value of the custom `test_field`, which currently always is "hello world", in the CUAHSI / WDC tab