### PR TITLE
Update CINERGI API URL to official production host

### DIFF
--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -14,7 +14,7 @@ from apps.bigcz.utils import RequestTimedOutError
 
 
 CATALOG_NAME = 'cinergi'
-CATALOG_URL = 'http://132.249.238.169:8080/geoportal/opensearch'
+CATALOG_URL = 'http://cinergi.sdsc.edu/geoportal/opensearch'
 PAGE_SIZE = settings.BIGCZ_CLIENT_PAGE_SIZE
 
 


### PR DESCRIPTION
## Overview

- We were using an IP address + port number to access CINERGI 3.0
- 3.0 now has a real production version, so this PR switches over to it

Connects #2141

### Demo

![screen shot 2017-08-16 at 10 40 48 am](https://user-images.githubusercontent.com/7633670/29369028-629730b4-826f-11e7-8dc1-c7c91ee2d1d0.png)

## Testing Instructions

 * Pull branch and confirm CINERGI searchs still work
 * The `api-url` in the response should show the new domain
