### PR TITLE
Geoprocessing API: Enable & document `"simplify": false` value for RWD

### DIFF
--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -57,11 +57,17 @@ def start_rwd(request, format=None):
 
     `snappingOn` (`boolean`): Snap to the nearest stream? Default is false
 
+    `simplify` (`number`): Simplify tolerance for delineated watershed shape in
+                response. Use `0` to receive an unsimplified shape. When this
+                parameter is not supplied, `simplify` defaults to `0.0001` for
+                "drb" and is a function of the shape's area for "nhd".
+
     **Example**
 
         {
-            "location": [39.97185812402583,-75.16742706298828],
+            "location": [39.67185812402583,-75.76742706298828],
             "snappingOn": true,
+            "simplify": 0,
             "dataSource":"nhd"
         }
 
@@ -86,12 +92,12 @@ def start_rwd(request, format=None):
                             "coordinates": [
                                 [
                                     [
-                                        -75.24776006176894,
-                                        39.98166667527191
+                                        -75.24776,
+                                        39.98166
                                     ],
                                     [
-                                        -75.24711191361516,
-                                        39.98166667527191
+                                        -75.24711,
+                                        39.98166
                                     ]
                                 ], ...
                             ]
@@ -119,8 +125,8 @@ def start_rwd(request, format=None):
                         "geometry": {
                             "type": "Point",
                             "coordinates": [
-                                -75.24938043215342,
-                                39.97875000854888
+                                -75.24938,
+                                39.97875
                             ]
                         },
                         "type": "Feature",
@@ -165,12 +171,13 @@ def start_rwd(request, format=None):
     location = request.data['location']
     data_source = request.data.get('dataSource', 'drb')
     snapping = request.data.get('snappingOn', False)
+    simplify = request.data.get('simplify', False)
 
     job = Job.objects.create(created_at=created, result='', error='',
                              traceback='', user=user, status='started')
 
-    task_list = _initiate_rwd_job_chain(location, snapping, data_source,
-                                        job.id)
+    task_list = _initiate_rwd_job_chain(location, snapping, simplify,
+                                        data_source, job.id)
 
     job.uuid = task_list.id
     job.save()
@@ -939,12 +946,12 @@ def start_analyze_climate(request, format=None):
     ], area_of_interest, user)
 
 
-def _initiate_rwd_job_chain(location, snapping, data_source,
+def _initiate_rwd_job_chain(location, snapping, simplify, data_source,
                             job_id, testing=False):
     errback = save_job_error.s(job_id)
 
-    return chain(tasks.start_rwd_job.s(location, snapping, data_source),
-                 save_job_result.s(job_id, location)) \
+    return chain(tasks.start_rwd_job.s(location, snapping, simplify,
+                 data_source), save_job_result.s(job_id, location)) \
         .apply_async(link_error=errback)
 
 


### PR DESCRIPTION
## Overview

This PR enables and documents passing a `"simplify": false` parameter to RWD via the geoprocessing API. 

Connects #2241 

### Demo

<img width="732" alt="screen shot 2017-09-25 at 6 14 11 pm" src="https://user-images.githubusercontent.com/4165523/30833523-6095930a-a21d-11e7-8701-8cbbc89ae24a.png">

### Notes

The example point in the Swagger docs currently returns a really large watershed from the nhd endpoint. While I think that's desirable behavior, the JSON response seems to be so large that it causes the Swagger UI to drag to a halt. It doesn't do the same when I post to :5000/rwd-nhd directly.

Wonder if we should consider changing the demo point?

## Testing Instructions
- get this branch, then set up RWD
- visit `/api/docs` and verify that RWD works with and without the new `simplify` parameter and that `simplify` works as described in the docs.
