### PR TITLE
Replace BiG-CZ Data Catalog Filter Header With Filter Sidebar

### DIFF
--- a/src/mmw/apps/core/templates/base.html
+++ b/src/mmw/apps/core/templates/base.html
@@ -7,6 +7,9 @@
 
     <div id="sidebar">
         <div id="sidebar-content"></div>
+        <div id="secondary-sidebar">
+            <div id="secondary-sidebar-content"></div>
+        </div>
     </div>
 
     <div class="map-container {% if project %} -projectheader {% endif %} -sidebar">

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -82,7 +82,7 @@ var MapModel = Backbone.Model.extend({
     },
 
     setDataCatalogSize: function(fit) {
-        this.setNoHeaderSidebarSize(fit, utils.sidebarWide);
+        this.setNoHeaderSidebarSize(fit);
     },
 
     setModelSize: function(fit) {
@@ -101,6 +101,14 @@ var MapModel = Backbone.Model.extend({
         this.set('size', updatedSize);
     },
 
+    toggleSecondarySidebar: function() {
+        var sizeCopy = _.clone(this.get('size')),
+            updatedSize =_.merge(sizeCopy, {
+                hasSecondarySidebar: !sizeCopy.hasSecondarySidebar
+            });
+        this.set('size', updatedSize);
+    },
+
 // Set the sizing options for the map. `options` are...
 //      fit                  - bool, true if should fit the map to the AoI
 //      hasProjectHeader     - bool, true if the -projectheader class should
@@ -109,12 +117,9 @@ var MapModel = Backbone.Model.extend({
 //                             be on the map container
 //      hasSidebar           - bool, true if the -sidebar class should
 //                             be on the map container
-//      barWidth             - string, if matches width option (eg 'wide'),
-//                             and `hasSidebar === true`, map will add
-//                             class to container accordingly.
-//                             If option doesn't exist or is falsey, no
-//                             class will be added, and map container will
-//                             use the default sidebar size if `hasSidebar`
+//      hasSecondarySidebar  - bool, true if the -double class
+//                             should be on the map. Will on apply if `hasSidebar`
+
     _setSizeOptions: function(options) {
         this.set('size', options);
     }

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -33,8 +33,6 @@ var utils = {
 
     projectsPageTitle: 'Projects',
 
-    sidebarWide: 'wide',
-
     filterNoData: function(data) {
         if (data && !isNaN(data) && isFinite(data)) {
             return data.toFixed(3);

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -69,7 +69,8 @@ var RootView = Marionette.LayoutView.extend({
     el: 'body',
     ui: {
         mapContainer: '.map-container',
-        sidebar: '#sidebar'
+        sidebar: '#sidebar',
+        secondarySidebar: '#secondary-sidebar'
     },
     regions: {
         mainRegion: '#container',
@@ -80,6 +81,10 @@ var RootView = Marionette.LayoutView.extend({
         sidebarRegion: {
             regionClass: TransitionRegion,
             selector: '#sidebar-content'
+        },
+        secondarySidebarRegion: {
+            regionClass: TransitionRegion,
+            selector: '#secondary-sidebar-content'
         },
         compareRegion: '#compare',
         footerRegion: '#footer'
@@ -623,8 +628,7 @@ var MapView = Marionette.ItemView.extend({
         $container.toggleClass('-projectheader', !!size.hasProjectHeader);
         $container.toggleClass('-toolbarheader', !!size.hasToolbarHeader);
         $container.toggleClass('-sidebar', !!size.hasSidebar);
-        $container.toggleClass('-wide', !!size.hasSidebar &&
-            size.sidebarWidth === coreUtils.sidebarWide);
+        $container.toggleClass('-double', !!size.hasSecondarySidebar);
 
         _.delay(function() {
             self._leafletMap.invalidateSize();

--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -22,6 +22,7 @@ var DataCatalogController = {
         });
 
         var form = new models.SearchForm();
+        var dateFilter = new models.DateFilter();
 
         var catalogs = new models.Catalogs([
             new models.Catalog({
@@ -29,19 +30,23 @@ var DataCatalogController = {
                 name: 'CINERGI',
                 active: true,
                 results: new models.Results(null, { catalog: 'cinergi' }),
+                filters: new models.FilterCollection([dateFilter])
             }),
             new models.Catalog({
                 id: 'hydroshare',
                 name: 'HydroShare',
                 results: new models.Results(null, { catalog: 'hydroshare' }),
+                filters: new models.FilterCollection([dateFilter])
             }),
             new models.Catalog({
                 id: 'cuahsi',
                 name: 'WDC',
-                has_filters: true,
-                options: new models.SearchOptions([{ id: 'gridded' }]),
                 is_pageable: false,
                 results: new models.Results(null, { catalog: 'cuahsi' }),
+                filters: new models.FilterCollection([
+                    dateFilter,
+                    new models.GriddedServicesFilter()
+                ])
             })
         ]);
 

--- a/src/mmw/js/src/data_catalog/templates/checkboxFilter.html
+++ b/src/mmw/js/src/data_catalog/templates/checkboxFilter.html
@@ -1,0 +1,11 @@
+<div class="checkbox data-catalog-filter-checkbox">
+    <h5>{{ label }}</h5>
+     <label>
+         <input type="checkbox"
+                name={{id}}
+                id={{id}}
+                {{ "checked" if active }}
+         >
+         Active
+     </label>
+ </div>

--- a/src/mmw/js/src/data_catalog/templates/dateFilter.html
+++ b/src/mmw/js/src/data_catalog/templates/dateFilter.html
@@ -1,0 +1,33 @@
+<div class="data-catalog-search-dates">
+    <h5>Data collected between</h5>
+    <label for="from-date">From Date</label>
+    <div class="data-catalog-clearable-input">
+        <input
+            id="from-date"
+            class="data-catalog-date-input from-date form-control"
+            value="{{fromDate}}"
+        />
+        {% if fromDate %}
+        <a href="javascript:0;" class="data-catalog-clear-icon" title="Clear">
+            <i class="fa fa-times"></i>
+        </a>
+        {% endif %}
+    </div>
+    <label for="to-date">To Date</label>
+    <div class="data-catalog-clearable-input">
+        <input
+            id="to-date"
+            class="data-catalog-date-input to-date form-control"
+            value="{{toDate}}"
+        />
+        {% if toDate %}
+        <a href="javascript:0;" class="data-catalog-clear-icon" title="Clear">
+            <i class="fa fa-times"></i>
+        </a>
+        {% endif %}
+    </div>
+</div>
+
+{% if not isValid %}
+<div class="small data-catalog-validation-msg">From date must be earlier than To date</div>
+{% endif %}

--- a/src/mmw/js/src/data_catalog/templates/filterSidebar.html
+++ b/src/mmw/js/src/data_catalog/templates/filterSidebar.html
@@ -1,0 +1,9 @@
+<header class="data-catalog-filters-header">
+    <h3 class="filter-title">Filters</h3>
+    <button
+        type="button"
+        class="btn btn-link btn-md btn-reset"
+        data-action="reset-filters">
+        Reset
+    </button>
+</header>

--- a/src/mmw/js/src/data_catalog/templates/form.html
+++ b/src/mmw/js/src/data_catalog/templates/form.html
@@ -1,38 +1,12 @@
-<button class="btn btn-link date-filter-toggle small">{{filterText}}</button>
-
-{% if showingFilters %}
-    <div class="data-catalog-search-dates">
-        <h5>Data collected between:</h5>
-        <div class="data-catalog-clearable-input">
-            <input
-                class="data-catalog-date-input from-date form-control"
-                value="{{fromDate}}"
-            />
-            {% if fromDate %}
-            <a href="javascript:0;" class="data-catalog-clear-icon" title="Clear">
-                <i class="fa fa-times"></i>
-            </a>
-            {% endif %}
-        </div>
-        <span>and</span>
-        <div class="data-catalog-clearable-input">
-            <input
-                class="data-catalog-date-input to-date form-control"
-                value="{{toDate}}"
-            />
-            {% if toDate %}
-            <a href="javascript:0;" class="data-catalog-clear-icon" title="Clear">
-                <i class="fa fa-times"></i>
-            </a>
-            {% endif %}
-        </div>
-    </div>
-
-    {% if not isValid %}
-    <div class="small data-catalog-validation-msg">From date must be earlier than To date</div>
-    {% endif %}
-
-{% endif %}
+<button class="btn
+               {% if filterNumText %}
+               btn-secondary
+               {% else %}
+               btn-active
+               {% endif %}
+               btn-md filter-sidebar-toggle">
+    Filters {{filterNumText}}
+</button>
 
 <div class="data-catalog-search-component">
     <i class="data-catalog-search-icon fa fa-search"></i>
@@ -43,3 +17,5 @@
         value="{{query}}"
     />
 </div>
+
+<div class="filter-sidebar-region"></div>

--- a/src/mmw/js/src/data_catalog/templates/tabContent.html
+++ b/src/mmw/js/src/data_catalog/templates/tabContent.html
@@ -1,16 +1,3 @@
-{% if has_filters %}
-    <div class="filters-region">
-        {% if id == 'cuahsi' %}
-            <div class="checkbox">
-                <label>
-                    <input name="gridded" type="checkbox" id="gridded">
-                    Include Gridded
-                </label>
-            </div>
-        {% endif %}
-    </div>
-{% endif %}
-
 {% if description %}
 <div class="catalog-description">
     {{ description }}

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -20,6 +20,12 @@
   &.-sidebar {
     left: $sidebar-width;
   }
+
+  // Sets map to correct container size for sidebar + secondary sidebar
+  &.-sidebar.-double {
+      left: calc(#{$sidebar-width} + #{$secondary-sidebar-width});
+  }
+
   .compare-scenarios-container & {
     top: 0;
   }

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -40,10 +40,6 @@
         }
     }
 
-    .filters-region {
-        padding: 6px 10px 0 10px;
-    }
-
     .result-region {
         height: auto !important;
         width: auto !important;
@@ -78,20 +74,13 @@
         padding: 10px;
     }
 
-    .data-catalog-search-dates {
-        background-color: #D8D8D8;
-        padding: 12px 10px;
-        margin: 0 -10px 10px;
-
-        h5 {
-            margin-top: 0;
-            font-weight: 600;
-        }
-    }
-
     .data-catalog-form {
         position: relative;
         padding: 4px 10px;
+
+        &:hover {
+            text-decoration: none;
+        }
 
         .data-catalog-search-component {
             position: relative;
@@ -103,32 +92,6 @@
             border: none;
             padding-left: 31px;
         }
-        .data-catalog-clearable-input {
-            display: inline-block;
-            position: relative;
-        }
-        .data-catalog-date-input {
-            width: 202px;
-            height: 38px;
-            border: none;
-            border-radius: 0;
-            display: inline;
-        }
-        .data-catalog-clear-icon {
-            color: $ui-secondary;
-            position: relative;
-            font-size: 13px;
-            position: absolute;
-            right: 10px;
-            top: 10px;
-        }
-        &:hover {
-            text-decoration: none;
-        }
-        .data-catalog-validation-msg {
-          color: $ui-danger;
-          margin-top: 8px;
-        }
         .data-catalog-search-icon {
             color: $ui-grey;
             position: absolute;
@@ -139,11 +102,10 @@
         .form-group {
           margin-right: 15px;
         }
-        .date-filter-toggle {
+        .filter-sidebar-toggle {
           position: absolute;
-          right: 0;
+          right: 1.5rem;
           top: -36px;
-          color: $brand-primary;
         }
     }
 
@@ -259,5 +221,89 @@
     .data-catalog-popover-details-btn {
         border-radius: 0px;
         margin-top: 10px;
+    }
+}
+
+.data-catalog-filter-window {
+    padding: 1rem;
+    padding-top: 2rem;
+    left: $sidebar-width;
+    width: $secondary-sidebar-width;
+    transition: all 200ms;
+    background-color: #D8D8D8;
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    bottom: 0;
+    top: 90px;
+}
+
+.data-catalog-filter-window > .data-catalog-filters-header {
+    display: flex;
+    flex-direction: row;
+    > .filter-title {
+        line-height: $height-md;
+    }
+    > .btn-reset {
+        margin-left: auto;
+        font-weight: 600;
+        color: $brand-primary;
+    }
+}
+
+.data-catalog-filter-window > .data-catalog-filter-group {
+    h5 {
+        text-transform: uppercase;
+        font-weight: 800;
+    }
+}
+
+.data-catalog-filter-group .data-catalog-filter-checkbox {
+    input[type=checkbox] {
+      position: relative;
+      margin-right: 5px;
+    }
+
+    label {
+      font-size: $font-size-h4;
+    }
+}
+
+.data-catalog-filter-group .data-catalog-search-dates {
+    padding: 12px 10px;
+    margin: 0 -10px 10px;
+
+    label {
+        text-transform: uppercase;
+        display: block;
+        font-size: $font-size-h5;
+    }
+}
+
+.data-catalog-filter-group {
+    .data-catalog-clearable-input {
+        width: 100%;
+        display: inline-block;
+        position: relative;
+    }
+    .data-catalog-date-input {
+        height: 38px;
+        border: none;
+        border-radius: 0;
+        display: inline;
+        margin-bottom: 12px;
+    }
+    .data-catalog-clear-icon {
+        color: $ui-secondary;
+        position: relative;
+        font-size: 13px;
+        position: absolute;
+        right: 10px;
+        top: 10px;
+    }
+
+    .data-catalog-validation-msg {
+        color: $ui-danger;
+        margin-top: 8px;
     }
 }

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -42,6 +42,7 @@ $analyze-tab-height: 40px;
 
 //Widths
 $sidebar-width: 460px;
+$secondary-sidebar-width: 300px;
 $layerpicker-width: 240px;
 $search-width: 300px;
 


### PR DESCRIPTION
## Overview

Consolidate all the data catalog filters into a single sidebar. This will make it easier to add more filters in the future.

This is a big, single commit. I recommend looking at the changes in the data catalog models first; that's where the meat is (see commit message). The view changes should all be either (a) moving operations into the models (b) moving views from the form into the new sidebar views.

**Behavioral differences:**
- Kick off a new search any time there's a change in the date, if the there's a query string and whatever's in the date filter is valid. Before we waited for the explicit <kbd>Enter</kbd>

Connects #2232 

## Notes

This is maybe a little more subclassing than we usually do. My goal with all the refactoring was to make it easy to add new filters, and have them conform to similar interfaces.

### Demo

![4stmtwevkv](https://user-images.githubusercontent.com/7633670/30447838-25e8e9ac-995b-11e7-8883-8862bfc29ec2.gif)

## Testing Instructions

 * Pull and `./scripts/bundle.sh`. Make sure the sass compiles
 * On all major browsers test combinations of each tab + filter states + query field states
