### PR TITLE
Fix Draw Tools

### DIFF
--- a/src/mmw/js/src/draw/models.js
+++ b/src/mmw/js/src/draw/models.js
@@ -13,8 +13,7 @@ var ToolbarModel = Backbone.Model.extend({
         pollError: false,
         activeDrawTool: null,
         activeDrawToolItem: null,
-        openDrawTool: null,
-        leafletDrawTool: null,
+        openDrawTool: null
     },
 
     reset: function() {
@@ -46,13 +45,6 @@ var ToolbarModel = Backbone.Model.extend({
         if (map && this.has('rwd-original-point')) {
             map.removeLayer(this.get('rwd-original-point'));
             this.unset('rwd-original-point');
-        }
-    },
-
-    disableLeafletDrawTool: function() {
-        var leafletDrawTool = this.get('leafletDrawTool');
-        if (leafletDrawTool) {
-            leafletDrawTool.disable();
         }
     }
 });

--- a/src/mmw/js/src/draw/tests.js
+++ b/src/mmw/js/src/draw/tests.js
@@ -6,6 +6,7 @@ var $ = require('jquery'),
     _ = require('underscore'),
     L = require('leaflet'),
     assert = require('chai').assert,
+    sinon = require('sinon'),
     Marionette = require('../../shim/backbone.marionette'),
     App = require('../app'),
     models = require('./models'),
@@ -171,12 +172,13 @@ describe('Draw', function() {
         });
 
         it('removes in progress drawing on Reset', function() {
-            var setup = setupResetTestObject();
+            var setup = setupResetTestObject(),
+                spy = sinon.spy(utils, 'cancelDrawing');
 
-            utils.drawPolygon(setup.map, setup.view.model);
+            utils.drawPolygon(setup.map);
             setup.view.resetDrawingState();
 
-            assert.equal(setup.view.model.get('leafletDrawTool')._enabled, false);
+            assert.equal(spy.callCount, 1);
         });
     });
 });

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -673,7 +673,8 @@ var DrawAreaView = DrawToolBaseView.extend({
     },
 
     enableDrawArea: function() {
-        var map = App.getLeafletMap(),
+        var self = this,
+            map = App.getLeafletMap(),
             revertLayer = clearAoiLayer();
 
         utils.drawPolygon(map)
@@ -684,11 +685,13 @@ var DrawAreaView = DrawToolBaseView.extend({
             }).fail(function(message) {
                 revertLayer();
                 displayAlert(message, modalModels.AlertTypes.error);
+                self.model.reset();
             });
     },
 
     enableStampTool: function() {
-        var map = App.getLeafletMap(),
+        var self = this,
+            map = App.getLeafletMap(),
             revertLayer = clearAoiLayer();
 
         utils.placeMarker(map).then(function(latlng) {
@@ -720,6 +723,7 @@ var DrawAreaView = DrawToolBaseView.extend({
         }).fail(function(message) {
             revertLayer();
             displayAlert(message, modalModels.AlertTypes.error);
+            self.model.reset();
         });
     }
 });

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -198,8 +198,8 @@ var DrawWindow = Marionette.LayoutView.extend({
         this.model.clearRwdClickedPoint(App.getLeafletMap());
         this.rwdTaskModel.reset();
         this.model.reset();
-        utils.removeDrawEventListeners(App.getLeafletMap());
-        this.model.disableLeafletDrawTool();
+
+        utils.cancelDrawing(App.getLeafletMap());
         clearAoiLayer();
         clearBoundaryLayer(this.model);
     }
@@ -673,11 +673,10 @@ var DrawAreaView = DrawToolBaseView.extend({
     },
 
     enableDrawArea: function() {
-        var self = this,
-            map = App.getLeafletMap(),
+        var map = App.getLeafletMap(),
             revertLayer = clearAoiLayer();
 
-        utils.drawPolygon(map, self.model)
+        utils.drawPolygon(map)
             .then(validateShape)
             .then(function(shape) {
                 addLayer(shape);
@@ -685,16 +684,14 @@ var DrawAreaView = DrawToolBaseView.extend({
             }).fail(function(message) {
                 revertLayer();
                 displayAlert(message, modalModels.AlertTypes.error);
-                self.enableDrawArea();
             });
     },
 
     enableStampTool: function() {
-        var self = this,
-            map = App.getLeafletMap(),
+        var map = App.getLeafletMap(),
             revertLayer = clearAoiLayer();
 
-        utils.placeMarker(map, self.model).then(function(latlng) {
+        utils.placeMarker(map).then(function(latlng) {
             var point = L.marker(latlng).toGeoJSON(),
                 halfKmbufferPoints = _.map([-180, -90, 0, 90], function(bearing) {
                     var p = turfDestination(point, 0.5, bearing, 'kilometers');
@@ -723,7 +720,6 @@ var DrawAreaView = DrawToolBaseView.extend({
         }).fail(function(message) {
             revertLayer();
             displayAlert(message, modalModels.AlertTypes.error);
-            self.enableStampTool();
         });
     }
 });


### PR DESCRIPTION
Only the third commit is the real one. Ensure that:

 * drawing cancels correctly in the Draw stage
 * watershed delineation still works
 * boundary selection still works, both before and after canceling drawing
 * both draw and stamp tools work
 * drawing modifications on TR-55 scenarios works in the project page, both when going from draw to analyze to project, and when resuming an existing project