### PR TITLE
Don't open login modal on page load of homepage

### DIFF
--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -21,12 +21,7 @@ App.on('start', function() {
     });
     Backbone.history.start({ pushState: true });
 
-    // Show login modal only if landing on home page
-    if (Backbone.history.getFragment() === '') {
-        this.getUserOrShowLoginIfNotItsiEmbed();
-    } else {
-        this.user.fetch();
-    }
+    this.user.fetch();
 });
 
 App.start();


### PR DESCRIPTION
## Overview

The login modal will no longer open automatically when a guest or
unlogged in user visits the homepage. Per the design team.

Connects to #2050

### Demo

![mmw1](https://user-images.githubusercontent.com/1042475/28379793-fd7226d2-6c82-11e7-8e51-59dbe3717fb2.gif)

## Testing Instructions

- If you are currently logged into the app, log out.
- Visit the home page. Verify that the login modal does not open.
- Attempt to login.
- Refresh the page. Verify that you are still logged in.
