### PR TITLE
Add correct units for SRAT stream output

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -330,10 +330,10 @@ LAYER_GROUPS = {
             'css_class_prefix': 'stream',
             # Defined in tiler/server.js
             'legend_mapping': {
-                1: 'Less than 1 kg/y',
-                2: 'Less than 2 kg/y',
-                3: 'Less than 3 kg/y',
-                4: 'Less than 4 kg/y',
+                1: 'Less than 1 mg/L',
+                2: 'Less than 2 mg/L',
+                3: 'Less than 3 mg/L',
+                4: 'Less than 4 mg/L',
                 'NA': 'No Data'
             }
         },
@@ -346,10 +346,10 @@ LAYER_GROUPS = {
             'css_class_prefix': 'stream',
             # Defined in tiler/server.js
             'legend_mapping': {
-                1: 'Less than 0.03 kg/y',
-                2: 'Less than 0.06 kg/y',
-                3: 'Less than 0.09 kg/y',
-                4: 'Less than 0.12 kg/y',
+                1: 'Less than 0.03 mg/L',
+                2: 'Less than 0.06 mg/L',
+                3: 'Less than 0.09 mg/L',
+                4: 'Less than 0.12 mg/L',
                 'NA': 'No Data'
             }
         },
@@ -362,10 +362,10 @@ LAYER_GROUPS = {
             'css_class_prefix': 'stream',
             # Defined in tiler/server.js
             'legend_mapping': {
-                1: 'Less than 50 kg/y',
-                2: 'Less than 100 kg/y',
-                3: 'Less than 150 kg/y',
-                4: 'Less than 200 kg/y',
+                1: 'Less than 50 mg/L',
+                2: 'Less than 100 mg/L',
+                3: 'Less than 150 mg/L',
+                4: 'Less than 200 mg/L',
                 'NA': 'No Data'
             }
         },


### PR DESCRIPTION
## Overview

The units were misidentified as "kg/y" when in fact they are actually
reported in "mg/L".

Connects #2162 

### Demo
Compare with screenshot from issue.
![screenshot from 2017-08-24 13 15 27](https://user-images.githubusercontent.com/1014341/29679005-8bf3e8e8-88ce-11e7-8bf4-f5f0bf2dd199.png)

## Testing Instructions

 * Open the legend for all three stream SRAT layers and ensure they are reporting `mg/L`
