### PR TITLE
Backend Geometry filtering

### DIFF
--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -9,7 +9,7 @@ from django.contrib.gis.geos import Polygon
 
 from django.conf import settings
 
-from apps.bigcz.models import ResourceLink, ResourceList, BBox
+from apps.bigcz.models import ResourceLink, ResourceList
 from apps.bigcz.utils import RequestTimedOutError
 
 from apps.bigcz.clients.cinergi.models import CinergiResource
@@ -105,8 +105,7 @@ def parse_record(item):
         cinergi_url=parse_cinergi_url(source.get('fileid')))
 
 
-def prepare_bbox(value):
-    box = BBox(value)
+def prepare_bbox(box):
     return '{},{},{},{}'.format(box.xmin, box.ymin, box.xmax, box.ymax)
 
 

--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -232,12 +232,11 @@ def search(**kwargs):
         raise ValidationError({
             'error': 'Required argument: bbox'})
 
-    box = BBox(bbox)
-    world = BBox('-180,-90,180,90')
+    world = BBox(-180, -90, 180, 90)
 
     services = get_services_in_box(world)
     networkIDs = filter_networkIDs(services, gridded)
-    series = get_series_catalog_in_box(box, from_date, to_date, networkIDs)
+    series = get_series_catalog_in_box(bbox, from_date, to_date, networkIDs)
     series = group_series_by_location(series)
     results = sorted(parse_records(series, services),
                      key=attrgetter('end_date'),

--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -9,7 +9,7 @@ from rest_framework.exceptions import ValidationError
 
 from django.conf import settings
 
-from apps.bigcz.models import Resource, ResourceLink, ResourceList, BBox
+from apps.bigcz.models import Resource, ResourceLink, ResourceList
 from apps.bigcz.utils import RequestTimedOutError
 
 
@@ -35,8 +35,7 @@ def parse_record(item):
         geom=None)
 
 
