### PR TITLE
Specify Java major version and flavor

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -33,6 +33,8 @@ nodejs_npm_version: 2.1.17
 apache_version: "2.4.7-*"
 
 java_version: "7u151-*"
+java_major_version: "7"
+java_flavor: "openjdk"
 
 graphite_carbon_version: "0.9.13-pre1"
 graphite_whisper_version: "0.9.13-pre1"


### PR DESCRIPTION
## Overview

Provisioning the services VM was failing because the default `java_major_version` set by the `azavea.java` role is 8 and we specify a `java_version` from the 7 series.

While making this change we also specify an explicit `java_flavor` to avoid relying on the shared role default value.

Connects #2279

## Testing Instructions

 * Destroy any existing `services` VM and `vagrant up services`.
