### PR TITLE
Reformat CUAHSI Results

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/models.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/models.py
@@ -8,9 +8,18 @@ from apps.bigcz.models import Resource
 
 class CuahsiResource(Resource):
     def __init__(self, id, description, author, links, title,
-                 created_at, updated_at, geom, test_field):
+                 created_at, updated_at, geom, details_url, sample_mediums,
+                 concept_keywords, service_org, service_code, service_url,
+                 begin_date, end_date):
         super(CuahsiResource, self).__init__(id, description, author, links,
                                              title, created_at, updated_at,
                                              geom)
 
-        self.test_field = test_field
+        self.details_url = details_url
+        self.sample_mediums = sample_mediums
+        self.concept_keywords = concept_keywords
+        self.service_org = service_org
+        self.service_code = service_code
+        self.service_url = service_url
+        self.begin_date = begin_date
+        self.end_date = end_date

--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -76,7 +76,15 @@ def parse_record(record, service):
         created_at=record['begin_date'],
         updated_at=None,
         geom=geom,
-        test_field="hello world")
+        details_url=details_url,
+        sample_mediums=record['sample_mediums'],
+        concept_keywords=record['concept_keywords'],
+        service_org=service['organization'],
+        service_code=record['ServCode'],
+        service_url=service['ServiceDescriptionURL'],
+        begin_date=record['begin_date'],
+        end_date=record['end_date']
+    )
 
 
 def find_service(services, service_code):

