### PR TITLE
Upgrade to Java 8

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -45,6 +45,6 @@
 - src: azavea.beaver
   version: 1.0.1
 - src: azavea.java
-  version: 0.2.5
+  version: 0.5.0
 - src: azavea.docker
   version: 1.0.2

--- a/deployment/ansible/roles/model-my-watershed.geoprocessing/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.geoprocessing/meta/main.yml
@@ -1,3 +1,8 @@
 ---
 dependencies:
   - { role: "model-my-watershed.spark-jobserver" }
+  - {
+      role: "azavea.java",
+      java_major_version: "8",
+      java_version: "8u141*"
+    }


### PR DESCRIPTION
## Overview

This is required to run Akka HTTP services natively. Previously we were running Spark JobServer within a Docker container, so did not need to install this. Now, for performance reasons, we will run the service natively, thus necessitating this install.

I did not remove the Spark JobServer dependency. That should be done in #2103.

Note that this and all other Collections API PRs will target `feature/collections-api` branch.

Connects #2100 

### Notes

OpenJDK 8 does not seem to be available for Ubuntu, so I had to switch to using the Oracle flavor. Not sure if this has any consequences for our overall licensing. /cc @hectcastro @mmcfarland 

## Testing Instructions

 * Check out this branch
 * Run `vagrant provision worker`
 * Run `vagrant ssh worker -c 'java -version'`. Ensure you see this output:

       java version "1.8.0_131"
       Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
       Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)