### PR TITLE
BiG-CZ: Cache CUAHSI Requests

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -9,6 +9,7 @@ from socket import timeout
 from operator import attrgetter
 
 from suds.client import Client
+from suds.sudsobject import asdict
 from rest_framework.exceptions import ValidationError
 from django.contrib.gis.geos import Point
 
@@ -42,6 +43,27 @@ GRIDDED = [
 client = Client(CATALOG_URL, timeout=settings.BIGCZ_CLIENT_TIMEOUT)
 
 
+def recursive_asdict(d):
+    """
+    Convert Suds object into serializable format, so it can be cached.
+    From https://gist.github.com/robcowie/a6a56cf5b17a86fdf461
+    """
+    out = {}
+    for k, v in asdict(d).iteritems():
+        if hasattr(v, '__keylist__'):
+            out[k] = recursive_asdict(v)
+        elif isinstance(v, list):
+            out[k] = []
+            for item in v:
+                if hasattr(item, '__keylist__'):
+                    out[k].append(recursive_asdict(item))
+                else:
+                    out[k].append(item)
+        else:
+            out[k] = v
+    return out
+
+
 def filter_networkIDs(services, gridded=False):
     """
     Transforms list of services to list of ServiceIDs, with respect to
@@ -52,8 +74,8 @@ def filter_networkIDs(services, gridded=False):
     If no filters apply, we return an empty list to disable filtering.
     """
     if not gridded:
-        return [str(s.ServiceID) for s in services
-                if s.NetworkName not in GRIDDED]
+        return [str(s['ServiceID']) for s in services
+                if s['NetworkName'] not in GRIDDED]
 
     return []
 
@@ -173,7 +195,8 @@ def group_series_by_location(series):
 
 def make_request(request, **kwargs):
     try:
-        return request(**kwargs)
+        response = recursive_asdict(request(**kwargs))
+        return response
     except URLError, e:
         if isinstance(e.reason, timeout):
             raise RequestTimedOutError()

--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -13,6 +13,7 @@ from suds.sudsobject import asdict
 from rest_framework.exceptions import ValidationError
 from django.contrib.gis.geos import Point
 
+from django.core.cache import cache
 from django.conf import settings
 
 from apps.bigcz.models import ResourceLink, ResourceList, BBox
@@ -193,9 +194,16 @@ def group_series_by_location(series):
     return records
 
 
-def make_request(request, **kwargs):
+def make_request(request, expiry, **kwargs):
+    key = 'bigcz_{}_{}'.format(request.method.name,
+                               hash(frozenset(kwargs.items())))
+    cached = cache.get(key)
+    if cached:
+        return cached
+
     try:
         response = recursive_asdict(request(**kwargs))
+        cache.set(key, response, timeout=expiry)
         return response
     except URLError, e:
         if isinstance(e.reason, timeout):
@@ -208,6 +216,7 @@ def make_request(request, **kwargs):
 
 def get_services_in_box(box):
     result = make_request(client.service.GetServicesInBox2,
+                          604800,  # Cache for one week
                           xmin=box.xmin,
                           xmax=box.xmax,
                           ymin=box.ymin,
@@ -228,6 +237,7 @@ def get_series_catalog_in_box(box, from_date, to_date, networkIDs):
     to_date = to_date or DATE_MAX
 
     result = make_request(client.service.GetSeriesCatalogForBox2,
+                          300,  # Cache for 5 minutes
                           xmin=box.xmin,
                           xmax=box.xmax,
                           ymin=box.ymin,


### PR DESCRIPTION
## Overview

CUAHSI searches use two endpoints: one for fetching services, and another for fetching series within them. The services rarely update, so we cache them for a week. The series update more frequently, so we cache them for 5 minutes. Each cache key is composed of `bigcz_{name of request method}_{sorted hashset of arguments}` so new requests should work as expected, and existing requests should be cached for the given TTL.

This work complements the filters PR #2258 which triggers searches on click. This should make enabling and disabling filters a lot quicker.

Connects #1932 

### Demo

![2017-09-15 11 54 47](https://user-images.githubusercontent.com/1430060/30492079-59290132-9a0d-11e7-9074-56a7ee9f33a9.gif)

## Testing Instructions

 * Check out this branch, go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Run a WDC search. It'll take it's time the first time.
 * Try and run the same search again. It should be noticeably faster.
 * Ensure the results are the same as before.