### PR TITLE
Affix Pagination Controls to the Bottom

### DIFF
--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -39,6 +39,7 @@ var DataCatalogController = {
                 id: 'cuahsi',
                 name: 'WDC',
                 description: 'Optional catalog description here...',
+                is_pageable: false,
                 results: new models.Results(null, { catalog: 'cuahsi' }),
             })
         ]);

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -24,6 +24,7 @@ var Catalog = Backbone.Model.extend({
         active: false,
         results: null, // Results collection
         resultCount: 0,
+        is_pageable: true,
         page: 1,
         error: '',
     },

--- a/src/mmw/js/src/data_catalog/templates/tabContent.html
+++ b/src/mmw/js/src/data_catalog/templates/tabContent.html
@@ -10,6 +10,6 @@
 
 <div class="error-region"></div>
 
-<div class="result-region"></div>
+<div class="result-region {{ 'paginated' if is_pageable }}"></div>
 
 <div class="pager-region"></div>

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -274,9 +274,7 @@ var TabContentView = Marionette.LayoutView.extend({
             model: this.model,
         }));
 
-        // CUAHSI does not support pagination, but others do
-        if (this.model.id !== 'cuahsi') {
-            this.resultRegion.$el.addClass('paginated');
+        if (this.model.get('is_pageable')) {
             this.pagerRegion.show(new PagerView({
                 model: this.model,
             }));

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -276,6 +276,7 @@ var TabContentView = Marionette.LayoutView.extend({
 
         // CUAHSI does not support pagination, but others do
         if (this.model.id !== 'cuahsi') {
+            this.resultRegion.$el.addClass('paginated');
             this.pagerRegion.show(new PagerView({
                 model: this.model,
             }));

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -16,16 +16,29 @@
     }
 
     .result-region {
-        padding-top: 6px;
+        padding: 6px 0px;
+
+        &.paginated {
+            position: absolute;
+            overflow-y: auto;
+            top: 0px;
+            bottom: 54px;  // .pager-region height + padding-top
+        }
     }
 
     .pager-region {
-        padding: 10px 0;
-        background-color: #e6e6e6;
+        > div {
+            padding: 10px 0;
+            background-color: #e6e6e6;
+            border-top: 1px solid $black-12;
+            position: fixed;
+            bottom: 0px;
+            width: $sidebar-width;
 
-        .row {
-            margin-left: -5px !important;
-            margin-right: -5px !important;
+            .row {
+                margin-left: -5px !important;
+                margin-right: -5px !important;
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

Previously the pagination controls would be all the way down below the search results, and the user would have to scroll to the very bottom to discover them. Now they are positioned to be fixed.

Connects #2091 

### Demo

![2017-08-01 16 02 05](https://user-images.githubusercontent.com/1430060/28844693-852babca-76d3-11e7-9fa9-f87ac8d1bb94.gif)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/bigcz](http://localhost:8000/?bigcz)
 * Select an area of interest and proceed to Analyze and then Search
 * Search for "water". Wait for results
 * Ensure the pagination buttons are fixed to the bottom of the screen
 * Ensure you can scroll to see all results and they are never obscured
 * Ensure you can turn on and off the Filters at the top and the search results are still accessible
 * Ensure WDC tab does not have the controls, and CINERGI and Hydroshare both have them, and the styling is correct in each
 * Try out various browsers