### PR TITLE
Remove toggle buttons from data page when leaving

### DIFF
--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -64,6 +64,7 @@ var DataCatalogController = {
                 catalogModel.cancelSearch();
             }
         );
+        App.rootView.subHeaderRegion.empty();
     }
 };
 


### PR DESCRIPTION
## Overview

The toggle buttons should only be present on the data page.

Connects #2095
Connects #2129

### Demo

![bigcz2](https://user-images.githubusercontent.com/1042475/29132041-dcb5a2c2-7cfc-11e7-84fa-0f5276543f0c.gif)

## Testing Instructions

- Navigate to the data page. The toggle buttons should appear.
- Navigate away from the data page. The toggle buttons should disappear.
