### PR TITLE
Add date range filters to the search UI

### DIFF
--- a/src/mmw/bundle.sh
+++ b/src/mmw/bundle.sh
@@ -98,6 +98,7 @@ CONCAT_VENDOR_CSS_COMMAND="cat \
     ./node_modules/leaflet-draw/dist/leaflet.draw.css \
     ./node_modules/font-awesome/css/font-awesome.min.css \
     ./node_modules/bootstrap-table/dist/bootstrap-table.min.css \
+    ./node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker3.min.css \
     ./css/shim/nv.d3.min.css \
     > $VENDOR_CSS_FILE"
 
@@ -105,6 +106,7 @@ JS_DEPS=(backbone
          backbone.marionette
          blueimp-md5
          bootstrap
+         bootstrap-datepicker
          bootstrap-select
          bootstrap-table/dist/bootstrap-table.js
          bootstrap-table/dist/extensions/export/bootstrap-table-export.min.js

--- a/src/mmw/js/src/core/setup.js
+++ b/src/mmw/js/src/core/setup.js
@@ -21,6 +21,7 @@ require('../modeling/filters');
 require('../analyze/filters');
 
 require('bootstrap');
+require('bootstrap-datepicker');
 require('bootstrap-select');
 require('bootstrap-table/dist/bootstrap-table.js');
 require('../../shim/tableExport.min.js');

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -17,6 +17,8 @@ var Catalog = Backbone.Model.extend({
         id: '',
         name: '',
         description: '',
+        fromDate: null,
+        toDate: null,
         query: '',
         bbox: '',
         loading: false,
@@ -27,10 +29,12 @@ var Catalog = Backbone.Model.extend({
         error: '',
     },
 
-    search: function(query, bounds) {
+    search: function(query, fromDate, toDate, bounds) {
         this.set({
             query: query,
             bbox: utils.formatBounds(bounds),
+            fromDate: fromDate,
+            toDate: toDate,
         });
 
         return this.startSearch(1);
@@ -43,6 +47,8 @@ var Catalog = Backbone.Model.extend({
                 catalog: this.id,
                 query: this.get('query'),
                 bbox: this.get('bbox'),
+                from_date: this.get('fromDate'),
+                to_date: this.get('toDate'),
             };
 
         if (thisPage > 1 && thisPage <= lastPage) {
@@ -166,7 +172,11 @@ var Results = Backbone.Collection.extend({
 
 var SearchForm = Backbone.Model.extend({
     defaults: {
-        query: ''
+        fromDate: null,
+        toDate: null,
+        query: '',
+        showingFilters: false,
+        isValid: true,
     }
 });
 

--- a/src/mmw/js/src/data_catalog/templates/form.html
+++ b/src/mmw/js/src/data_catalog/templates/form.html
@@ -1,6 +1,31 @@
-<i class="data-catalog-search-icon fa fa-search"></i>
-<input
-    class="data-catalog-search-input"
-    type="text"
-    placeholder="Search data sources"
-/>
+<button class="btn btn-link date-filter-toggle small">{{filterText}}</button>
+
+{% if showingFilters %}
+    <div class="data-catalog-search-dates">
+        <h5>Data collected between:</h5>
+        <input
+            class="data-catalog-date-input from-date form-control"
+            value="{{fromDate}}"
+        />
+        <span>and</span>
+        <input
+            class="data-catalog-date-input to-date form-control"
+            value="{{toDate}}"
+        />
+    </div>
+
+    {% if not isValid %}
+    <div class="small data-catalog-validation-msg">From date must be earlier than To date</div>
+    {% endif %}
+
+{% endif %}
+
+<div>
+    <i class="data-catalog-search-icon fa fa-search"></i>
+    <input
+        class="data-catalog-search-input"
+        type="text"
+        placeholder="Search data sources"
+        value="{{query}}"
+    />
+</div>

--- a/src/mmw/js/src/data_catalog/templates/form.html
+++ b/src/mmw/js/src/data_catalog/templates/form.html
@@ -3,15 +3,29 @@
 {% if showingFilters %}
     <div class="data-catalog-search-dates">
         <h5>Data collected between:</h5>
-        <input
-            class="data-catalog-date-input from-date form-control"
-            value="{{fromDate}}"
-        />
+        <div class="data-catalog-clearable-input">
+            <input
+                class="data-catalog-date-input from-date form-control"
+                value="{{fromDate}}"
+            />
+            {% if fromDate %}
+            <a href="javascript:0;" class="data-catalog-clear-icon" title="Clear">
+                <i class=" fa fa-times"></i>
+            </a>
+            {% endif %}
+        </div>
         <span>and</span>
-        <input
-            class="data-catalog-date-input to-date form-control"
-            value="{{toDate}}"
-        />
+        <div class="data-catalog-clearable-input">
+            <input
+                class="data-catalog-date-input to-date form-control"
+                value="{{toDate}}"
+            />
+            {% if toDate %}
+            <a href="javascript:0;" title="Clear">
+                <i class="data-catalog-clear-icon fa fa-times"></i>
+            </a>
+            {% endif %}
+        </div>
     </div>
 
     {% if not isValid %}

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -1,7 +1,9 @@
 "use strict";
 
-var L = require('leaflet'),
+var $ = require('jquery'),
+    L = require('leaflet'),
     Marionette = require('../../shim/backbone.marionette'),
+    moment = require('moment'),
     App = require('../app'),
     modalModels = require('../core/modals/models'),
     modalViews = require('../core/modals/views'),
@@ -82,6 +84,8 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
     doSearch: function() {
         var catalog = this.getActiveCatalog(),
             query = this.model.get('query'),
+            fromDate = this.model.get('fromDate'),
+            toDate = this.model.get('toDate'),
             bounds = L.geoJson(App.map.get('areaOfInterest')).getBounds(),
             area = utils.areaOfBounds(bounds);
 
@@ -90,10 +94,10 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
             var alertView = new modalViews.AlertView({
                 model: new modalModels.AlertModel({
                     alertMessage: "The bounding box of the current area of " +
-                                  "interest is " + Math.round(area) + " km², " +
+                                  "interest is " + formattedArea + "&nbsp;km², " +
                                   "which is larger than the current maximum " +
-                                  "area of " + MAX_AREA_SQKM + " km² supported " +
-                                  "for WDC.",
+                                  "area of " + MAX_AREA_FORMATTED + "&nbsp;km² " +
+                                  "supported for WDC.",
                     alertType: modalModels.AlertTypes.error
                 })
             });
@@ -111,7 +115,7 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
         this.ui.introText.addClass('hide');
         this.ui.tabs.removeClass('hide');
 
-        catalog.search(query, bounds);
+        catalog.search(query, fromDate, toDate, bounds);
     },
 
     updateMap: function() {
@@ -126,20 +130,85 @@ var FormView = Marionette.ItemView.extend({
     className: 'data-catalog-form',
 
     ui: {
+        dateInput: '.data-catalog-date-input',
+        filterToggle: '.date-filter-toggle',
         searchInput: '.data-catalog-search-input'
     },
 
+    modelEvents: {
+        'change:showingFilters change:isValid': 'render'
+    },
+
     events: {
-        'keyup @ui.searchInput': 'onSearchInputChanged'
+        'keyup @ui.searchInput': 'onSearchInputChanged',
+        'click @ui.filterToggle': 'onFilterToggle',
+        'change @ui.dateInput': 'onDateInputChanged',
+        'keyup @ui.dateInput': 'onDateInputKeyup'
+    },
+
+    onRender: function() {
+        $('.data-catalog-date-input').datepicker();
     },
 
     onSearchInputChanged: function(e) {
         var query = this.ui.searchInput.val().trim();
         if (e.keyCode === ENTER_KEYCODE) {
-            this.triggerMethod('search');
+            this.triggerSearch();
         } else {
             this.model.set('query', query);
         }
+    },
+
+    onDateInputKeyup: function(e) {
+        if (e.keyCode === ENTER_KEYCODE) {
+            this.triggerSearch();
+        }
+    },
+
+    onDateInputChanged: function(e) {
+        var dateControl = $(e.currentTarget),
+            isFromDate = dateControl.hasClass('from-date'),
+            attr = isFromDate ? 'fromDate' : 'toDate';
+
+        this.model.set(attr, dateControl.val());
+    },
+
+    onFilterToggle: function() {
+        var newVal = !this.model.get('showingFilters');
+        this.model.set('showingFilters', newVal);
+    },
+
+    triggerSearch: function() {
+        if (this.validate()) {
+            this.triggerMethod('search');
+        }
+    },
+
+    validate: function() {
+        // Only need to validate if there are two dates.  Ensure that
+        // before is earlier than after
+        var dateFormat = "MM/DD/YYYY",
+            toDate = this.model.get('toDate'),
+            fromDate = this.model.get('fromDate'),
+            isValid = false;
+
+        if (!toDate || !fromDate) {
+            isValid = true;
+        } else {
+            isValid = moment(fromDate, dateFormat)
+                        .isBefore(moment(toDate, dateFormat));
+        }
+
+        this.model.set('isValid', isValid);
+        return isValid;
+    },
+
+    templateHelpers: function() {
+        var showingFilters = this.model.get('showingFilters');
+
+        return {
+            filterText: showingFilters ? 'Hide Filters' : 'Show Filters',
+        };
     }
 });
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -20,6 +20,7 @@ var $ = require('jquery'),
 
 var ENTER_KEYCODE = 13,
     MAX_AREA_SQKM = 1500,
+    MAX_AREA_FORMATTED = MAX_AREA_SQKM.toLocaleString(),
     PAGE_SIZE = settings.get('data_catalog_page_size'),
     CATALOG_RESULT_TEMPLATE = {
         cinergi: searchResultTmpl,
@@ -91,7 +92,8 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
 
         // CUAHSI should not be fetched beyond a certain size
         if (catalog.get('id') === 'cuahsi' && area > MAX_AREA_SQKM) {
-            var alertView = new modalViews.AlertView({
+            var formattedArea = Math.round(area).toLocaleString(),
+                alertView = new modalViews.AlertView({
                 model: new modalModels.AlertModel({
                     alertMessage: "The bounding box of the current area of " +
                                   "interest is " + formattedArea + "&nbsp;km², " +

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -134,22 +134,29 @@ var FormView = Marionette.ItemView.extend({
     ui: {
         dateInput: '.data-catalog-date-input',
         filterToggle: '.date-filter-toggle',
-        searchInput: '.data-catalog-search-input'
+        searchInput: '.data-catalog-search-input',
+        clearable: '.data-catalog-clearable-input a',
     },
 
     modelEvents: {
-        'change:showingFilters change:isValid': 'render'
+        'change:showingFilters change:isValid change:toDate change:fromDate': 'render'
     },
 
     events: {
         'keyup @ui.searchInput': 'onSearchInputChanged',
         'click @ui.filterToggle': 'onFilterToggle',
         'change @ui.dateInput': 'onDateInputChanged',
-        'keyup @ui.dateInput': 'onDateInputKeyup'
+        'keyup @ui.dateInput': 'onDateInputKeyup',
+        'click @ui.clearable': 'onClearInput',
     },
 
     onRender: function() {
         $('.data-catalog-date-input').datepicker();
+    },
+
+    onClearInput: function(e) {
+        var $el = $(e.currentTarget).siblings('input').val('');
+        this.updateDateInput($el);
     },
 
     onSearchInputChanged: function(e) {
@@ -168,16 +175,19 @@ var FormView = Marionette.ItemView.extend({
     },
 
     onDateInputChanged: function(e) {
-        var dateControl = $(e.currentTarget),
-            isFromDate = dateControl.hasClass('from-date'),
-            attr = isFromDate ? 'fromDate' : 'toDate';
-
-        this.model.set(attr, dateControl.val());
+        this.updateDateInput($(e.currentTarget));
     },
 
     onFilterToggle: function() {
         var newVal = !this.model.get('showingFilters');
         this.model.set('showingFilters', newVal);
+    },
+
+    updateDateInput: function($dateEl) {
+        var isFromDate = $dateEl.hasClass('from-date'),
+            attr = isFromDate ? 'fromDate' : 'toDate';
+
+        this.model.set(attr, $dateEl.val());
     },
 
     triggerSearch: function() {

--- a/src/mmw/npm-shrinkwrap.json
+++ b/src/mmw/npm-shrinkwrap.json
@@ -44,6 +44,11 @@
       "from": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz"
     },
+    "bootstrap-datepicker": {
+      "version": "1.7.1",
+      "from": "bootstrap-datepicker@*",
+      "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.7.1.tgz"
+    },
     "bootstrap-select": {
       "version": "1.6.4",
       "from": "../../tmp/npm-25360-e04608df/1472064034158-0.4662157059647143/f1755efa102a41e43fc367ba36ce905b8f2b90e1",

--- a/src/mmw/package.json
+++ b/src/mmw/package.json
@@ -23,6 +23,7 @@
     "backbone.paginator": "2.0.5",
     "blueimp-md5": "1.1.0",
     "bootstrap": "3.3.4",
+    "bootstrap-datepicker": "1.7.1",
     "bootstrap-select": "git://github.com/azavea/bootstrap-select",
     "bootstrap-table": "1.11.0",
     "browserify": "9.0.3",

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -7,8 +7,6 @@
     .data-catalog-title {
         margin: 0.5em 0;
         padding: 0.5em;
-        font-size: 0.8em;
-        text-transform: uppercase;
     }
 
     .data-catalog-form {
@@ -47,7 +45,7 @@
         .date-filter-toggle {
           position: absolute;
           right: 0;
-          top: -30px;
+          top: -45px;
         }
     }
 

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -16,18 +16,38 @@
         padding: 0.5em;
 
         .data-catalog-search-input {
-            width: 100%;
+            width: 99%;
             height: 38px;
             border: none;
+            border-radius: 0;
             padding-left: 38px;
             font-size: 0.8em;
         }
+        .data-catalog-date-input {
+            width: 46%;
+            height: 38px;
+            border: none;
+            border-radius: 0;
+            display: inline;
+        }
+        .data-catalog-validation-msg {
+          color: $ui-danger;
+          margin-top: 8px;
+        }
         .data-catalog-search-icon {
             color: $ui-grey;
-            position: absolute;
-            top: 15px;
-            left: 15px;
+            position: relative;
+            top: 30px;
+            left: 8px;
             font-size: 18px;
+        }
+        .form-group {
+          margin-right: 15px;
+        }
+        .date-filter-toggle {
+          position: absolute;
+          right: 0;
+          top: -30px;
         }
     }
 

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -21,12 +21,24 @@
             padding-left: 38px;
             font-size: 0.8em;
         }
+        .data-catalog-clearable-input {
+            display: inline;
+        }
         .data-catalog-date-input {
-            width: 46%;
+            width: 42%;
             height: 38px;
             border: none;
             border-radius: 0;
             display: inline;
+        }
+        .data-catalog-clear-icon {
+            color: $ui-grey;
+            position: relative;
+            right: 25px;
+            font-size: 18px;
+        }
+        &:hover {
+            text-decoration: none;
         }
         .data-catalog-validation-msg {
           color: $ui-danger;


### PR DESCRIPTION
## Overview

Adds UI elements for collecting start and end date filters and passes them along to the existing API endpoint using the pre-existing querystring parameters.  Does some light validation to ensure that
`before < after`, which would otherwise raise exceptions on the backend.

Also adds a small formatting improvement to the warning dialog for areas which are too large for WDC to handle.

Connects #1933  

### Demo
#### Added filter toggle
![screenshot from 2017-07-25 09 03 56](https://user-images.githubusercontent.com/1014341/28573330-554577f8-7118-11e7-8973-94a5f16fb926.png)

#### Filters exposed with date-picker
![screenshot from 2017-07-25 09 04 15](https://user-images.githubusercontent.com/1014341/28573333-554694e4-7118-11e7-8d3f-5da26e643458.png)

#### Validation response
![screenshot from 2017-07-25 09 04 34](https://user-images.githubusercontent.com/1014341/28573331-5545863a-7118-11e7-983f-1df86ca64a69.png)

#### Warning - before
![screenshot from 2017-07-25 09 00 59](https://user-images.githubusercontent.com/1014341/28573334-55472c92-7118-11e7-84f0-2b73621b588d.png)

#### Warning - after
![screenshot from 2017-07-25 08 16 18](https://user-images.githubusercontent.com/1014341/28573332-5545fdc2-7118-11e7-9e6d-896ca3029d03.png)

### Notes
I uncovered an issue that is visible here, but also on staging (though less pronounced), captured here: #2080.  I also made a good-faith effort to match the styling shown in screenshots, but this could use some touch-ups as part of a final style pass on the larger feature.

I had to derive a bit of UX from the screenshot listed in the issue.  My decisions on the behavior are as followed, and are open to feedback:

* 0, 1 or both dates can be filled in without a validation error.  The backend appears to support this configuration.
* The datepicker library handles making sure a date format is valid, so I only ensure that the date precedence is appropriate.  If after < before in the WDC query, it will return an exception.
* I didn't do validation on blur from the field, since that would be annoying if the user was changing the values and after changing one, had them temporarily in an invalid state.  Validation is only run on search.
* Toggling the filter keeps the date values in place, so they are there when you re-toggle.  This means they are still used, even when hidden.  This could be confusing, but in my opinion, it's not any clearer than having them disappear when you click "Hide Filters".  Or if worse if they are not used when hidden, but are still there when you un-toggle.  I'm open to "Hide Filters" just clearing them from state altogether as an alternative.
* Hitting enter in a datebox will execute the search.  At first, I didn't like that approach, but in practice, having search results displayed and going back and tweaking the date seemed like a natural workflow.  Not having to tab into the query box to enter seems appropriate in that case.  

## Testing Instructions

 * A new JS dependency was added (datepicker), so npm install and rebundle the vendor and client assets.
* Navigate to the search and execute a number of searches with and without dates, or partial dates.
* Attempt to provide bad date values to the search.
* Date range input should be reflected in the results.
