### PR TITLE
Implement Compare View Navigation

### DIFF
--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -6,7 +6,9 @@ var _ = require('lodash'),
     ControlsCollection = require('../modeling/models').ModelPackageControlsCollection;
 
 var CHART = 'chart',
-    TABLE = 'table';
+    TABLE = 'table',
+    CHART_AXIS_WIDTH = 82,
+    COMPARE_COLUMN_WIDTH = 134;
 
 var ChartRowModel = Backbone.Model.extend({
     defaults: {
@@ -225,5 +227,7 @@ module.exports = {
     constants: {
         CHART: CHART,
         TABLE: TABLE,
+        CHART_AXIS_WIDTH: CHART_AXIS_WIDTH,
+        COMPARE_COLUMN_WIDTH: COMPARE_COLUMN_WIDTH,
     },
 };

--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -206,6 +206,7 @@ var WindowModel = Backbone.Model.extend({
         mode: CHART, // or TABLE
         scenarios: null, // ScenariosCollection
         tabs: null,  // TabsCollection
+        visibleScenarioIndex: 0, // Index of the first visible scenario
     },
 
     addOrReplaceInput: function(input) {

--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -7,6 +7,7 @@ var _ = require('lodash'),
 
 var CHART = 'chart',
     TABLE = 'table',
+    MIN_VISIBLE_SCENARIOS = 3,
     CHART_AXIS_WIDTH = 82,
     COMPARE_COLUMN_WIDTH = 134;
 
@@ -228,6 +229,7 @@ module.exports = {
     constants: {
         CHART: CHART,
         TABLE: TABLE,
+        MIN_VISIBLE_SCENARIOS: MIN_VISIBLE_SCENARIOS,
         CHART_AXIS_WIDTH: CHART_AXIS_WIDTH,
         COMPARE_COLUMN_WIDTH: COMPARE_COLUMN_WIDTH,
     },

--- a/src/mmw/js/src/compare/templates/compareWindow2.html
+++ b/src/mmw/js/src/compare/templates/compareWindow2.html
@@ -25,7 +25,7 @@
         <button class="visible btn-prev-scenario">
             <i class="fa fa-arrow-left"></i>
         </button>
-        <button class="visible active btn-next-scenario">
+        <button class="visible btn-next-scenario">
             <i class="fa fa-arrow-right"></i>
         </button>
     </div>

--- a/src/mmw/js/src/compare/templates/compareWindow2.html
+++ b/src/mmw/js/src/compare/templates/compareWindow2.html
@@ -22,10 +22,10 @@
     <div id="compare-title-row" class="compare-scenario-row-content-container">
     </div>
     <div class="compare-scenario-buttons">
-        <button class="visible">
+        <button class="visible btn-prev-scenario">
             <i class="fa fa-arrow-left"></i>
         </button>
-        <button class="visible active">
+        <button class="visible active btn-next-scenario">
             <i class="fa fa-arrow-right"></i>
         </button>
     </div>

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -106,7 +106,8 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
                     $('.compare-scenario-row-content-container', this.$el)
                         .css('width')),
             componentWidth =
-                (this.model.get('scenarios').length * models.constants.COMPARE_COLUMN_WIDTH);
+                (this.model.get('scenarios').length * models.constants.COMPARE_COLUMN_WIDTH),
+            hiddenCols = parseInt(-1 * currMargin / models.constants.COMPARE_COLUMN_WIDTH + 1);
 
         if ((componentWidth - 14) > parentWidth) {
             var newMargin = _.max(
@@ -128,6 +129,16 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
                     'margin-left': newMargin.toString() + 'px',
                     'transition': 'all 0.3s ease-in-out',
                 });
+
+            this.$('.nvd3.nv-wrap.nv-axis').css({
+                'transform': 'translate(' + (-newMargin).toString() + 'px)',
+                'transition': 'all 0.3s ease-in-out',
+            });
+
+            this.$('.nv-group > rect:nth-child(-1n + ' + hiddenCols.toString() + ')').css({
+                'opacity': 0,
+                'transition': 'all 0.3s ease-in-out',
+            });
         }
     },
 
@@ -140,6 +151,8 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
 
         var maxMargin = 0;
         var newMargin = _.min([currMargin + models.constants.COMPARE_COLUMN_WIDTH, maxMargin]);
+
+        var shownCols = parseInt(-1 * currMargin / models.constants.COMPARE_COLUMN_WIDTH);
 
         $('.compare-scenarios' +
             ' > .compare-scenario-row-content-container' +
@@ -156,6 +169,16 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
                 'margin-left': newMargin.toString() + 'px',
                 'transition': 'all 0.3s ease-in-out',
             });
+
+        this.$('.nvd3.nv-wrap.nv-axis').css({
+            'transform': 'translate(' + (-newMargin).toString() + 'px)',
+            'transition': 'all 0.3s ease-in-out',
+        });
+
+        this.$('.nv-group > rect:nth-child(n + ' + shownCols.toString() + ')').css({
+            'opacity': 1,
+            'transition': 'all 0.3s ease-in-out',
+        });
     },
 });
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -308,7 +308,8 @@ var ChartRowView = Marionette.ItemView.extend({
     },
 
     renderChart: function() {
-        var chartDiv = this.model.get('chartDiv'),
+        var self = this,
+            chartDiv = this.model.get('chartDiv'),
             chartEl = document.getElementById(chartDiv),
             name = this.model.get('name'),
             label = this.model.get('unitLabel') +
@@ -335,11 +336,15 @@ var ChartRowView = Marionette.ItemView.extend({
                             y: value,
                         };
                     }),
-                }];
+                }],
+            onRenderComplete = function() {
+                self.triggerMethod('chart:rendered');
+            };
 
         $(chartEl.parentNode).css({ 'width': ((_.size(this.model.get('values')) * models.constants.COMPARE_COLUMN_WIDTH + models.constants.CHART_AXIS_WIDTH)  + 'px') });
         chart.renderCompareMultibarChart(
-            chartEl, name, label, colors, stacked, yMax, data, models.constants.COMPARE_COLUMN_WIDTH, models.constants.CHART_AXIS_WIDTH);
+            chartEl, name, label, colors, stacked, yMax, data,
+            models.constants.COMPARE_COLUMN_WIDTH, models.constants.CHART_AXIS_WIDTH, onRenderComplete);
     },
 });
 