--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -70,7 +70,7 @@ def parse_record(record, service):
 
     return CuahsiResource(
         id=record['location'],
-        title=record['Sitename'],
+        title=record['site_name'],
         description=service['aabstract'],
         author=None,
         links=links,
@@ -81,7 +81,7 @@ def parse_record(record, service):
         sample_mediums=record['sample_mediums'],
         concept_keywords=record['concept_keywords'],
         service_org=service['organization'],
-        service_code=record['ServCode'],
+        service_code=record['serv_code'],
         service_url=service['ServiceDescriptionURL'],
         begin_date=record['begin_date'],
         end_date=record['end_date']
@@ -101,7 +101,7 @@ def parse_records(series, services):
     """
     result = []
     for record in series:
-        service = find_service(services, record['ServCode'])
+        service = find_service(services, record['serv_code'])
         if service:
             record = parse_record(record, service)
             result.append(record)
@@ -126,10 +126,10 @@ def group_series_by_location(series):
     records = []
     for location, group in groups.iteritems():
         records.append({
-            'ServCode': group[0]['ServCode'],
-            'ServURL': group[0]['ServURL'],
+            'serv_code': group[0]['ServCode'],
+            'serv_url': group[0]['ServURL'],
             'location': group[0]['location'],
-            'Sitename': group[0]['Sitename'],
+            'site_name': group[0]['Sitename'],
             'latitude': group[0]['latitude'],
             'longitude': group[0]['longitude'],
             'sample_mediums': ', '.join(sorted(set([r['samplemedium']

--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -6,6 +6,7 @@ from __future__ import division
 from datetime import date
 from urllib2 import URLError
 from socket import timeout
+from operator import attrgetter
 
 from suds.client import Client
 from rest_framework.exceptions import ValidationError
@@ -212,7 +213,9 @@ def search(**kwargs):
     series = get_series_catalog_in_box(box, from_date, to_date)
     series = group_series_by_location(series)
     services = get_services_in_box(world)
-    results = parse_records(series, services)
+    results = sorted(parse_records(series, services),
+                     key=attrgetter('end_date'),
+                     reverse=True)
 
     return ResourceList(
         api_url=None,

--- a/src/mmw/apps/bigcz/clients/cuahsi/serializers.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/serializers.py
@@ -3,10 +3,17 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from rest_framework.serializers import CharField
+from rest_framework.serializers import CharField, DateTimeField
 
 from apps.bigcz.serializers import ResourceSerializer
 
 
 class CuahsiResourceSerializer(ResourceSerializer):
-    test_field = CharField()
+    details_url = CharField()
+    sample_mediums = CharField()
+    concept_keywords = CharField()
+    service_org = CharField()
+    service_code = CharField()
+    service_url = CharField()
+    begin_date = DateTimeField()
+    end_date = DateTimeField()

--- a/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
+++ b/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
@@ -14,6 +14,27 @@
         {{ author }}
     </div>
 {% endif %}
-<div class="resource-test-field">
-    {{ test_field }}
+<div class="resource-details_url">
+    {{ details_url }}
+</div>
+<div class="resource-sample_medium">
+    {{ sample_medium }}
+</div>
+<div class="resource-concept_keyword">
+    {{ concept_keyword }}
+</div>
+<div class="resource-service_org">
+    {{ service_org }}
+</div>
+<div class="resource-service_code">
+    {{ service_code }}
+</div>
+<div class="resource-service_url">
+    {{ service_url }}
+</div>
+<div class="resource-begin_date">
+    {{ begin_date }}
+</div>
+<div class="resource-end_date">
+    {{ end_date }}
 </div>

--- a/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
+++ b/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
@@ -1,40 +1,26 @@
 <h3 class="resource-title">
-    {{ title }}
+    {{ id }}
 </h3>
-<div class="resource-description">
-    {{ summary }}
+<div>
+    {% if details_url %}
+        <a href="{{ details_url }}" target="_blank" rel="noreferrer noopener">
+        {{ title }}</a>.
+    {% else %}
+        {{ title }}.
+    {% endif %}
+    Observations on {{ sample_mediums }}.
 </div>
-{% if created_at %}
-    <div class="resource-date">
-        {{ created_at|toDateFullYear }}
-    </div>
-{% endif %}
-{% if author %}
-    <div class="resource-author">
-        {{ author }}
-    </div>
-{% endif %}
-<div class="resource-details_url">
-    {{ details_url }}
+<div>
+    Variables: {{ concept_keywords }}
 </div>
-<div class="resource-sample_medium">
-    {{ sample_medium }}
+<div>
+    From <a href="{{ service_url }}" target="_blank" rel="noreferrer noopener">
+    {{ service_org }} - {{ service_code }}</a> web service.
 </div>
-<div class="resource-concept_keyword">
-    {{ concept_keyword }}
-</div>
-<div class="resource-service_org">
-    {{ service_org }}
-</div>
-<div class="resource-service_code">
-    {{ service_code }}
-</div>
-<div class="resource-service_url">
-    {{ service_url }}
-</div>
-<div class="resource-begin_date">
-    {{ begin_date }}
-</div>
-<div class="resource-end_date">
-    {{ end_date }}
+<div>
+    {% if begin_date == end_date %}
+        Date for site: {{ begin_date|toFriendlyDate }}
+    {% else %}
+        Date range for site: {{ begin_date|toFriendlyDate }} - {{ end_date|toFriendlyDate }}
+    {% endif %}
 </div>

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -38,6 +38,7 @@
     .tab-content {
         padding: 0;
         background: $ui-light;
+        height: 100vh;
 
         .loading-panel,
         .no-results-panel {


### PR DESCRIPTION
## Overview

Using the guidelines from https://github.com/WikiWatershed/model-my-watershed/issues/1931#issuecomment-306838234, add aggregate fields to the record grouping, include them in the CUAHSI resource model and serializers, and show them in the front end as requested in https://github.com/WikiWatershed/model-my-watershed/issues/1931#issuecomment-311170676. Also add rudimentary scrolling to ease testing.

Builds on top of #2048 
Connects #1990 
Connects #1991 

### Demo

![image](https://user-images.githubusercontent.com/1430060/28291159-43fc6b5c-6b17-11e7-816d-d886151d9458.png)

### Notes

In some cases, the Sample Medium has a value `Unknown`. Should these be kept in the UI (as in the screenshot above) or omitted? /cc @aufdenkampe @emiliom 

I also went with semicolons for delimiting a list with commas in the values, which felt more standard to me, but if we'd rather have the hyphens I can easily change to that.

I added some rudimentary scrolling to assist in testing, but actual scrolling should be added as part of #1938.

## Testing Instructions

 * Check out the branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Go to the search page and search for `water`
 * Inspect CUAHSI / WDC results and ensure that they match the formatting as requested in #1990 
 * Ensure that only the `NWISDV` values have links in the title