-def prepare_bbox(value):
-    box = BBox(value)
+def prepare_bbox(box):
     return {
         'west': box.xmin,
         'east': box.xmax,

--- a/src/mmw/apps/bigcz/models.py
+++ b/src/mmw/apps/bigcz/models.py
@@ -35,11 +35,7 @@ class BBox(object):
     """
     Bounding box from incoming search API request.
     """
-    def __init__(self, value):
-        try:
-            xmin, ymin, xmax, ymax = value.split(',')
-        except ValueError:
-            raise ValueError('Expected bbox format: xmin,ymin,xmax,ymax')
+    def __init__(self, xmin, ymin, xmax, ymax):
         self.xmin = xmin
         self.xmax = xmax
         self.ymin = ymin

--- a/src/mmw/apps/bigcz/utils.py
+++ b/src/mmw/apps/bigcz/utils.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from apps.bigcz.models import BBox
+
 from rest_framework.exceptions import APIException
 import dateutil.parser
 
@@ -11,6 +13,38 @@ def parse_date(value):
     if not value:
         return None
     return dateutil.parser.parse(value)
+
+
+def filter_aoi_intersection(aoi, results):
+    """Only include results with no geometries, or geometries
+    which intersect with the AoI from the provided results.
+
+    Args:
+        aoi (GEOSGeometry): Area of Interest to filter in
+        results (ResultList): Collection of results to filter
+
+    Returns:
+        ResultList: the filtered set of results
+    """
+    aoip = aoi.prepared
+    return [result for result in results if (result.geom is None or
+                                             aoip.intersects(result.geom))]
+
+
+def get_bounds(aoi):
+    """Returns the bounding box of the GEOSGeometry
+
+    Args:
+        aoi (GEOSGeometry): Geometry for which to calculate bounds
+
+    Returns:
+        BBox of the supplied geometry
+    """
+    bounds = aoi.boundary.coords[0]
+    x_coords = {coord[0] for coord in bounds}
+    y_coords = {coord[1] for coord in bounds}
+
+    return BBox(min(x_coords), min(y_coords), max(x_coords), max(y_coords))
 
 
 class RequestTimedOutError(APIException):

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -30,7 +30,7 @@ var Catalog = Backbone.Model.extend({
         fromDate: null,
         toDate: null,
         query: '',
-        bbox: '',
+        geom: '',
         loading: false,
         active: false,
         results: null, // Results collection
@@ -58,17 +58,17 @@ var Catalog = Backbone.Model.extend({
         });
     },
 
-    searchIfNeeded: function(query, fromDate, toDate, bbox) {
+    searchIfNeeded: function(query, fromDate, toDate, geom) {
         var self = this,
             error = this.get('error'),
             isSameSearch = query === this.get('query') &&
                            fromDate === this.get('fromDate') &&
                            toDate === this.get('toDate') &&
-                           bbox === this.get('bbox');
+                           geom === this.get('geom');
 
         if (!isSameSearch || error) {
             this.cancelSearch();
-            this.searchPromise = this.search(query, fromDate, toDate, bbox)
+            this.searchPromise = this.search(query, fromDate, toDate, geom)
                                      .always(function() {
                                         delete self.searchPromise;
                                      });
@@ -83,10 +83,10 @@ var Catalog = Backbone.Model.extend({
         }
     },
 
-    search: function(query, fromDate, toDate, bbox) {
+    search: function(query, fromDate, toDate, geom) {
         this.set({
             query: query,
-            bbox: bbox,
+            geom: geom,
             fromDate: fromDate,
             toDate: toDate,
         });
@@ -103,7 +103,7 @@ var Catalog = Backbone.Model.extend({
             data = {
                 catalog: this.id,
                 query: this.get('query'),
-                bbox: this.get('bbox'),
+                geom: this.get('geom'),
                 from_date: this.get('fromDate'),
                 to_date: this.get('toDate'),
             };
@@ -121,8 +121,15 @@ var Catalog = Backbone.Model.extend({
         this.set('loading', true);
         this.set('error', false);
 
+        var request = {
+            data: JSON.stringify(data),
+            type: 'POST',
+            dataType: 'json',
+            contentType: 'application/json'
+        };
+
         return this.get('results')
-                   .fetch({ data: data })
+                   .fetch(request)
                    .done(_.bind(this.doneSearch, this))
                    .fail(_.bind(this.failSearch, this))
                    .always(_.bind(this.finishSearch, this));

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -3,8 +3,6 @@
 var $ = require('jquery'),
     _ = require('lodash'),
     Backbone = require('../../shim/backbone'),
-    turfIntersect = require('turf-intersect'),
-    App = require('../app'),
     settings = require('../core/settings');
 
 var REQUEST_TIMED_OUT_CODE = 408;
@@ -236,15 +234,7 @@ var Results = Backbone.Collection.extend({
     },
 
     parse: function(response) {
-        var aoi = App.map.get('areaOfInterest'),
-            data = _.findWhere(response, { catalog: this.catalog }),
-            // Filter results to only include those without geometries (Hydroshare)
-            // and those that intersect the area of interest (CINERGI and CUAHSI).
-            filteredResults = _.filter(data.results, function(r) {
-                return r.geom === null || turfIntersect(aoi, r.geom) !== undefined;
-            });
-
-        return filteredResults;
+        return _.findWhere(response, { catalog: this.catalog }).results;
     },
 
     getDetail: function() {

--- a/src/mmw/js/src/data_catalog/utils.js
+++ b/src/mmw/js/src/data_catalog/utils.js
@@ -12,17 +12,6 @@ function areaOfBounds(bounds) {
     return area * SQKM_PER_SQM;
 }
 
-// Convert LatLngBounds to BBox format
-function formatBounds(bounds) {
-    return [
-        bounds.getWest(),
-        bounds.getSouth(),
-        bounds.getEast(),
-        bounds.getNorth()
-    ].join(',');
-}
-
 module.exports = {
     areaOfBounds: areaOfBounds,
-    formatBounds: formatBounds
 };

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -1,13 +1,11 @@
 "use strict";
 
 var $ = require('jquery'),
-    L = require('leaflet'),
     Marionette = require('../../shim/backbone.marionette'),
     moment = require('moment'),
     App = require('../app'),
     analyzeViews = require('../analyze/views.js'),
     settings = require('../core/settings'),
-    utils = require('./utils'),
     errorTmpl = require('./templates/error.html'),
     formTmpl = require('./templates/form.html'),
     pagerTmpl = require('./templates/pager.html'),
@@ -152,14 +150,13 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
             query = this.model.get('query'),
             fromDate = this.model.get('fromDate'),
             toDate = this.model.get('toDate'),
-            aoiGeoJson = L.geoJson(App.map.get('areaOfInterest')),
-            bounds = utils.formatBounds(aoiGeoJson.getBounds());
+            aoiGeoJson = App.map.get('areaOfInterest');
 
         // Disable intro text after first search request
         this.ui.introText.addClass('hide');
         this.ui.tabs.removeClass('hide');
 
-        catalog.searchIfNeeded(query, fromDate, toDate, bounds);
+        catalog.searchIfNeeded(query, fromDate, toDate, aoiGeoJson);
     },
 
     updateMap: function() {


### PR DESCRIPTION
## Overview

Move complete search filtering to API.  The application was responsible for doing post processing on API search results and resulted in a quirk of result count not matching the count displayed in the list or map.  The post processing has been moved to a centralized spot in the API so that results that are returned match the expected query, including boundary filtering.  From the client perspective, the raw geometry is now `POSTed` to the API, instead of the bounding box.  The bbox is still used to perform the catalog search, but it is calculated on the backend so consumers don't need to be aware of the implementation details of the post processing.

Connects #2151 

### Demo

Compared to the screenshot in the issue, expected counts are now shown in the search.
![screenshot from 2017-09-11 11 59 43](https://user-images.githubusercontent.com/1014341/30290758-957404d2-96fe-11e7-83cf-45cc52945d8c.png)

### Notes
For large, multi-paged results, it is impossible to know the true count, since we're only post-processing the results from a page at a time.  In reality, the count does not reflect the upstream catalog count minus the spatial filtering done locally, since we don't have access to all of the features.  This was the case in the previous implementation and if it becomes problematic/confusing, we may want to generalize the count to something like "1000+" when there are many records.

I also had to infer some desired behavior from the existing code, so please verify the changes make logical sense.

## Testing Instructions

* Test various queries at various level of geographies.  
* For paged results, the approximate total should still be displayed if the count is greater than that of the page size.