@@ -352,6 +357,11 @@ var ChartView = Marionette.CollectionView.extend({
 
     onRender: function() {
         // To initialize chart correctly when switching between tabs
+        this.slide();
+    },
+
+    onChildviewChartRendered: function() {
+        // Update chart status after it is rendered
         this.slide();
     },
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -60,6 +60,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
     highlightButtons: function() {
         var i = this.model.get('visibleScenarioIndex'),
             total = this.model.get('scenarios').length,
+            minScenarios = models.constants.MIN_VISIBLE_SCENARIOS,
             prevButton = this.ui.prevButton,
             nextButton = this.ui.nextButton;
 
@@ -69,7 +70,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
             prevButton.addClass('active');
         }
 
-        if (i + 1 >= total) {
+        if (i + minScenarios >= total) {
             nextButton.removeClass('active');
         } else {
             nextButton.addClass('active');
@@ -120,7 +121,8 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
 
     nextScenario: function() {
         var visibleScenarioIndex = this.model.get('visibleScenarioIndex'),
-            last = this.model.get('scenarios').length - 1;
+            last = Math.max(0, this.model.get('scenarios').length -
+                               models.constants.MIN_VISIBLE_SCENARIOS);
 
         this.model.set({
             visibleScenarioIndex: Math.min(++visibleScenarioIndex, last)

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -108,6 +108,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
             }));
         } else {
             this.sectionsRegion.show(new TableView({
+                model: this.model,
                 collection: this.model.get('tabs')
                                 .findWhere({ active: true })
                                 .get('table'),
@@ -425,6 +426,26 @@ var TableView = Marionette.CollectionView.extend({
     collectionEvents: {
         'change': 'render',
     },
+
+    modelEvents: {
+        'change:visibleScenarioIndex': 'slide',
+    },
+
+    onRender: function() {
+        // To initialize table correctly when switching between tabs,
+        // and when receiving new values from server
+        this.slide();
+    },
+
+    slide: function() {
+        var i = this.model.get('visibleScenarioIndex'),
+            width = models.constants.COMPARE_COLUMN_WIDTH,
+            marginLeft = -i * width;
+
+        this.$('.compare-scenario-row-content').css({
+            'margin-left': marginLeft + 'px',
+        });
+    }
 });
 
 var CompareWindow = Marionette.LayoutView.extend({

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -112,14 +112,13 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
         if ((componentWidth - 14) > parentWidth) {
             var newMargin = _.max(
                 [currMargin - models.constants.COMPARE_COLUMN_WIDTH,
-                 -(componentWidth * (1 / (componentWidth / parentWidth)))]);
+                 -(parentWidth)]);
 
             $('.compare-scenarios' +
               ' > .compare-scenario-row-content-container' +
               ' > .compare-scenario-row-content', this.$el)
                 .css({
                     'margin-left': newMargin.toString() + 'px',
-                    'transition': 'all 0.3s ease-in-out',
                 });
 
             $('.compare-chart-row' +
@@ -127,17 +126,14 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
                 ' > .compare-scenario-row-content', this.$el)
                 .css({
                     'margin-left': newMargin.toString() + 'px',
-                    'transition': 'all 0.3s ease-in-out',
                 });
 
             this.$('.nvd3.nv-wrap.nv-axis').css({
                 'transform': 'translate(' + (-newMargin).toString() + 'px)',
-                'transition': 'all 0.3s ease-in-out',
             });
 
             this.$('.nv-group > rect:nth-child(-1n + ' + hiddenCols.toString() + ')').css({
                 'opacity': 0,
-                'transition': 'all 0.3s ease-in-out',
             });
         }
     },
@@ -159,7 +155,6 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
             ' > .compare-scenario-row-content', this.$el)
             .css({
                 'margin-left': newMargin.toString() + 'px',
-                'transition': 'all 0.3s ease-in-out',
             });
 
         $('.compare-chart-row' +
@@ -167,17 +162,14 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
             ' > .compare-scenario-row-content', this.$el)
             .css({
                 'margin-left': newMargin.toString() + 'px',
-                'transition': 'all 0.3s ease-in-out',
             });
 
         this.$('.nvd3.nv-wrap.nv-axis').css({
             'transform': 'translate(' + (-newMargin).toString() + 'px)',
-            'transition': 'all 0.3s ease-in-out',
         });
 
         this.$('.nv-group > rect:nth-child(n + ' + shownCols.toString() + ')').css({
             'opacity': 1,
-            'transition': 'all 0.3s ease-in-out',
         });
     },
 });

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -35,10 +35,14 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
 
     ui: {
         closeButton: '.compare-close > button',
+        nextButton: '.compare-scenario-buttons > .btn-next-scenario',
+        prevButton: '.compare-scenario-buttons > .btn-prev-scenario',
     },
 
     events: _.defaults({
         'click @ui.closeButton': 'hide',
+        'click @ui.nextButton' : 'nextScenario',
+        'click @ui.prevButton' : 'prevScenario',
     }, modalViews.ModalBaseView.prototype.events),
 
     modelEvents: {
@@ -89,6 +93,69 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
 
     onModalHidden: function() {
         App.rootView.compareRegion.empty();
+    },
+
+    nextScenario: function() {
+        var currMargin =
+                parseInt(
+                    $('.compare-scenario-row-content-container' +
+                      ' > .compare-scenario-row-content', this.$el)
+                        .css('margin-left')),
+            parentWidth =
+                parseInt(
+                    $('.compare-scenario-row-content-container', this.$el)
+                        .css('width')),
+            componentWidth =
+                (this.model.get('scenarios').length * models.constants.COMPARE_COLUMN_WIDTH);
+
+        if ((componentWidth - 14) > parentWidth) {
+            var newMargin = _.max(
+                [currMargin - models.constants.COMPARE_COLUMN_WIDTH,
+                 -(componentWidth * (1 / (componentWidth / parentWidth)))]);
+
+            $('.compare-scenarios' +
+              ' > .compare-scenario-row-content-container' +
+              ' > .compare-scenario-row-content', this.$el)
+                .css({
+                    'margin-left': newMargin.toString() + 'px',
+                    'transition': 'all 0.3s ease-in-out',
+                });
+
+            $('.compare-chart-row' +
+                ' > .compare-scenario-row-content-container' +
+                ' > .compare-scenario-row-content', this.$el)
+                .css({
+                    'margin-left': newMargin.toString() + 'px',
+                    'transition': 'all 0.3s ease-in-out',
+                });
+        }
+    },
+
+    prevScenario: function() {
+        var currMargin =
+                parseInt(
+                    $('.compare-scenario-row-content-container' +
+                        ' > .compare-scenario-row-content', this.$el)
+                        .css('margin-left'));
+
+        var maxMargin = 0;
+        var newMargin = _.min([currMargin + models.constants.COMPARE_COLUMN_WIDTH, maxMargin]);
+
+        $('.compare-scenarios' +
+            ' > .compare-scenario-row-content-container' +
+            ' > .compare-scenario-row-content', this.$el)
+            .css({
+                'margin-left': newMargin.toString() + 'px',
+                'transition': 'all 0.3s ease-in-out',
+            });
+
+        $('.compare-chart-row' +
+            ' > .compare-scenario-row-content-container' +
+            ' > .compare-scenario-row-content', this.$el)
+            .css({
+                'margin-left': newMargin.toString() + 'px',
+                'transition': 'all 0.3s ease-in-out',
+            });
     },
 });
 
@@ -300,8 +367,9 @@ var ChartRowView = Marionette.ItemView.extend({
                     }),
                 }];
 
