### PR TITLE
Increase number of rows in pageable tables

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1091,7 +1091,7 @@ var PointSourceResultView = AnalyzeResultView.extend({
             associatedLayerCodes = ['pointsource'],
             avgRowHeight = 30,  // Most rows are between 2-3 lines, 12px per line
             minScreenHeight = 768 + 45, // height of landscape iPad + extra content below the table
-            pageSize = utils.calculateVisibleRows(minScreenHeight, avgRowHeight, 3),
+            pageSize = utils.calculateVisibleRows(minScreenHeight, avgRowHeight, 6),
             chart = null;
         this.showAnalyzeResults(coreModels.PointSourceCensusCollection,
             PointSourcePageableTableView, chart, title, source, helpText, associatedLayerCodes, pageSize);
@@ -1111,7 +1111,7 @@ var CatchmentWaterQualityResultView = AnalyzeResultView.extend({
             ],
             avgRowHeight = 18,  // Most rows are between 1-2 lines, 12px per line
             minScreenHeight = 768 + 45, // height of landscape iPad + extra content below the table
-            pageSize = utils.calculateVisibleRows(minScreenHeight, avgRowHeight, 5),
+            pageSize = utils.calculateVisibleRows(minScreenHeight, avgRowHeight, 6),
             chart = null;
         this.showAnalyzeResults(coreModels.CatchmentWaterQualityCensusCollection,
             CatchmentWaterQualityPageableTableView, chart, title, source, helpText,

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -573,13 +573,13 @@ var AnimalCensusCollection = Backbone.Collection.extend({
 var PointSourceCensusCollection = Backbone.PageableCollection.extend({
     comparator: 'city',
     mode: 'client',
-    state: { pageSize: 3, firstPage: 1 }
+    state: { pageSize: 6, firstPage: 1 }
 });
 
 var CatchmentWaterQualityCensusCollection = Backbone.PageableCollection.extend({
     comparator: 'nord',
     mode: 'client',
-    state: { pageSize: 5, firstPage: 1 }
+    state: { pageSize: 6, firstPage: 1 }
 });
 
 var GeoModel = Backbone.Model.extend({

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -141,6 +141,11 @@
 .pageable-table-container {
   overflow: visible;
   padding-bottom:10%;
+
+  tbody {
+    white-space: nowrap;
+  }
+
   @media (max-height: 884px) {
     padding-bottom:0px;
   }


### PR DESCRIPTION
## Overview

Double the number of rows for the point source and water quality tables.

Word wrapping is turned off for these tables so that there is a uniform row
size. Discrepancies in table height were caused by wrapping of the City
column.

Connects to #2064

### Demo

<img width="456" alt="screen shot 2017-08-22 at 2 34 45 pm" src="https://user-images.githubusercontent.com/1042475/29581386-15fd63ea-8747-11e7-9b58-0efaeae9b6bc.png">

<img width="455" alt="screen shot 2017-08-22 at 2 34 52 pm" src="https://user-images.githubusercontent.com/1042475/29581384-15f24c62-8747-11e7-81c7-c8195d8e0d3b.png">

### Notes

Depending on which browser you are using, there is a varying degree of whitespace in the tab content panes. This makes them scrollable even though there is nothing to scroll to but more whitespace. I made some attempts to reduce this whitespace, but its a little tough to deal with because of how it varies between browsers. If we want to fix this, we should gets some help from a designer.

## Testing Instructions

- Draw an AoI that is at least as large as Philadelphia, to ensure there are lots of results for the point source and water quality tables.
- Advance to analyze, and view the point source and water quality tabs.
- Ensure there are 6 rows of data per page, and there is not excessive whitespace.
