### PR TITLE
Add geometry of selected BigCZ result to map

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -23,6 +23,7 @@ var MapModel = Backbone.Model.extend({
         previousAreaOfInterest: null,
         dataCatalogResults: null,       // GeoJSON array
         dataCatalogActiveResult: null,  // GeoJSON
+        dataCatalogDetailResult: null,  // GeoJSON
         selectedGeocoderArea: null,     // GeoJSON
     },
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -129,18 +129,22 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
 
         if (!detailResult) {
             this.closeDetails();
-            App.map.set('dataCatalogActiveResult', null);
+            App.map.set('dataCatalogDetailResult', null);
         } else {
             this.detailsRegion.show(new ResultDetailsView({
                 model: detailResult,
                 activeCatalog: activeCatalog.id
             }));
-            App.map.set('dataCatalogActiveResult', detailResult.get('geom'));
+            App.map.set({
+                'dataCatalogResults': null,
+                'dataCatalogDetailResult': detailResult.get('geom')
+            });
         }
     },
 
     closeDetails: function() {
         this.detailsRegion.empty();
+        this.updateMap();
     },
 
     doSearch: function() {

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -37,6 +37,14 @@
     height: 100%;
     position: absolute;
   }
+
+  &.bigcz-detail-map:after {
+    content: "";
+    border: 3px solid steelblue;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+  }
 }
 
 #overlay-subclass-vector .disabled, #overlay-subclass-raster .disabled {


### PR DESCRIPTION
## Overview

When a user views the details of a BigCZ result, the geometry of the
selected result is highlighted on the map, and all of the other items
on the map are removed.

Connects #2152

### Demo

![bigcz4](https://user-images.githubusercontent.com/1042475/29933035-25168b96-8e44-11e7-84df-de980c3a4926.gif)

### Notes

I initially tried using the same layer group as the highlight layer, but because of the way the events are wired up for that layer, I wasn't able to do it. The `mouseout` event of the result item in the list would fire when the user moves the mouse over detail pane, and the highlight would be cleared. 

Marker styling was based on the wireframes: https://marvelapp.com/5a66caa/screen/29866795

## Testing Instructions

- Start BiGCZ mode, draw an AoI, and make a search.
- Select different results, and verify that when you do, the geometry for that result is the only marker on the map.