### PR TITLE
Upgrade geoprocessing to support area pixels

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -45,7 +45,7 @@ docker_options: "--storage-driver=aufs"
 geop_host: "localhost"
 geop_port: 8090
 
-geop_version: "3.0.0-beta-2"
+geop_version: "3.0.0-beta-3"
 geop_cache_enabled: 1
 
 nginx_cache_dir: "/var/cache/nginx"

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -536,6 +536,7 @@ GEOP = {
                 'polygonCRS': 'LatLng',
                 'rasters': [],
                 'targetRaster': 'climatology-ppt-{:02d}-epsg5070',
+                'pixelIsArea': True,
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedAverage',
                 'zoom': 0
@@ -547,6 +548,7 @@ GEOP = {
                 'polygonCRS': 'LatLng',
                 'rasters': [],
                 'targetRaster': 'climatology-tmean-{:02d}-epsg5070',
+                'pixelIsArea': True,
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedAverage',
                 'zoom': 0


### PR DESCRIPTION
## Overview

Previously, for low resolution rasters with very large pixels, when paired with small areas of interest, we would get 0 values. This was because the pixels were treated as points, and if the centroid of the pixel was outside the area of interest, there would be no intersection.

By adding a `pixelIsArea: true` parameter, we treat those pixels as polygons instead of points, and can calculate the intersection even with small areas of interest. The Precipitation and Temperature rasters are prime use cases for this, and their usage is corrected with this new setting.

Connects #2253

### Demo

For demo and other notes, see https://github.com/WikiWatershed/mmw-geoprocessing/pull/74

## Testing Instructions

 * Check out this branch
 * Reprovision Worker
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Draw a 1 sq km area of interest. Ensure that the Climate Analyze tab shows real values and not all 0s.