### PR TITLE
BiG-CZ Add Search Option Support, Filter CUAHSI Results

### DIFF
--- a/src/mmw/apps/bigcz/views.py
+++ b/src/mmw/apps/bigcz/views.py
@@ -32,6 +32,7 @@ def _do_search(request):
         'to_date': parse_date(request.query_params.get('to_date')),
         'from_date': parse_date(request.query_params.get('from_date')),
         'bbox': request.query_params.get('bbox'),
+        'options': request.query_params.get('options', ''),
         'page': page,
     }
 

--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -38,7 +38,8 @@ var DataCatalogController = {
             new models.Catalog({
                 id: 'cuahsi',
                 name: 'WDC',
-                description: 'Optional catalog description here...',
+                has_filters: true,
+                options: new models.SearchOptions([{ id: 'gridded' }]),
                 is_pageable: false,
                 results: new models.Results(null, { catalog: 'cuahsi' }),
             })

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -160,8 +160,8 @@ var Result = Backbone.Model.extend({
         description: '',
         geom: null, // GeoJSON
         links: null, // Array
-        created: '',
-        updated: '',
+        created_at: '',
+        updated_at: '',
         show_detail: false // Show this result as the detail view?
     },
 

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var $ = require('jquery'),
-    _ = require('underscore'),
+    _ = require('lodash'),
     Backbone = require('../../shim/backbone'),
     turfIntersect = require('turf-intersect'),
     App = require('../app'),
@@ -10,6 +10,17 @@ var $ = require('jquery'),
 var REQUEST_TIMED_OUT_CODE = 408;
 var DESCRIPTION_MAX_LENGTH = 100;
 var PAGE_SIZE = settings.get('data_catalog_page_size');
+
+var SearchOption = Backbone.Model.extend({
+    defaults: {
+        id: '',
+        active: false,
+    },
+});
+
+var SearchOptions = Backbone.Collection.extend({
+    model: SearchOption,
+});
 
 var Catalog = Backbone.Model.extend({
     defaults: {
@@ -24,6 +35,8 @@ var Catalog = Backbone.Model.extend({
         active: false,
         results: null, // Results collection
         resultCount: 0,
+        has_filters: false, // If local filters apply
+        options: null,      // SearchOptions collection
         is_pageable: true,
         page: 1,
         error: '',
@@ -34,6 +47,14 @@ var Catalog = Backbone.Model.extend({
         var self = this;
         this.get('results').on('change:show_detail', function() {
             self.set('detail_result', self.get('results').getDetail());
+        });
+
+        // Initialize and listen to options for changes
+        if (this.get('options') === null) {
+            this.set({ options: new SearchOptions() });
+        }
+        this.get('options').on('change:active', function() {
+            self.startSearch(1);
         });
     },
 
@@ -76,6 +97,9 @@ var Catalog = Backbone.Model.extend({
     startSearch: function(page) {
         var lastPage = Math.ceil(this.get('resultCount') / PAGE_SIZE),
             thisPage = parseInt(page) || 1,
+            has_filters = this.get('has_filters'),
+            options = this.get('options'),
+            id = function(option) { return option.id; },
             data = {
                 catalog: this.id,
                 query: this.get('query'),
@@ -86,6 +110,12 @@ var Catalog = Backbone.Model.extend({
 
         if (thisPage > 1 && thisPage <= lastPage) {
             _.assign(data, { page: thisPage });
+        }
+
+        if (has_filters && options) {
+            _.assign(data, {
+                options: options.where({ active: true }).map(id).join(',')
+            });
         }
 
         this.set('loading', true);
@@ -260,6 +290,8 @@ var SearchForm = Backbone.Model.extend({
 });
 
 module.exports = {
+    SearchOption: SearchOption,
+    SearchOptions: SearchOptions,
     Catalog: Catalog,
     Catalogs: Catalogs,
     Result: Result,

--- a/src/mmw/js/src/data_catalog/templates/tabContent.html
+++ b/src/mmw/js/src/data_catalog/templates/tabContent.html
@@ -1,3 +1,8 @@
+{% if has_filters %}
+    <div class="filters-region">
+    </div>
+{% endif %}
+
 {% if description %}
 <div class="catalog-description">
     {{ description }}

--- a/src/mmw/js/src/data_catalog/templates/tabContent.html
+++ b/src/mmw/js/src/data_catalog/templates/tabContent.html
@@ -1,5 +1,13 @@
 {% if has_filters %}
     <div class="filters-region">
+        {% if id == 'cuahsi' %}
+            <div class="checkbox">
+                <label>
+                    <input name="gridded" type="checkbox" id="gridded">
+                    Include Gridded
+                </label>
+            </div>
+        {% endif %}
     </div>
 {% endif %}
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -336,17 +336,17 @@ var TabContentView = Marionette.LayoutView.extend({
         this.toggleActiveClass();
 
         this.resultRegion.show(new ResultsView({
-            collection: this.model.get('results'),
-            catalog: this.model.id,
+            collection: model.get('results'),
+            catalog: model.id,
         }));
 
         this.errorRegion.show(new ErrorView({
-            model: this.model,
+            model: model,
         }));
 
-        if (this.model.get('is_pageable')) {
+        if (model.get('is_pageable')) {
             this.pagerRegion.show(new PagerView({
-                model: this.model,
+                model: model,
             }));
         }
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -352,6 +352,13 @@ var TabContentView = Marionette.LayoutView.extend({
 
         if (model.get('has_filters')) {
             // TODO Generalize for different types of filters
+            if (model.id === 'cuahsi') {
+                $('input#gridded').change(function() {
+                    model.get('options')
+                         .findWhere({ id: 'gridded' })
+                         .set({ active: this.checked });
+                });
+            }
         }
     },
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -331,6 +331,8 @@ var TabContentView = Marionette.LayoutView.extend({
     },
 
     onShow: function() {
+        var model = this.model;
+
         this.toggleActiveClass();
 
         this.resultRegion.show(new ResultsView({
@@ -346,6 +348,10 @@ var TabContentView = Marionette.LayoutView.extend({
             this.pagerRegion.show(new PagerView({
                 model: this.model,
             }));
+        }
+
+        if (model.get('has_filters')) {
+            // TODO Generalize for different types of filters
         }
     },
 

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -40,6 +40,10 @@
         }
     }
 
+    .filters-region {
+        padding: 6px 10px 0 10px;
+    }
+
     .result-region {
         height: auto !important;
         width: auto !important;


### PR DESCRIPTION
## Overview

Filters out "gridded" results, as described in the original issue, by default when fetching CUAHSI results. In cases when the gridded results may be a lot, removing them can potentially speed up the network request, thus we prefer filtering in the middleware rather than the client side. The main use case (as described [here](https://github.com/WikiWatershed/model-my-watershed/issues/2133#issuecomment-325013206)) is that users will rarely want gridded services, so we prioritize the initial request over the switching performance (the former slower and the latter faster in a client-side implementation).

To communicate complex filters such as this to the middleware, I've added an `options` query parameter, which takes a list of string flags. Their presence can enable arbitrary behavior defined on each catalog.

Currently there is only one option: `gridded` supported by the `cuahsi` catalog. If it is absent, we exclude certain services from the back-end request which delay the entire payload. If it is absent, no filtering is done.

On the front-end, we add a `has_filters` flag to the Catalog model, which shows a special filters div if present. We also add an `options` array, to store all enabled flags. For CUAHSI, this div includes an "Include Gridded" checkbox, checking which enables the `gridded` flag and fires a search request.

Connects #2133 

### Demo

![2017-08-28 13 28 39](https://user-images.githubusercontent.com/1430060/29785332-2df2b920-8bf5-11e7-9d92-13815ec4efb1.gif)

### Notes

The supported flags for each catalog should probably be documented somewhere. I'm not sure if this should be in a separate README, in code comments, or in a special "discovery" API endpoint. Something to think about when we add Swagger support and make the API public down the line.

The front-end implementation of the checkbox is also rather slapdash, because I had burned more time than I'd estimated on this. Since we don't know what kinds of filters we may have in the future (text, date, range, numeric, option buttons, more checkboxes, etc) so instead of attempting a generalization here, I'm deferring until we have more information.

## Testing Instructions

 * Check out this branch and run `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz), and perform a search around Philadelphia
 * Go to the CUAHSI tab. Ensure there are no NLDAS_FORA or NLDAS_NOAH results
 * Check the "Include Gridded" box. Ensure there is a new search performed and that those results are now included
 * Ensure the other two tabs work as before