### PR TITLE
Compare View Revamp: Wire Up Precipitation Slider

### DIFF
--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -5,15 +5,9 @@ var _ = require('lodash'),
     router = require('../router').router,
     views = require('./views'),
     modelingModels = require('../modeling/models.js'),
-    modelingControls = require('../modeling/controls'),
-    coreUtils = require('../core/utils'),
-    synchronizer = modelingControls.PrecipitationSynchronizer;
+    coreUtils = require('../core/utils');
 
 var CompareController = {
-    comparePrepare: function() {
-        synchronizer.on();
-    },
-
     compare: function(projectId) {
         var first = null,
             aoi_census = null;
@@ -53,7 +47,6 @@ var CompareController = {
     },
 
     compareCleanUp: function() {
-        synchronizer.off();
         App.user.off('change:guest', saveAfterLogin);
         App.origProject.off('change:id', updateUrl);
 

--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var Backbone = require('../../shim/backbone');
+var Backbone = require('../../shim/backbone'),
+    ControlsCollection = require('../modeling/models').ModelPackageControlsCollection;
 
 var CHART = 'chart',
     TABLE = 'table';
@@ -39,6 +40,7 @@ var TabsCollection = Backbone.Collection.extend({
 
 var WindowModel = Backbone.Model.extend({
     defaults: {
+        controls: null, // ModelPackageControlsCollection
         mode: TABLE, // or CHART
         tabs: null,  // TabsCollection
     },
@@ -47,6 +49,7 @@ var WindowModel = Backbone.Model.extend({
         Backbone.Model.prototype.initialize.apply(this, arguments);
 
         this.set({
+            controls: new ControlsCollection(attrs.controls),
             tabs: new TabsCollection(attrs.tabs),
         });
     }

--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -42,6 +42,7 @@ var WindowModel = Backbone.Model.extend({
     defaults: {
         controls: null, // ModelPackageControlsCollection
         mode: TABLE, // or CHART
+        scenarios: null, // ScenariosCollection
         tabs: null,  // TabsCollection
     },
 

--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -53,6 +53,12 @@ var WindowModel = Backbone.Model.extend({
             controls: new ControlsCollection(attrs.controls),
             tabs: new TabsCollection(attrs.tabs),
         });
+    },
+
+    addOrReplaceInput: function(input) {
+        this.get('scenarios').each(function(scenario) {
+            scenario.addOrReplaceInput(input);
+        });
     }
 });
 

--- a/src/mmw/js/src/compare/templates/compareInputs.html
+++ b/src/mmw/js/src/compare/templates/compareInputs.html
@@ -1,4 +1,4 @@
-<div class="compare-precipitation compare-input">Precipitation -----|----</div>
+<div class="compare-precipitation compare-input"></div>
 <div class="compare-toggles compare-input">
     <button id="compare-input-button-chart" class="{{ 'active' if mode == 'chart' }}"><i class="fa fa-bar-chart"></i></button>
     <button id="compare-input-button-table" class="{{ 'active' if mode == 'table' }}"><i class="fa fa-table"></i></button>

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -129,19 +129,19 @@ var InputsView = Marionette.LayoutView.extend({
     },
 
     onShow: function() {
-        var setPrecipitationValue = _.bind(this.setPrecipitationValue, this),
+        var addOrReplaceInput = _.bind(this.model.addOrReplaceInput, this.model),
+            controlModel = this.model.get('scenarios')
+                               .findWhere({ active: true })
+                               .get('inputs')
+                               .findWhere({ name: 'precipitation' }),
             precipitationModel = this.model.get('controls')
                                      .findWhere({ name: 'precipitation' });
 
         this.precipitationRegion.show(new PrecipitationView({
             model: precipitationModel,
-            addOrReplaceInput: setPrecipitationValue,
+            controlModel: controlModel,
+            addOrReplaceInput: addOrReplaceInput,
         }));
-    },
-
-    setPrecipitationValue: function(input) {
-        // TODO Make this set the precipitation value for all scenarios
-        console.log(input);
     },
 
     setChartView: function() {
@@ -585,6 +585,14 @@ function showCompare() {
         });
 
     compareModel.set({ scenarios: scenarios });
+
+    if (isTr55) {
+        // Set compare model to have same precipitation as active scenario
+        compareModel.addOrReplaceInput(
+            scenarios.findWhere({ active: true })
+                     .get('inputs')
+                     .findWhere({ name: 'precipitation' }));
+    }
 
     App.rootView.compareRegion.show(new CompareWindow2({
         model: compareModel,

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -9,7 +9,6 @@ var _ = require('lodash'),
     models = require('./models'),
     modelingModels = require('../modeling/models'),
     modelingViews = require('../modeling/views'),
-    modelingControls = require('../modeling/controls'),
     modConfigUtils = require('../modeling/modificationConfigUtils'),
     compareWindowTmpl = require('./templates/compareWindow.html'),
     compareWindow2Tmpl = require('./templates/compareWindow2.html'),
@@ -20,8 +19,7 @@ var _ = require('lodash'),
     compareScenariosTmpl = require('./templates/compareScenarios.html'),
     compareScenarioTmpl = require('./templates/compareScenario.html'),
     compareModelingTmpl = require('./templates/compareModeling.html'),
-    compareModificationsTmpl = require('./templates/compareModifications.html'),
-    synchronizer = modelingControls.PrecipitationSynchronizer;
+    compareModificationsTmpl = require('./templates/compareModifications.html');
 
 var CompareWindow2 = Marionette.LayoutView.extend({
     template: compareWindow2Tmpl,
@@ -225,7 +223,6 @@ var CompareWindow = Marionette.LayoutView.extend({
             model: this.model,
             collection: this.model.get('scenarios')
          }));
-        synchronizer.sync();
     }
 });
 

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -444,72 +444,6 @@ var GwlfeConservationPracticeView = ModificationsView.extend({
     }
 });
 
-var PrecipitationSynchronizer = (function() {
-    var isEnabled = false,
-        precipViews = [];
-
-    // Add a view to the list of views to be kept syncrhonized
-    function add(precipView) {
-        if (isEnabled) {
-            precipViews.push(precipView);
-        }
-    }
-
-    // Remove a view from the list
-    function remove(precipView) {
-        if (isEnabled) {
-            precipViews = _.without(precipViews, precipView);
-        }
-    }
-
-    // Turn synchronization on
-    function on() {
-        precipViews = [];
-        isEnabled = true;
-    }
-
-    // Turn synchronization off
-    function off() {
-        isEnabled = false;
-        precipViews = [];
-    }
-
-    // Synchronize the group to the given slider
-    function syncTo(precipView) {
-        if (isEnabled) {
-            var value = precipView.ui.slider.val();
-
-            isEnabled = false;
-
-            precipViews.forEach(function(otherPrecipView) {
-                var otherValue = otherPrecipView.ui.slider.val();
-                if (otherValue !== value) {
-                    otherPrecipView.ui.slider.val(value);
-                    otherPrecipView.onSliderChanged();
-                }
-            });
-
-            isEnabled = true;
-        }
-    }
-
-    // Synchronize the group to the first slider
-    function sync() {
-        if (precipViews.length > 0) {
-            syncTo(precipViews[0]);
-        }
-    }
-
-    return {
-        add: add,
-        remove: remove,
-        on: on,
-        off: off,
-        sync: sync,
-        syncTo: syncTo
-    };
-})();
-
 var PrecipitationView = ControlView.extend({
     template: precipitationTmpl,
 
@@ -554,17 +488,7 @@ var PrecipitationView = ControlView.extend({
         this.ui.slider.attr('value', value);
         this.ui.displayValue.text(this.getDisplayValue(value));
 
-        PrecipitationSynchronizer.syncTo(this);
-
         this.addOrReplaceInput(modification);
-    },
-
-    onAttach: function() {
-        PrecipitationSynchronizer.add(this);
-    },
-
-    onBeforeDestroy: function() {
-        PrecipitationSynchronizer.remove(this);
     },
 
     onRender: function() {
@@ -600,5 +524,4 @@ module.exports = {
     GwlfeConservationPracticeView: GwlfeConservationPracticeView,
     PrecipitationView: PrecipitationView,
     getControlView: getControlView,
-    PrecipitationSynchronizer: PrecipitationSynchronizer
 };

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -537,6 +537,9 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
 
     &.compare-precipitation {
       margin-right: 20px;
+      label {
+        font-size: 12px;
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

Adds precipitation slider to the new Compare View. The slider is initialized to the precipitation value of the active scenario. Moving the slider updates all scenarios in comparison, running the model for the given value.

Also duplicates scenarios before giving them to the Compare View, rather than giving the original set of scenarios. This is done so that we can change the precipitation value in the Compare View and run a number of models, without affecting the underlying original scenarios. When the Compare View is closed and the user returns to the Modeling View, all scenarios retain their original precipitation values.

The synchronization code used to keep the many precipitation sliders in the old Compare View has been removed.

I would recommend code review to be done commit by commit, since they all touch the same files.

Connects #2074 

### Demo

![2017-08-04 18 07 39](https://user-images.githubusercontent.com/1430060/28988858-f944c960-793f-11e7-83be-3e237c31f79e.gif)

### Notes

The numbers in the displayed table don't update with the scenarios. These are tasks for #2073 and #2076.

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to either a saved TR-55 project or a new one, make sure it has more than one scenario, and hit "Compare"
 * Ensure that you see the new Compare Window, and it has a precipitation slider
 * Ensure the value of the precipitation slider is the same as that of the active scenario
 * Open the network tab, and then move the precipitation slider. Ensure that whenever there is a new value, a TR-55 job is fired for every scenario in the comparison
 * Close the Compare Window. Ensure that the precipitation values of all scenarios are the same as they were before the comparison.