### PR TITLE
Use Hydroshare Production URL

### DIFF
--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -14,7 +14,7 @@ from apps.bigcz.utils import RequestTimedOutError
 
 
 CATALOG_NAME = 'hydroshare'
-CATALOG_URL = 'https://playground.hydroshare.org/hsapi/resource/'
+CATALOG_URL = 'https://www.hydroshare.org/hsapi/resource/'
 
 
 def parse_date(value):


### PR DESCRIPTION
## Overview

We switched to using a beta / playground URL in #2145. The production URL is no longer broken, so we switch back to using it instead of the playground URL.

Connects #2149 

### Demo

![image](https://user-images.githubusercontent.com/1430060/30831860-122f44be-a217-11e7-9c49-3515923e8d46.png)

## Testing Instructions

 * Check out this branch, and go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Select / draw a shape, then go to the search view
 * Search for any term, such as "water", and go to the Hydroshare tab
 * Ensure you see real values, and there are no errors in the console
 * Ensure that the `search` endpoint response contains the Production URL as the `api_url`