### PR TITLE
Sort Pageable Analyze Tables Over Full Collection

### DIFF
--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
@@ -1,59 +1,28 @@
-<div class="pageable-table-container">
-{% if totalPages > 1 %}
-<div class="row paging-ctl-row">
-    {% if hasPreviousPage %}
-        <button
-            class="btn-prev-page btn btn-primary col-sm-1 col-sm-offset-3"
-            data-toggle="tooltip"
-            title="Previous Page"
-            data-placement="right"
-        >
-            <span aria-hidden="true">&larr;</span>
-        </button>
-    {% endif %}
-    <p class="col-sm-3 {{ "col-sm-offset-4" if not hasPreviousPage else "" }}">
-        {{currentPage}} of {{totalPages}}
-    </p>
-    {% if hasNextPage %}
-        <button
-            class="btn-next-page btn btn-primary col-sm-1"
-            data-toggle="tooltip"
-            title="Next Page"
-            data-placement="right"
-        >
-            <span aria-hidden="true">&rarr;</span>
-        </button>
-    {% endif %}
-</div>
-{% endif %}
-  <table class="table custom-hover catchment-water-quality pageable-table-size" data-toggle="table">
-      <thead>
-          <tr>
-              <th data-sortable="true">Id</th>
-              <th data-sortable="true" data-sorter="window.noDataSort"> Area (ha)</th>
-              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                  Total N (kg/ha)
-              </th>
-              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                  Total P (kg/ha)
-              </th>
-              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                  Total SS (kg/ha)
-              </th>
-              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                  Avg TN (mg/l)
-              </th>
-              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                  Avg TP (mg/l)
-              </th>
-              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                  Avg TSS (mg/l)
-              </th>
-          </tr>
-      </thead>
-      <tbody>
-      </tbody>
-      <tfoot>
-      </tfoot>
-  </table>
-</div>
+<table class="table custom-hover catchment-water-quality pageable-table-size" data-toggle="table">
+    <thead>
+        <tr>
+            <th data-sortable="true" data-field="nord">Id</th>
+            <th data-sortable="true" data-field="areaha" data-sorter="window.noDataSort"> Area (ha)</th>
+            <th class="text-right" data-field="tn_tot_kgy" data-sortable="true" data-sorter="window.noDataSort">
+                Total N (kg/ha)
+            </th>
+            <th class="text-right" data-field="tp_tot_kgy" data-sortable="true" data-sorter="window.noDataSort">
+                Total P (kg/ha)
+            </th>
+            <th class="text-right" data-field="tss_tot_kg" data-sortable="true" data-sorter="window.noDataSort">
+                Total SS (kg/ha)
+            </th>
+            <th class="text-right" data-field="tn_yr_avg_" data-sortable="true" data-sorter="window.noDataSort">
+                Avg TN (mg/l)
+            </th>
+            <th class="text-right" data-field="tp_yr_avg_" data-sortable="true" data-sorter="window.noDataSort">
+                Avg TP (mg/l)
+            </th>
+            <th class="text-right"  data-field="tss_concmg" data-sortable="true" data-sorter="window.noDataSort">
+                Avg TSS (mg/l)
+            </th>
+        </tr>
+    </thead>
+    <tbody></tbody>
+    <tfoot></tfoot>
+</table>

--- a/src/mmw/js/src/analyze/templates/pageableTable.html
+++ b/src/mmw/js/src/analyze/templates/pageableTable.html
@@ -1,0 +1,30 @@
+<div class="pageable-table-container">
+    {% if totalPages > 1 %}
+        <div class="row paging-ctl-row">
+            {% if hasPreviousPage %}
+                <button
+                    class="btn-prev-page btn btn-primary col-sm-1 col-sm-offset-3"
+                    data-toggle="tooltip"
+                    title="Previous Page"
+                    data-placement="right"
+                >
+                    <span aria-hidden="true">&larr;</span>
+                </button>
+            {% endif %}
+            <p class="col-sm-3 {{ "col-sm-offset-4" if not hasPreviousPage else "" }}">
+                {{currentPage}} of {{totalPages}}
+            </p>
+            {% if hasNextPage %}
+                <button
+                    class="btn-next-page btn btn-primary col-sm-1"
+                    data-toggle="tooltip"
+                    title="Next Page"
+                    data-placement="right"
+                >
+                    <span aria-hidden="true">&rarr;</span>
+                </button>
+            {% endif %}
+        </div>
+    {% endif %}
+    <div id="bootstrap-table-region"></div>
+</div>

