### PR TITLE
Calculate SedNitr value from SoilN raster

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -101,7 +101,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       guest: 2375,
       host: 2375
     }.merge(VAGRANT_NETWORK_OPTIONS)
-    # SJS
+    # Geoprocessing Service
     worker.vm.network "forwarded_port", {
       guest: 8090,
       host: 8090

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -106,7 +106,7 @@ def geoprocess(data, retry=None):
                         'Details: {}'.format(response.text))
 
 
-def parse(sjs_result):
+def parse(result):
     """
     Converts raw JSON results from Spark JobServer to dictionary of tuples
 
@@ -124,10 +124,10 @@ def parse(sjs_result):
             (4, 5): 6
         }
 
-    :param sjs_result: Dictionary mapping strings like 'List(a,b,c)' to ints
+    :param result: Dictionary mapping strings like 'List(a,b,c)' to ints
     :return: Dictionary mapping tuples of ints to ints
     """
-    return {make_tuple(key[4:]): val for key, val in sjs_result.items()}
+    return {make_tuple(key[4:]): val for key, val in result.items()}
 
 
 def to_one_ring_multipolygon(area_of_interest):

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -156,7 +156,7 @@ def collect_data(geop_result, geojson):
 
 
 @shared_task(throws=Exception)
-def nlcd_streams(sjs_result):
+def nlcd_streams(result):
     """
     From a dictionary mapping NLCD codes to the count of stream pixels on
     each, return a dictionary with keys 'ag_stream_pct', 'low_urban_stream_pct'
@@ -189,13 +189,12 @@ def nlcd_streams(sjs_result):
     This task should be used as a template for making other geoprocessing
     post-processing tasks, to be used in geop_tasks.
     """
-    if 'error' in sjs_result:
-        raise Exception('[nlcd_streams] {}'.format(sjs_result['error']))
+    if 'error' in result:
+        raise Exception('[nlcd_streams] {}'.format(result['error']))
 
-    # Parse SJS results
-    # This can't be done in mapshed_finish because the keys may be tuples,
+    # This can't be done in geoprocessing.run because the keys may be tuples,
     # which are not JSON serializable and thus can't be shared between tasks
-    result = parse(sjs_result)
+    result = parse(result)
 
     ag_count = sum(result.get(nlcd, 0) for nlcd in AG_NLCD_CODES)
     low_urban_count = sum(result.get(nlcd, 0) for nlcd in [21, 22])
@@ -222,15 +221,15 @@ def nlcd_streams(sjs_result):
 
 
 @shared_task(throws=Exception)
-def nlcd_streams_drb(sjs_result):
+def nlcd_streams_drb(result):
     """
     This callback is run when the geometry falls within the DRB. We calculate
     the percentage of DRB streams in each land use type.
     """
-    if 'error' in sjs_result:
-        raise Exception('[nlcd_streams_drb] {}'.format(sjs_result['error']))
+    if 'error' in result:
+        raise Exception('[nlcd_streams_drb] {}'.format(result['error']))
 
-    result = parse(sjs_result)
+    result = parse(result)
     total = sum(result.values())
 
     lu_stream_pct_drb = [0.0] * NLU
@@ -245,7 +244,7 @@ def nlcd_streams_drb(sjs_result):
 
 
 @shared_task(throws=Exception)
-def nlcd_soils(sjs_result):
+def nlcd_soils(result):
     """
     Results are expected to be in the format:
     {
@@ -255,10 +254,10 @@ def nlcd_soils(sjs_result):
     We calculate a number of values relying on various combinations
     of these raster datasets.
     """
-    if 'error' in sjs_result:
-        raise Exception('[nlcd_soils] {}'.format(sjs_result['error']))
+    if 'error' in result:
+        raise Exception('[nlcd_soils] {}'.format(result['error']))
 
-    ngt_count = parse(sjs_result)
+    ngt_count = parse(result)
 
     # Raise exception if no NLCD values
     if len(ngt_count.values()) == 0:
@@ -285,15 +284,15 @@ def nlcd_soils(sjs_result):
 
 
 @shared_task(throws=Exception)
