### PR TITLE
Upgrade geoprocessing service to 3.0.0-beta-2

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -45,7 +45,7 @@ docker_options: "--storage-driver=aufs"
 geop_host: "localhost"
 geop_port: 8090
 
-geop_version: "3.0.0-beta-1"
+geop_version: "3.0.0-beta-2"
 geop_cache_enabled: 1
 
 nginx_cache_dir: "/var/cache/nginx"


### PR DESCRIPTION
## Overview

This PR upgrades the geoprocessing service to incorporate the change to fetch tiles using Futures from this PR: https://github.com/WikiWatershed/mmw-geoprocessing/pull/70

Connects https://github.com/WikiWatershed/mmw-geoprocessing/issues/67

## Testing Instructions
- get this branch, then `vagrant reload worker --provision` and verify that it pulls a new geoprocessing jar
- compare the analyze,  TR-55, and MapShed values for some known AOIs on staging with the values on this branch to ensure they're the same