--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -1,64 +1,34 @@
-<div class="pageable-table-container">
-{% if totalPages > 1 %}
-    <div class="row paging-ctl-row">
-        {% if hasPreviousPage %}
-            <button
-                class="btn-prev-page btn btn-primary col-sm-1 col-sm-offset-3"
-                data-toggle="tooltip"
-                title="Previous Page"
-                data-placement="right"
-            >
-                <span aria-hidden="true">&larr;</span>
-            </button>
-        {% endif %}
-        <p class="col-sm-3 {{ "col-sm-offset-4" if not hasPreviousPage else "" }}">
-            {{currentPage}} of {{totalPages}}
-        </p>
-        {% if hasNextPage %}
-            <button
-                class="btn-next-page btn btn-primary col-sm-1"
-                data-toggle="tooltip"
-                title="Next Page"
-                data-placement="right"
-            >
-                <span aria-hidden="true">&rarr;</span>
-            </button>
-        {% endif %}
-    </div>
-{% endif %}
-  <table class="table custom-hover point-source pageable-table-size" data-toggle="table">
-      <thead>
-          <tr>
-              <th data-sortable="true">NPDES Code</th>
-              <th data-sortable="true">City</th>
-              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                  Discharge (MGD)
-              </th>
-              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                  TN Load (kg/yr)
-              </th>
-              <th class="text-right" data-sortable="true" data-sorter="window.noDataSort">
-                  TP Load (kg/yr)
-              </th>
-          </tr>
-      </thead>
-      <tbody>
-      </tbody>
-      <tfoot>
-          <tr class="ptsrc-table-footer">
-              <td class="strong text-right" colspan="2">
-                  Total For Area of Interest
-              </td>
-              <td class="ptsrc-footer-item strong text-right">
-                  {{ totalMGD|filterNoData()|toLocaleString(3) }}
-              </td>
-              <td class="ptsrc-footer-item strong text-right">
-                  {{ totalKGN|filterNoData()|toLocaleString(3) }}
-              </td>
-              <td class="ptsrc-footer-item strong text-right">
-                  {{ totalKGP|filterNoData()|toLocaleString(3) }}
-              </td>
-          </tr>
-      </tfoot>
-  </table>
-</div>
+<table class="table custom-hover point-source pageable-table-size" data-toggle="table">
+    <thead>
+      <tr>
+          <th data-field="npdes_id" data-sortable="true">NPDES Code</th>
+          <th data-field="city" data-sortable="true">City</th>
+          <th data-field="mgd" class="text-right" data-sortable="true">
+              Discharge (MGD)
+          </th>
+          <th data-field="kgn_yr" class="text-right" data-sortable="true">
+              TN Load (kg/yr)
+          </th>
+          <th data-field="kgp_yr" class="text-right" data-sortable="true">
+              TP Load (kg/yr)
+          </th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+    <tfoot>
+    <tr class="ptsrc-table-footer">
+        <td class="strong text-right" colspan="2">
+            Total For Area of Interest
+        </td>
+        <td class="ptsrc-footer-item strong text-right">
+            {{ totalMGD|filterNoData()|toLocaleString(3) }}
+        </td>
+        <td class="ptsrc-footer-item strong text-right">
+            {{ totalKGN|filterNoData()|toLocaleString(3) }}
+        </td>
+        <td class="ptsrc-footer-item strong text-right">
+            {{ totalKGP|filterNoData()|toLocaleString(3) }}
+        </td>
+    </tr>
+    </tfoot>
+</table>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -28,6 +28,7 @@ var $ = require('jquery'),
     tableRowTmpl = require('./templates/tableRow.html'),
     animalTableTmpl = require('./templates/animalTable.html'),
     animalTableRowTmpl = require('./templates/animalTableRow.html'),
+    pageableTableTmpl = require('./templates/pageableTable.html'),
     pointSourceTableTmpl = require('./templates/pointSourceTable.html'),
     pointSourceTableRowTmpl = require('./templates/pointSourceTableRow.html'),
     catchmentWaterQualityTableTmpl = require('./templates/catchmentWaterQualityTable.html'),
