### PR TITLE
Return async job results as JSON

### DIFF
--- a/src/mmw/apps/geoprocessing_api/calcs.py
+++ b/src/mmw/apps/geoprocessing_api/calcs.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import json
+
 from django.contrib.gis.geos import GEOSGeometry
 
 from django.conf import settings
@@ -123,12 +125,12 @@ def catchment_water_quality(geojson):
             columns = [col[0] for col in cursor.description]
             catchment_water_quality_results = [
                 # The TN, TP, and TSS values return as type Decimal,
-                # but we want floats.
+                # but we want floats.  For geom (22), we want a JSON object
                 dict(zip(columns,
                          ([int(row[0]) if row[0] else None] +
                           [float(value) if value else None
                            for value in row[1:22]] +
-                          [row[22]])))
+                          [json.loads(row[22])])))
                 for row in cursor.fetchall()
             ]
         else:

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -40,6 +40,7 @@ class ProjectSerializer(gis_serializers.GeoModelSerializer):
         geo_field = 'area_of_interest'
 
     user = UserSerializer(default=serializers.CurrentUserDefault())
+    gis_data = JsonField()
     scenarios = ScenarioSerializer(many=True, read_only=True)
 
 

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -526,11 +526,18 @@ def get_job(request, job_uuid, format=None):
 
     # TODO Should we return the error? Might leak info about the internal
     # workings that we don't want exposed.
+
+    # Parse results to json if it is valid json
+    try:
+        result = json.loads(job.result)
+    except ValueError:
+        result = job.result
+
     return Response(
         {
             'job_uuid': job.uuid,
             'status': job.status,
-            'result': job.result,
+            'result': result,
             'error': job.error,
             'started': job.created_at,
             'finished': job.delivered_at,

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -64,9 +64,9 @@ var ModelSelectionDropdownView = Marionette.ItemView.extend({
                 shape: App.map.get('areaOfInterest'),
                 place: App.map.get('areaOfInterestName')
             }),
-            analysisResults = JSON.parse(App.getAnalyzeCollection()
-                                            .findWhere({taskName: 'analyze/land'})
-                                            .get('result') || "{}"),
+            analysisResults = App.getAnalyzeCollection()
+                                  .findWhere({taskName: 'analyze/land'})
+                                  .get('result') || {},
             landResults = analysisResults.survey;
 
         if (modelPackageName === 'gwlfe' && settings.get('mapshed_max_area')) {
@@ -335,7 +335,7 @@ var TabContentView = Marionette.LayoutView.extend({
 
     showResults: function() {
         var name = this.model.get('name'),
-            result = JSON.parse(this.model.get('result')).survey,
+            result = this.model.get('result').survey,
             resultModel = new models.LayerModel(result),
             ResultView = AnalyzeResultViews[name];
 
@@ -850,7 +850,7 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
             'nord', data.nord);
         var geoJson = {
             "type": "Feature",
-            "geometry": JSON.parse(geom),
+            "geometry": geom,
         };
         this.catchmentPolygon = L.geoJson(geoJson, {
             style: {

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -913,12 +913,7 @@ var WatershedDelineationView = DrawToolBaseView.extend({
             pollSuccess: function(response) {
                 self.model.set('polling', false);
 
-                var result;
-                try {
-                    result = JSON.parse(response.result);
-                } catch (ex) {
-                    return this.pollFailure();
-                }
+                var result = response.result;
 
                 if (result.watershed) {
                     // Convert watershed to MultiPolygon to pass shape validation.

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -433,7 +433,7 @@ var GwlfeConservationPracticeView = ModificationsView.extend({
                     rows: [['urban_buffer_strips', 'urban_streambank_stabilization', 'water_retention', 'infiltration']]
                 }
             ],
-            dataModel: gwlfeConfig.cleanDataModel(JSON.parse(App.currentProject.get('gis_data'))),
+            dataModel: gwlfeConfig.cleanDataModel(App.currentProject.get('gis_data')),
             errorMessages: null,
             infoMessages: null
         });

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -769,12 +769,11 @@ var ScenarioModel = Backbone.Model.extend({
     },
 
     setResults: function() {
-        var rawServerResults = this.get('taskModel').get('result');
+        var serverResults = this.get('taskModel').get('result');
 
-        if (rawServerResults === '' || rawServerResults === null) {
+        if (_.isEmpty(serverResults)) {
             this.get('results').setNullResults();
         } else {
-            var serverResults = JSON.parse(rawServerResults);
             this.get('results').forEach(function(resultModel) {
                 var resultName = resultModel.get('name');
 
@@ -899,7 +898,7 @@ var ScenarioModel = Backbone.Model.extend({
                 // Merge the values that came back from Mapshed with the values
                 // in the modifications from the user.
                 var modifications = self.get('modifications'),
-                    mergedGisData = JSON.parse(project.get('gis_data'));
+                    mergedGisData = project.get('gis_data');
 
                 modifications.forEach(function(mod) {
                     _.assign(mergedGisData, mod.get('output'));


### PR DESCRIPTION
## Overview

Previously, results of async jobs were stringified for unknown reasons.  These are now transmitted as real JSON objects and the deserialization step has been removed.  This will be a more straightforward artifact for users of the geoprocessing API, as well as in debugging our own app.

Connects #2200 

### Demo

```json
{
	"status": "complete",
	"started": "2017-09-19T23:36:59.104Z",
	"finished": "2017-09-19T23:32:35.294Z",
	"result": {
		"survey": {
			"displayName": "Animals",
			"name": "animals",
			"categories": [{
				"type": "Sheep",
				"aeu": 0
			}, {
				"type": "Horses",
				"aeu": 0
			}, {
				"type": "Turkeys",
				"aeu": 0
			}, {
				"type": "Chickens, Layers",
				"aeu": 0
			}, {
				"type": "Cows, Beef",
				"aeu": 0
			}, {
				"type": "Pigs/Hogs/Swine",
				"aeu": 0
			}, {
				"type": "Cows, Dairy",
				"aeu": 0
			}, {
				"type": "Chickens, Broilers",
				"aeu": 1
			}]
		}
	},
	"error": "",
	"job_uuid": "613678d6-afff-4c74-9cd9-11884c3bbd62"
}
```

### Notes

Some objects, like Water Quality and Mapshed Results were deeply nested with strings and had to have specific serializations removed.  As this doesn't affect the _storage_ of the information, just the serialization, saved results should be handled correctly.  Mapshed is not part of the API, but I still thought it prudent to convert all responses to JSON.

## Testing Instructions

 * Create and Save Mapshed & Tr55 jobs on the current `develop` branch
 * Check out this branch
 * Bundle and reload Celery
 * Run through analysis, load the previously saved TR55 & Mapshed projects, create new projects (of both types) and create scenarios for both (ie, run the whole app), and ensure that the results are parsed by the client.
 * Using the swagger UI `/api/docs/`, ensure the that response types for jobs are in proper json and not stringified.