### PR TITLE
Turn off mouse events for highlighted BigCZ geom

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -41,7 +41,8 @@ var dataCatalogActiveStyle = {
     opacity: 1,
     fill: true,
     fillColor: 'gold',
-    fillOpacity: 0.2
+    fillOpacity: 0.2,
+    pointerEvents: 'none'
 };
 
 var selectedGeocoderAreaStyle = {


### PR DESCRIPTION
## Overview

Turning off mouse events prevents an event from firing when the feature
is hovered over, but is in the process of being rerendered.

Connects to #2114

## Testing Instructions

- Attempt to recreate the bug described in #2114. You shouldn't be able to.