@@ -590,6 +591,119 @@ var AnimalTableView = Marionette.CompositeView.extend({
     }
 });
 
+var PageableTableBaseView = Marionette.LayoutView.extend({
+    tableView: null, // a View that renders a bootstrap table. Required
+
+    template: pageableTableTmpl,
+    regions: {
+        'bootstrapTableRegion': '#bootstrap-table-region',
+    },
+
+    ui: {
+        'nextPageBtn': '.btn-next-page',
+        'prevPageBtn': '.btn-prev-page',
+    },
+
+    events: {
+        'click @ui.nextPageBtn': 'nextPage',
+        'click @ui.prevPageBtn': 'prevPage',
+    },
+
+    templateHelpers: function() {
+        return {
+            hasNextPage: this.collection.hasNextPage(),
+            hasPreviousPage: this.collection.hasPreviousPage(),
+            currentPage: this.collection.state.currentPage,
+            totalPages: this.collection.state.totalPages,
+        };
+    },
+
+    renderBootstrapTable: function() {
+        var self = this,
+            sortOrderClass = this.collection.state.order  === -1 ? 'asc' : 'desc',
+            tableHeaderSelector = '[data-toggle="table"]' +
+                                  '[data-field="' + this.collection.state.sortKey +'"]';
+
+        // We handle sorting for the collection. The bootstrap table handles
+        // sorting per page. Set its sort order to the collections
+        $(tableHeaderSelector).data("sortOrder", sortOrderClass);
+
+        $('[data-toggle="table"]').bootstrapTable({
+            // `name` will be the column's `data-field`
+            onSort: function(name) {
+                var prevSortKey = self.collection.state.sortKey,
+                    shouldSwitchDirection = prevSortKey === name,
+                    sortOrder = shouldSwitchDirection ?
+                                self.collection.state.order * -1 : 1,
+
+                    sortAscending = function(row) {
+                        var data = row.get(name);
+                        if (data === utils.noData) {
+                            return -Infinity;
+                        }
+                        if (typeof data === "string") {
+                            return utils.negateString(data);
+                        }
+                        return -row.get(name);
+                    },
+
+                    sortDescending = function(row) {
+                        var data = row.get(name);
+                        if (data === utils.noData) {
+                            return -Infinity;
+                        }
+                        return row.get(name);
+                    };
+
+                self.collection.setSorting(name, sortOrder);
+                self.collection.fullCollection.comparator = sortOrder === -1 ?
+                                                            sortAscending : sortDescending;
+                self.collection.fullCollection.sort();
+                self.render();
+            }
+        });
+
+        this.addSortedColumnStyling();
+    },
+
+    // Ensure the bootstrap table shows the appropriate "sorting caret" (up or down)
+    // based on the collection's sort order.
+    addSortedColumnStyling: function() {
+        var currentSortKey = this.collection.state.sortKey,
+            sortOrderClass = this.collection.state.order === -1 ? 'asc' : 'desc',
+            headerSelector = '[data-field="' + currentSortKey +'"]';
+
+        $(headerSelector + ' > div.th-inner').addClass(sortOrderClass);
+    },
+
+    nextPage: function() {
+        if (this.collection.hasNextPage()) {
+            this.collection.getNextPage();
+            this.render();
+        }
+    },
+
+    prevPage: function() {
+        if (this.collection.hasPreviousPage()) {
+            this.collection.getPreviousPage();
+            this.render();
+        }
+    },
+
+    onAttach: function() {
+        this.renderBootstrapTable();
+    },
+
+    onRender: function() {
+        this.bootstrapTableRegion.show(new this.tableView({
+                collection: this.collection,
+                units: this.options.units,
+            })
+        );
+        this.renderBootstrapTable();
+    },
+});
+
 var PointSourceTableRowView = Marionette.ItemView.extend({
     tagName: 'tr',
     className: 'point-source',
@@ -612,31 +726,20 @@ var PointSourceTableView = Marionette.CompositeView.extend({
     },
     templateHelpers: function() {
         return {
-            headerUnits: this.options.units,
             totalMGD: utils.totalForPointSourceCollection(
                 this.collection.fullCollection.models, 'mgd'),
             totalKGN: utils.totalForPointSourceCollection(
                 this.collection.fullCollection.models, 'kgn_yr'),
             totalKGP: utils.totalForPointSourceCollection(
                 this.collection.fullCollection.models, 'kgp_yr'),
-            hasNextPage: this.collection.hasNextPage(),
-            hasPreviousPage: this.collection.hasPreviousPage(),
-            currentPage: this.collection.state.currentPage,
-            totalPages: this.collection.state.totalPages,
         };
     },
     childViewContainer: 'tbody',
     template: pointSourceTableTmpl,
 
-    onAttach: function() {
-        $('[data-toggle="table"]').bootstrapTable();
-    },
-
     ui: {
         'pointSourceTR': 'tr.point-source',
         'pointSourceId': '.point-source-id',
-        'pointSourceTblNext': '.btn-next-page',
-        'pointSourceTblPrev': '.btn-prev-page'
     },
 
     events: {
@@ -644,8 +747,6 @@ var PointSourceTableView = Marionette.CompositeView.extend({
         'mouseout @ui.pointSourceId': 'removePointSourceMarker',
         'mouseover @ui.pointSourceTR': 'addPointSourceMarkerToMap',
         'mouseout @ui.pointSourceTR': 'removePointSourceMarker',
-        'click @ui.pointSourceTblNext': 'nextPage',
-        'click @ui.pointSourceTblPrev': 'prevPage'
     },
 
     createPointSourceMarker: function(data) {
@@ -658,22 +759,6 @@ var PointSourceTableView = Marionette.CompositeView.extend({
         }).bindPopup(new pointSourceLayer.PointSourcePopupView({
           model: new Backbone.Model(data)
       }).render().el, { closeButton: false });
-    },
-
-    nextPage: function() {
-        if (this.collection.hasNextPage()) {
-            this.collection.getNextPage();
-            this.render();
-            $('[data-toggle="table"]').bootstrapTable();
-        }
-    },
-
-    prevPage: function() {
-        if (this.collection.hasPreviousPage()) {
-            this.collection.getPreviousPage();
-            this.render();
-            $('[data-toggle="table"]').bootstrapTable();
-        }
     },
 
     addPointSourceMarkerToMap: function(e) {
@@ -707,6 +792,10 @@ var PointSourceTableView = Marionette.CompositeView.extend({
     }
 });
 
+var PointSourcePageableTableView = PageableTableBaseView.extend({
+    tableView: PointSourceTableView,
+});
+
 var CatchmentWaterQualityTableRowView = Marionette.ItemView.extend({
     tagName: 'tr',
     className: 'catchment-water-quality',
@@ -730,24 +819,14 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
     templateHelpers: function() {
         return {
             headerUnits: this.options.units,
-            hasNextPage: this.collection.hasNextPage(),
-            hasPreviousPage: this.collection.hasPreviousPage(),
-            currentPage: this.collection.state.currentPage,
-            totalPages: this.collection.state.totalPages,
         };
     },
     childViewContainer: 'tbody',
     template: catchmentWaterQualityTableTmpl,
 
-    onAttach: function() {
-        $('[data-toggle="table"]').bootstrapTable();
-    },
-
     ui: {
         'catchmentWaterQualityTR': 'tr.catchment-water-quality',
         'catchmentWaterQualityId': '.catchment-water-quality-id',
-        'catchmentWaterQualityTblNext': '.btn-next-page',
-        'catchmentWaterQualityTblPrev': '.btn-prev-page',
     },
 
     events: {
@@ -755,24 +834,6 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
         'mouseout @ui.catchmentWaterQualityId': 'removeCatchmentPolygon',
         'mouseover @ui.catchmentWaterQualityTR': 'addCatchmentToMap',
         'mouseout @ui.catchmentWaterQualityTR': 'removeCatchmentPolygon',
-        'click @ui.catchmentWaterQualityTblNext': 'nextPage',
-        'click @ui.catchmentWaterQualityTblPrev': 'prevPage',
-    },
-
-    nextPage: function() {
-        if (this.collection.hasNextPage()) {
-            this.collection.getNextPage();
-            this.render();
-            $('[data-toggle="table"]').bootstrapTable();
-        }
-    },
-
-    prevPage: function() {
-        if (this.collection.hasPreviousPage()) {
-            this.collection.getPreviousPage();
-            this.render();
-            $('[data-toggle="table"]').bootstrapTable();
-        }
     },
 
     createCatchmentPolygon: function(data) {
@@ -825,6 +886,10 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
             map.removeLayer(this.catchmentPolygon);
         }
     }
+});
+
+var CatchmentWaterQualityPageableTableView = PageableTableBaseView.extend({
+    tableView: CatchmentWaterQualityTableView,
 });
 
 var ChartView = Marionette.ItemView.extend({
@@ -925,10 +990,10 @@ var AnalyzeResultView = Marionette.LayoutView.extend({
 
             if (dataName === 'pointsource') {
                 census = new coreModels.PointSourceCensusCollection(data);
-                TableView = PointSourceTableView;
+                TableView = PointSourcePageableTableView;
             } else if (dataName === 'catchment_water_quality') {
                 census = new coreModels.CatchmentWaterQualityCensusCollection(data);
-                TableView = CatchmentWaterQualityTableView;
+                TableView = CatchmentWaterQualityPageableTableView;
             }
 
             // Ensure all the data is rendered
@@ -1026,7 +1091,7 @@ var PointSourceResultView = AnalyzeResultView.extend({
             pageSize = utils.calculateVisibleRows(minScreenHeight, avgRowHeight, 3),
             chart = null;
         this.showAnalyzeResults(coreModels.PointSourceCensusCollection,
-            PointSourceTableView, chart, title, source, helpText, associatedLayerCodes, pageSize);
+            PointSourcePageableTableView, chart, title, source, helpText, associatedLayerCodes, pageSize);
     }
 });
 
@@ -1046,7 +1111,7 @@ var CatchmentWaterQualityResultView = AnalyzeResultView.extend({
             pageSize = utils.calculateVisibleRows(minScreenHeight, avgRowHeight, 5),
             chart = null;
         this.showAnalyzeResults(coreModels.CatchmentWaterQualityCensusCollection,
-            CatchmentWaterQualityTableView, chart, title, source, helpText,
+            CatchmentWaterQualityPageableTableView, chart, title, source, helpText,
             associatedLayerCodes, pageSize);
     }
 });

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -659,6 +659,9 @@ var PageableTableBaseView = Marionette.LayoutView.extend({
                 self.collection.fullCollection.comparator = sortOrder === -1 ?
                                                             sortAscending : sortDescending;
                 self.collection.fullCollection.sort();
+
+                self.collection.getFirstPage();
+
                 self.render();
             }
         });

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -193,6 +193,15 @@ var utils = {
         return utils.numericSort(x, y);
     },
 
+    negateString: function(str) {
+        // From https://stackoverflow.com/a/5639070
+        return String.fromCharCode.apply(String,
+            _.map(str.split(""), function (c) {
+                return 0xffff - c.charCodeAt();
+            })
+        );
+    },
+
     // Parse query strings for Backbone
     // Takes queryString of format "key1=value1&key2=value2"
     // Returns object of format {key1: value1, key2: value2}


### PR DESCRIPTION
## Overview

- Previously, clicking the column headers for the Point Source or Catchment Water Quality tables, would only sort the data within the visible page
- Extract out a `PageableTableBaseView` that handles pagination, and overrides the bootstrap-table's `onSort` to sort the whole collection, and rerender the table

Connects #1594 

### Demo

![1rkoyw9t2h](https://user-images.githubusercontent.com/7633670/28671772-d6dd3e9c-72ab-11e7-9fa7-945e3bef7ca6.gif)

## Testing Instructions

 * Pull + `./scripts/bundle.sh`
 * Analyze a big AoI in the DRB (eg the schuykill huc-08)
 * Confirm the Point Source and Water Quality tables
     - still paginate properly
     - sort across the whole table on column sort for each column
     - still download
  * Site storm model the AoI and confirm the Analyze toggled view works and isn't laggy
  * For a smaller AoI confirm the point source + water quality tables still render and sort okay when not paginated
  * For an AoI outside the DRB, confirm the point source + water quality no-data tables render okay

