### PR TITLE
Bug: show model details popover tooltip for new projects

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -169,7 +169,7 @@ var ProjectMenuView = Marionette.ItemView.extend({
         'change': 'render'
     },
 
-    onShow: function() {
+    onRender: function() {
         this.ui.modelDescriptionIcon.popover({
             placement: 'right',
             trigger: 'focus'


### PR DESCRIPTION
## Overview

There was a bug in the recent work done for #1366 where the model description tooltip wouldn't appear if the project was new.


![screen shot 2017-09-06 at 9 10 49 am](https://user-images.githubusercontent.com/7633670/30113617-49e5b570-92e3-11e7-97e6-ca95a6cefa1e.png)


Connects #1366 

## Testing Instructions

 * Draw an aoi and select a model. Confirm you can click the tooltip next to the model name and see the model description
* Load a saved project and do the same
