### PR TITLE
Add tooltip to inactive layers

### DIFF
--- a/src/mmw/js/src/core/templates/layerPickerLayer.html
+++ b/src/mmw/js/src/core/templates/layerPickerLayer.html
@@ -1,7 +1,7 @@
 <div class="layerpicker-layer">
     <button
         class="{{layerClass}}"
-        {% if isDisabled %} disabled {% endif %}
+        {% if isDisabled %}title="This layer is unavailable at this location" disabled {% endif %}
     >
         {{ layerDisplay }}
     </button>

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -48,7 +48,7 @@
   border: 0;
   outline: 0;
   background: none;
-  color: #999;
+  color: $ui-primary;
   &:hover {
     color: inherit;
   }
@@ -56,7 +56,7 @@
     color: $brand-primary;
   }
   &:disabled {
-      color: $ui-light;
+      color: $ui-medium-light;
   }
 }
 

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -16,6 +16,7 @@ $paper: #ffffff;
 $ui-primary: #273238; /*Dark Grey*/
 $ui-secondary: #394750; /*Medium Grey*/
 $ui-light: #eceff1; /*Light Grey*/
+$ui-medium-light: #BDBDBD; /* Medium Light Grey */
 $ui-grey: #787878 ; /* Output Tab Bar */
 $ui-danger: #e0412d; /*Errors*/
 $ui-warning: #e4b72f; /*Warnings*/


### PR DESCRIPTION
## Overview

Adds a tooltip to deactivated layers in the layer picker and also makes active and inactive layers a shade darker.

Connects #1797 
Connects #1581 
Connects #1725 

### Demo

_Staging_
![screenshot from 2017-07-18 17 18 58](https://user-images.githubusercontent.com/1014341/28340295-34f1bd6c-6bdd-11e7-89a7-daf9905051ad.png)

_The Branch_
![screenshot from 2017-07-18 17 13 53](https://user-images.githubusercontent.com/1014341/28340281-25a068a4-6bdd-11e7-9d04-1c7281e55b30.png)


### Notes

I got sign off from @jfrankl in #1725, but please comment on the outcome.

## Testing Instructions

 * After bundling, pan the map far to the Atlantic which will disable the Delaware stream layer title.
 * Ensure that hovering displays the tooltip
 * Ensure that hovering over active layers does not show a tooltip
 * The styles should be darker and more legible.