### PR TITLE
Add Pagination Support

### DIFF
--- a/src/mmw/apps/bigcz/clients/__init__.py
+++ b/src/mmw/apps/bigcz/clients/__init__.py
@@ -10,15 +10,18 @@ CATALOGS = {
         'model': cinergi.model,
         'serializer': cinergi.serializer,
         'search': cinergi.search,
+        'is_pageable': True,
     },
     hydroshare.CATALOG_NAME: {
         'model': hydroshare.model,
         'serializer': hydroshare.serializer,
         'search': hydroshare.search,
+        'is_pageable': True,
     },
     cuahsi.CATALOG_NAME: {
         'model': cuahsi.model,
         'serializer': cuahsi.serializer,
         'search': cuahsi.search,
+        'is_pageable': False,
     },
 }

--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -115,7 +115,8 @@ def search(**kwargs):
     bbox = kwargs.get('bbox')
 
     params = {
-        'f': 'json'
+        'f': 'json',
+        'sort': 'sys_modified_dt:desc',
     }
 
     if query:

--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -15,6 +15,7 @@ from apps.bigcz.utils import RequestTimedOutError
 
 CATALOG_NAME = 'cinergi'
 CATALOG_URL = 'http://132.249.238.169:8080/geoportal/opensearch'
+PAGE_SIZE = settings.BIGCZ_CLIENT_PAGE_SIZE
 
 
 def parse_date(value):
@@ -113,10 +114,12 @@ def search(**kwargs):
     to_date = kwargs.get('to_date')
     from_date = kwargs.get('from_date')
     bbox = kwargs.get('bbox')
+    page = kwargs.get('page')
 
     params = {
         'f': 'json',
         'sort': 'sys_modified_dt:desc',
+        'size': PAGE_SIZE,
     }
 
     if query:
@@ -130,6 +133,11 @@ def search(**kwargs):
     if bbox:
         params.update({
             'bbox': prepare_bbox(bbox)
+        })
+    if page:
+        params.update({
+            # page 1 is from 1, page 2 from 101, page 3 from 201, ...
+            'from': PAGE_SIZE * (page - 1) + 1
         })
 
     try:

--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -54,6 +54,7 @@ def search(**kwargs):
     to_date = kwargs.get('to_date')
     from_date = kwargs.get('from_date')
     bbox = kwargs.get('bbox')
+    page = kwargs.get('page')
 
     if not query:
         raise ValidationError({
@@ -73,6 +74,10 @@ def search(**kwargs):
         })
     if bbox:
         params.update(prepare_bbox(bbox))
+    if page:
+        params.update({
+            'page': page
+        })
 
     try:
         response = requests.get(CATALOG_URL,

--- a/src/mmw/apps/bigcz/serializers.py
+++ b/src/mmw/apps/bigcz/serializers.py
@@ -3,9 +3,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from math import ceil
+
 from rest_framework.serializers import \
     Serializer, CharField, DateTimeField, IntegerField, SerializerMethodField
 from rest_framework_gis.serializers import GeometryField
+from rest_framework.utils.urls import remove_query_param, replace_query_param
+
+from django.conf import settings
 
 
 class ResourceLinkSerializer(Serializer):
@@ -29,7 +34,51 @@ class ResourceListSerializer(Serializer):
     api_url = CharField()
     results = SerializerMethodField()
     count = IntegerField()
+    page = SerializerMethodField()
+    previous = SerializerMethodField()
+    next = SerializerMethodField()
 
     def get_results(self, obj):
         serializer = self.context.get('serializer', ResourceSerializer)
         return [serializer(r).data for r in obj.results]
+
+    def get_page(self, obj):
+        if not self.context.get('is_pageable', False):
+            return None
+
+        return self.context.get('page')
+
+    def get_previous(self, obj):
+        request_uri = self.context.get('request_uri')
+        page = self.context.get('page')
+
+        if not request_uri:
+            return None
+
+        if not self.context.get('is_pageable', False):
+            return None
+
+        if page < 2:
+            return None
+
+        if page == 2:
+            return remove_query_param(request_uri, 'page')
+
+        return replace_query_param(request_uri, 'page', page - 1)
+
+    def get_next(self, obj):
+        request_uri = self.context.get('request_uri')
+        page = self.context.get('page')
+
+        if not request_uri:
+            return None
+
+        if not self.context.get('is_pageable', False):
+            return None
+
+        last_page = ceil(obj.count / settings.BIGCZ_CLIENT_PAGE_SIZE)
+
+        if page >= last_page:
+            return None
+
+        return replace_query_param(request_uri, 'page', page + 1)

--- a/src/mmw/apps/bigcz/views.py
+++ b/src/mmw/apps/bigcz/views.py
@@ -15,6 +15,8 @@ from apps.bigcz.utils import parse_date
 
 def _do_search(request):
     catalog = request.query_params.get('catalog')
+    page = int(request.query_params.get('page', 1))
+    request_uri = request.build_absolute_uri()
 
     if not catalog:
         raise ValidationError({
@@ -30,14 +32,20 @@ def _do_search(request):
         'to_date': parse_date(request.query_params.get('to_date')),
         'from_date': parse_date(request.query_params.get('from_date')),
         'bbox': request.query_params.get('bbox'),
+        'page': page,
     }
 
     search = CATALOGS[catalog]['search']
     serializer = CATALOGS[catalog]['serializer']
+    is_pageable = CATALOGS[catalog]['is_pageable']
 
     try:
         result = ResourceListSerializer(search(**search_kwargs),
-                                        context={'serializer': serializer})
+                                        context={
+                                            'page': page,
+                                            'is_pageable': is_pageable,
+                                            'request_uri': request_uri,
+                                            'serializer': serializer})
         return [result.data]
     except ValueError as ex:
         raise ParseError(ex.message)

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -137,6 +137,7 @@ def get_client_settings(request):
             'model_packages': get_model_packages(),
             'mapshed_max_area': settings.GWLFE_CONFIG['MaxAoIArea'],
             'data_catalog_enabled': bigcz,
+            'data_catalog_page_size': settings.BIGCZ_CLIENT_PAGE_SIZE,
             'itsi_enabled': not bigcz,
             'title': title,
         }),

