### PR TITLE
Compare View Revamp: wire up maps and modification popovers

### DIFF
--- a/src/mmw/js/src/compare/templates/compareDescriptionPopover.html
+++ b/src/mmw/js/src/compare/templates/compareDescriptionPopover.html
@@ -1,0 +1,16 @@
+{% if is_pre_columbian %}
+    <h3 class="compare-no-mod-title">{{name}}</h3>
+    <p>
+        Lorem ipsum this scenario shows the tr55 model results under pre columbian conditions...
+    </p>
+{% elif is_current_conditions %}
+    <h3 class="compare-no-mod-title">{{name}}</h3>
+    <p>
+        Lorem ipsum this is the model run under current conditions
+    </p>
+{% else %}
+    <h3 class="compare-no-mod-title">No modifications</h3>
+    <p>
+        To add modifications, close this modal and select "Land cover" or "Conservation practices" lorem ipsum dolor sit
+    </p>
+{% endif %}

--- a/src/mmw/js/src/compare/templates/compareModificationsPopover.html
+++ b/src/mmw/js/src/compare/templates/compareModificationsPopover.html
@@ -1,0 +1,23 @@
+{% macro modificationsTable(caption, modifications) %}
+<table class="compare-modifications-table">
+    {% if modifications.length > 0 %}
+        <h5>{{ caption }}</h5>
+    {% endif %}
+    <tbody>
+        {% for mod in modifications %}
+            <tr>
+                <td class="modification-value">
+                    {{ modConfigUtils.getHumanReadableShortName(mod.get('value')) }}
+                </td>
+                <td class="modification-area">
+                    +{{ mod.get('area').toFixed(1) }} {{ mod.get('units') }}
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endmacro %}
+
+<h3>Modifications</h3>
+{{ modificationsTable('Land Cover', landCovers) }}
+{{ modificationsTable('Conservation Practices', conservationPractices) }}

--- a/src/mmw/js/src/compare/templates/compareScenarioItem.html
+++ b/src/mmw/js/src/compare/templates/compareScenarioItem.html
@@ -1,2 +1,2 @@
-<div class="compare-mapplaceholder"></div>
+<div class="compare-map-container"></div>
 <h3><span class="scenario-badge"></span> {{ name }}</h3>

--- a/src/mmw/js/src/compare/templates/compareScenarioItem.html
+++ b/src/mmw/js/src/compare/templates/compareScenarioItem.html
@@ -1,2 +1,2 @@
-<div class="compare-map-container"></div>
-<h3><span class="scenario-badge"></span> {{ name }}</h3>
+<div class="compare-map-container" role="button" data-html="true" data-toggle="popover"></div>
+<div class="compare-scenario-title"><span class="scenario-badge"></span> {{ name }}</div>

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -20,7 +20,8 @@ var _ = require('lodash'),
     compareScenariosTmpl = require('./templates/compareScenarios.html'),
     compareScenarioTmpl = require('./templates/compareScenario.html'),
     compareModelingTmpl = require('./templates/compareModeling.html'),
