### PR TITLE
BiG-CZ: Always conjunct CINERGI query items

### DIFF
--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -120,6 +120,25 @@ def prepare_time(from_date, to_date):
     return value
 
 
+def prepare_query(query):
+    """
+    Prepare query to always AND all search terms
+
+    Spaces will be replaced with AND. Existing ANDs and ORs will be preserved.
+    """
+    def intersperse_and(phrase):
+        # For a given phrase, intersperse AND between all words,
+        # except "and" which is removed
+        return ' AND '.join([word for word in phrase.split()
+                             if word != 'and'])
+
+    # If the query has any ORs, split it into phrases to be ANDed
+    phrases = query.split(' or ')
+
+    # AND words in each phrase, and OR all phrases together
+    return ' OR '.join(map(intersperse_and, phrases))
+
+
 def search(**kwargs):
     query = kwargs.get('query')
     to_date = kwargs.get('to_date')
@@ -134,7 +153,7 @@ def search(**kwargs):
 
     if query:
         params.update({
-            'q': query
+            'q': prepare_query(query.lower())
         })
     if from_date:
         params.update({


### PR DESCRIPTION
## Overview

By default, the CINERGI query items would be ORd, thus expanding the search as more terms were specified instead of narrowing it down. By always ANDing the terms, we ensure that the more information a user provides, the narrower the search becomes.

Connects #2228 

### Demo

![2017-09-15 17 57 30](https://user-images.githubusercontent.com/1430060/30504958-a82262ba-9a3f-11e7-8e21-2b66bb0d5081.gif)

## Testing Instructions

 * Check out this branch, and go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Search for something on the CINERGI tab
 * Search for more things. Ensure that as the query gets longer, the results get fewer.
