### PR TITLE
Upgrade Celery

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.celery/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-celery_version: 3.1.18
+celery_version: 4.1.0
 djcelery_version: 3.1.16

--- a/deployment/ansible/roles/model-my-watershed.celery/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 celery_version: 4.1.0
-djcelery_version: 3.1.16

--- a/deployment/ansible/roles/model-my-watershed.celery/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery/tasks/main.yml
@@ -3,4 +3,3 @@
   pip: name="{{ item.name }}" version={{ item.version }} state=present
   with_items:
     - { name: "celery[redis]", version: "{{ celery_version }}" }
-    - { name: "django-celery", version: "{{ djcelery_version }}" }

--- a/scripts/debugcelery.sh
+++ b/scripts/debugcelery.sh
@@ -6,6 +6,6 @@ set -e
 
 STOP_SERVICE="(sudo service celeryd stop || /bin/true)"
 CHANGE_DIR="cd /opt/app/"
-RUN_CELERY="envdir /etc/mmw.d/env celery -A 'mmw.celery:app' worker --autoreload -l debug -n debug@%n"
+RUN_CELERY="envdir /etc/mmw.d/env celery -A 'mmw.celery:app' worker -l debug -n debug@%n"
 
 vagrant ssh worker -c "$STOP_SERVICE && $CHANGE_DIR && $RUN_CELERY"

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -934,7 +934,6 @@ def start_analyze_climate(request, format=None):
 
     return start_celery_job([
         group(geotasks),
-        tasks.combine_climate.s(),
         tasks.collect_climate.s(),
     ], area_of_interest, user, link_error=False)
 

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -19,7 +19,7 @@ from django.core.cache import cache
 from django.conf import settings
 
 
-@shared_task(bind=True, default_retry_delay=1, max_retries=42)
+@shared_task(bind=True, default_retry_delay=1, max_retries=6)
 def run(self, opname, input_data, wkaoi=None, cache_key=''):
     """
     Run a geoprocessing operation.

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -77,7 +77,7 @@ def run(self, opname, input_data, wkaoi=None, cache_key=''):
         raise r
     except Exception as x:
         return {
-            'error': x.message
+            'error': str(x)
         }
 
 

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -75,6 +75,10 @@ def run(self, opname, input_data, wkaoi=None, cache_key=''):
         return result
     except Retry as r:
         raise r
+    except ConnectionError:
+        return {
+            'error': 'Could not reach the geoprocessing service'
+        }
     except Exception as x:
         return {
             'error': str(x)

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -45,7 +45,9 @@ NO_LAND_COVER = 'NO_LAND_COVER'
 
 
 @shared_task
-def collect_data(geop_result, geojson):
+def collect_data(geop_results, geojson):
+    geop_result = {k: v for r in geop_results for k, v in r.items()}
+
     geom = GEOSGeometry(geojson, srid=4326)
     area = geom.transform(5070, clone=True).area  # Square Meters
 
@@ -489,19 +491,6 @@ def geoprocessing_chains(aoi, wkaoi, errback):
         callback.s().set(link_error=errback)
         for (opname, callback, data) in task_defs
     ]
-
-
-@shared_task
-def combine(geop_results):
-    """
-    Flattens the incoming results dictionaries into one
-    which has all the keys of the components.
-
-    This could be a part of collect_data, but we need
-    a buffer in a chord as a workaround to
-    https://github.com/celery/celery/issues/3191
-    """
-    return {k: v for r in geop_results for k, v in r.items()}
 
 
 def get_lu_index(nlcd):

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -202,7 +202,7 @@ class TaskRunnerTestCase(TestCase):
                                       status='started')
         self.job.save()
 
-    @override_settings(CELERY_ALWAYS_EAGER=True)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     def test_tr55_job_runs_in_chain(self):
         # For the purposes of this test, there are no modifications
         self.model_input['modification_pieces'] = []
@@ -228,7 +228,7 @@ class TaskRunnerTestCase(TestCase):
                          'complete',
                          'Job found but incomplete.')
 
-    @override_settings(CELERY_ALWAYS_EAGER=True)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     def test_tr55_job_error_in_chain(self):
         model_input = {
             'inputs': [],
@@ -401,7 +401,7 @@ class TaskRunnerTestCase(TestCase):
                             else False for t in needed_tasks]),
                         'missing necessary job in chain')
 
-    @override_settings(CELERY_ALWAYS_EAGER=True)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     def test_tr55_chain_generates_modification_censuses_if_they_are_old(self):
         """If they modification censuses exist in the model input, but the
         hash stored with the censuses does not match the hash passed in
