### PR TITLE
Allow Drawing Modifications During Initial Model Run

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -606,6 +606,7 @@ var ScenarioModel = Backbone.Model.extend({
         modification_hash: null, // MD5 string
         active: false,
         job_id: null,
+        poll_error: null,
         results: null, // ResultCollection
         aoi_census: null, // JSON blob
         modification_censuses: null, // JSON blob
@@ -801,6 +802,7 @@ var ScenarioModel = Backbone.Model.extend({
                 postData: gisData,
 
                 onStart: function() {
+                    self.set('poll_error', null);
                     results.setPolling(true);
                 },
 
@@ -808,8 +810,9 @@ var ScenarioModel = Backbone.Model.extend({
                     self.setResults();
                 },
 
-                pollFailure: function() {
+                pollFailure: function(error) {
                     console.log('Failed to get modeling results.');
+                    self.set('poll_error', error);
                     results.setNullResults();
                 },
 
@@ -820,11 +823,12 @@ var ScenarioModel = Backbone.Model.extend({
 
                 startFailure: function(response) {
                     console.log('Failed to start modeling job.');
-
+                    var error = 'Failed to start modeling job';
                     if (response.responseJSON && response.responseJSON.error) {
                         console.log(response.responseJSON.error);
+                        error = response.responseJSON.error;
                     }
-
+                    self.set('poll_error', error);
                     results.setNullResults();
                     results.setPolling(false);
                 }


### PR DESCRIPTION
## Overview
- If you tried to play with the precipitation slider or draw a modification while TR-55 was still completing its initial job, the new job and all jobs following it would fail
- If the initial job failed, all new jobs with modifications would fail

I've adjusted the `fetchResults` pipeline on the frontend to either:
- wait for the initial run to complete, before running the model with the modifications
- If there's no results and the initial run isn't underway, start `fetchResults` without any modifications, then try

Connects #1901 

Also includes https://github.com/project-icp/bee-pollinator-app/pull/116
### Demo

![exqu2lyeok](https://user-images.githubusercontent.com/7633670/28537758-fb7c3e1c-7079-11e7-8074-e6c816edcfdc.gif)

## Testing Instructions

 * Confirm MapShed still works as expected
 * For TR-55
    * Draw an AOI
    * Before polling completes, move the precipitation slider
    * Create a new scenario, and before polling completes, draw a modification
    * Create a new scenario and while polling, use the Developer Network Tools to make the browser offline (Should see a generic error in the sidebar)
    * Put the browser online again, and draw a modification
     
  
