### PR TITLE
Compare View Revamp: TR-55 Water Quality Charts and Table

### DIFF
--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -34,6 +34,7 @@ var ChartRowsCollection = Backbone.Collection.extend({
         var update = _.bind(this.update, this);
 
         this.scenarios = options.scenarios;
+        this.aoiVolumeModel = options.aoiVolumeModel;
 
         this.scenarios.forEach(function(scenario) {
             scenario.get('results').on('change', update);
@@ -70,6 +71,31 @@ var Tr55RunoffCharts = ChartRowsCollection.extend({
             chart.set({
                 precipitation: precipitation,
                 values: values
+            });
+        });
+    }
+});
+
+var Tr55QualityCharts = ChartRowsCollection.extend({
+    update: function() {
+        var aoivm = this.aoiVolumeModel,
+            results = this.scenarios.map(function(scenario) {
+                return scenario.get('results')
+                               .findWhere({ name: 'quality' })
+                               .get('result');
+            });
+
+        this.forEach(function(chart) {
+            var name = chart.get('name'),
+                values = _.map(results, function(result) {
+                    var measures = result.quality.modified,
+                        load = _.find(measures, { measure: name }).load;
+
+                    return aoivm.getLoadingRate(load);
+                });
+
+            chart.set({
+                values: values,
             });
         });
     }
@@ -189,6 +215,7 @@ var WindowModel = Backbone.Model.extend({
 module.exports = {
     ControlsCollection: ControlsCollection,
     Tr55QualityTable: Tr55QualityTable,
+    Tr55QualityCharts: Tr55QualityCharts,
     Tr55RunoffTable: Tr55RunoffTable,
     Tr55RunoffCharts: Tr55RunoffCharts,
     TabsCollection: TabsCollection,

--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -17,6 +17,7 @@ var ChartRowModel = Backbone.Model.extend({
         legendItems: null,
         values: [],
         unit: '',
+        unitLabel: '',
         precipitation: null,
     },
 });
@@ -214,6 +215,7 @@ var WindowModel = Backbone.Model.extend({
 
 module.exports = {
     ControlsCollection: ControlsCollection,
+    ChartRowModel: ChartRowModel,
     Tr55QualityTable: Tr55QualityTable,
     Tr55QualityCharts: Tr55QualityCharts,
     Tr55RunoffTable: Tr55RunoffTable,

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -620,8 +620,29 @@ function getTr55Tabs(scenarios) {
             scenarios: scenarios,
             aoiVolumeModel: aoiVolumeModel,
         }),
-        // TODO Calculate Water Quality charts
-        qualityCharts = [];
+        qualityCharts = new models.Tr55QualityCharts([
+            {
+                name: 'Total Suspended Solids',
+                chartDiv: 'tss-chart',
+                seriesColors: ['#389b9b'],
+                legendItems: null,
+                unit: 'kg/ha',
+            },
+            {
+                name: 'Total Nitrogen',
+                chartDiv: 'tn-chart',
+                seriesColors: ['#389b9b'],
+                legendItems: null,
+                unit: 'kg/ha',
+            },
+            {
+                name: 'Total Phosphorus',
+                chartDiv: 'tp-chart',
+                seriesColors: ['#389b9b'],
+                legendItems: null,
+                unit: 'kg/ha',
+            }
+        ], { scenarios: scenarios, aoiVolumeModel: aoiVolumeModel });
 
     return new models.TabsCollection([
         {

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -253,7 +253,8 @@ var ChartRowView = Marionette.ItemView.extend({
         var chartDiv = this.model.get('chartDiv'),
             chartEl = document.getElementById(chartDiv),
             name = this.model.get('name'),
-            label = 'Level (' + this.model.get('unit') + ')',
+            label = this.model.get('unitLabel') +
+                    ' (' + this.model.get('unit') + ')',
             colors = this.model.get('seriesColors'),
             stacked = name.indexOf('Hydrology') > -1,
             yMax = stacked ? this.model.get('precipitation') : null,
@@ -590,6 +591,7 @@ function getTr55Tabs(scenarios) {
                     },
                 ],
                 unit: 'cm',
+                unitLabel: 'Level',
             },
             {
                 key: 'et',
@@ -598,6 +600,7 @@ function getTr55Tabs(scenarios) {
                 seriesColors: ['#C2D33C'],
                 legendItems: null,
                 unit: 'cm',
+                unitLabel: 'Level',
             },
             {
                 key: 'runoff',
@@ -606,6 +609,7 @@ function getTr55Tabs(scenarios) {
                 seriesColors: ['#CF4300'],
                 legendItems: null,
                 unit: 'cm',
+                unitLabel: 'Level',
             },
             {
                 key: 'inf',
@@ -614,6 +618,7 @@ function getTr55Tabs(scenarios) {
                 seriesColors: ['#F8AA00'],
                 legendItems: null,
                 unit: 'cm',
+                unitLabel: 'Level',
             }
         ], { scenarios: scenarios }),
         qualityTable = new models.Tr55QualityTable({
@@ -627,6 +632,7 @@ function getTr55Tabs(scenarios) {
                 seriesColors: ['#389b9b'],
                 legendItems: null,
                 unit: 'kg/ha',
+                unitLabel: 'Loading Rate',
             },
             {
                 name: 'Total Nitrogen',
@@ -634,6 +640,7 @@ function getTr55Tabs(scenarios) {
                 seriesColors: ['#389b9b'],
                 legendItems: null,
                 unit: 'kg/ha',
+                unitLabel: 'Loading Rate',
             },
             {
                 name: 'Total Phosphorus',
@@ -641,6 +648,7 @@ function getTr55Tabs(scenarios) {
                 seriesColors: ['#389b9b'],
                 legendItems: null,
                 unit: 'kg/ha',
+                unitLabel: 'Loading Rate',
             }
         ], { scenarios: scenarios, aoiVolumeModel: aoiVolumeModel });
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -10,6 +10,7 @@ var _ = require('lodash'),
     models = require('./models'),
     modelingModels = require('../modeling/models'),
     modelingViews = require('../modeling/views'),
+    tr55Models = require('../modeling/tr55/models'),
     PrecipitationView = require('../modeling/controls').PrecipitationView,
     modConfigUtils = require('../modeling/modificationConfigUtils'),
     compareWindowTmpl = require('./templates/compareWindow.html'),
@@ -565,7 +566,9 @@ var CompareModificationsView = Marionette.ItemView.extend({
 
 function getTr55Tabs(scenarios) {
     // TODO Account for loading and error scenarios
-    var runoffTable = new models.Tr55RunoffTable({ scenarios: scenarios }),
+    var aoi = App.currentProject.get('area_of_interest'),
+        aoiVolumeModel = new tr55Models.AoiVolumeModel({ areaOfInterest: aoi }),
+        runoffTable = new models.Tr55RunoffTable({ scenarios: scenarios }),
         runoffCharts = new models.Tr55RunoffCharts([
             {
                 key: 'combined',
@@ -613,8 +616,10 @@ function getTr55Tabs(scenarios) {
                 unit: 'cm',
             }
         ], { scenarios: scenarios }),
-        // TODO Calculate Water Quality table
-        qualityTable = [],
+        qualityTable = new models.Tr55QualityTable({
+            scenarios: scenarios,
+            aoiVolumeModel: aoiVolumeModel,
+        }),
         // TODO Calculate Water Quality charts
         qualityCharts = [];
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -169,10 +169,14 @@ var InputsView = Marionette.LayoutView.extend({
     },
 
     setChartView: function() {
+        this.ui.chartButton.addClass('active');
+        this.ui.tableButton.removeClass('active');
         this.model.set({ mode: models.constants.CHART });
     },
 
     setTableView: function() {
+        this.ui.chartButton.removeClass('active');
+        this.ui.tableButton.addClass('active');
         this.model.set({ mode: models.constants.TABLE });
     },
 });

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -324,6 +324,7 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
             minBarWidth: 120,
             maxBarWidth: 150,
         },
+        yTickFormat = stacked ? '0.1f' : yFormat(),
         chart = nv.models.multiBarChart(),
         svg = makeSvg(chartEl),
         $svg = $(svg);
@@ -333,6 +334,24 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
         chartEl.style.width = scenariosWidth + "px";
 
         chart.width(chartEl.offsetWidth);
+    }
+
+    function yFormat() {
+        var getYs = function(d) { return _.map(d.values, 'y'); },
+            nonZero = function(x) { return x > 0; },
+            ys = _(data).map(getYs).flatten().filter(nonZero).value(),
+            minY = Math.min.apply(null, ys);
+
+        if (minY > 1) {
+            return '0.1f';
+        }
+
+        // Count decimal places to most significant digit, up to 4
+        for (var i = 0; minY < 1 && i < 4; i++) {
+            minY *= 10;
+        }
+
+        return '0.0' + i + 'f';
     }
 
     nv.addGraph(function() {
@@ -349,6 +368,7 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
 
         chart.yAxis
              .axisLabel(label)
+             .tickFormat(d3.format(yTickFormat))
              .showMaxMin(false);
 
         chart.tooltip.enabled(true);


### PR DESCRIPTION
## Overview

Adds Water Quality charts and table for TR-55. Also enables tab switching, and adds visualization for chart / table switching. Builds on the work done in #2148.

I talked to @jfrankl about how to show the many values of Water Quality in the app:

![image](https://user-images.githubusercontent.com/1430060/29584175-dcc673c8-8750-11e7-9fcf-076ad17f5fa3.png)

On his recommendation, we're showing only the Loading Rate (kg/ha) values, corresponding to the values shown in the charts. All the values are simple mathematical transformations of the same value, thus the trend seen in the charts would hold for all of them.

Connects #2076 

### Demo

![2017-08-22 15 50 30](https://user-images.githubusercontent.com/1430060/29584444-bc1e212e-8751-11e7-9c6d-86abbc304aab.gif)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/](http://localhost:8000/)
 * Load a saved project, or make a new one. Ensure it has at least 2 scenarios.
 * Open the Compare View
 * Switch between table and chart modes. Ensure the buttons update correctly.
 * Switch between Runoff and Water Quality tabs. Ensure the contents and the tab buttons update correctly.
 * Ensure the numbers in the Water Quality tab are accurate.
 * Ensure that changing the precipitation slider updates all values in all tabs