### PR TITLE
Hide Cinergi "REQUIRED FIELD"

### DIFF
--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
@@ -14,9 +14,9 @@
             <i class="fa fa-user"></i>{{ author }}
         </p>
     {% endif %}
-        <p>
-            <i class="fa fa-calendar"></i> {{ created_at|toDateFullYear }}
-        </p>
+    <p>
+        <i class="fa fa-calendar"></i> {{ created_at|toDateFullYear }}
+    </p>
     {% if not (description == "REQUIRED FIELD") %}
     <p>
         {{ description }}

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
@@ -17,9 +17,11 @@
         <p>
             <i class="fa fa-calendar"></i> {{ created_at|toDateFullYear }}
         </p>
+    {% if not (description == "REQUIRED FIELD") %}
     <p>
         {{ description }}
     </p>
+    {% endif %}
     <p>
         <a class="btn btn-secondary" href="{{ cinergi_url }}"
            target="_blank" rel="noreferrer noopener">

--- a/src/mmw/js/src/data_catalog/templates/searchResult.html
+++ b/src/mmw/js/src/data_catalog/templates/searchResult.html
@@ -2,9 +2,11 @@
     <h3 class="resource-title">
         {{ title }}
     </h3>
+    {% if not (summary == "REQUIRED FIELD") %}
     <div class="resource-description">
         {{ summary }}
     </div>
+    {% endif %}
     {% if created_at %}
     <div class="resource-date">
         <i class="fa fa-calendar"></i> {{ created_at|toDateFullYear }}


### PR DESCRIPTION
## Overview

This PR hides the "REQUIRED FIELD" text which appeared as the summary/description for some Cinergi results. To accomplish this we check whether the value for the search result summary or the result description is "REQUIRED FIELD" and only show them if not.

Connects #2215 

### Demo

<img width="560" alt="screen shot 2017-09-19 at 10 25 39 am" src="https://user-images.githubusercontent.com/4165523/30597488-23225a0a-9d25-11e7-9ccd-4a569ddae5f0.png">

## Testing Instructions
- get this branch then bundle and visit :8000/?bigcz
- select an AOI, then search data sources for "water"
- in the Cinergi results verify that you do not see any summaries/descriptions with values of "REQUIRED FIELD" but that the other results do show summaries & descriptions
- check that the other catalogs' results display properly