### PR TITLE
Fix Map Interaction

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -507,7 +507,10 @@ var DrawToolBaseView = Marionette.ItemView.extend({
 
     initialize: function(options) {
         this.resetDrawingState = options.resetDrawingState;
-        var self = this;
+        this.onMapZoom = _.bind(this.onMapZoom, this);
+
+        var self = this,
+            map = App.getLeafletMap();
 
         $(document).on('mouseup', function(e) {
             var isTargetOutside = $(e.target).parents('.dropdown-menu').length === 0;
@@ -516,7 +519,7 @@ var DrawToolBaseView = Marionette.ItemView.extend({
             }
         });
 
-        this.listenTo(App.getLeafletMap(), 'zoomend', _.bind(this.onMapZoom, this));
+        map.on('zoomend', this.onMapZoom);
     },
 
     templateHelpers: function() {
@@ -574,6 +577,12 @@ var DrawToolBaseView = Marionette.ItemView.extend({
             placement: 'top',
             trigger: 'focus'
         });
+    },
+
+    onDestroy: function() {
+        var map = App.getLeafletMap();
+
+        map.off('zoomend', this.onMapZoom);
     }
 });
 


### PR DESCRIPTION
## Overview

Apparently by using listenTo on non-Backbone events caused all pre-existing listeners on that event to be removed or corrupted. By using the common "on" pattern we achieve the same behavior while maintaining map interaction.

Connects #2303 

### Demo

![2017-09-28 16 58 51](https://user-images.githubusercontent.com/1430060/30990325-cb7166f6-a46e-11e7-9bd3-c94beaea53d8.gif)

### Notes

I'm not quite sure _why_ this is working. There seem to [be other](https://github.com/WikiWatershed/model-my-watershed/blob/6476f2338921b53217c75f21ddc2d590850c2018/src/mmw/js/src/core/views.js#L399) [use cases](https://github.com/WikiWatershed/model-my-watershed/blob/6476f2338921b53217c75f21ddc2d590850c2018/src/mmw/js/src/core/views.js#L423)  where this works. But since we remove the listeners when the views are destroyed, we effectively achieve the same functionality.

## Testing Instructions

 * Check out this branch and `bundle`
 * Select an area to analyze
 * Ensure you can move and zoom the map in draw/, analyze/, and project/ stages