### PR TITLE
Cuahsi/WDC search result UI improvements

### DIFF
--- a/src/mmw/js/src/core/filters.js
+++ b/src/mmw/js/src/core/filters.js
@@ -51,3 +51,17 @@ nunjucks.env.addFilter('toFriendlyDate', function(date) {
 nunjucks.env.addFilter('toDateFullYear', function(date) {
     return new Date(date).getFullYear();
 });
+
+nunjucks.env.addFilter('toDateWithoutTime', function(date) {
+    var fullDate = new Date(date);
+
+    return fullDate.getUTCMonth() + '/' +
+           fullDate.getUTCDate() + '/' +
+           fullDate.getUTCFullYear();
+});
+
+nunjucks.env.addFilter('split', function(str, splitChar, indexToReturn) {
+    var items = str.split(splitChar);
+
+    return items[indexToReturn];
+});

--- a/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
+++ b/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
@@ -1,22 +1,24 @@
 <h3 class="resource-title">
-    {{ id }}
+    <a href="{{service_url}}" target="_blank">{{ service_code }}</a> {{ id | split(":", 1) }}
 </h3>
 <div class="resource-detail">
-    <i class="fa fa-map-marker"></i> {{ title }}
-</div>
-<div class="resource-detail">
-    <i class="fa fa-eyedropper"></i> {{ sample_mediums }}
-</div>
-<div class="resource-detail">
-    <i class="fa fa-subscript"></i> {{ concept_keywords }}
+    <i class="fa fa-map-marker"></i>
+    {% if details_url %}
+        <a href="{{ details_url }}" target="_blank" rel="noreferrer noopener">{{ title }}</a>.
+    {% else %}
+        {{ title }}
+    {% endif %}
 </div>
 <div class="resource-detail">
     <i class="fa fa-file-text-o"></i> {{ service_org }}<!-- , {{ service_code }} -->
 </div>
 <div class="resource-detail">
+    <i class="fa fa-subscript"></i> {{ concept_keywords }}
+</div>
+<div class="resource-detail">
     {% if begin_date == end_date %}
-        <i class="fa fa-calendar"></i> {{ begin_date|toFriendlyDate }}
+        <i class="fa fa-calendar"></i> {{ begin_date|toDateWithoutTime }}
     {% else %}
-        <i class="fa fa-calendar"></i> {{ begin_date|toFriendlyDate }}-{{ end_date|toFriendlyDate }}
+        <i class="fa fa-calendar"></i> {{ begin_date|toDateWithoutTime }} - {{ end_date|toDateWithoutTime }}
     {% endif %}
 </div>


### PR DESCRIPTION
## Overview

Implement small changes to the UI of Cuahsi/WDC search results based on feedback from the client and input from the design team:

* Add a link to the service in the service code, which is now separated the item id.
* Remove the medium from the results.
* Remove the time from the collection date range.
* Place the source agency below the location.

Connects #2096

### Demo

Before:

![image](https://user-images.githubusercontent.com/1042475/29140954-50d826d0-7d1a-11e7-860f-68600fa2b03f.png)

After:

![image](https://user-images.githubusercontent.com/1042475/29140819-d49fd752-7d19-11e7-8054-ed5136e334ad.png)

### Notes

These tasks from https://github.com/WikiWatershed/model-my-watershed/issues/2096#issuecomment-319114271 were deemed as more design-oriented and will be moved to a separate design task.

> - We could consider combining the first two lines, location and sitename.
> - Is there a clever way we can abbreviate the list of variables?
> - Another style idea: potentially make the variables look like tags, a la https://slack-imgs.com/?c=1&url=https%3A%2F%2Fkristarella.blog%2Fwp-content%2Fuploads%2Fclick-tags.png

## Testing Instructions

- Draw an AoI and proceed to the search page.
- Fetch results for WDC.
- Verify the search results meet the requirements laid out in https://github.com/WikiWatershed/model-my-watershed/issues/2096#issuecomment-319114271.