### PR TITLE
BiGCZ: Clear results from map after leaving search page

### DIFF
--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -48,6 +48,13 @@ var DataCatalogController = {
             collection: catalogs
         });
         App.rootView.sidebarRegion.show(view);
+    },
+
+    dataCatalogCleanUp: function() {
+        App.map.set({
+            dataCatalogResults: null,
+            dataCatalogActiveResult: null,
+        });
     }
 };
 

--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -55,6 +55,11 @@ var DataCatalogController = {
             dataCatalogResults: null,
             dataCatalogActiveResult: null,
         });
+        App.rootView.sidebarRegion.currentView.collection.forEach(
+            function(catalogModel) {
+                catalogModel.cancelSearch();
+            }
+        );
     }
 };
 


### PR DESCRIPTION
## Overview

The BiG-CZ data catalog results would remain on the map even after you'd navigated back to the splash page/analyze.

Connects #2054 

### Demo

![ajsopqfv4j](https://user-images.githubusercontent.com/7633670/28845695-e1847ad4-76d6-11e7-91f8-e51503c021a1.gif)

## Testing Instructions

 * Pull and `bundle`
 * Search for something that yields shapes in WDC and cinergi
 * Confirm they clear if you use the browser back navigation or click the header to go to the splash
 * Confirm you can still search another shape
