### PR TITLE
Compare View Revamp: Loading States

### DIFF
--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -208,6 +208,25 @@ var WindowModel = Backbone.Model.extend({
         scenarios: null, // ScenariosCollection
         tabs: null,  // TabsCollection
         visibleScenarioIndex: 0, // Index of the first visible scenario
+        polling: false,  // If any results are polling
+    },
+
+    initialize: function() {
+        var setPolling = _.bind(this.setPolling, this);
+
+        this.get('scenarios').forEach(function(scenario) {
+            scenario.get('results').on('change', setPolling);
+        });
+    },
+
+    setPolling: function() {
+        var getPolling = function(scenario) {
+                return scenario.get('results').pluck('polling');
+            },
+            scenarios = this.get('scenarios'),
+            polling = _(scenarios.map(getPolling)).flatten().some();
+
+        this.set({ polling: polling });
     },
 
     addOrReplaceInput: function(input) {

--- a/src/mmw/js/src/compare/templates/compareWindow2.html
+++ b/src/mmw/js/src/compare/templates/compareWindow2.html
@@ -30,5 +30,5 @@
         </button>
     </div>
 </div>
-<div class="compare-sections">
+<div class="compare-sections polling">
 </div>

--- a/src/mmw/js/src/compare/templates/compareWindow2.html
+++ b/src/mmw/js/src/compare/templates/compareWindow2.html
@@ -3,6 +3,7 @@
     <div class="compare-title">
         <h1>Compare</h1>
     </div>
+    <div class="spinner hidden"></div>
     <div class="compare-close">
         <button>
             <i class="fa fa-times"></i>

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -37,6 +37,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
         closeButton: '.compare-close > button',
         nextButton: '.compare-scenario-buttons > .btn-next-scenario',
         prevButton: '.compare-scenario-buttons > .btn-prev-scenario',
+        spinner: '.spinner',
     },
 
     events: _.defaults({
@@ -141,8 +142,10 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
 
     setPolling: function() {
         if (this.model.get('polling')) {
+            this.ui.spinner.removeClass('hidden');
             this.sectionsRegion.$el.addClass('polling');
         } else {
+            this.ui.spinner.addClass('hidden');
             this.sectionsRegion.$el.removeClass('polling');
         }
     },

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -48,6 +48,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
     modelEvents: {
         'change:mode': 'showSectionsView',
         'change:visibleScenarioIndex': 'highlightButtons',
+        'change:polling': 'setPolling',
     },
 
     regions: {
@@ -136,6 +137,14 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
         this.model.set({
             visibleScenarioIndex: Math.max(--visibleScenarioIndex, 0)
         });
+    },
+
+    setPolling: function() {
+        if (this.model.get('polling')) {
+            this.sectionsRegion.$el.addClass('polling');
+        } else {
+            this.sectionsRegion.$el.removeClass('polling');
+        }
     },
 });
 
@@ -406,7 +415,7 @@ var ChartView = Marionette.CollectionView.extend({
 
         // Show charts from visibleScenarioIndex
         this.$('.nv-group > rect:nth-child(n + ' + (i+1) + ')').css({
-            'opacity': 1,
+            'opacity': '',
         });
 
         // Hide charts up to visibleScenarioIndex

--- a/src/mmw/sass/components/_spinner.scss
+++ b/src/mmw/sass/components/_spinner.scss
@@ -1,0 +1,21 @@
+.spinner:after {
+  content: '';
+  box-sizing: border-box;
+  position: absolute;
+  top: 22px;
+  right: 14px;
+  width: 20px;
+  height: 20px;
+  margin-top: -10px;
+  margin-left: -10px;
+  border-radius: 50%;
+  border: 2px solid #ccc;
+  border-top-color: #333;
+  animation: spinner-animation 0.6s linear infinite;
+}
+
+@keyframes spinner-animation {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -64,6 +64,7 @@
   "components/sidebar",
   "components/global-navigation",
   "components/layerpicker",
+  "components/spinner",
   "components/slider";
 
 /**

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -319,6 +319,12 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
   .compare-sections {
     flex: 0 1 auto;
     overflow: auto;
+
+    &.polling {
+      .compare-column, rect {
+        opacity: 0.25;
+      }
+    }
   }
 
   .compare-close {
@@ -514,6 +520,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
   .compare-column {
     min-width: 120px;
     width: 120px;
+    transition: opacity 0.3s ease-in-out;
 
     .compare-scenario-title {
       font-size: $font-size-h5;

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -327,6 +327,12 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
     }
   }
 
+  .spinner {
+    position: absolute;
+    top: 53px;
+    right: 50%;
+  }
+
   .compare-close {
     position: absolute;
     top: 20px;


### PR DESCRIPTION
## Overview

Adds loading states to indicate that the models are being run. All results are faded, and a spinner is added at the top-right corner. Interactivity is not impacted at all. See commit messages for details.

Connects #2134 

### Demo

![2017-09-06 17 15 28](https://user-images.githubusercontent.com/1430060/30135015-46aebf98-9327-11e7-88e9-6dad61d9faf2.gif)

## Testing Instructions

 * Check out this branch and `bundle`
 * Open a project with many scenarios. Open the Compare Window.
 * Ensure that the results start out faded, and saturate once all of them stop polling.
 * Try changing the precipitation value. Ensure that the spinner behaves accordingly.