@@ -455,7 +455,7 @@ class TaskRunnerTestCase(TestCase):
                             else False for t in needed_tasks]),
                         'missing necessary job in chain')
 
-    @override_settings(CELERY_ALWAYS_EAGER=True)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     def test_tr55_chain_generates_both_censuses_if_they_are_missing(self):
         """If neither the AoI censuses or the modification censuses exist,
         they are both generated.

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -234,7 +234,7 @@ def _initiate_mapshed_job_chain(mapshed_input, job_id):
         collect_data.s(area_of_interest).set(link_error=errback) |
         save_job_result.s(job_id, mapshed_input))
 
-    return chain(job_chain).apply_async(link_error=errback)
+    return chain(job_chain).apply_async()
 
 
 @decorators.api_view(['POST'])

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -31,7 +31,6 @@ from apps.core.permissions import IsTokenAuthenticatedOrNotSwagger
 from apps.core.decorators import log_request
 from apps.modeling import tasks, geoprocessing
 from apps.modeling.mapshed.tasks import (geoprocessing_chains,
-                                         combine,
                                          collect_data,
                                          )
 from apps.modeling.models import Project, Scenario
@@ -230,7 +229,6 @@ def _initiate_mapshed_job_chain(mapshed_input, job_id):
 
     job_chain = (
         group(geoprocessing_chains(area_of_interest, wkaoi, errback)) |
-        combine.s() |
         collect_data.s(area_of_interest).set(link_error=errback) |
         save_job_result.s(job_id, mapshed_input))
 

--- a/src/mmw/mmw/celery.py
+++ b/src/mmw/mmw/celery.py
@@ -2,85 +2,11 @@ from __future__ import absolute_import
 
 import os
 import rollbar
-import logging
 
 from celery import Celery
-from celery._state import connect_on_app_finalize
 from celery.signals import task_failure
 
 from django.conf import settings
-
-
-@connect_on_app_finalize
-def add_unlock_chord_task_shim(app):
-    """
-    Override native unlock_chord to support configurable max_retries.
-    Original code taken from https://goo.gl/3mX0ie
-
-    This task is used by result backends without native chord support.
-    It joins chords by creating a task chain polling the header for completion.
-    """
-    from celery.canvas import maybe_signature
-    from celery.exceptions import ChordError
-    from celery.result import allow_join_result, result_from_tuple
-
-    logger = logging.getLogger(__name__)
-
-    MAX_RETRIES = settings.CELERY_CHORD_UNLOCK_MAX_RETRIES
-
-    @app.task(name='celery.chord_unlock', shared=False, default_retry_delay=1,
-              ignore_result=True, lazy=False, bind=True,
-              max_retries=MAX_RETRIES)
-    def unlock_chord(self, group_id, callback, interval=None,
-                     max_retries=MAX_RETRIES, result=None,
-                     Result=app.AsyncResult, GroupResult=app.GroupResult,
-                     result_from_tuple=result_from_tuple, **kwargs):
-        if interval is None:
-            interval = self.default_retry_delay
-
-        # check if the task group is ready, and if so apply the callback.
-        callback = maybe_signature(callback, app)
-        deps = GroupResult(
-            group_id,
-            [result_from_tuple(r, app=app) for r in result],
-            app=app,
-        )
-        j = deps.join_native if deps.supports_native_join else deps.join
-
-        try:
-            ready = deps.ready()
-        except Exception as exc:
-            raise self.retry(
-                exc=exc, countdown=interval, max_retries=max_retries)
-        else:
-            if not ready:
-                raise self.retry(countdown=interval, max_retries=max_retries)
-
-        callback = maybe_signature(callback, app=app)
-        try:
-            with allow_join_result():
-                ret = j(timeout=3.0, propagate=True)
-        except Exception as exc:
-            try:
-                culprit = next(deps._failed_join_report())
-                reason = 'Dependency {0.id} raised {1!r}'.format(
-                    culprit, exc,
-                )
-            except StopIteration:
-                reason = repr(exc)
-            logger.error('Chord %r raised: %r', group_id, exc, exc_info=1)
-            app.backend.chord_error_from_stack(callback,
-                                               ChordError(reason))
-        else:
-            try:
-                callback.delay(ret)
-            except Exception as exc:
-                logger.error('Chord %r raised: %r', group_id, exc, exc_info=1)
-                app.backend.chord_error_from_stack(
-                    callback,
-                    exc=ChordError('Callback error: {0!r}'.format(exc)),
-                )
-    return unlock_chord
 
 
 # set the default Django settings module for the 'celery' program.
@@ -91,8 +17,8 @@ app = Celery('mmw')
 
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-app.config_from_object('django.conf:settings')
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()
 
 rollbar_settings = getattr(settings, 'ROLLBAR', {})
 if rollbar_settings:

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -115,22 +115,21 @@ POSTGIS_VERSION = tuple(
 
 
 # CELERY CONFIGURATION
-BROKER_URL = 'redis://{0}:{1}/2'.format(
+CELERY_BROKER_URL = 'redis://{0}:{1}/2'.format(
     environ.get('MMW_CACHE_HOST', 'localhost'),
     environ.get('MMW_CACHE_PORT', 6379))
 
-CELERY_IMPORTS = ('celery.task.http',
-                  # Submodule task is not always autodiscovered
-                  'apps.modeling.mapshed.tasks',
-                  )
+CELERY_IMPORTS = (
+    # Submodule task is not always autodiscovered
+    'apps.modeling.mapshed.tasks',
+)
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
-CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
+CELERY_RESULT_BACKEND = 'django-cache'
 STATSD_CELERY_SIGNALS = True
 CELERY_CREATE_MISSING_QUEUES = True
 CELERY_CHORD_PROPAGATES = True
-CELERY_CHORD_UNLOCK_MAX_RETRIES = 60
 CELERY_DEFAULT_QUEUE = STACK_COLOR
 CELERY_DEFAULT_ROUTING_KEY = "task.%s" % STACK_COLOR
 # END CELERY CONFIGURATION
@@ -294,6 +293,7 @@ THIRD_PARTY_APPS = (
     'rest_framework_swagger',
     'rest_framework.authtoken',
     'registration',
+    'django_celery_results',
 )
 
 # THIRD-PARTY CONFIGURATION

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -18,3 +18,4 @@ rollbar==0.13.8
 retry==0.9.1
 python-dateutil==2.6.0
 suds==0.4
+django_celery_results==1.0.1


### PR DESCRIPTION
## Overview

Upgrades Celery to the latest 4.1.0, which should keep us current and supported, as well as fix a number of issues. For an overview of various hacks done, read the "Implementation Details and Gotchas" section of this blog post: https://www.azavea.com/blog/2016/10/20/how-to-build-asynchronous-workflows-geospatial-application/

Also removes the now defunct [djcelery](https://github.com/celery/django-celery) for the new [django_celery_results](https://github.com/celery/django-celery-results). We _could_ use a straight up Redis URL for the `CELERY_RESULT_BACKEND` field and get rid of `django_celery_results` completely, but I kept it around to better mimic the current manner of doing things.

Much thanks to @kellyi who did most of the groundwork for this in #2267.

Connects #2249 

### Demo

This is MapShed running on this branch with upgraded Celery:

![2017-09-22 18 52 48](https://user-images.githubusercontent.com/1430060/30767094-e314f0f8-9fc7-11e7-8f07-96a6edfed548.gif)

### Notes

I've tested all our current tasks that deal with Celery, and have found them all to work flawlessly. However, because of our past struggles with Celery, I am cautiously optimistic about this upgrade.

## Testing Instructions

 * Check out this branch, and reprovision / destroy and recreate `app` and `worker`:

       vagrant reload app worker --provision

    or

       vagrant destroy app worker && vagrant up app worker
 * Go to [:8000/](http://localhost:8000/) and draw a shape. Make sure it analyzes correctly.
 * Make a TR-55 model. Make sure that runs correctly.
 * Make a MapShed model. Make sure that runs correctly.
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and draw a shape. Make sure it analyzes correctly.
 * Try anything else you can think of.