### PR TITLE
Add WKAoI field to Project Model

### DIFF
--- a/src/mmw/apps/modeling/migrations/0022_project_wkaoi.py
+++ b/src/mmw/apps/modeling/migrations/0022_project_wkaoi.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0021_old_scenarios'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='wkaoi',
+            field=models.CharField(help_text='Well-Known Area of Interest ID for faster geoprocessing', max_length=255, null=True),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -43,6 +43,10 @@ class Project(models.Model):
         null=True,
         help_text='Serialized JSON representation of additional'
                   ' data gathering steps, such as MapShed.')
+    wkaoi = models.CharField(
+        null=True,
+        max_length=255,
+        help_text='Well-Known Area of Interest ID for faster geoprocessing')
 
     def __unicode__(self):
         return self.name

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -34,7 +34,8 @@ var ModelingController = {
 
                     App.map.set({
                         'areaOfInterest': project.get('area_of_interest'),
-                        'areaOfInterestName': project.get('area_of_interest_name')
+                        'areaOfInterestName': project.get('area_of_interest_name'),
+                        'wellKnownAreaOfInterest': project.get('wkaoi'),
                     });
                     initScenarioEvents(project);
                     initViews(project, lock);
@@ -168,7 +169,8 @@ var ModelingController = {
             .done(function() {
                 App.map.set({
                     'areaOfInterest': project.get('area_of_interest'),
-                    'areaOfInterestName': project.get('area_of_interest_name')
+                    'areaOfInterestName': project.get('area_of_interest_name'),
+                    'wellKnownAreaOfInterest': project.get('wkaoi'),
                 });
                 if (project.get('scenarios').isEmpty()) {
                     // No scenarios available. Set the `needs_reset` flag so
@@ -197,6 +199,7 @@ function itsiResetProject(project) {
         'user_id': App.user.get('id'),
         'area_of_interest': App.map.get('areaOfInterest'),
         'area_of_interest_name': App.map.get('areaOfInterestName'),
+        'wkaoi': App.map.get('wellKnownAreaOfInterest'),
         'needs_reset': false
     });
 
@@ -276,6 +279,7 @@ function projectCleanUp() {
     App.rootView.subHeaderRegion.empty();
     App.rootView.sidebarRegion.empty();
     App.rootView.compareRegion.empty();
+    App.clearAnalyzeCollection();
 }
 
 function projectErrorState() {
@@ -347,7 +351,8 @@ function reinstateProject(number, lock) {
         .done(function() {
             App.map.set({
                 'areaOfInterest': project.get('area_of_interest'),
-                'areaOfInterestName': project.get('area_of_interest_name')
+                'areaOfInterestName': project.get('area_of_interest_name'),
+                'wellKnownAreaOfInterest': project.get('wkaoi'),
             });
             setPageTitle();
             lock.resolve();

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -227,7 +227,8 @@ var ProjectMenuView = Marionette.ItemView.extend({
                 App.projectNumber = undefined;
                 App.map.set({
                     'areaOfInterest': null,
-                    'areaOfInterestName': null
+                    'areaOfInterestName': null,
+                    'wellKnownAreaOfInterest': null,
                 });
 
                 router.navigate('projects/', { trigger: true });

--- a/src/mmw/js/src/projects/views.js
+++ b/src/mmw/js/src/projects/views.js
@@ -48,7 +48,8 @@ var ProjectsView = Marionette.LayoutView.extend({
         App.projectNumber = undefined;
         App.map.set({
             'areaOfInterest': null,
-            'areaOfInterestName': null
+            'areaOfInterestName': null,
+            'wellKnownAreaOfInterest': null,
         });
 
         router.navigate('', { trigger: true });
@@ -170,7 +171,8 @@ var ProjectRowView = Marionette.ItemView.extend({
         App.clearAnalyzeCollection();
         App.map.set({
             'areaOfInterest': null,
-            'areaOfInterestName': ''
+            'areaOfInterestName': '',
+            'wellKnownAreaOfInterest': null,
         });
         router.navigate('/project/' + this.model.id, { trigger: true });
     }


### PR DESCRIPTION
## Overview

Adds WKAoI field to project model, so when using a predefined boundary, that boundary's id is now saved to the project. Thus, when the project is reloaded at a later date, the user can still benefit from the cached results by specifying the WKAoI id. Previously, since this id was not available, reloaded used projects would trigger unnecessary fresh bouts of geoprocessing.

Connects #1899 

### Demo

![2017-09-08 13 36 00](https://user-images.githubusercontent.com/1430060/30223958-e329be08-949a-11e7-9f8a-7415b3ae90f6.gif)

## Testing Instructions

 * On `develop`, log in to MMW and create and save a TR-55 and a MapShed project with well-known boundaries (HUC-12s)
 * Check out this branch, and run `manage migrate` and `bundle`
 * Create and save a new TR-55 project using a HUC-12. Ensure that the Analyze and TR-55 requests use WKAoI when they start their run.
 * Reload the saved TR-55 project, and ensure that this also uses the saved WKAoI.
 * Do the same for MapShed.
 * Test the TR-55 and MapShed projects created before this branch. Ensure that while they don't use WKAoI, they otherwise work correctly and just as before.
 * Ensure there are no errors in the console.