--- a/src/mmw/js/src/data_catalog/templates/pager.html
+++ b/src/mmw/js/src/data_catalog/templates/pager.html
@@ -1,0 +1,14 @@
+{% if has_results %}
+<div class="row">
+    <div class="col-xs-6">
+        <button id="pager-previous" class="btn btn-block" {{ "disabled" if not has_previous }}>
+            <i class="fa fa-arrow-left"></i> Previous
+        </button>
+    </div>
+    <div class="col-xs-6">
+        <button id="pager-next" class="btn btn-block" {{ "disabled" if not has_next }}>
+            Next <i class="fa fa-arrow-right"></i>
+        </button>
+    </div>
+</div>
+{% endif %}

--- a/src/mmw/js/src/data_catalog/templates/tabContent.html
+++ b/src/mmw/js/src/data_catalog/templates/tabContent.html
@@ -10,4 +10,6 @@
 
 <div class="error-region"></div>
 
+<div class="pager-region"></div>
+
 <div class="result-region"></div>

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -359,6 +359,7 @@ OMGEO_SETTINGS = [[
 # BiG-CZ Host, for enabling custom behavior.
 BIGCZ_HOST = 'portal.bigcz.org'
 BIGCZ_CLIENT_TIMEOUT = 5  # timeout in seconds
+BIGCZ_CLIENT_PAGE_SIZE = 100
 
 # ITSI Portal Settings
 ITSI = {


### PR DESCRIPTION
## Overview

Adds pagination support to CINERGI and Hydroshare results. CUAHSI does not support pagination. In this effort we:

 * Add a `page=` query parameter to the back-end that can take a page number and get a set of at most 100 results corresponding to that page. This 100 page limit is configurable, but comes from Hydroshare's unchangeable page size of 100.
 * Translate the value of `page=` parameter to whatever it needs for CINERGI and Hydroshare under the hood to their pagination scheme. CINERGI uses `size=` and `from=` parameters, whereas Hydroshare just takes a single `page=` parameter, with the page size hard set to 100.
 * Add front-end for exercising this pagination back-end

See commit messages for details.

The implementation was more focused on the back-end than the front-end. There are obvious stylistic issues, as well as some software design concerns. I've made #2066 to follow up.

Connects #1850 

### Demo

![2017-07-21 12 57 39](https://user-images.githubusercontent.com/1430060/28473853-5c422d0a-6e14-11e7-87ec-279d0df4b867.gif)

```json
{
  "api_url": "http://132.249.238.169:8080/geoportal/opensearch?sort=sys_modified_dt%3Adesc&q=water&from=201&bbox=-75.2585830259156%2C39.876054698521%2C-75.159759422944%2C40.0310812816138&f=json&size=100",
  "catalog": "cinergi",
  "count": 5779,
  "next": "http://localhost:8000/api/bigcz/search?bbox=-75.2585830259156%2C39.876054698521%2C-75.159759422944%2C40.0310812816138&catalog=cinergi&page=4&query=water",
  "page": 3,
  "previous": "http://localhost:8000/api/bigcz/search?bbox=-75.2585830259156%2C39.876054698521%2C-75.159759422944%2C40.0310812816138&catalog=cinergi&page=2&query=water",
  "results": [ ... ]
}
```

### Notes

Known Issues:

 * No UI for jumping to specific page, no display of current page, or how many pages there are total #2066 
 * Switching back to tab does not preserve page because search is retriggered #1960 

## Testing Instructions

 * Check out this branch and run `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz), draw a shape and proceed to search.
 * Search for anything, say "water". Wait for CINERGI results. Ensure that you see a large number representing the total count of results in the CINERGI tab header. Ensure that there are 100 results shown in the list.
 * Ensure you cannot click "Previous". Try clicking "Next", and wait for the results to update. Ensure the results are different. Click "Previous" and ensure that the first page of results is shown again.
 * Try the same for Hydroshare.
 * Ensure there are no pagination controls in CUAHSI, and that all results (which may be more than 100, the page size) are shown at once.