### PR TITLE
Allow analyzing a boundary result from geocoder

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -22,7 +22,8 @@ var MapModel = Backbone.Model.extend({
         geolocationEnabled: true,
         previousAreaOfInterest: null,
         dataCatalogResults: null,       // GeoJSON array
-        dataCatalogActiveResult: null   // GeoJSON
+        dataCatalogActiveResult: null,  // GeoJSON
+        selectedGeocoderArea: null,     // GeoJSON
     },
 
     revertMaskLayer: function() {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -44,6 +44,16 @@ var dataCatalogActiveStyle = {
     fillOpacity: 0.2
 };
 
+var selectedGeocoderAreaStyle = {
+    stroke: true,
+    fill: true,
+    weight: 3,
+    opacity: 0.5,
+    fillOpacity: 0.2,
+    fillColor: '#E77471',
+    color: '#E77471'
+};
+
 var RootView = Marionette.LayoutView.extend({
     el: 'body',
     ui: {
@@ -195,7 +205,8 @@ var MapView = Marionette.ItemView.extend({
         'change:size': 'toggleMapSize',
         'change:maskLayerApplied': 'toggleMask',
         'change:dataCatalogResults': 'renderDataCatalogResults',
-        'change:dataCatalogActiveResult': 'renderDataCatalogActiveResult'
+        'change:dataCatalogActiveResult': 'renderDataCatalogActiveResult',
+        'change:selectedGeocoderArea': 'renderSelectedGeocoderArea',
     },
 
     // L.Map instance.
@@ -209,8 +220,14 @@ var MapView = Marionette.ItemView.extend({
     // L.FeatureGroup instance.
     _modificationsLayer: null,
 
+    // Shapes for the active data catalog tab's results.
+    // L.FeatureGroup instance
     _dataCatalogResultsLayer: null,
     _dataCatalogActiveLayer: null,
+
+    // The shape for a selected geocoder boundary result
+    // L.FeatureGroup instance
+    _selectedGeocoderAreaLayer: null,
 
     // Flag used to determine if AOI change should trigger a prompt.
     _areaOfInterestSet: false,
@@ -242,6 +259,7 @@ var MapView = Marionette.ItemView.extend({
         this._modificationsLayer = new L.FeatureGroup();
         this._dataCatalogResultsLayer = new L.FeatureGroup();
         this._dataCatalogActiveLayer = new L.FeatureGroup();
+        this._selectedGeocoderAreaLayer = new L.FeatureGroup();
 
         this.fitToDefaultBounds();
 
@@ -281,6 +299,7 @@ var MapView = Marionette.ItemView.extend({
         map.addLayer(this._modificationsLayer);
         map.addLayer(this._dataCatalogResultsLayer);
         map.addLayer(this._dataCatalogActiveLayer);
+        map.addLayer(this._selectedGeocoderAreaLayer);
     },
 
     fitToDefaultBounds: function() {
@@ -700,6 +719,20 @@ var MapView = Marionette.ItemView.extend({
                 layer.setStyle(dataCatalogActiveStyle);
                 this._dataCatalogActiveLayer.addLayer(layer);
             }
+        }
+    },
+
+    renderSelectedGeocoderArea: function() {
+        var geom = this.model.get('selectedGeocoderArea');
+
+        this._selectedGeocoderAreaLayer.clearLayers();
+
+        if (geom) {
+            this.disableGeolocation();
+
+            var layer = new L.GeoJSON(geom, { style: selectedGeocoderAreaStyle });
+            this._leafletMap.fitBounds(layer.getBounds(), { reset: true });
+            this._selectedGeocoderAreaLayer.addLayer(layer);
         }
     }
 });

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -20,7 +20,10 @@ var DrawController = {
         toolbarModel.set('predefinedShapeTypes',
             _.filter(settings.get('boundary_layers'), { selectable: true }));
 
-        App.rootView.geocodeSearchRegion.show(geocodeSearch);
+        if (!App.rootView.geocodeSearchRegion.hasView()) {
+            App.rootView.geocodeSearchRegion.show(geocodeSearch);
+        }
+
         App.rootView.sidebarRegion.show(new views.DrawWindow({
             model: toolbarModel
         }));

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -1114,6 +1114,8 @@ module.exports = {
     DrawWindow: DrawWindow,
     getShapeAndAnalyze: getShapeAndAnalyze,
     addLayer: addLayer,
+    validateShape: validateShape,
+    displayAlert: displayAlert,
     clearAoiLayer: clearAoiLayer,
     selectBoundary: selectBoundary,
     drawArea: drawArea,

--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -7,6 +7,7 @@ var _ = require('underscore'),
 
 var GeocoderModel = Backbone.Model.extend({
     defaults: {
+        selectedLocation: '',
         query: ''
     }
 });

--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -7,7 +7,7 @@ var _ = require('underscore'),
 
 var GeocoderModel = Backbone.Model.extend({
     defaults: {
-        selectedLocation: '',
+        selectedSuggestion: null, // SuggestionModel
         query: ''
     }
 });

--- a/src/mmw/js/src/geocode/templates/search.html
+++ b/src/mmw/js/src/geocode/templates/search.html
@@ -1,4 +1,4 @@
-<input class="search-input" id="geocoder-search" type="text" placeholder="Search"/>
+<input class="search-input" id="geocoder-search" type="text" placeholder="Jump to location or HUC"/>
 <i class="search-icon fa fa-search"></i>
 <div id="geocode-search-results-region"></div>
 <div class="message hidden">

--- a/src/mmw/js/src/geocode/templates/search.html
+++ b/src/mmw/js/src/geocode/templates/search.html
@@ -1,11 +1,14 @@
 <input class="search-input" id="geocoder-search" type="text"
-       {%- if selectedLocation %}
-       placeholder="{{selectedLocation}}"
+       {%- if selectedSuggestion %}
+           placeholder="{{selectedSuggestion.get('text')}}"
        {%- else %}
-       placeholder="Jump to location or HUC"
+           placeholder="Jump to location or HUC"
        {% endif -%}
 >
 <i class="search-icon fa fa-search"></i>
+{% if selectedSuggestion and selectedSuggestion.get('isBoundaryLayer') %}
+    <button class="search-select-btn">Select</button>
+{% endif %}
 <div id="geocode-search-results-region"></div>
 <div class="message hidden">
     <span></span>

--- a/src/mmw/js/src/geocode/templates/search.html
+++ b/src/mmw/js/src/geocode/templates/search.html
@@ -1,4 +1,10 @@
-<input class="search-input" id="geocoder-search" type="text" placeholder="Jump to location or HUC"/>
+<input class="search-input" id="geocoder-search" type="text"
+       {%- if selectedLocation %}
+       placeholder="{{selectedLocation}}"
+       {%- else %}
+       placeholder="Jump to location or HUC"
+       {% endif -%}
+>
 <i class="search-icon fa fa-search"></i>
 <div id="geocode-search-results-region"></div>
 <div class="message hidden">

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -35,6 +35,16 @@
     }
   }
 
+  .search-select-btn {
+      font-size: $font-size-p;
+      position: absolute;
+      top: 12px;
+      right: 42px;
+      background-color: $brand-primary;
+      color: $paper;
+      border: none;
+  }
+
   .message {
     position: absolute;
     color: $paper-74;


### PR DESCRIPTION
## Overview

Implements behavior in [these wireframes](https://marvelapp.com/33efhfb/screen/31228062)

- when you search for and select a location, the selected location's name appears in the geocoder, and you are directed to `/draw`
- if the the selected location is a boundary layer, a `Select` button appears in the geocoder
- clicking the `Select` button analyzes the shape

#### Enhancement
- Pressing `ESC` now clears the selected shape and resets the query

Connects #2138 

### Demo
_Selecting a boundary_
![xbgyajudai](https://user-images.githubusercontent.com/7633670/29287985-21f9f46c-8105-11e7-8d5a-632d17a6c7fd.gif)

_If you select a regular search result, displays the address_
![screen shot 2017-08-14 at 3 27 07 pm](https://user-images.githubusercontent.com/7633670/29287990-25e38db8-8105-11e7-8d27-e03b5865d8a6.png)

## Testing Instructions

 * Pull and `./scripts/bundle.sh`
 
**Address search**
* search for an address
* select a result
* confirm it appears in the search bar, that there are no errors in the console, and you are not directed to `/draw`
* press `ESC` and confirm the result clears
* search for something else and press `ENTER`. The first result should get selected

**Boundary search**
* search for and select a HUC
* Confirm you are taken to `/draw`
* Click `Select`
* Confirm you are taken to `/analyze` and the shape name, layer name, and wkaoi properties have come through (the names should be at the top of the sidebar)
* search again and this time press `ESC` --> the selected shape should clear from the map
