### PR TITLE
BiG-CZ Map Hover Improvements

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -685,14 +685,21 @@ var MapView = Marionette.ItemView.extend({
     },
 
     renderDataCatalogActiveResult: function() {
-        var geom = this.model.get('dataCatalogActiveResult');
+        var geom = this.model.get('dataCatalogActiveResult'),
+            mapBounds = this._leafletMap.getBounds();
 
         this._dataCatalogActiveLayer.clearLayers();
+        this.$el.removeClass('bigcz-highlight-map');
 
         if (geom) {
-            var layer = this.createDataCatalogShape(geom);
-            layer.setStyle(dataCatalogActiveStyle);
-            this._dataCatalogActiveLayer.addLayer(layer);
+            if ((geom.type === 'MultiPolygon' || geom.type === 'Polygon') &&
+                drawUtils.shapeBoundingBox(geom).contains(mapBounds)) {
+                this.$el.addClass('bigcz-highlight-map');
+            } else {
+                var layer = this.createDataCatalogShape(geom);
+                layer.setStyle(dataCatalogActiveStyle);
+                this._dataCatalogActiveLayer.addLayer(layer);
+            }
         }
     }
 });

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -343,11 +343,16 @@ var ResultView = Marionette.ItemView.extend({
     className: 'resource',
 
     events: {
-        'mouseover': 'highlightResult'
+        'mouseover': 'highlightResult',
+        'mouseout': 'unHighlightResult',
     },
 
     highlightResult: function() {
         App.map.set('dataCatalogActiveResult', this.model.get('geom'));
+    },
+
+    unHighlightResult: function() {
+        App.map.set({ dataCatalogActiveResult: null });
     }
 });
 

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -90,7 +90,8 @@ function cancelDrawing(map) {
 
 function getGeoJsonLatLngs(shape) {
     if (shape.coordinates) {
-        return L.GeoJSON.coordsToLatLngs(shape.coordinates, 2);
+        var nesting = shape.type === "MultiPolygon" ? 2 : 1;
+        return L.GeoJSON.coordsToLatLngs(shape.coordinates, nesting);
     } else if (shape.geometry) {
         return L.GeoJSON.coordsToLatLngs(shape.geometry.coordinates, 1);
     } else if (shape.features) {
@@ -109,10 +110,13 @@ function shapeArea(shape) {
             'm<sup>2</sup>', 'km<sup>2</sup>');
 }
 
+function shapeBoundingBox(shape) {
+    return L.latLngBounds(getGeoJsonLatLngs(shape));
+}
+
 // Get the bounding box of the shape and return its area in km2
 function shapeBoundingBoxArea(shape) {
-    var shapeLatLngPoints = getGeoJsonLatLngs(shape),
-        latLngBounds = L.latLngBounds(shapeLatLngPoints),
+    var latLngBounds = shapeBoundingBox(shape),
         boundingBox = [
             latLngBounds.getWest(),
             latLngBounds.getSouth(),
@@ -165,6 +169,7 @@ module.exports = {
     createRwdMarkerIcon: createRwdMarkerIcon,
     cancelDrawing: cancelDrawing,
     polygonDefaults: polygonDefaults,
+    shapeBoundingBox: shapeBoundingBox,
     shapeBoundingBoxArea: shapeBoundingBoxArea,
     isValidForAnalysis: isValidForAnalysis,
     loadAsyncShpFilesFromZip: loadAsyncShpFilesFromZip,

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -29,6 +29,14 @@
   right: 0;
   left: 0;
   height: 100%;
+
+  &.bigcz-highlight-map:after {
+    content: "";
+    border: 3px solid gold;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+  }
 }
 
 #overlay-subclass-vector .disabled, #overlay-subclass-raster .disabled {


### PR DESCRIPTION
## Overview

Improves map hover interactions on the search page in two ways:

 * When not hovering on anything, the map resets to the original state, instead of being stuck on the last hovered item
 * When hovering on an item that is larger than the map's bounds, we show a gold border around the map without obscuring the items, making for a less distracting experience

Connects #2089 
Connects #2090 

### Demo

![2017-07-31 17 27 34](https://user-images.githubusercontent.com/1430060/28799200-a264cbea-7615-11e7-9d98-ab1d80b7f0ef.gif)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Select an area of interest and search for something
 * Ensure items in the CINERGI tab that are too big to show cause the gold highlight
 * Ensure items fully contained within the map are highlighted as before
 * Ensure items partially contained within the map are highlighted as before
 * Ensure the Hydroshare tab, which has no geometries, works as before
 * Ensure the WDC tab, which has point geometries, supports the new "unhighlight on mouseout" behavior