### PR TITLE
Add time period slider for monthly overlays

### DIFF
--- a/src/mmw/apps/home/templates/home/home.html
+++ b/src/mmw/apps/home/templates/home/home.html
@@ -11,6 +11,7 @@
 </div>
 <div id="map"></div>
 <div class="layerpicker" id="layer-picker-region"></div>
+<div id="layer-picker-slider-region"></div>
 <div id="boundary-label"></div>
 {% endblock map %}
 

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -85,6 +85,7 @@ var App = new Marionette.Application({
         this.layerPickerView = new LayerPickerView({
             collection: this.layerTabs,
             leafletMap: this.getLeafletMap(),
+            timeSliderRegion: this.rootView.layerPickerSliderRegion,
         });
         this.rootView.layerPickerRegion.show(this.layerPickerView);
     },

--- a/src/mmw/js/src/core/layerPicker.js
+++ b/src/mmw/js/src/core/layerPicker.js
@@ -3,6 +3,7 @@
 var $ = require('jquery'),
     Backbone = require('../../shim/backbone'),
     Marionette = require('../../shim/backbone.marionette'),
+    moment = require('moment'),
     _ = require('underscore'),
     utils = require('./utils'),
     layerPickerTmpl = require('./templates/layerPicker.html'),
@@ -10,7 +11,62 @@ var $ = require('jquery'),
     layerPickerLayerTmpl = require('./templates/layerPickerLayer.html'),
     layerPickerLegendTmpl = require('./templates/layerPickerLegend.html'),
     layerPickerNavTmpl = require('./templates/layerPickerNav.html'),
-    opacityControlTmpl = require('./templates/opacityControl.html');
+    opacityControlTmpl = require('./templates/opacityControl.html'),
+    timeSliderTmpl = require('./templates/timeSliderControl.html');
+
+
+var LayerTimeSliderView = Marionette.LayoutView.extend({
+    template: timeSliderTmpl,
+
+    ui: {
+        slider: 'input',
+        monthLabel: '.time-slider-month',
+    },
+
+    events: {
+        'mousedown @ui.slider': 'onMouseDown',
+        'mouseup @ui.slider': 'onMouseUp',
+        'input @ui.slider': 'sliderMove',
+        'change @ui.slider': 'sliderMove', // IE only event
+    },
+
+    initialize: function(options) {
+        this.leafletMap = options.leafletMap;
+        this.layer = options.layer;
+
+    },
+
+    sliderMove: function(e) {
+        var sliderValue = $(e.target).val(),
+            month = moment(Number(sliderValue) + 1, 'M').format('MMM');
+
+        this.ui.monthLabel.text(month);
+    },
+
+    onMouseDown: function() {
+        this.leafletMap.dragging.disable();
+    },
+
+    onMouseUp: function(e) {
+        this.leafletMap.dragging.enable();
+        var el = $(e.target),
+        sliderValue = el.val();
+
+        this.model.set('selectedTimeLayerIdx', Number(sliderValue));
+    },
+
+    templateHelpers: function() {
+        var idx = this.model.get('selectedTimeLayerIdx') + 1,
+            month = moment(idx, 'M').format('MMM');
+
+        return {
+            min: 0,
+            max: this.layer.get('timeLayers').length - 1,
+            month: month,
+            shortDisplay: this.layer.get('shortDisplay'),
+        };
+    }
+});
 
 var LayerOpacitySliderView = Marionette.ItemView.extend({
     template: opacityControlTmpl,
@@ -35,6 +91,7 @@ var LayerOpacitySliderView = Marionette.ItemView.extend({
         sliderValue = el.val();
         this.layer.get('leafletLayer').setOpacity(sliderValue / 100);
         el.attr('value', sliderValue);
+        this.model.set('selectedOpacityValue', Number(sliderValue));
     },
 
     templateHelpers: function() {
@@ -97,7 +154,8 @@ var LayerPickerLayerView = Marionette.ItemView.extend({
 var LayerPickerLayerListView = Marionette.CollectionView.extend({
     childView: LayerPickerLayerView,
     modelEvents: {
-        'change': 'renderIfNotDestroyed'
+        'change': 'renderIfNotDestroyed',
+        'change:selectedTimeLayerIdx': 'updateTimePeriod',
     },
     collectionEvents: {
         'change': 'renderIfNotDestroyed',
@@ -126,6 +184,11 @@ var LayerPickerLayerListView = Marionette.CollectionView.extend({
         utils.toggleLayer(selectedLayer, this.leafletMap, this.model);
         this.triggerMethod('select:layer');
     },
+
+    updateTimePeriod: function() {
+        var layer = this.collection.findWhere({'active': true});
+        utils.toggleTimeLayer(layer, this.leafletMap, this.model);
+    },
 });
 
 /* The layer picker group view. Renders the layer group's title and a collection view
@@ -139,12 +202,12 @@ var LayerPickerGroupView = Marionette.LayoutView.extend({
     },
 
     modelEvents: {
-        'change': 'render',
-        'toggle:layer': 'addOpacityControl',
+        'toggle:layer': 'addLayerControls',
     },
 
     initialize: function(options) {
         this.leafletMap = options.leafletMap;
+        this.timeSliderRegion = options.timeSliderRegion;
     },
 
     onRender: function() {
@@ -156,19 +219,46 @@ var LayerPickerGroupView = Marionette.LayoutView.extend({
                 model: this.model,
                 leafletMap: this.leafletMap,
             }));
-            this.addOpacityControl();
+            this.addLayerControls();
         }
     },
 
-    addOpacityControl: function() {
-        var currentActiveOpacityLayer = this.model.get('layers').findWhere({
+    addLayerControls: function() {
+        // Add opacity or time sliders if this newly selected layer has them enabled
+        var activeLayer = this.model.get('layers').findWhere({
             active: true,
-            hasOpacitySlider: true,
         });
-        if (currentActiveOpacityLayer) {
+
+        if (activeLayer) {
+            this.addOpacityControl(activeLayer);
+            this.addTimeSliderControl(activeLayer);
+        } else {
+            // Always remove the time slider control when there is no active layer
+            this.hideTimeSliderRegion();
+        }
+    },
+
+    addTimeSliderControl: function(layer) {
+        if (layer.get('hasTimeSlider')) {
+            var timeSlider = new LayerTimeSliderView({
+                leafletMap: this.leafletMap,
+                model: this.model,
+                layer: layer,
+            });
+
+            this.showTimeSliderRegion(timeSlider);
+        } else {
+            this.hideTimeSliderRegion();
+        }
+
+    },
+
+    addOpacityControl: function(layer) {
+        if (layer.get('hasOpacitySlider')) {
             this.showChildView('opacityControl', new LayerOpacitySliderView({
                 leafletMap: this.leafletMap,
-                layer: currentActiveOpacityLayer,
+                layer: layer,
+                model: this.model,
             }));
         } else {
             this.opacityControl.empty();
@@ -186,6 +276,16 @@ var LayerPickerGroupView = Marionette.LayoutView.extend({
             layerGroupName: this.model.get('name'),
             message: message,
         };
+    },
+
+    showTimeSliderRegion: function(timeSlider) {
+        if (!this.timeSliderRegion) { return; }
+        this.timeSliderRegion.show(timeSlider);
+    },
+
+    hideTimeSliderRegion: function() {
+        if (!this.timeSliderRegion) { return; }
+        this.timeSliderRegion.empty();
     }
 });
 
@@ -194,11 +294,13 @@ var LayerPickerTabView = Marionette.CollectionView.extend({
     childViewOptions: function() {
         return {
             leafletMap: this.leafletMap,
+            timeSliderRegion: this.timeSliderRegion,
         };
     },
 
     initialize: function(options) {
         this.leafletMap = options.leafletMap;
+        this.timeSliderRegion = options.timeSliderRegion;
     }
 });
 
@@ -281,6 +383,7 @@ var LayerPickerView = Marionette.LayoutView.extend({
     regions: {
         layerTab: '#layerpicker-tab',
         layerTabNav: '.layerpicker-nav',
+        tileSlider: '.ghostmouse',
     },
 
     ui: {
@@ -305,6 +408,7 @@ var LayerPickerView = Marionette.LayoutView.extend({
         layerToMakeActive.set('active', true);
 
         this.leafletMap = options.leafletMap;
+        this.timeSliderRegion = options.timeSliderRegion;
         this.model = new Backbone.Model({
             isOpen: true,
         });
@@ -323,7 +427,8 @@ var LayerPickerView = Marionette.LayoutView.extend({
         if (activeLayerGroups && isOpen) {
             this.layerTab.show(new LayerPickerTabView({
                 collection: activeLayerGroups,
-                leafletMap: this.leafletMap
+                leafletMap: this.leafletMap,
+                timeSliderRegion: this.timeSliderRegion,
             }));
         }
     },

--- a/src/mmw/js/src/core/templates/timeSliderControl.html
+++ b/src/mmw/js/src/core/templates/timeSliderControl.html
@@ -1,0 +1,15 @@
+<div class="time-slider-display">
+    <span class="time-slider-short-name">{{ shortDisplay }},</span>
+    <span class="time-slider-month">{{ month }}</span>
+</div>
+
+<input title="Drag to change time period."
+   type="range"
+   min="{{ min }}"
+   max="{{ max }}"
+   step="1"
+   class="time-slider slider-leaflet custom-slider"
+   value="{{ selectedTimeLayerIdx }}"
+>
+<span class="time-slider-start">Jan</span>
+<span class="time-slider-end">Dec</span>

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -64,6 +64,7 @@ var RootView = Marionette.LayoutView.extend({
         mainRegion: '#container',
         geocodeSearchRegion: '#geocode-search-region',
         layerPickerRegion: '#layer-picker-region',
+        layerPickerSliderRegion: '#layer-picker-slider-region',
         subHeaderRegion: '#sub-header',
         sidebarRegion: {
             regionClass: TransitionRegion,

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -12,10 +12,14 @@ For basemaps, maxZoom must be defined.
 
 from os.path import join, dirname, abspath
 from collections import OrderedDict
+
 import json
 
 from django.contrib.gis.geos import GEOSGeometry
 from tr55_settings import NLCD_MAPPING, SOIL_MAPPING
+
+# [01, 02, ...] style list for layer time sliders
+MONTH_CODES = [str(m).zfill(2) for m in range(1, 13)]
 
 # Full perimeter of the Delaware River Basin (DRB).
 drb_perimeter_path = join(dirname(abspath(__file__)), 'data/drb_perimeter.json')
@@ -121,6 +125,32 @@ LAYER_GROUPS = {
                 SOIL_MAPPING[7],
                 SOIL_MAPPING[4],
             ]),
+        },
+        {
+            'code': 'mean_ppt',
+            'display': 'Mean Monthly Precipitation',
+            'short_display': 'Mean Precip',
+            'css_class_prefix': 'ppt',
+            'helptext': 'PRISM monthly mean precipitation.',
+            'url': 'https://{s}.tiles.azavea.com/climate/ppt_{month}/{z}/{x}/{y}.png',  # noqa
+            'maxNativeZoom': 10,
+            'maxZoom': 18,
+            'opacity': 0.85,
+            'has_opacity_slider': True,
+            'time_slider_values': MONTH_CODES,
+        },
+        {
+            'code': 'mean_temp',
+            'display': 'Mean Monthly Temperature',
+            'short_display': 'Mean Temp',
+            'css_class_prefix': 'ppt',
+            'helptext': 'PRISM monthly mean temperature.',
+            'url': 'https://{s}.tiles.azavea.com/climate/tmean_{month}/{z}/{x}/{y}.png',  # noqa
+            'maxNativeZoom': 10,
+            'maxZoom': 18,
+            'opacity': 0.85,
+            'has_opacity_slider': True,
+            'time_slider_values': MONTH_CODES,
         },
         {
             'code': 'urban_areas',

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -13,6 +13,34 @@
   }
 }
 
+#layer-picker-slider-region {
+  z-index: 500;
+  position: absolute;
+  left: 265px;
+  bottom: 23px;
+  width: 150px;
+  padding: 10px;
+  background-color: #fff;
+  box-shadow: 0 0 6px $black-74;
+  font-size: 13px;
+  &:empty {
+    display: none;
+  }
+}
+
+input.time-slider {
+  padding: 5px 0 5px 0;
+}
+
+.time-slider-short-name {
+  font-weight: bold;
+}
+
+span.time-slider-end {
+    position: absolute;
+    right: 10px;
+}
+
 .layerpicker-header {
     background-color: $ui-primary;
     color: $paper;


### PR DESCRIPTION
## Overview

A new layer type which has monthly sub-layers can now be configured and added to the existing layer picker.  This extends the UI so that an additional slider is made available to cycle through the months.
Top-Level layer settings like opacity are preserved across sub-layers when loaded.  Two new layers, Mean Temperature and Mean Precipitation have been added to the config which make use of this layer type.

Connects #2018 

### Demo

![screenshot from 2017-08-28 15 17 01](https://user-images.githubusercontent.com/1014341/29789401-f54decac-8c03-11e7-86a3-f7ccd7fed2c2.png)

### Notes

There are a few UX calls I made, such as preserving the selected month between time-enabled layers so that one can compare month-to-month, without having to adjust the sliders, between layers.  I also preserve opacity for a layer so that you don't have to re-tune it after loading new month-layers.

A few UX issues, mostly with small screens may have to be revisited in the future.  The current layer picker covers up map controls, and this extension UI makes the problem somewhat worse.  Additionally, I do not hide the time slider if the picker is minimized.

## Testing Instructions

 * After bundling, ensure that the new layers can be activated and months adjusted.  The month should correspond to the azavea datahub tiles loaded.
* Ensure that the month stays selected between layers, so they can be compared month-to-month
* Ensure opacity settings are persisted between months, as applied to the "top level" layer.
* Ensure the tile slider shows and hides under the appropriate conditions.

IE does not fire the `input` event for range inputs, so it has its own `change` event.  Ensure that IE allow updating the month label while dragging.