### PR TITLE
BiG-CZ Uniform AoI Limit

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -21,7 +21,6 @@ from apps.bigcz.clients.cuahsi.models import CuahsiResource
 
 
 SQKM_PER_SQM = 0.000001
-MAX_AREA_SQKM = 1500
 CATALOG_NAME = 'cuahsi'
 CATALOG_URL = 'http://hiscentral.cuahsi.org/webservices/hiscentral.asmx?WSDL'
 

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -120,6 +120,7 @@ def get_client_settings(request):
     # ?bigcz query parameter is present. This covers staging sites, etc.
     bigcz = settings.BIGCZ_HOST in request.get_host() or 'bigcz' in request.GET
     title = 'Critical Zone Data Explorer' if bigcz else 'Model My Watershed'
+    max_area = settings.BIGCZ_MAX_AREA if bigcz else settings.MMW_MAX_AREA
     EMBED_FLAG = settings.ITSI['embed_flag']
     client_settings = {
         'client_settings': json.dumps({
@@ -135,6 +136,7 @@ def get_client_settings(request):
             'vizer_ignore': settings.VIZER_IGNORE,
             'vizer_names': settings.VIZER_NAMES,
             'model_packages': get_model_packages(),
+            'max_area': max_area,
             'mapshed_max_area': settings.GWLFE_CONFIG['MaxAoIArea'],
             'data_catalog_enabled': bigcz,
             'data_catalog_page_size': settings.BIGCZ_CLIENT_PAGE_SIZE,

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -16,7 +16,8 @@ var defaultSettings = {
     vizer_urls: {},
     vizer_ignore: [],
     vizer_names: {},
-    model_packages: []
+    model_packages: [],
+    max_area: 75000,
 };
 
 var settings = (function() {

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -5,10 +5,7 @@ var $ = require('jquery'),
     Marionette = require('../../shim/backbone.marionette'),
     moment = require('moment'),
     App = require('../app'),
-    modalModels = require('../core/modals/models'),
-    modalViews = require('../core/modals/views'),
     settings = require('../core/settings'),
-    utils = require('./utils'),
     errorTmpl = require('./templates/error.html'),
     formTmpl = require('./templates/form.html'),
     pagerTmpl = require('./templates/pager.html'),
@@ -19,8 +16,6 @@ var $ = require('jquery'),
     windowTmpl = require('./templates/window.html');
 
 var ENTER_KEYCODE = 13,
-    MAX_AREA_SQKM = 1500,
-    MAX_AREA_FORMATTED = MAX_AREA_SQKM.toLocaleString(),
     PAGE_SIZE = settings.get('data_catalog_page_size'),
     CATALOG_RESULT_TEMPLATE = {
         cinergi: searchResultTmpl,
@@ -87,31 +82,7 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
             query = this.model.get('query'),
             fromDate = this.model.get('fromDate'),
             toDate = this.model.get('toDate'),
-            bounds = L.geoJson(App.map.get('areaOfInterest')).getBounds(),
-            area = utils.areaOfBounds(bounds);
-
-        // CUAHSI should not be fetched beyond a certain size
-        if (catalog.get('id') === 'cuahsi' && area > MAX_AREA_SQKM) {
-            var formattedArea = Math.round(area).toLocaleString(),
-                alertView = new modalViews.AlertView({
-                model: new modalModels.AlertModel({
-                    alertMessage: "The bounding box of the current area of " +
-                                  "interest is " + formattedArea + "&nbsp;km², " +
-                                  "which is larger than the current maximum " +
-                                  "area of " + MAX_AREA_FORMATTED + "&nbsp;km² " +
-                                  "supported for WDC.",
-                    alertType: modalModels.AlertTypes.error
-                })
-            });
-            alertView.render();
-
-            // Reset results
-            catalog.get('results').reset();
-            catalog.set({ resultCount: 0 });
-            this.updateMap();
-
-            return;
-        }
+            bounds = L.geoJson(App.map.get('areaOfInterest')).getBounds();
 
         // Disable intro text after first search request
         this.ui.introText.addClass('hide');

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -6,12 +6,12 @@ var $ = require('jquery'),
     JSZip = require('jszip'),
     turfArea = require('turf-area'),
     turfBboxPolygon = require('turf-bbox-polygon'),
+    settings = require('../core/settings'),
     coreUtils = require('../core/utils');
 
 var CANCEL_DRAWING = 'CANCEL_DRAWING';
 
-// Keep in sync with src/api/main.py in rapid-watershed-delineation.
-var MAX_AREA = 75000; // About the size of West Virginia (in km^2)
+var MAX_AREA = settings.get('max_area');
 
 var polygonDefaults = {
         fillColor: '#E77471',

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -104,10 +104,10 @@ function validateShape(polygon) {
     } else if (!utils.isValidForAnalysis(polygon)) {
         var maxArea = utils.MAX_AREA.toLocaleString(),
             selectedBoundingBoxArea = Math.floor(utils.shapeBoundingBoxArea(polygon)).toLocaleString(),
-            message = 'Sorry, the bounding box of the area you have delineated is too large ' +
-                      'to analyze or model. ' + selectedBoundingBoxArea + ' km² were ' +
+            message = 'Sorry, the bounding box of the selected area is too large ' +
+                      'to analyze or model. ' + selectedBoundingBoxArea + '&nbsp;km² were ' +
                       'selected, but the maximum supported size is ' +
-                      'currently ' + maxArea + ' km².';
+                      'currently ' + maxArea + '&nbsp;km².';
         d.reject(message);
     } else {
         d.resolve(polygon);
@@ -874,7 +874,7 @@ var WatershedDelineationView = DrawToolBaseView.extend({
                 navigateToAnalyze();
             })
             .fail(function(message) {
-                displayAlert(message, modalModels.AlertTypes.warn);
+                displayAlert(message, modalModels.AlertTypes.error);
                 self.resetDrawingState();
             })
             .always(function() {

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -1016,8 +1016,14 @@ function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {
                 clearBoundaryLayer(model);
                 navigateToAnalyze();
                 deferred.resolve();
-            }).fail(function() {
-                console.log('Shape endpoint failed');
+            }).fail(function(message) {
+                if (typeof(message) === "string") {
+                    // When validation fails with an error message
+                    displayAlert(message, modalModels.AlertTypes.error);
+                } else {
+                    // When AJAX fails with an XHR object
+                    console.log('Shape endpoint failed');
+                }
                 deferred.reject();
             });
     }

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -356,8 +356,11 @@ OMGEO_SETTINGS = [[
     }
 ]]
 
-# BiG-CZ Host, for enabling custom behavior.
-BIGCZ_HOST = 'portal.bigcz.org'
+# Keep in sync with src/api/main.py in rapid-watershed-delineation.
+MMW_MAX_AREA = 75000  # Max area in km2, about the size of West Virginia
+
+BIGCZ_HOST = 'portal.bigcz.org'  # BiG-CZ Host, for enabling custom behavior
+BIGCZ_MAX_AREA = 1500  # Max area in km2, limited by CUAHSI
 BIGCZ_CLIENT_TIMEOUT = 5  # timeout in seconds
 BIGCZ_CLIENT_PAGE_SIZE = 100
 


### PR DESCRIPTION
## Overview

Previously we allowed much larger AoI limits for CINERGI and Hydroshare APIs, since they are much faster, but had a limit in place for CUAHSI / WDC which is slower. However, it is also the richest in terms of information, and possibly the one most users are interested in. Thus, for them to move through Draw and Analyze and Search, only to be denied at the very end, can be frustrating. Hence, we change the limit on the draw section to 1,500 km².

See commit messages for details.

Connects #2092 
Connects #2015 

### Demo

![2017-07-31 14 23 32](https://user-images.githubusercontent.com/1430060/28791945-15582ef4-75fc-11e7-9928-148b951423ba.gif)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and try to draw, select, delineate, and upload shapes under and over 1,500 km² in size. Those under should succeed, those over should fail
 * Go to [:8000/](http://localhost:8000/), and test that the limit for MMW is still 75,000 km²