### PR TITLE
BiGCZ: Only search if query has changed

### DIFF
--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -30,12 +30,13 @@ var Catalog = Backbone.Model.extend({
 
     searchIfNeeded: function(query, fromDate, toDate, bbox) {
         var self = this,
+            error = this.get('error'),
             isSameSearch = query === this.get('query') &&
                            fromDate === this.get('fromDate') &&
                            toDate === this.get('toDate') &&
                            bbox === this.get('bbox');
 
-        if (!isSameSearch) {
+        if (!isSameSearch || error) {
             this.cancelSearch();
             this.searchPromise = this.search(query, fromDate, toDate, bbox)
                                      .always(function() {

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -6,6 +6,7 @@ var $ = require('jquery'),
     moment = require('moment'),
     App = require('../app'),
     settings = require('../core/settings'),
+    utils = require('./utils'),
     errorTmpl = require('./templates/error.html'),
     formTmpl = require('./templates/form.html'),
     pagerTmpl = require('./templates/pager.html'),
@@ -82,13 +83,14 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
             query = this.model.get('query'),
             fromDate = this.model.get('fromDate'),
             toDate = this.model.get('toDate'),
-            bounds = L.geoJson(App.map.get('areaOfInterest')).getBounds();
+            aoiGeoJson = L.geoJson(App.map.get('areaOfInterest')),
+            bounds = utils.formatBounds(aoiGeoJson.getBounds());
 
         // Disable intro text after first search request
         this.ui.introText.addClass('hide');
         this.ui.tabs.removeClass('hide');
 
-        catalog.search(query, fromDate, toDate, bounds);
+        catalog.searchIfNeeded(query, fromDate, toDate, bounds);
     },
 
     updateMap: function() {

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -45,7 +45,7 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
     },
 
     collectionEvents: {
-        'change:active, change:loading': 'updateMap'
+        'change:active change:loading': 'updateMap'
     },
 
     onShow: function() {
@@ -95,7 +95,7 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
 
     updateMap: function() {
         var catalog = this.getActiveCatalog(),
-            geoms = catalog.get('results').pluck('geom');
+            geoms = catalog && catalog.get('results').pluck('geom');
         App.map.set('dataCatalogResults', geoms);
     }
 });
@@ -238,9 +238,7 @@ var ErrorView = Marionette.ItemView.extend({
 });
 
 var TabContentView = Marionette.LayoutView.extend({
-    className: function() {
-        return 'tab-pane' + (this.model.get('active') ? ' active' : '');
-    },
+    className: 'tab-pane',
     id: function() {
         return this.model.id;
     },
@@ -260,10 +258,13 @@ var TabContentView = Marionette.LayoutView.extend({
     },
 
     modelEvents: {
-        'change': 'update'
+        'change': 'update',
+        'change:active': 'toggleActiveClass',
     },
 
     onShow: function() {
+        this.toggleActiveClass();
+
         this.resultRegion.show(new ResultsView({
             collection: this.model.get('results'),
             catalog: this.model.id,
@@ -279,6 +280,10 @@ var TabContentView = Marionette.LayoutView.extend({
                 model: this.model,
             }));
         }
+    },
+
+    toggleActiveClass: function() {
+        this.$el.toggleClass('active', this.model.get('active'));
     },
 
     update: function() {


### PR DESCRIPTION
## Overview

We were searching any time you made a catalog tab active. Now we only run a search if we've updated the query (or the search has never been run).

While looking through data catalog views, noticed we were setting `className` dynamically, which I've had trouble with in the past. Correcting this fixed the bug on IE11 where the tab contents would remain the same for all tabs (ie all tabs showed CINERGI results).

Connects #1960 
Connects #2014  

### Demo

![vujimkyvfj](https://user-images.githubusercontent.com/7633670/28828417-bb57a896-769e-11e7-8567-f81dfe6b1e9f.gif)

## Testing Instructions

 * Pull and `bundle`
 * `localhost:800?bigcz`
On the major browsers:
  * Draw an AoI and search for something
  * Confirm the search doesn't execute again when you switch between tabs, but does re-execute if you update the query (either date filters or query text)
  * Confirm the pagination still works