### PR TITLE
Fix modeling thumbselect controls on iOS

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -67,6 +67,7 @@ var ThumbSelectView = Marionette.ItemView.extend({
 
     events: {
         'click @ui.drawControl': 'onThumbClick',
+        'touchstart @ui.thumb': 'onThumbClick',
         'mouseenter @ui.thumb': 'onThumbHover'
     },
 


### PR DESCRIPTION
## Overview

On iOS, tapping on a modification thumb would open its details, but not select the tool:

[state would look like this, but clicking the map wouldn't draw anything]
![screen shot 2017-07-19 at 6 05 21 pm](https://user-images.githubusercontent.com/7633670/28391645-d95a1e7e-6cac-11e7-8589-63c3724cff72.png)

To select the tool you'd have to tap the same thumb again.

Connects #2058 


## Testing Instructions

 * On desktop, ASUS touch+mouse laptop, iPad, and nexus tablet
 -- confirm you can select modifications to TR-55 and gwlf-e with a single click/tap
 