+        $(chartEl.parentNode).css({ 'width': ((_.size(this.model.get('values')) * models.constants.COMPARE_COLUMN_WIDTH + models.constants.CHART_AXIS_WIDTH)  + 'px') });
         chart.renderCompareMultibarChart(
-            chartEl, name, label, colors, stacked, yMax, data);
+            chartEl, name, label, colors, stacked, yMax, data, models.constants.COMPARE_COLUMN_WIDTH, models.constants.CHART_AXIS_WIDTH);
     },
 });
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -350,6 +350,11 @@ var ChartView = Marionette.CollectionView.extend({
         'change:visibleScenarioIndex': 'slide',
     },
 
+    onRender: function() {
+        // To initialize chart correctly when switching between tabs
+        this.slide();
+    },
+
     slide: function() {
         var i = this.model.get('visibleScenarioIndex'),
             width = models.constants.COMPARE_COLUMN_WIDTH,

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -47,6 +47,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
 
     modelEvents: {
         'change:mode': 'showSectionsView',
+        'change:visibleScenarioIndex': 'highlightButtons',
     },
 
     regions: {
@@ -54,6 +55,25 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
         inputsRegion: '.compare-inputs',
         scenariosRegion: '#compare-title-row',
         sectionsRegion: '.compare-sections',
+    },
+
+    highlightButtons: function() {
+        var i = this.model.get('visibleScenarioIndex'),
+            total = this.model.get('scenarios').length,
+            prevButton = this.ui.prevButton,
+            nextButton = this.ui.nextButton;
+
+        if (i < 1) {
+            prevButton.removeClass('active');
+        } else {
+            prevButton.addClass('active');
+        }
+
+        if (i + 1 >= total) {
+            nextButton.removeClass('active');
+        } else {
+            nextButton.addClass('active');
+        }
     },
 
     onShow: function() {
@@ -74,6 +94,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
         }));
 
         showSectionsView();
