### PR TITLE
Link CINERGI Results to Original Repository

### DIFF
--- a/src/mmw/apps/bigcz/clients/cinergi/__init__.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/__init__.py
@@ -3,11 +3,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from apps.bigcz.models import Resource
-from apps.bigcz.serializers import ResourceSerializer
+from apps.bigcz.clients.cinergi.models import CinergiResource
+from apps.bigcz.clients.cinergi.serializers import CinergiResourceSerializer
 
 # Import catalog name and search function, so it can be exported from here
 from apps.bigcz.clients.cinergi.search import CATALOG_NAME, search  # NOQA
 
-model = Resource
-serializer = ResourceSerializer
+model = CinergiResource
+serializer = CinergiResourceSerializer

--- a/src/mmw/apps/bigcz/clients/cinergi/models.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/models.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from apps.bigcz.models import Resource
+
+
+class CinergiResource(Resource):
+    def __init__(self, id, description, author, links, title,
+                 created_at, updated_at, geom, cinergi_url):
+        super(CinergiResource, self).__init__(id, description, author, links,
+                                              title, created_at, updated_at,
+                                              geom)
+
+        self.cinergi_url = cinergi_url

--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -9,9 +9,10 @@ from django.contrib.gis.geos import Polygon
 
 from django.conf import settings
 
-from apps.bigcz.models import Resource, ResourceLink, ResourceList, BBox
+from apps.bigcz.models import ResourceLink, ResourceList, BBox
 from apps.bigcz.utils import RequestTimedOutError
 
+from apps.bigcz.clients.cinergi.models import CinergiResource
 
 
 CINERGI_HOST = 'http://cinergi.sdsc.edu'
@@ -100,7 +101,8 @@ def parse_record(item):
         links=links,
         created_at=parse_date(source.get('sys_created_dt')),
         updated_at=parse_date(source.get('src_lastupdate_dt')),
-        geom=geom)
+        geom=geom,
+        cinergi_url=parse_cinergi_url(source.get('fileid')))
 
 
 def prepare_bbox(value):

--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -13,8 +13,10 @@ from apps.bigcz.models import Resource, ResourceLink, ResourceList, BBox
 from apps.bigcz.utils import RequestTimedOutError
 
 
+
+CINERGI_HOST = 'http://cinergi.sdsc.edu'
 CATALOG_NAME = 'cinergi'
-CATALOG_URL = 'http://cinergi.sdsc.edu/geoportal/opensearch'
+CATALOG_URL = '{}/geoportal/opensearch'.format(CINERGI_HOST)
 PAGE_SIZE = settings.BIGCZ_CLIENT_PAGE_SIZE
 
 
@@ -78,11 +80,19 @@ def parse_links(source):
     return result
 
 
+def parse_cinergi_url(fileid):
+    """
+    Convert fileid to URL in CINERGI Portal
+    """
+
+    return '{}/geoportal/?filter=%22{}%22'.format(CINERGI_HOST, fileid)
+
+
 def parse_record(item):
     source = item['_source']
     geom = parse_geom(source)
     links = parse_links(source)
-    return Resource(
+    return CinergiResource(
         id=item['_id'],
         title=source['title'],
         description=source.get('description'),

--- a/src/mmw/apps/bigcz/clients/cinergi/serializers.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/serializers.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from rest_framework.serializers import CharField
+
+from apps.bigcz.serializers import ResourceSerializer
+
+
+class CinergiResourceSerializer(ResourceSerializer):
+    cinergi_url = CharField()

--- a/src/mmw/js/src/data_catalog/templates/resultDetails.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetails.html
@@ -32,4 +32,12 @@
     <p>
         {{ description }}
     </p>
+    <p>
+        {% if activeCatalog == 'cinergi' %}
+        <a class="btn btn-secondary" href="{{ cinergi_url }}"
+           target="_blank" rel="noreferrer noopener">
+            <i class="fa fa-external-link-square"></i>&nbsp;Repository
+        </a>
+        {% endif %}
+    </p>
 </div>


### PR DESCRIPTION
## Overview

Add a "repository" link to the CINERGI details view linking each result to the main website.

Tagging @jfrankl for visual review.

Connects #2140 

### Demo

![2017-08-21 13 06 22](https://user-images.githubusercontent.com/1430060/29530554-52b77e22-8672-11e7-99ff-d50c7485593c.gif)

![image](https://user-images.githubusercontent.com/1430060/29530653-d4686ed6-8672-11e7-9b25-8a9a1e2393ec.png)

## Testing Instructions

 * Check out this branch, bundle, and go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Search for something. Get CINERGI results back.
 * Click an any CINERGI result. Ensure that it has a Repository button.
 * Click the repository button. Ensure the same record is opened in the main CINERGI site, in a new tab.
 * Ensure HydroShare and CUAHSI tabs do not have the repository link