### PR TITLE
Show all values in a series on mouse hover

### DIFF
--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -437,7 +437,7 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                                     "width": bgWidth + 2,
                                     "height": bgHeight + 2,
                                     "stroke": 1,
-                                    "class": ("bar-value-text-bg-shadow_" + el)
+                                    "class": ("bar-value-text-bg-shadow " + el)
                                 });
 
                                 d3.select(this).style({
@@ -459,7 +459,7 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                                     "height": bgHeight,
                                     "stroke": "#aaaaaa",
                                     "stroke-width": 0.5,
-                                    "class": ("bar-value-text-bg_" + el)
+                                    "class": ("bar-value-text-bg " + el)
                                 });
 
                                 d3.select(this).style({
@@ -481,7 +481,7 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                                     "x": (parseFloat(b.attr("x")) + (parseFloat(barWidth) / 2)),
                                     "width": dialogTickSize,
                                     "height": dialogTickSize,
-                                    "class": ("bar-value-text-bg-tick_" + el)
+                                    "class": ("bar-value-text-bg-tick " + el)
                                 });
 
                                 d3.select(this).style({
@@ -510,7 +510,7 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                                     "font-size": "0.8rem",
                                     "font-weight": "normal",
                                     "font-family": "helvetica",
-                                    "class": ("bar-value-text_" + el)
+                                    "class": ("bar-value-text " + el)
                                 });
 
                                 d3.select(this).style({
@@ -531,21 +531,21 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                     .selectAll("rect.nv-bar")
                     .on("mouseover", function () {
                         d3.select("#" + chartContainerId)
-                            .selectAll(".bar-value-text_" + el)
+                            .selectAll(".bar-value-text." + el)
                             .style("opacity", "1");
 
                         d3.select("#" + chartContainerId)
-                            .selectAll(".bar-value-text-bg-shadow_" + el)
+                            .selectAll(".bar-value-text-bg-shadow." + el)
                             .style("opacity", "0.5")
                             .style("fill-opacity", "0.5");
 
                         d3.select("#" + chartContainerId)
-                            .selectAll(".bar-value-text-bg_" + el)
+                            .selectAll(".bar-value-text-bg." + el)
                             .style("opacity", "1")
                             .style("fill-opacity", "1");
 
                         d3.select("#" + chartContainerId)
-                            .selectAll(".bar-value-text-bg-tick_" + el)
+                            .selectAll(".bar-value-text-bg-tick." + el)
                             .style("opacity", "1")
                             .style("fill-opacity", "1");
                     });
@@ -556,21 +556,21 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                     .selectAll("rect.nv-bar")
                     .on("mouseout", function () {
                         d3.select("#" + chartContainerId)
-                            .selectAll(".bar-value-text_" + el)
+                            .selectAll(".bar-value-text." + el)
                             .style("opacity", "0");
 
                         d3.select("#" + chartContainerId)
-                            .selectAll(".bar-value-text-bg-shadow_" + el)
+                            .selectAll(".bar-value-text-bg-shadow." + el)
                             .style("opacity", "0")
                             .style("fill-opacity", "0");
 
                         d3.select("#" + chartContainerId)
-                            .selectAll(".bar-value-text-bg_" + el)
+                            .selectAll(".bar-value-text-bg." + el)
                             .style("opacity", "0")
                             .style("fill-opacity", "0");
 
                         d3.select("#" + chartContainerId)
-                            .selectAll(".bar-value-text-bg-tick_" + el)
+                            .selectAll(".bar-value-text-bg-tick." + el)
                             .style("opacity", "0")
                             .style("fill-opacity", "0");
                     });

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -495,9 +495,6 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                         parentG.append("text")
                             .each(function() {
                                 d3.select(this).text(function() {
-                                    if (bar.y === 0) {
-                                        return;
-                                    }
                                     return parseFloat(bar.y).toFixed(2);
                                 });
 

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -451,6 +451,13 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
     rect {
       transition: opacity 0.3s ease-in-out;
     }
+
+    .bar-value-text-bg-shadow,
+    .bar-value-text-bg,
+    .bar-value-text-bg-tick,
+    .bar-value-text {
+        pointer-events: none;
+    }
   }
 
   .compare-scenario-gradient {


### PR DESCRIPTION
## Overview

This PR adds a new implementation of series "tooltips" that appear on all series items in a chart when any member of the series is hovered over. The actual elements added are not D3 tooltips, as it ultimately proved prohibitively difficult to implement alternative tooltip rendering. Rather, the elements are SVG objects drawn programmatically in such a way that they fulfill the designed role.

Connects #2158 

### Demo

![recording 26](https://user-images.githubusercontent.com/18290666/30281529-aec3d872-96e0-11e7-8420-240419b786d4.gif)


### Notes

There's a bug/undesired rendering style on the charts showing the individual components of the combined hydrology. For bars that extend to the full height of the chart area, the tooltip element is cutoff, as shown here:

![download 27](https://user-images.githubusercontent.com/18290666/30281749-3fd33222-96e1-11e7-8c04-bc4fa0e87c9c.png)

However, the Water Quality charts, which appear to be the same form of chart, do not have this issue:

![download 28](https://user-images.githubusercontent.com/18290666/30281788-5943910c-96e1-11e7-9659-2eb738f50a62.png)

After a few hours, I couldn't determine which D3 property or attribute was ultimately responsible for it. It looks like the runoff charts charting area is extended to the full possible area, whereas the water quality are not, and the clipping rules result in the former having clipped tooltip elements while the latter does not. I didn't have much luck beyond that.


## Testing Instructions

* rebundle, then open the app
* set an AoI, do a model run, then add some scenarios and open the compare view
* check that hovering over the charted items results in labels rendering for each item in that series
* check that the hovered item is made more opaque than the others
