### PR TITLE
Upgrade nginx ansible role

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -7,7 +7,7 @@
 - src: azavea.git
   version: 0.1.0
 - src: azavea.nginx
-  version: 0.2.1
+  version: 0.3.1
 - src: azavea.daemontools
   version: 0.1.0
 - src: azavea.postgresql-support


### PR DESCRIPTION
## Overview

Upgraded to allow gzipping of our javascript assets.  Other changes include turning off server tokens and installing the full nginx package which includes additional modules which are not utilized by the app.

Corresponding upstream PR: https://github.com/azavea/ansible-nginx/pull/8

### Demo
After reprovisioning, *.js files served from nginx should note a `Content-Encoding: gzip`.  Additionally, note that there are no longer nginx server version numbers included in responses.
```
HTTP/1.1 200 OK
Server: nginx
Date: Fri, 01 Sep 2017 14:08:51 GMT
Content-Type: application/javascript
Last-Modified: Fri, 01 Sep 2017 14:07:32 GMT
Transfer-Encoding: chunked
Connection: keep-alive
Vary: Accept-Encoding
ETag: W/"59a969a4-c3b28c"
Content-Encoding: gzip
```

## Testing Instructions

 * Reprovision the app server `vagrant provision app`
 * Load the main page and check that `vendor.js` is served with gzip, as noted in the Demo section above.