### PR TITLE
Decrease zoom level of geocoder mapmove

### DIFF
--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -17,7 +17,7 @@ var SuggestionModel = Backbone.Model.extend({
     idAttribute: 'magicKey',
 
     defaults: {
-        zoom: 18,
+        zoom: 14,
         isBoundaryLayer: false
     },
 


### PR DESCRIPTION
## Overview

To provide a "watershed" perspective to address queries, zoom further out with results.

Connects #2139 

### Demo

The Azavea office, before and after:

### Original
![screenshot from 2017-08-29 14 17 19](https://user-images.githubusercontent.com/1014341/29836986-e11b7a94-8cc4-11e7-86f4-4bd5a7b367cf.png)

### Zoom 14
![screenshot from 2017-08-29 14 17 29](https://user-images.githubusercontent.com/1014341/29837001-ea65d55e-8cc4-11e7-95d1-62fabee2832f.png)

### Notes

It maybe harder to locate the exact spot you searched for, if that's what was important.  To clarify, we may want to drop a marker on the spot, although that introduces a UX workflow around the appropriate time to remove it.

The issue refers to "see how this looks", so I'm tagging @ajrobbins.  We can also just merge to staging and have Stroud evaluate firsthand.

## Testing Instructions

 * Bundle and perform an address geocode.
