### PR TITLE
Ensure GWLFE modification tooltip text wraps

### DIFF
--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -123,7 +123,7 @@ header {
     flex-wrap: nowrap;
 
     .tooltip-inner {
-        white-space: initial;
+        white-space: normal;
         max-width: 100px;
         width: 100px;
     }


### PR DESCRIPTION
## Overview

Setting this property to normal ensures that the text in the
modification tooltip is wrapped in every browser so that it does not
extend outside of the tooltip boundary.

Connects to #2039

### Demo

![image](https://user-images.githubusercontent.com/1042475/28386133-9a5d629e-6c98-11e7-937c-e499e769dee0.png)
*Screenshot from IE*

## Testing Instructions

- In every major browser (especially IE), open a MapShed project.
- Go to a scenario and add a modification.
- Once the modification has been added, hover over the thumbnail in the modification sidebar, and ensure the text is always wrapped and does not extend outside of the tooltip border.
