### PR TITLE
BiG-CZ: Climate Charts

### DIFF
--- a/src/mmw/apps/geoprocessing_api/tasks.py
+++ b/src/mmw/apps/geoprocessing_api/tasks.py
@@ -31,6 +31,7 @@ RWD_HOST = os.environ.get('RWD_HOST', 'localhost')
 RWD_PORT = os.environ.get('RWD_PORT', '5000')
 
 ACRES_PER_SQM = 0.000247105
+CM_PER_MM = 0.1
 
 
 @shared_task
@@ -204,7 +205,7 @@ def collect_climate(results):
     categories = [{
         'monthidx': i,
         'month': month_name[i],
-        'ppt': results['ppt'][str(i)],
+        'ppt': results['ppt'][str(i)] * CM_PER_MM,
         'tmean': results['tmean'][str(i)],
     } for i in xrange(1, 13)]
 

--- a/src/mmw/js/src/analyze/templates/analyzeResults.html
+++ b/src/mmw/js/src/analyze/templates/analyzeResults.html
@@ -1,5 +1,6 @@
 <div class="results-content">
     <div class="desc-region"></div>
+    <div class="selector-region"></div>
     <div class="chart-region"></div>
     <div class="table-region"></div>
     <div class="downloadcsv-link" data-action="download-csv">

--- a/src/mmw/js/src/analyze/templates/climateTable.html
+++ b/src/mmw/js/src/analyze/templates/climateTable.html
@@ -4,7 +4,7 @@
         <th data-visible="false" data-field="monthidx">Month Index</th>
         <th data-sortable="true" data-field="month" data-sort-name="monthidx">Month</th>
         <th class="text-right" data-field="ppt" data-sortable="true" data-sorter="window.numericSort">
-            Mean Precip. (mm)
+            Mean Precip. (cm)
         </th>
         <th class="text-right" data-field="tmean" data-sortable="true" data-sorter="window.numericSort">
             Mean Temp. (&deg;C)

--- a/src/mmw/js/src/analyze/templates/selector.html
+++ b/src/mmw/js/src/analyze/templates/selector.html
@@ -1,0 +1,7 @@
+<select class="form-control btn btn-small btn-primary">
+    {% for key in keys %}
+        <option value="{{ key.name }}" {{ "selected" if key.name == activeVar }}>
+            {{ key.label }}
+        </option>
+    {% endfor %}
+</select>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -30,6 +30,7 @@ var $ = require('jquery'),
     animalTableRowTmpl = require('./templates/animalTableRow.html'),
     climateTableTmpl = require('./templates/climateTable.html'),
     climateTableRowTmpl = require('./templates/climateTableRow.html'),
+    selectorTmpl = require('./templates/selector.html'),
     pageableTableTmpl = require('./templates/pageableTable.html'),
     pointSourceTableTmpl = require('./templates/pointSourceTable.html'),
     pointSourceTableRowTmpl = require('./templates/pointSourceTableRow.html'),
@@ -982,6 +983,7 @@ var AnalyzeResultView = Marionette.LayoutView.extend({
     template: analyzeResultsTmpl,
     regions: {
         descriptionRegion: '.desc-region',
+        selectorRegion: '.selector-region',
         chartRegion: '.chart-region',
         tableRegion: '.table-region',
         printTableRegion: '.print-table-region'
@@ -1162,6 +1164,38 @@ var CatchmentWaterQualityResultView = AnalyzeResultView.extend({
     }
 });
 
+var SelectorView = Marionette.ItemView.extend({
+    template: selectorTmpl,
+
+    ui: {
+        selector: 'select',
+    },
+
+    events: {
+        'change @ui.selector': 'updateActiveVar',
+    },
+
+    modelEvents: {
+        'change:activeVar': 'render',
+    },
+
+    initialize: function(options) {
+        this.keys = options.keys;
+    },
+
+    templateHelpers: function() {
+        return {
+            keys: this.keys,
+        };
+    },
+
+    updateActiveVar: function() {
+        var activeVar = this.ui.selector.val();
+
+        this.model.set({ activeVar: activeVar });
+    }
+});
+
 var ClimateResultView = AnalyzeResultView.extend({
     initialize: function() {
         this.model.set('activeVar', 'ppt');
@@ -1178,6 +1212,14 @@ var ClimateResultView = AnalyzeResultView.extend({
             chart = null;
         this.showAnalyzeResults(coreModels.ClimateCensusCollection, ClimateTableView,
             chart, title, source, helpText, associatedLayerCodes);
+
+        this.selectorRegion.show(new SelectorView({
+            model: this.model,
+            keys: [
+                { name: 'ppt', label: 'Mean Precipitation' },
+                { name: 'tmean', label: 'Mean Temperature' },
+            ],
+        }));
     }
 });
 

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1163,6 +1163,10 @@ var CatchmentWaterQualityResultView = AnalyzeResultView.extend({
 });
 
 var ClimateResultView = AnalyzeResultView.extend({
+    initialize: function() {
+        this.model.set('activeVar', 'ppt');
+    },
+
     onShow: function() {
         var title = 'Mean Monthly Precipitation and Temperature',
             source = 'PRISM Climate Group',

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1208,7 +1208,7 @@ var ClimateChartView = ChartView.extend({
         var chartEl = this.$('.bar-chart').get(0),
             activeVar = this.model.get('activeVar'),
             config = activeVar === 'ppt' ?
-                {label: 'Water Depth (mm)', unit: 'mm', key: 'Mean Precipitation'} :
+                {label: 'Water Depth (cm)', unit: 'cm', key: 'Mean Precipitation'} :
                 {label: 'Temperature (°C)', unit: '°C', key: 'Mean Temperature'  },
             data = [
                 {

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -168,3 +168,7 @@
 .hidden-analyze-table-column {
   display: none;
 }
+
+#climate select.form-control {
+  margin: 10px 0;
+}


### PR DESCRIPTION
## Overview

Adds line charts for mean precipitation and temperature for the Climate tab under Analyze for BiG-CZ. Also switches the mean precipitation results from being in mm to cm, to better match the rest of the app.

Connects #1975 

### Demo

![2017-09-18 16 44 33](https://user-images.githubusercontent.com/1430060/30563782-fa48c7ac-9c90-11e7-836e-0fd8a467938a.gif)

GiFox didn't capture the dropdown properly, but you see the two values in it, and selecting it updates the chart.

### Notes

Most of the charting logic was modeled after the GWLF-E Runoff treatment, done in [`modeling/gwlfe/runoff/views.js`](https://github.com/WikiWatershed/model-my-watershed/blob/develop/src/mmw/js/src/modeling/gwlfe/runoff/views.js).

## Testing Instructions

 * Check out this branch, bundle, and restart Celery `vagrant ssh worker -c 'sudo service celeryd restart'`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Pick a shape and go to the Analyze stage. Look at the Climate tab. Ensure you see a precipitation chart.
 * Ensure you can toggle between Precipitation and Temperature charts using the dropdown.
 * Ensure units and values line up between the chart, axes, tooltips, and table.