-    compareModificationsTmpl = require('./templates/compareModifications.html');
+    compareModificationsTmpl = require('./templates/compareModifications.html'),
+    compareModificationsPopoverTmpl = require('./templates/compareModificationsPopover.html');
 
 var CompareWindow2 = Marionette.LayoutView.extend({
     template: compareWindow2Tmpl,
@@ -153,6 +154,22 @@ var InputsView = Marionette.LayoutView.extend({
     },
 });
 
+var CompareModificationsPopoverView = Marionette.ItemView.extend({
+    template: compareModificationsPopoverTmpl,
+
+    templateHelpers: function() {
+        return {
+            conservationPractices: this.model.filter(function(modification) {
+                return modification.get('name') === 'conservation_practice';
+            }),
+            landCovers: this.model.filter(function(modification) {
+                return modification.get('name') === 'landcover';
+            }),
+            modConfigUtils: modConfigUtils
+        };
+    }
+});
+
 var ScenarioItemView = Marionette.ItemView.extend({
     className: 'compare-column',
     template: compareScenarioItemTmpl,
@@ -180,6 +197,20 @@ var ScenarioItemView = Marionette.ItemView.extend({
         mapView.updateModifications(this.model.get('modifications'));
         mapView.fitToModificationsOrAoi();
         mapView.render();
+    },
+
+    onRender: function() {
+        var modifications = this.model.get('modifications');
+
+        if (modifications.length > 0) {
+            this.ui.mapContainer.popover({
+                placement: 'bottom',
+                trigger: 'hover focus',
+                content: new CompareModificationsPopoverView({
+                    model: this.model.get('modifications')
+                }).render().el
+            });
+        }
     }
 });
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -21,7 +21,8 @@ var _ = require('lodash'),
     compareScenarioTmpl = require('./templates/compareScenario.html'),
     compareModelingTmpl = require('./templates/compareModeling.html'),
     compareModificationsTmpl = require('./templates/compareModifications.html'),
-    compareModificationsPopoverTmpl = require('./templates/compareModificationsPopover.html');
+    compareModificationsPopoverTmpl = require('./templates/compareModificationsPopover.html'),
+    compareDescriptionPopoverTmpl = require('./templates/compareDescriptionPopover.html');
 
 var CompareWindow2 = Marionette.LayoutView.extend({
     template: compareWindow2Tmpl,
@@ -155,6 +156,7 @@ var InputsView = Marionette.LayoutView.extend({
 });
 
 var CompareModificationsPopoverView = Marionette.ItemView.extend({
+    // model: ModificationsCollection
     template: compareModificationsPopoverTmpl,
 
     templateHelpers: function() {
@@ -168,6 +170,12 @@ var CompareModificationsPopoverView = Marionette.ItemView.extend({
             modConfigUtils: modConfigUtils
         };
     }
+});
+
+var CompareDescriptionPopoverView = Marionette.ItemView.extend({
+    // model: ScenarioModel
+    template: compareDescriptionPopoverTmpl,
+    className: 'compare-no-mods-popover'
 });
 
 var ScenarioItemView = Marionette.ItemView.extend({
@@ -200,17 +208,20 @@ var ScenarioItemView = Marionette.ItemView.extend({
     },
 
     onRender: function() {
-        var modifications = this.model.get('modifications');
+        var modifications = this.model.get('modifications'),
+            popOverView = modifications.length > 0 ?
+                              new CompareModificationsPopoverView({
+                                  model: modifications
+                              }) :
+                              new CompareDescriptionPopoverView({
+                                  model: this.model
+                              });
 
-        if (modifications.length > 0) {
-            this.ui.mapContainer.popover({
-                placement: 'bottom',
-                trigger: 'hover focus',
-                content: new CompareModificationsPopoverView({
-                    model: this.model.get('modifications')
-                }).render().el
-            });
-        }
+        this.ui.mapContainer.popover({
+            placement: 'bottom',
+            trigger: 'hover focus',
+            content: popOverView.render().el
+        });
     }
 });
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -156,6 +156,31 @@ var InputsView = Marionette.LayoutView.extend({
 var ScenarioItemView = Marionette.ItemView.extend({
     className: 'compare-column',
     template: compareScenarioItemTmpl,
+
+    ui: {
+        'mapContainer': '.compare-map-container',
+    },
+
+    onShow: function() {
+        var mapView = new coreViews.MapView({
+            model: new coreModels.MapModel({
+                'areaOfInterest': App.currentProject.get('area_of_interest'),
+                'areaOfInterestName': App.currentProject.get('area_of_interest_name'),
+            }),
+            el: this.ui.mapContainer,
+            addZoomControl: false,
+            addLocateMeButton: false,
+            addSidebarToggleControl: false,
+            showLayerAttribution: false,
+            initialLayerName: App.getLayerTabCollection().getCurrentActiveBaseLayerName(),
+            layerTabCollection: new coreModels.LayerTabCollection(),
+            interactiveMode: false,
+        });
+        mapView.updateAreaOfInterest();
+        mapView.updateModifications(this.model.get('modifications'));
+        mapView.fitToModificationsOrAoi();
+        mapView.render();
+    }
 });
 
 var ScenariosRowView = Marionette.CollectionView.extend({

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -608,6 +608,16 @@ var MapView = Marionette.ItemView.extend({
         }
     },
 
+    fitToModificationsOrAoi: function() {
+        var modificationsBounds = this._modificationsLayer.getBounds();
+
+        if (modificationsBounds.isValid()) {
+            this._leafletMap.fitBounds(modificationsBounds, { reset: true });
+        } else {
+            this.fitToAoi();
+        }
+    },
+
     updateCurrentZoomLevel: function(layer) {
         var layerMaxZoom = layer.options.maxZoom,
             map = this,

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -452,7 +452,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
     min-width: 120px;
     width: 120px;
 
-    h3 {
+    .compare-scenario-title {
       font-size: $font-size-h5;
       font-weight: 400;
     }
@@ -505,10 +505,23 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
   }
 
   .compare-map-container {
-    height: 90px;
-    background-color: #aaa;
-    margin-bottom: 10px;
-    width: 120px;
+      cursor: pointer !important;
+      height: 90px;
+      background-color: #aaa;
+      margin-bottom: 10px;
+      width: 120px;
+  }
+
+  .compare-modifications-table {
+      font-size: $font-size-h5;
+      width: 100%;
+      .modification-value {
+          padding-right: 12px;
+      }
+      .modification-area {
+          color: $brand-primary;
+          text-align: right;
+      }
   }
 
   .compare-inputs {

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -504,7 +504,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
     }
   }
 
-  .compare-mapplaceholder {
+  .compare-map-container {
     height: 90px;
     background-color: #aaa;
     margin-bottom: 10px;

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -524,6 +524,13 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
       }
   }
 
+  .compare-no-mods-popover {
+      width: 189px;
+      > .compare-no-mod-title {
+          margin-bottom: 2px;
+      }
+  }
+
   .compare-inputs {
     float: right;
     margin-right: -5px;

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -300,6 +300,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
   margin-top: 20px;
   max-width: 1200px;
   max-height: calc(100% - 20px);
+  -webkit-font-smoothing: antialiased;
 
   @media screen and (max-width: 1300px) {
     max-width: 1000px;


### PR DESCRIPTION
## Overview
- Add map views to each scenario column in the new compare view
- Add modifications popovers to each map

Connects #2071 

### Demo

![screen shot 2017-08-15 at 4 38 54 pm](https://user-images.githubusercontent.com/7633670/29336214-11e29a3a-81db-11e7-8be9-bb1a934740ab.png)

![screen shot 2017-08-15 at 4 40 08 pm](https://user-images.githubusercontent.com/7633670/29336208-0ef5969c-81db-11e7-912d-b3a585203a44.png)

### Notes

@jfrankl, two things:
-  If there's no modifications on the scenario, I opted not to show any popover. Let me know if you'd like to see one that says "No modifications" or something.
- In the wireframe, you've dropped the mod type label "Land Cover" or "Conservation Practices". Was this intentional?
<img width="331" alt="screen shot 2017-08-15 at 5 17 50 pm" src="https://user-images.githubusercontent.com/7633670/29336993-c49786f2-81dd-11e7-9622-0bc9b4e09daa.png">
I kept them in for now.



## Testing Instructions
* Pull and `./scripts/bundle.sh`
 * In the compare view for a TR-55 project with some modified scenarios...
* Confirm the mini-maps' extents are the modifications, if they exist.
* Hover over a map with mods (or tap on mobile) and confirm a popover appears with the areas for each type