### PR TITLE
BiG-CZ: De-truncate WDC Keyword Results

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -753,7 +753,7 @@ var MapView = Marionette.ItemView.extend({
                 self.model.set('dataCatalogActiveResult', null);
             });
             layer.bindPopup(new PopoverView({
-                    model: resultModels.findWhere({ id: layer.options.id }),
+                    model: result,
                     catalog: catalogId
                 }).render().el, { className: 'data-catalog-popover' });
         });

--- a/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
+++ b/src/mmw/js/src/data_catalog/templates/cuahsiSearchResult.html
@@ -12,8 +12,11 @@
 <div class="resource-detail">
     <i class="fa fa-file-text-o"></i> {{ service_org }}<!-- , {{ service_code }} -->
 </div>
-<div class="resource-detail">
-    <i class="fa fa-subscript"></i> {{ concept_keywords }}
+<div class="resource-detail -showall">
+    <i class="fa fa-subscript"></i>
+    <div class="detail-text">
+        {{ concept_keywords }}
+    </div>
 </div>
 <div class="resource-detail">
     {% if begin_date == end_date %}

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -179,6 +179,20 @@
         padding: 10px;
     }
 
+    .resource {
+        background: $paper;
+        padding: 10px;
+        margin: 0 10px 3px 10px;
+        cursor: pointer;
+
+        &:hover {
+            background: #F3F3F3;
+        }
+    }
+}
+
+.data-catalog-window,
+.data-catalog-resource-popover {
     .resource-description {
         color: $ui-grey;
         font-size: $font-size-h5;
@@ -196,16 +210,20 @@
         text-overflow: ellipsis;
     }
 
-    .resource {
-        background: $paper;
-        padding: 10px;
-        margin: 0 10px 3px 10px;
-        cursor: pointer;
-
-        &:hover {
-            background: #F3F3F3;
+    .resource-detail.-showall {
+        display: flex;
+        white-space: normal;
+        overflow: auto;
+        text-overflow: initial;
+        > i {
+            flex: 0 0 18px;
         }
+        > .detail-text {
+            display: inline;
+        }
+    }
 
+    .resource {
         .resource-title {
             font-size: $font-size-h4;
             font-weight: 600;


### PR DESCRIPTION
## Overview

We were eliding the WDC concept keywords (values next to the `x_2` icon). We want to show all the values, so this PR adds special styling for that line. We weren't adding the styling properly to the popover before. This PR fixes that so that the new markup for keywords doesn't look back.
 
Connects #2164 

### Demo

![screen shot 2017-08-30 at 11 16 05 am](https://user-images.githubusercontent.com/7633670/29886290-8e64aee2-8d87-11e7-89c9-7451bd165395.png)


![screen shot 2017-08-30 at 12 00 22 pm](https://user-images.githubusercontent.com/7633670/29886285-8a95af78-8d87-11e7-8481-acf5620e3049.png)

## Testing Instructions

 * Pull and `bundle`. Make sure the SASS compiles
 * Search for something with results for each catalog
 * Confirm the results + popover still look good and the scroll still works properly with the variable height elements.
