### PR TITLE
Add NLCD code to analyze land results csv

### DIFF
--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -2,6 +2,9 @@
     <thead>
         <tr>
             <th data-sortable="true">Type</th>
+            {% if isLandTable %}
+                <th class="hidden-analyze-table-column" data-tableexport-display="always">NLCD Code</th>
+            {% endif %}
             <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Area ({{ headerUnits }})</th>
             <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Coverage (%)</th>
         </tr>

--- a/src/mmw/js/src/analyze/templates/tableRow.html
+++ b/src/mmw/js/src/analyze/templates/tableRow.html
@@ -1,3 +1,6 @@
 <td>{{ type }}</td>
+{% if isLandTable %}
+    <td class="hidden-analyze-table-column" data-tableexport-display="always">{{ code }}</td>
+{% endif %}
 <td class="strong text-right">{{ scaledArea|round(2)|toLocaleString(2) }}</td>
 <td class="strong text-right">{{ coveragePct|toFixed(1) }}</td>

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -68,12 +68,18 @@ function testAnalysisType(type) {
         resultView.listenTo(resultView, 'show', function() {
             var expectedTableHeaders = tableHeaders[type],
                 expectedTableRows = tableRows(type, result),
-                actualTableHeaders = $('table thead th').map(function() {
+                actualTableHeaders = _.compact($('table thead th').map(function() {
+                    if ($(this).hasClass('hidden-analyze-table-column')) {
+                        return null;
+                    }
                     return $(this).text().trim();
-                }).toArray(),
-                actualTableRows = $('table tbody td').map(function() {
+                }).toArray()),
+                actualTableRows = _.compact($('table tbody td').map(function() {
+                    if ($(this).hasClass('hidden-analyze-table-column')) {
+                        return null;
+                    }
                     return $(this).text().trim();
-                }).toArray();
+                }).toArray());
 
             assert.deepEqual(expectedTableHeaders, actualTableHeaders);
             assert.deepEqual(expectedTableRows, actualTableRows);

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -530,13 +530,17 @@ var TableRowView = Marionette.ItemView.extend({
     template: tableRowTmpl,
     templateHelpers: function() {
         var area = this.model.get('area'),
-            units = this.options.units;
+            units = this.options.units,
+            isLandTable = this.options.isLandTable,
+            code = isLandTable ? this.model.get('nlcd') : null;
 
         return {
             // Convert coverage to percentage for display.
             coveragePct: (this.model.get('coverage') * 100),
             // Scale the area to display units.
-            scaledArea: utils.changeOfAreaUnits(area, 'm<sup>2</sup>', units)
+            scaledArea: utils.changeOfAreaUnits(area, 'm<sup>2</sup>', units),
+            code: code,
+            isLandTable: isLandTable
         };
     }
 });
@@ -545,12 +549,14 @@ var TableView = Marionette.CompositeView.extend({
     childView: TableRowView,
     childViewOptions: function() {
         return {
-            units: this.options.units
+            units: this.options.units,
+            isLandTable: this.options.modelName === 'land'
         };
     },
     templateHelpers: function() {
         return {
-            headerUnits: this.options.units
+            headerUnits: this.options.units,
+            isLandTable: this.options.modelName === 'land'
         };
     },
     childViewContainer: 'tbody',
@@ -1027,7 +1033,8 @@ var AnalyzeResultView = Marionette.LayoutView.extend({
 
         this.tableRegion.show(new AnalyzeTableView({
             units: units,
-            collection: census
+            collection: census,
+            modelName: this.model.get('name')
         }));
 
         if (AnalyzeChartView) {

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -151,3 +151,7 @@
   max-width: 650px !important;
   height: 100%;
 }
+
+.hidden-analyze-table-column {
+  display: none;
+}


### PR DESCRIPTION
## Overview

This PR adds an "NLCD Code" column to the exported CSV, but not to the visible analyze results table. We accomplish this by adding a hidden column to the table which is registered to be exported along with the CSV.

Since both the land and soils tab use the TableView component, the changes here also include some checks for whether or not to add the hidden column. If we decide we want to show a soil code for that table, we can drop the checks in the template and instead pick the value and header text conditionally. 

Connects #2127

### Demo

<img width="453" alt="screen shot 2017-08-22 at 3 01 41 pm" src="https://user-images.githubusercontent.com/4165523/29583456-2e66da68-874e-11e7-878b-a79a6ff573f0.png">

->

<img width="562" alt="screen shot 2017-08-22 at 3 02 15 pm" src="https://user-images.githubusercontent.com/4165523/29583460-3221d734-874e-11e7-8fbe-691f38b28abe.png">

## Testing Instructions
- get this branch, then `vagrant up` and `bundle`
- draw an AOI and wait for the analysis results to complete. Once they're back check that the tabs all render as before and that all the csv exports work as before -- aside from the land export, which now includes a "NLCD Code" column in its csv
