### PR TITLE
Compare View Revamp: Darken Background

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -7,6 +7,7 @@ var _ = require('lodash'),
     coreModels = require('../core/models'),
     coreViews = require('../core/views'),
     chart = require('../core/chart.js'),
+    modalViews = require('../core/modals/views'),
     models = require('./models'),
     modelingModels = require('../modeling/models'),
     modelingViews = require('../modeling/views'),
@@ -27,7 +28,7 @@ var _ = require('lodash'),
     compareModificationsPopoverTmpl = require('./templates/compareModificationsPopover.html'),
     compareDescriptionPopoverTmpl = require('./templates/compareDescriptionPopover.html');
 
-var CompareWindow2 = Marionette.LayoutView.extend({
+var CompareWindow2 = modalViews.ModalBaseView.extend({
     template: compareWindow2Tmpl,
 
     id: 'compare-new',
@@ -36,9 +37,9 @@ var CompareWindow2 = Marionette.LayoutView.extend({
         closeButton: '.compare-close > button',
     },
 
-    events: {
-        'click @ui.closeButton': 'closeView',
-    },
+    events: _.defaults({
+        'click @ui.closeButton': 'hide',
+    }, modalViews.ModalBaseView.prototype.events),
 
     modelEvents: {
         'change:mode': 'showSectionsView',
@@ -86,7 +87,7 @@ var CompareWindow2 = Marionette.LayoutView.extend({
         }
     },
 
-    closeView: function() {
+    onModalHidden: function() {
         App.rootView.compareRegion.empty();
     },
 });

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -18,7 +18,7 @@ var _ = require('underscore'),
     ENTER_KEYCODE = 13,
     BASIC_MODAL_CLASS = 'modal modal-basic fade';
 
-var ModalBaseView = Marionette.ItemView.extend({
+var ModalBaseView = Marionette.LayoutView.extend({
     className: BASIC_MODAL_CLASS,
 
     attributes: function() {
@@ -389,6 +389,7 @@ var PlotView = ModalBaseView.extend({
 });
 
 module.exports = {
+    ModalBaseView: ModalBaseView,
     ShareView: ShareView,
     InputView: InputView,
     ConfirmView: ConfirmView,


### PR DESCRIPTION
## Overview

Extends the Compare View window from ModalBaseView, so that it behaves like a modal:

 * Background darkens
 * Background cannot be interacted with (clicking / scrolling)
 * Modal fades in and fades out
 * Clicking the close button ✖️ or hitting <kbd>Esc</kbd> closes the Compare View

Connects #2120

### Demo

![2017-08-25 09 06 19](https://user-images.githubusercontent.com/1430060/29716128-3170d3f4-8978-11e7-9ba4-8677341abce4.gif)

### Notes

I do not observe #2180 on this branch. Perhaps this incidentally fixes that too?

As a result of the modal styling, the Compare View modal reaches all the way to the bottom even when the content stops earlier, like in the table mode:

![image](https://user-images.githubusercontent.com/1430060/29716303-d7840f40-8978-11e7-87f9-6fb188ec7173.png)

which I think this is fine.

Issues for IE11 still persist. I will add new screenshots to #2098.

## Testing Instructions

 * Check out this branch. Run `bundle`.
 * Get to the modeling stage with more than one scenario
 * Open the Compare View. Ensure it fades in, and the background darkens.
 * Ensure that you cannot click or scroll or otherwise interact with the background as long as the Compare View is open
 * Ensure clicking the ✖️  button closes the Compare View and it fades out. Ensure that the `#compare` div is emptied out on the page.
 * Open the Compare View again. Ensure that hitting <kbd>Esc</kbd> closes it as well.
 * Test existing modals to ensure they still work correctly. Try renaming a scenario (InputView), making a project public (ConfirmView), sharing a project (ShareView), drawing a very large shape (AlertView), and the observation tab (PlotView).