+        this.highlightButtons();
     },
 
     showSectionsView: function() {

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -69,6 +69,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
             model: this.model,
         }));
         this.scenariosRegion.show(new ScenariosRowView({
+            model: this.model,
             collection: this.model.get('scenarios'),
         }));
 
@@ -107,19 +108,16 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
                         .css('width')),
             componentWidth =
                 (this.model.get('scenarios').length * models.constants.COMPARE_COLUMN_WIDTH),
+            lastScenario = this.model.get('scenarios').length - 1,
+            visibleScenarioIndex = this.model.get('visibleScenarioIndex'),
             hiddenCols = parseInt(-1 * currMargin / models.constants.COMPARE_COLUMN_WIDTH + 1);
+
+        this.model.set({ visibleScenarioIndex: Math.min(++visibleScenarioIndex, lastScenario) });
 
         if ((componentWidth - 14) > parentWidth) {
             var newMargin = _.max(
                 [currMargin - models.constants.COMPARE_COLUMN_WIDTH,
                  -(parentWidth)]);
-
-            $('.compare-scenarios' +
-              ' > .compare-scenario-row-content-container' +
-              ' > .compare-scenario-row-content', this.$el)
-                .css({
-                    'margin-left': newMargin.toString() + 'px',
-                });
 
             $('.compare-chart-row' +
                 ' > .compare-scenario-row-content-container' +
@@ -148,14 +146,11 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
         var maxMargin = 0;
         var newMargin = _.min([currMargin + models.constants.COMPARE_COLUMN_WIDTH, maxMargin]);
 
+        var visibleScenarioIndex = this.model.get('visibleScenarioIndex');
+
         var shownCols = parseInt(-1 * currMargin / models.constants.COMPARE_COLUMN_WIDTH);
 
-        $('.compare-scenarios' +
-            ' > .compare-scenario-row-content-container' +
-            ' > .compare-scenario-row-content', this.$el)
-            .css({
-                'margin-left': newMargin.toString() + 'px',
-            });
+        this.model.set({ visibleScenarioIndex: Math.max(--visibleScenarioIndex, 0) });
 
         $('.compare-chart-row' +
             ' > .compare-scenario-row-content-container' +
@@ -337,6 +332,20 @@ var ScenarioItemView = Marionette.ItemView.extend({
 var ScenariosRowView = Marionette.CollectionView.extend({
     className: 'compare-scenario-row-content',
     childView: ScenarioItemView,
+
+    modelEvents: {
+        'change:visibleScenarioIndex': 'slide',
+    },
+
+    slide: function() {
+        var i = this.model.get('visibleScenarioIndex'),
+            width = models.constants.COMPARE_COLUMN_WIDTH,
+            marginLeft = -i * width;
+
+        this.$el.css({
+            'margin-left': marginLeft + 'px',
+        });
+    }
 });
 
 var ChartRowView = Marionette.ItemView.extend({

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -314,7 +314,7 @@ function renderLineChart(chartEl, data, options) {
     });
 }
 
-function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax, data, columnWidth, xAxisWidth) {
+function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax, data, columnWidth, xAxisWidth, callback) {
     var options = {
             margin: {
                 top: 20,
@@ -322,6 +322,7 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                 left: 60,
             },
         },
+        onRenderComplete = (callback) ? callback : _.noop,
         yTickFormat = stacked ? '0.1f' : yFormat(),
         chart = nv.models.multiBarChart(),
         svg = makeSvg(chartEl),
@@ -383,7 +384,7 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
           .call(chart);
 
         return chart;
-    });
+    }, onRenderComplete);
 }
 
 module.exports = {

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -314,15 +314,13 @@ function renderLineChart(chartEl, data, options) {
     });
 }
 