-def gwn(sjs_result):
+def gwn(result):
     """
     Derive Groundwater Nitrogen and Phosphorus
     """
-    if 'error' in sjs_result:
+    if 'error' in result:
         raise Exception('[gwn] {}'
-                        .format(sjs_result['error']))
+                        .format(result['error']))
 
-    result = parse(sjs_result)
+    result = parse(result)
     gr_nitr_conc, gr_phos_conc = groundwater_nitrogen_conc(result)
 
     return {
@@ -303,17 +302,17 @@ def gwn(sjs_result):
 
 
 @shared_task(throws=Exception)
-def avg_awc(sjs_result):
+def avg_awc(result):
     """
     Get `AvgAwc` from MMW-Geoprocessing endpoint
 
     Original at Class1.vb@1.3.0:4150
     """
-    if 'error' in sjs_result:
+    if 'error' in result:
         raise Exception('[awc] {}'
-                        .format(sjs_result['error']))
+                        .format(result['error']))
 
-    result = parse(sjs_result)
+    result = parse(result)
 
     return {
         'avg_awc': result.values()[0]
@@ -321,17 +320,17 @@ def avg_awc(sjs_result):
 
 
 @shared_task(throws=Exception)
-def soiln(sjs_result):
+def soiln(result):
     """
     Get `SoilN` from MMW-Geoprocessing endpoint
 
     Originally a static value of 2000 at Class1.vb@1.3.0:9587
     """
-    if 'error' in sjs_result:
+    if 'error' in result:
         raise Exception('[soiln] {}'
-                        .format(sjs_result['error']))
+                        .format(result['error']))
 
-    result = parse(sjs_result)
+    result = parse(result)
 
     return {
         'soiln': result.values()[0]

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -553,6 +553,18 @@ GEOP = {
                 'operationType': 'RasterGroupedAverage',
                 'zoom': 0
             }
+        },
+        'soiln': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [],
+                'targetRaster': 'soiln-epsg5070',
+                'pixelIsArea': True,
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterGroupedAverage',
+                'zoom': 0
+            }
         }
     }
 }

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -59,7 +59,6 @@ GWLFE_DEFAULTS = {
     'SoilPFlag': b.YES,  # Flag: Soil P Layer Detected (0 No; 1 Yes)
     'GWNFlag': b.YES,  # Flag: Groundwater N Layer Detected (0 No; 1 Yes)
     'SedAAdjust': 1.4,  # Default Percent ET
-    'SedNitr': 2000,  # Soil Concentration: N (mg/l)
     'BankNFrac': 0.25,  # % Bank N Fraction (0 - 1)
     'BankPFrac': 0.25,  # % Bank P Fraction (0 - 1)
     'ManuredAreas': 2,  # Manure Spreading Periods (Default = 2)


### PR DESCRIPTION
## Overview

Calculates the average SoilN value for a given area of interest
and multiplies it by 4.0 to get the SedNitr value. This was
previously staticly set at 2000.

Connects #1754 

### Demo

Here is the GMS file produced on this branch: [MapShed_SoilN.gms.txt](https://github.com/WikiWatershed/model-my-watershed/files/1307427/MapShed_SoilN.gms.txt)

As can be seen on line 37 position 1, the value is not 2000:

```
1004,320,5.576021102150538,0.047421639784946235,0.25,0.25
```

The value of 1004 is for a square kilometer AoI in Center City Philadelphia.

![image](https://user-images.githubusercontent.com/1430060/30497859-6f0a97da-9a22-11e7-9ee7-d2d6124d6562.png)

### Notes

I imagine that the value of 2000 is typical of agricultural land use heavy areas of interest, so a value of ~1000 for a city sounds reasonable. For an area of interest with most land use in the categories of Cultivated Crops and Pasture / Hay, we are more likely to get a higher value.

## Testing Instructions

 * Check out this branch, and restart Celery `vagrant ssh worker -c 'sudo service celeryd restart'`
 * Go to [:8000/](http://localhost:8000/) and draw a shape and create a MapShed job
 * Export the GMS file and observer line 37, position 1. Ensure that it isn't 2000.