### PR TITLE
Use Hydroshare Playground while Production is Broken

### DIFF
--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -14,7 +14,7 @@ from apps.bigcz.utils import RequestTimedOutError
 
 
 CATALOG_NAME = 'hydroshare'
-CATALOG_URL = 'https://www.hydroshare.org/hsapi/resource/'
+CATALOG_URL = 'https://playground.hydroshare.org/hsapi/resource/'
 
 
 def parse_date(value):


### PR DESCRIPTION
## Overview

Make the HydroShare tab work again.

Connects #2143 

### Notes

This should be reverted once https://github.com/hydroshare/hydroshare/issues/2257 is deployed to production.

## Testing Instructions

 * Check out this branch.
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Do a search. Ensure all tabs work. Ensure HydroShare results are within bounding box. Should be in tens, not hundreds.