### PR TITLE
Implement details view for BiG CZ

### DIFF
--- a/src/mmw/js/src/data_catalog/templates/resultDetails.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetails.html
@@ -1,0 +1,35 @@
+<div class="result">
+    <div class="result-detail-header">
+        <h2>
+            {{ title }}
+        </h2>
+        <button type="button" class="close" aria-label="Close">
+            <span aria-hidden="true">×</span>
+        </button>
+        <a href="#"><i class="fa fa-search-plus"></i> Zoom to extent</a>
+    </div>
+    <hr>
+    {% if author %}
+        <p>
+            <i class="fa fa-user"></i>{{ author }}
+        </p>
+    {% endif %}
+    {% if activeCatalog != 'cuahsi' %}
+        <p>
+            <i class="fa fa-calendar"></i> {{ created_at|toDateFullYear }}
+        </p>
+    {% else %}
+        {% if begin_date == end_date %}
+            <p>
+                <i class="fa fa-calendar"></i> {{ begin_date|toDateWithoutTime }}
+            </p>
+        {% else %}
+            <p>
+                <i class="fa fa-calendar"></i> {{ begin_date|toDateWithoutTime }} - {{ end_date|toDateWithoutTime }}
+            </p>
+        {% endif %}
+    {% endif %}
+    <p>
+        {{ description }}
+    </p>
+</div>

--- a/src/mmw/js/src/data_catalog/templates/window.html
+++ b/src/mmw/js/src/data_catalog/templates/window.html
@@ -1,3 +1,5 @@
+<div class="result-details-region"></div>
+
 <h2 class="data-catalog-title">
     Data sources
 </h2>

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -15,6 +15,31 @@
         position: relative;
     }
 
+    .result-details-region {
+        .result {
+            padding: 10px;
+            bottom: 0px;
+            top: 0px;
+            width: 100%;
+            position: absolute;
+            z-index: 10000;
+            background-color: #fff;
+            overflow: auto;
+
+            .result-detail-header {
+              h2 {
+                  display: inline-block;
+                  margin: 4px 0;
+                  max-width: 95%;
+              }
+
+              a {
+                display: block;
+              }
+            }
+        }
+    }
+
     .result-region {
         height: auto !important;
         width: auto !important;


### PR DESCRIPTION
## Overview

Clicking on a search result in the BiG CZ results pane will open a pane with the details for that result. Only the fields that were common between all three APIs were added.

Connects to #1934

### Demo

![bigcz3](https://user-images.githubusercontent.com/1042475/29325015-2de08c00-81b4-11e7-921e-70f97e97c535.gif)

### Notes

I tried various approaches to wiring up the events, and unfortunately, the only one I could get working was propagating the event manually. Triggering a collection event didn't work nor did using `childViewEvents`.

## Testing Instructions

- Visit the BiGCZ site.
- Draw an AoI and make a search.
- For each API, click a few results, and verify the details view is displayed.