### PR TITLE
Fix nonsensical Geoprocessing API whitelist check

### DIFF
--- a/src/mmw/apps/core/permissions.py
+++ b/src/mmw/apps/core/permissions.py
@@ -8,19 +8,19 @@ from rest_framework.authentication import TokenAuthentication
 from django.conf import settings
 
 
-class IsTokenAuthenticatedOrClientApp(BasePermission):
+class IsTokenAuthenticatedOrNotSwagger(BasePermission):
     """
-    Global permission check for request being
-    (a) from a whitelisted IP
-      ie. is this our own client web app and not the swagger docs?
-    (b) from a user authenticated via auth token
+    TODO This is just to test the token authentication
+    Only anonymous requests from the client app should
+    be allowed:
+    https://github.com/WikiWatershed/model-my-watershed/issues/2270
+    Currently all anonymous requests are allowed, unless you're using
+    swagger
     """
 
     def has_permission(self, request, view):
-        ip_addr = request.META['REMOTE_ADDR']
         from_swagger = 'api/docs' in request.META['HTTP_REFERER'] \
                        if 'HTTP_REFERER' in request.META else False
-        whitelisted = ip_addr in settings.ALLOWED_HOSTS
         token_authenticated = type(request.successful_authenticator) \
             is TokenAuthentication
-        return (not from_swagger and whitelisted) or token_authenticated
+        return not from_swagger or token_authenticated

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from apps.core.models import Job
 from apps.core.tasks import (save_job_error,
                              save_job_result)
-from apps.core.permissions import IsTokenAuthenticatedOrClientApp
+from apps.core.permissions import IsTokenAuthenticatedOrNotSwagger
 from apps.modeling import geoprocessing
 from apps.modeling.views import load_area_of_interest
 from apps.geoprocessing_api import tasks
@@ -23,7 +23,7 @@ from apps.geoprocessing_api import tasks
 
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
-@decorators.permission_classes((IsTokenAuthenticatedOrClientApp, ))
+@decorators.permission_classes((IsTokenAuthenticatedOrNotSwagger, ))
 def start_rwd(request, format=None):
     """
     Starts a job to run Rapid Watershed Delineation on a point-based location.
@@ -184,7 +184,7 @@ def start_rwd(request, format=None):
 
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
-@decorators.permission_classes((IsTokenAuthenticatedOrClientApp, ))
+@decorators.permission_classes((IsTokenAuthenticatedOrNotSwagger, ))
 def start_analyze_land(request, format=None):
     """
     Starts a job to produce a land-use histogram for a given area.
@@ -378,7 +378,7 @@ def start_analyze_land(request, format=None):
 
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
-@decorators.permission_classes((IsTokenAuthenticatedOrClientApp, ))
+@decorators.permission_classes((IsTokenAuthenticatedOrNotSwagger, ))
 def start_analyze_soil(request, format=None):
     """
     Starts a job to produce a soil-type histogram for a given area.
@@ -504,7 +504,7 @@ def start_analyze_soil(request, format=None):
 
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
-@decorators.permission_classes((IsTokenAuthenticatedOrClientApp, ))
+@decorators.permission_classes((IsTokenAuthenticatedOrNotSwagger, ))
 def start_analyze_animals(request, format=None):
     """
     Starts a job to produce counts for animals in a given area.
@@ -614,7 +614,7 @@ def start_analyze_animals(request, format=None):
 
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
-@decorators.permission_classes((IsTokenAuthenticatedOrClientApp, ))
+@decorators.permission_classes((IsTokenAuthenticatedOrNotSwagger, ))
 def start_analyze_pointsource(request, format=None):
     """
     Starts a job to analyze the discharge monitoring report annual
@@ -703,7 +703,7 @@ def start_analyze_pointsource(request, format=None):
 
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
-@decorators.permission_classes((IsTokenAuthenticatedOrClientApp, ))
+@decorators.permission_classes((IsTokenAuthenticatedOrNotSwagger, ))
 def start_analyze_catchment_water_quality(request, format=None):
     """
     Starts a job to calculate the calibrated GWLF-E (MapShed) model
@@ -821,7 +821,7 @@ def start_analyze_catchment_water_quality(request, format=None):
 
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
-@decorators.permission_classes((IsTokenAuthenticatedOrClientApp, ))
+@decorators.permission_classes((IsTokenAuthenticatedOrNotSwagger, ))
 def start_analyze_climate(request, format=None):
     """
     Start a job to calculate the monthly climate (precipitation

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -27,7 +27,7 @@ from django.core.servers.basehttp import FileWrapper
 
 from apps.core.models import Job
 from apps.core.tasks import save_job_error, save_job_result
-from apps.core.permissions import IsTokenAuthenticatedOrClientApp
+from apps.core.permissions import IsTokenAuthenticatedOrNotSwagger
 from apps.modeling import tasks, geoprocessing
 from apps.modeling.mapshed.tasks import (geoprocessing_chains,
                                          combine,
@@ -487,7 +487,7 @@ def drb_point_sources(request):
 @decorators.api_view(['GET'])
 @decorators.authentication_classes((TokenAuthentication,
                                     SessionAuthentication, ))
-@decorators.permission_classes((IsTokenAuthenticatedOrClientApp, ))
+@decorators.permission_classes((IsTokenAuthenticatedOrNotSwagger, ))
 def get_job(request, job_uuid, format=None):
     """
     Get a job's status. If it's complete, get its result.


### PR DESCRIPTION
## Overview

* Remove REMOTE_ADDR check to determine if a request is from our own client
  app...none will ever be on the allowed_host lists unless you're running
  everything on localhost

* Only check if a user is token authenticated if the request comes from the
  swagger docs. This allows us to fix the above problem with a minimal diff, and
  still see that the token auth works

Connects #2248 

## Testing Instructions

 * Pull branch
*  Confirm you can send requests without a token
* Confirm tokens are required when sending a request via swagger