### PR TITLE
Account for 0-based UTCMonth rendering

### DIFF
--- a/src/mmw/js/src/core/filters.js
+++ b/src/mmw/js/src/core/filters.js
@@ -55,7 +55,7 @@ nunjucks.env.addFilter('toDateFullYear', function(date) {
 nunjucks.env.addFilter('toDateWithoutTime', function(date) {
     var fullDate = new Date(date);
 
-    return fullDate.getUTCMonth() + '/' +
+    return (fullDate.getUTCMonth() + 1) + '/' +
            fullDate.getUTCDate() + '/' +
            fullDate.getUTCFullYear();
 });


### PR DESCRIPTION
## Overview
The `getUTCMonth` method returns a month number from 0-11, so it is adjusted for readability in display by adding 1.  UTCDate and UTCFullYear are not 0 based and so are left unchanged.

Connects #2142 

### Demo
![screenshot from 2017-09-01 09 53 05](https://user-images.githubusercontent.com/1014341/29973109-5c1b8962-8efc-11e7-90c0-e9a43c7df8bf.png)


### Notes
The issue states that both UTCMonth and UTCDate are zero-based, but the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate) says otherwise:

> *dateObj.getUTCDate()*
**Return value**
An integer number, between 1 and 31, representing the day of the month in the given date according to universal time.

So that was not adjusted.

## Testing Instructions

 * Bundle and do a `?bigcz=true` search for Water around Philadelphia.
 * Activate the WDC tab and ensure that there are no 0 based days or months, as illustrated in the connected issue.