### PR TITLE
Add button for default GMS file download

### DIFF
--- a/src/mmw/js/src/modeling/templates/gmsDownloadForm.html
+++ b/src/mmw/js/src/modeling/templates/gmsDownloadForm.html
@@ -1,0 +1,6 @@
+<form id="export-gms-form" method="post" action="/mmw/modeling/export/gms/" target="_blank">
+    <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrftoken }}">
+    <input type="hidden" name="filename" class="gms-filename" value="export.gms">
+    <!-- Put `gis_data` in single quotes, to keep any unescaped chars from breaking the template -->
+    <input type="hidden" name="mapshed_data" value='{{ gis_data }}'>
+</form>

--- a/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
+++ b/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
@@ -1,6 +1,16 @@
-<div class="tab-content scenario-toolbar-tab-content"></div>
-{% if isOnlyCurrentConditions %}
+{% if isOnlyCurrentConditions and isGwlfe %}
+<button id="download-cc-gms" class="btn btn-link" type="button" aria-expanded="true">
+    <i class="fa fa-download"></i> Export GMS
+</button>
+
+{% include "./gmsDownloadForm.html" %}
+
+{% endif %}
+<div class="right-controls-container">
+    <div class="tab-content scenario-toolbar-tab-content"></div>
+    {% if isOnlyCurrentConditions %}
     <button id="add-changes" class="btn btn-link" type="button" aria-expanded="true">
         <i class="fa fa-plus-circle"></i> Add changes to this area
     </button>
-{% endif %}
+    {% endif %}
+</div>

--- a/src/mmw/js/src/modeling/templates/scenarioMenuItemOptions.html
+++ b/src/mmw/js/src/modeling/templates/scenarioMenuItemOptions.html
@@ -15,12 +15,7 @@
 {% endif %}
 {% if is_gwlfe %}
     <li class="scenario-options-dropdown-menu-item" role="presentation" data-action="export-gms">
-        <form id="export-gms-form" method="post" action="/mmw/modeling/export/gms/" target="_blank">
-            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrftoken }}">
-            <input type="hidden" name="filename" class="gms-filename" value="export.gms">
-            <!-- Put `gis_data` in single quotes, to keep any unescaped chars from breaking the template -->
-            <input type="hidden" name="mapshed_data" value='{{ gis_data }}'>
-        </form>
+        {% include './gmsDownloadForm.html' %}
         <i class="fa fa-download" title="Export GMS"></i> Export GMS
     </li>
 {% endif %}

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -61,7 +61,7 @@ describe('Modeling', function() {
                     collection = projectModel.get('scenarios'),
                     view = new views.ScenarioToolbarView({
                         collection: collection,
-                        model_package: "tr-55"
+                        model: projectModel,
                     });
 
                 $(sandboxSelector).html(view.render().el);
@@ -73,16 +73,17 @@ describe('Modeling', function() {
         });
 
         describe('ScenarioToolbarView', function() {
-            it('does not show the add changes button when there are non-current condition scenario', function() {
+            it('does not show the non-current condition scenario buttons', function() {
                 var collection = getTestScenarioCollection(),
                     view = new views.ScenarioToolbarView({
                         collection: collection,
-                        model_package: "tr-55"
+                        model: getTestProject(),
                     });
 
                 $(sandboxSelector).html(view.render().el);
 
                 assert.equal($('#sandbox #add-changes').text(), '');
+                assert.equal($('#sandbox #download-cc-gms').text(), '');
             });
         });
 

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -205,13 +205,29 @@ header {
         white-space: nowrap;
     }
 
+
     #toolbar-region {
-        margin-right: 0;
-        margin-left: auto;
+        width: 100%;
+    }
+
+    #toolbar-region > .toolbar-container {
+        display: flex;
+        flex-basis: 100%;
+        flex-direction: row;
+        height: 100%;
+
+        .right-controls-container {
+            margin-left: auto;
+        }
+
         #add-changes {
-          position: relative;
-          top: -2px;
-          color: $brand-primary;
+            color: $brand-primary;
+            height: 100%;
+        }
+
+        #download-cc-gms {
+            font-size: 13px;
+            color: inherit;
         }
     }
 

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -70,3 +70,8 @@
     }
   }
 }
+
+// Hidden form for GMS file downloads
+#export-gms-form {
+  display: none;
+}


### PR DESCRIPTION
## Overview

Recent UI work led to the pre-scenario MapShed model not having the
ability to download a GMS file.  When current conditions is the only
scenario in MapShed, a button is now placed in the header which has the
same functionality as that expressed in the menu options dropdown.

Connects #2041 

### Demo

![screenshot from 2017-08-30 15 14 17](https://user-images.githubusercontent.com/1014341/29890527-eaf231ee-8d95-11e7-9248-176aeb45a8dd.png)

### Notes

The mockups call the button "Download GMS", but I used the same language as the drop down options for consistency.

## Testing Instructions

* After bundling, 
* Check that a new single scenario MapShed project has the download button, and that it downloads
* Add a scenario, the button is removed
* Can still download GMS from the drop downs
* Removing the scenario restores the working button
* TR55 does not have the button, even with single scenario