### PR TITLE
BiG-CZ Style Filters Panel

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -65,16 +65,16 @@ def recursive_asdict(d):
     return out
 
 
-def filter_networkIDs(services, gridded=False):
+def filter_networkIDs(services, exclude_gridded=False):
     """
     Transforms list of services to list of ServiceIDs, with respect to
     given options.
 
-    If gridded=False, then GRIDDED services will not be included.
+    If exclude_gridded=True, then GRIDDED services will not be included.
 
     If no filters apply, we return an empty list to disable filtering.
     """
-    if not gridded:
+    if exclude_gridded:
         return [str(s['ServiceID']) for s in services
                 if s['NetworkName'] not in GRIDDED]
 
@@ -261,7 +261,7 @@ def search(**kwargs):
     bbox = kwargs.get('bbox')
     to_date = kwargs.get('to_date')
     from_date = kwargs.get('from_date')
-    gridded = 'gridded' in kwargs.get('options')
+    exclude_gridded = 'exclude_gridded' in kwargs.get('options')
 
     if not bbox:
         raise ValidationError({
@@ -270,7 +270,7 @@ def search(**kwargs):
     world = BBox(-180, -90, 180, 90)
 
     services = get_services_in_box(world)
-    networkIDs = filter_networkIDs(services, gridded)
+    networkIDs = filter_networkIDs(services, exclude_gridded)
     series = get_series_catalog_in_box(bbox, from_date, to_date, networkIDs)
     series = group_series_by_location(series)
     results = sorted(parse_records(series, services),

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -55,9 +55,10 @@ var SearchOption = FilterModel.extend({
 
 var GriddedServicesFilter = SearchOption.extend({
     defaults: _.defaults({
-        id: 'gridded',
+        id: 'exclude_gridded',
         type: 'checkbox',
-        label: 'Gridded Services',
+        label: 'Exclude Gridded Services',
+        active: true,
     }, SearchOption.prototype.defaults)
 });
 

--- a/src/mmw/js/src/data_catalog/templates/checkboxFilter.html
+++ b/src/mmw/js/src/data_catalog/templates/checkboxFilter.html
@@ -1,11 +1,11 @@
 <div class="checkbox data-catalog-filter-checkbox">
-    <h5>{{ label }}</h5>
      <label>
          <input type="checkbox"
                 name={{id}}
                 id={{id}}
                 {{ "checked" if active }}
          >
-         Active
+         <div class="checkbox--styled"></div>
+         Exclude gridded services
      </label>
  </div>

--- a/src/mmw/js/src/data_catalog/templates/checkboxFilter.html
+++ b/src/mmw/js/src/data_catalog/templates/checkboxFilter.html
@@ -6,6 +6,6 @@
                 {{ "checked" if active }}
          >
          <div class="checkbox--styled"></div>
-         Exclude gridded services
+         {{ label }}
      </label>
  </div>

--- a/src/mmw/js/src/data_catalog/templates/dateFilter.html
+++ b/src/mmw/js/src/data_catalog/templates/dateFilter.html
@@ -1,6 +1,5 @@
 <div class="data-catalog-search-dates">
-    <h5>Data collected between</h5>
-    <label for="from-date">From Date</label>
+    <label for="from-date">From date</label>
     <div class="data-catalog-clearable-input">
         <input
             id="from-date"
@@ -13,7 +12,7 @@
         </a>
         {% endif %}
     </div>
-    <label for="to-date">To Date</label>
+    <label for="to-date">To date</label>
     <div class="data-catalog-clearable-input">
         <input
             id="to-date"

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -596,7 +596,7 @@ var CheckboxFilterView = FilterBaseView.extend({
     },
 
     modelEvents: {
-        'change:active': 'render'
+        'change': 'render'
     },
 
     toggleState: function() {

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -200,6 +200,8 @@ var FormView = Marionette.ItemView.extend({
                 this.showFilterSidebar();
             }
 
+            this.render();
+
         }, this);
 
         // Update the filter sidebar when there's a new active catalog

--- a/src/mmw/sass/components/_buttons.scss
+++ b/src/mmw/sass/components/_buttons.scss
@@ -76,12 +76,12 @@
   position: relative;
   display: inline-block;
   background-color: $brand-primary !important;
-  border: darken($brand-primary, 5%);
+  border-color: darken($brand-primary, 5%);
 
   &:hover, &:focus {
     color: $paper!important;
     background-color: darken($brand-primary, 5%);
-    border: darken($brand-primary, 10%);
+    border-color: darken($brand-primary, 10%);
   }
 }
 

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -120,7 +120,7 @@
         .filter-sidebar-toggle {
           position: absolute;
           right: 1.5rem;
-          top: -36px;
+          top: -42px;
         }
     }
 
@@ -222,7 +222,7 @@
     .resource {
         .resource-title {
             font-size: $font-size-h4;
-            font-weight: 600;
+            font-weight: 800;
             margin-bottom: 4px;
         }
 
@@ -249,7 +249,7 @@
 
 .data-catalog-filter-window {
     padding: 1rem;
-    padding-top: 2rem;
+    padding-top: 1.4rem;
     left: $sidebar-width;
     width: $secondary-sidebar-width;
     transition: all 200ms;
@@ -264,6 +264,7 @@
 .data-catalog-filter-window > .data-catalog-filters-header {
     display: flex;
     flex-direction: row;
+    padding-bottom: 6px;
     > .filter-title {
         line-height: $height-md;
     }
@@ -271,13 +272,20 @@
         margin-left: auto;
         font-weight: 600;
         color: $brand-primary;
+        padding: 0;
+        font-size: 13px;
+        position: relative;
+        top: 0px;
     }
 }
 
 .data-catalog-filter-window > .data-catalog-filter-group {
-    h5 {
-        text-transform: uppercase;
-        font-weight: 800;
+    & > h5,
+    & > label {
+        font-weight: 700;
+        margin-top: 4px;
+        font-size: 12px;
+        color: #4d6d82;
     }
 }
 
@@ -285,6 +293,37 @@
     input[type=checkbox] {
       position: relative;
       margin-right: 5px;
+      display: none;
+      &:checked + .checkbox--styled {
+        background-color: $brand-primary;
+        border-color: $brand-primary;
+        text-align: center;
+        &:after {
+            content: "\f00c";
+            font-family: FontAwesome;
+            color: #fff;
+            position: absolute;
+            top: 1px;
+            left: 2px;
+        }
+      }
+    }
+
+    .checkbox--styled {
+        display: inline-block;
+        width: 18px;
+        height: 18px;
+        border: 0;
+        border-radius: 2px;
+        position: relative;
+        margin-right: 3px;
+        top: 3px;
+        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+        background-color: #fff;
+    }
+
+    input, .checkbox--styled {
+        border: 1px solid #ccc;
     }
 
     label {
@@ -293,11 +332,10 @@
 }
 
 .data-catalog-filter-group .data-catalog-search-dates {
-    padding: 12px 10px;
-    margin: 0 -10px 10px;
+    padding: 0 10px;
+    margin: 0 -10px 0;
 
     label {
-        text-transform: uppercase;
         display: block;
         font-size: $font-size-h5;
     }
@@ -311,7 +349,6 @@
     }
     .data-catalog-date-input {
         height: 38px;
-        border: none;
         border-radius: 0;
         display: inline;
         margin-bottom: 12px;
@@ -355,4 +392,18 @@
     th {
         padding-right: 20px;
     }
+}
+
+.data-catalog-search-dates label {
+    font-weight: 600;
+    color: #555;
+    font-size: 13px;
+    margin: 10px 0px 12px;
+}
+
+.data-catalog-filter-group .data-catalog-filter-checkbox label {
+    font-size: 13px;
+    font-weight: 600;
+    color: #555;
+    padding-left: 0;
 }

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -303,8 +303,9 @@
             font-family: FontAwesome;
             color: #fff;
             position: absolute;
-            top: 1px;
-            left: 2px;
+            left: 0;
+            right: 0;
+            line-height: 18px;
         }
       }
     }


### PR DESCRIPTION
## Overview

Style updates for the Filters panel. Also:

 * Updates gridded services filter to read "Exclude Gridded Services" and be enabled by default. This better matches the intuition of results reducing with each checked filter.
 * Update filter button to be more consistent when switching between no filters and active filters
 * Update filter button when switching between catalog tabs

Tagging @ajrobbins and @jfrankl for visual review.

Supersedes #2316

### Demo

![2017-10-02 12 51 27](https://user-images.githubusercontent.com/1430060/31089068-c3411666-a770-11e7-9da5-d32f92558e3b.gif)

## Testing Instructions

 * Check out this branch, run `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz). Pick a shape and search for something.
 * Go to the WDC tab. Ensure that "Filters" button changes to indicate that there is one active filter. 
 * Ensure the size of the button does not change between states of having and not having filters, only the colors.
 * Ensure that the "Exclude Gridded Services" filter is enabled by default for WDC
 * Ensure that unchecking it includes gridded services, and checking it excludes them (Gridded Services are the NLDAS_NOAH ones)
 * Ensure that resetting filters enables "Exclude Gridded Services" for WDC