### PR TITLE
Keep layer time slider under legend

### DIFF
--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -14,7 +14,7 @@
 }
 
 #layer-picker-slider-region {
-  z-index: 500;
+  z-index: 400;
   position: absolute;
   left: 265px;
   bottom: 23px;


### PR DESCRIPTION
## Overview

The z-index of the slider kept the slider above the legend, obscuring
it.  This new value keeps it above the map controls but below the
legend.


Connects #2018 

### Demo

##### Before
![screenshot from 2017-08-29 14 37 39](https://user-images.githubusercontent.com/1014341/29838398-1cb9f6ee-8cc9-11e7-9e51-a19108fb2691.png)

##### After
![screenshot from 2017-08-29 14 46 57](https://user-images.githubusercontent.com/1014341/29838397-1cb676ae-8cc9-11e7-9e06-e5000c8f3cf4.png)



### Notes

A quick fix for the recently merged UI component.

## Testing Instructions

 * Ensure the slider is appropriately displayed when compared to neighboring UI elements like a legend.
