### PR TITLE
Upgrade RWD to 1.2.2

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -2,7 +2,7 @@
 rwd_data_path: "/opt/rwd-data"
 rwd_host: "localhost"
 rwd_port: 5000
-rwd_docker_image: "quay.io/wikiwatershed/rwd:1.2.1"
+rwd_docker_image: "quay.io/wikiwatershed/rwd:1.2.2"
 
 app_config:
     RWD_HOST: "{{ rwd_host }}"


### PR DESCRIPTION
## Overview

This PR upgrades MMW's version of RWD to 1.2.2, which includes rounding the response watershed coordinates to 5 decimal places to reduce the payload size.

1.2.2 also solidifies an option to retrieve the unsimplified shape back from RWD by passing `?simplify=0` -- it was already available as an option, but it's now documented there. In practice this shouldn't affect DRB shapes but will show up in NHD shapes, depending on their size.

Connects https://github.com/WikiWatershed/rapid-watershed-delineation/issues/73

## Testing Instructions
- get this branch, reprovision the worker vm, then try out running RWD for DRB & NHD
- verify that the completed jobs include feature collections with coordinates rounded to 5 decimal places
- try posting to the endpoint using the instructions here https://github.com/WikiWatershed/rapid-watershed-delineation#linux--docker-for-mac-on-macos and verify that you can use the `?simplify=0` option