-function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax, data) {
+function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax, data, columnWidth, xAxisWidth) {
     var options = {
             margin: {
                 top: 20,
                 bottom: 20,
                 left: 60,
             },
-            minBarWidth: 120,
-            maxBarWidth: 150,
         },
         yTickFormat = stacked ? '0.1f' : yFormat(),
         chart = nv.models.multiBarChart(),
@@ -330,9 +328,10 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
         $svg = $(svg);
 
     function setChartWidth() {
-        var scenariosWidth = (document.getElementById('compare-title-row').offsetWidth + 100);
-        chartEl.style.width = scenariosWidth + "px";
+        var scenarioCount = _.size(_.head(data).values),
+            scenariosWidth = scenarioCount * columnWidth + xAxisWidth;
 
+        chartEl.style.width = scenariosWidth + "px";
         chart.width(chartEl.offsetWidth);
     }
 

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -443,6 +443,14 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
     .nv-x .tick line {
       display: none;
     }
+
+    .nvd3.nv-wrap.nv-axis {
+      transition: transform 0.3s ease-in-out;
+    }
+
+    rect {
+      transition: opacity 0.3s ease-in-out;
+    }
   }
 
   .compare-scenario-gradient {
@@ -494,6 +502,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
     flex: 1;
     display: flex;
     flex-flow: row nowrap;
+    transition: margin 0.3s ease-in-out;
   }
 
   .compare-scenario-samplechartplaceholder {

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -493,7 +493,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
   .compare-scenario-row-content {
     flex: 1;
     display: flex;
-    flex-wrap: nowrap;
+    flex-flow: row nowrap;
   }
 
   .compare-scenario-samplechartplaceholder {


### PR DESCRIPTION
## Overview

This PR implements the sliding navigation behavior for the revamped compare view. The navigation only has an effect when there are enough items in the view to be hidden (that is, when the width of the item container is larger than the modal component), otherwise the navigation buttons do nothing. The view may be moved leftwards only until about half the viewable space is empty, and rightwards until the first item is in view.

Connects #2075 

### Demo
No scrolling (not enough items) -->
![recording 21](https://user-images.githubusercontent.com/18290666/29731567-df5f6356-89b2-11e7-9d72-1f1e687f5edb.gif)

Scrolling -->
![recording 22](https://user-images.githubusercontent.com/18290666/29731602-f5a2b8de-89b2-11e7-89bd-95c8975f4663.gif)


### Notes

The limit on the leftwards scrolling was a judgment call, but it may be easily revised to some other value.

## Testing Instructions

* rebundle the app and open it
* set an area of interest and proceed to the model view
* check that, for smaller numbers of scenarios, the compare view doesn't change when the navigation buttons are clicked
* check that, for larger numbers of scenarios, the compare view moves as described, with the chart and the header items moving together.