### PR TITLE
Adjust user dropdown zindex

### DIFF
--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -53,6 +53,7 @@ header {
         .dropdown-menu {
           left: auto;
           right: 0px;
+          z-index: 1010;
           a {
             color: $ui-secondary;
 


### PR DESCRIPTION
## Overview

This PR adjusts the z-index for the user dropdown menu to set it higher than MapShed's conservation practice button: the button is 1002, so we set the dropdown to 1010.

Connects #2268 

### Demo

![screen shot 2017-09-26 at 12 54 54 pm](https://user-images.githubusercontent.com/4165523/30873096-1d641636-a2ba-11e7-9330-426c6267f5e0.png)

### Notes

While working on this I encountered #2294, #2296, and #2298. I started down the path of working on #2298 but I *think* all of these issues may have a similar cause and probably merit tackling together. It might be something related to the new JSON format.

## Testing Instructions
- get this branch, `bundle`, then run a mapshed job when not logged in
- when the job returns, click "Add changed to this area" to reveal the "Conservation Practice" button
- sign in to the app
- toggle the user menu in the top left open and verify that the menu now sits above the "Conservation Practice" button