### PR TITLE
Remove compare view download button

### DIFF
--- a/src/mmw/js/src/compare/templates/compareInputs.html
+++ b/src/mmw/js/src/compare/templates/compareInputs.html
@@ -3,8 +3,3 @@
     <button id="compare-input-button-chart" class="{{ 'active' if mode == 'chart' }}"><i class="fa fa-bar-chart"></i></button>
     <button id="compare-input-button-table" class="{{ 'active' if mode == 'table' }}"><i class="fa fa-table"></i></button>
 </div>
-<div class="compare-download compare-input">
-    <button>
-        <i class="fa fa-download"></i>
-    </button>
-</div>


### PR DESCRIPTION
## Overview

This PR removes the download button from the compare view in prep for the next release. Since we're going to be bringing it back in in #2313, I only deleted the element and didn't touch anything in the supporting view file.

Connects #2312 

### Demo

<img width="966" alt="screen shot 2017-10-02 at 4 02 24 pm" src="https://user-images.githubusercontent.com/4165523/31096859-5e5e124c-a78b-11e7-9466-ac721aea5c21.png">

## Testing Instructions
- get this branch, then `bundle`
- using Chrome, IE, FF, and Safari visit a project, open the compare view, then verify that the download button is no longer there but that the other toggle buttons are & still work.