### PR TITLE
Fix gis_data serialization

### DIFF
--- a/src/mmw/apps/modeling/migrations/0023_fix_gis_data_serialization.py
+++ b/src/mmw/apps/modeling/migrations/0023_fix_gis_data_serialization.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import ast
+import json
+
+from django.db import migrations
+
+
+def fix_gis_data_serialization(apps, schema_editor):
+    Project = apps.get_model('modeling', 'Project')
+    for project in Project.objects.filter(gis_data__startswith='{u'):
+        project.gis_data = json.dumps(ast.literal_eval(project.gis_data))
+        project.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0022_project_wkaoi'),
+    ]
+
+    operations = [
+         migrations.RunPython(fix_gis_data_serialization,
+                              migrations.RunPython.noop)
+    ]

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -40,7 +40,7 @@ class ProjectSerializer(gis_serializers.GeoModelSerializer):
         geo_field = 'area_of_interest'
 
     user = UserSerializer(default=serializers.CurrentUserDefault())
-    gis_data = JsonField()
+    gis_data = JsonField(required=False, allow_null=True)
     scenarios = ScenarioSerializer(many=True, read_only=True)
 
 
@@ -61,3 +61,4 @@ class ProjectUpdateSerializer(gis_serializers.GeoModelSerializer):
 
     user = UserSerializer(default=serializers.CurrentUserDefault(),
                           read_only=True)
+    gis_data = JsonField(required=False, allow_null=True)


### PR DESCRIPTION
## Overview

We recently changed the `ProjectSerializer` to use a `JsonField` serializer for the `gis_data` field to reflect that fact that this data is now returned from the geoprocessing service as an actual JSON object rather than a string containing JSON data. Because this field serializer change was not also made to the `ProjectUpdateSerializer` we ended up saving the string representation of a Python dict into the database rather than a JSON string. This caused the model to crash when attempting to load a previously saved project.

Adding a plain `JsonField()` to the `ProjectUpdateSerializer` caused test failures that were resolved by adding attributes signifying that it is a nullable field, which matches the underlying model. I changed both usages of `JsonField` for consistency.

Connects #2296 
Connects #2294

### Notes

I tried to make `ProjectUpdateSerializer` inherit from `ProjectSerializer` but it caused problems with scenario serialization.

## Testing Instructions

 * Before checking out this branch, run a MapShed model on a drawn AOI.
 * Verify that the GMS file fails to download.
 * Refresh the project and verify that it does not load correctly.  
 * Remember the project ID.
 * Check out the branch and run migrations.
 * Reload the previously created project and verify that it loads correctly.
 * Verify that the GMS file download works correctly.
 * Run a new MapShed model, refresh the project, and verify that it also loads correctly and the GMS file download works.
