### PR TITLE
BiGCZ: Implement minor search improvements

### DIFF
--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -118,7 +118,6 @@ def search(**kwargs):
 
     params = {
         'f': 'json',
-        'sort': 'sys_modified_dt:desc',
         'size': PAGE_SIZE,
     }
 

--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -74,6 +74,9 @@ def search(**kwargs):
         })
     if bbox:
         params.update(prepare_bbox(bbox))
+        params.update({
+            'coverage_type': 'box'
+        })
     if page:
         params.update({
             'page': page


### PR DESCRIPTION
## Overview

4cfc5f6 allows Hydroshare searches to use the AoI bounding box for searching.
4db0de7 turns off date sorting in Cinergi, which keeps the results in order of relevancy. 

Connects #2108 

## Testing Instructions

- Apply the following change to the code (the bounding box functionality is not supported in production hydroshare).

```diff
diff --git a/src/mmw/apps/bigcz/clients/hydroshare/search.py b/src/mmw/apps/bigcz/clients/hydroshare/search.py
index 1f7389c..ab37cbc 100644
--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -14,7 +14,7 @@ from apps.bigcz.utils import RequestTimedOutError


 CATALOG_NAME = 'hydroshare'
-CATALOG_URL = 'https://www.hydroshare.org/hsapi/resource/'
+CATALOG_URL = 'https://playground.hydroshare.org/hsapi/resource/'


 def parse_date(value):
```

- Draw an AoI
- Make the same search locally and on staging.
- For Hydroshare, verify that there are less results locally (since they are restricted to the bounding box). You can also take a look at the data returned from our API and verify that the `coverage_type` parameter is included in the request URL.
- For Cinergi, verify that the results on the first page contain the search term "water" locally, and that they don't on staging.

