### PR TITLE
Copy aoi_census and modification_censuses to duplicated TR-55 scenarios

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -298,14 +298,7 @@ var ScenarioButtonsView = Marionette.ItemView.extend({
     },
 
     addScenario: function() {
-        var first = this.collection.first();
-
-        if (first) {
-            var aoi_census = first.get('aoi_census');
-            this.collection.createNewScenario(aoi_census);
-        } else {
-            this.collection.createNewScenario();
-        }
+        this.collection.createNewScenario();
     },
 
     templateHelpers: function() {


### PR DESCRIPTION
## Overview

This PR fixes a bug described in #2084 whereby duplicate scenarios wouldn't model properly. The cause was that the `duplicateScenario` method didn't copy the `aoi_census` or `modification_censuses`; the fix is to copy those in `duplicateScenario` -- and I added a second commit to copy everything else from the original scenario except the name & id fields.

Connects #1943 
Connects #2084 

### Notes

I thought about trying to duplicate the Backbone model using `.clone` or `Object.assign` or similar, but the verbose version seemed like it'd be easier to debug.

## Testing Instructions

* get branch, then `bundle` and visit the app on 8000
* draw an AOI, then run TR-55 and add modifications
* duplicate that scenario and verify that the duplicated version is able to show modeling results
* get the share link for the duplicated scenario, then visit it in the browser & verify that the model results load properly
