### PR TITLE
Show compare pagination buttons only if > 5 scenarios

### DIFF
--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -7,7 +7,7 @@ var _ = require('lodash'),
 
 var CHART = 'chart',
     TABLE = 'table',
-    MIN_VISIBLE_SCENARIOS = 3,
+    MIN_VISIBLE_SCENARIOS = 5,
     CHART_AXIS_WIDTH = 82,
     COMPARE_COLUMN_WIDTH = 134;
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -66,16 +66,21 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
             prevButton = this.ui.prevButton,
             nextButton = this.ui.nextButton;
 
-        if (i < 1) {
-            prevButton.removeClass('active');
+        if (total <= minScenarios) {
+            prevButton.hide();
+            nextButton.hide();
         } else {
-            prevButton.addClass('active');
-        }
+            if (i < 1) {
+                prevButton.removeClass('active');
+            } else {
+                prevButton.addClass('active');
+            }
 
-        if (i + minScenarios >= total) {
-            nextButton.removeClass('active');
-        } else {
-            nextButton.addClass('active');
+            if (i + minScenarios >= total) {
+                nextButton.removeClass('active');
+            } else {
+                nextButton.addClass('active');
+            }
         }
     },
 


### PR DESCRIPTION
## Overview

This PR updates the compare view to show the pagination buttons only if there are more than the minimum number of scenarios -- a value which is currently set to 3.

(And was adjusted to 5 for this PR!)

Connects #2242 

### Demo

![screen shot 2017-09-26 at 2 28 00 pm](https://user-images.githubusercontent.com/4165523/30877225-12ad93fe-a2c7-11e7-924f-f6fb58ae2a76.png)

->

![screen shot 2017-09-26 at 2 28 13 pm](https://user-images.githubusercontent.com/4165523/30877232-169fe0b6-a2c7-11e7-97ab-f914a5b17c9f.png)

## Testing Instructions
- get this branch, bundle, then create a TR-55 project
- create one new scenario, then launch compare view and verify that you don't see the pagination buttons
- create another new scenario, then launch compare view and verify that you do see the pagination buttons and that they work as before
- delete one scenario, launch compare again, and verify that you don't see the pagination buttons
