### PR TITLE
Compare Chart Tooltip Fixes

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -353,6 +353,7 @@ var ChartRowView = Marionette.ItemView.extend({
             chartDiv = this.model.get('chartDiv'),
             chartEl = document.getElementById(chartDiv),
             name = this.model.get('name'),
+            chartName = name.replace(/\s/g, ''),
             label = this.model.get('unitLabel') +
                     ' (' + this.model.get('unit') + ')',
             colors = this.model.get('seriesColors'),
@@ -384,7 +385,7 @@ var ChartRowView = Marionette.ItemView.extend({
 
         $(chartEl.parentNode).css({ 'width': ((_.size(this.model.get('values')) * models.constants.COMPARE_COLUMN_WIDTH + models.constants.CHART_AXIS_WIDTH)  + 'px') });
         chart.renderCompareMultibarChart(
-            chartEl, name, label, colors, stacked, yMax, data,
+            chartEl, chartName, label, colors, stacked, yMax, data,
             models.constants.COMPARE_COLUMN_WIDTH, models.constants.CHART_AXIS_WIDTH, onRenderComplete);
     },
 });

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -422,6 +422,13 @@ var ChartView = Marionette.CollectionView.extend({
             'transform': 'translate(' + (-marginLeft) + 'px)',
         });
 
+        // Slide clipPath so tooltips don't show outside charts
+        // It doesn't matter too much what the y-translate is
+        // so long as its sufficiently large
+        this.$('defs > clipPath > rect').attr({
+            'transform': 'translate(' + (-marginLeft) + ', -30)',
+        });
+
         // Show charts from visibleScenarioIndex
         this.$('.nv-group > rect:nth-child(n + ' + (i+1) + ')').css({
             'opacity': '',

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -512,7 +512,7 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                         parentG.append("text")
                             .each(function() {
                                 d3.select(this).text(function() {
-                                    return parseFloat(bar.y).toFixed(2);
+                                    return parseFloat(bar.y).toFixed(3);
                                 });
 
                                 var width = this.getBBox().width;

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -383,6 +383,17 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
             .datum(data)
             .call(chart);
 
+        // The clipPath that nvd3 creates wraps the bars,
+        // not the bars+tooltip. Scale and move the clipPath
+        // so it doesn't cut the tooltip off
+        d3.select(svg)
+            .selectAll("defs")
+            .selectAll("clipPath")
+            .selectAll("rect")
+            .attr("height", "100%")
+            .attr("width", "100%")
+            .attr("transform", "translate(0, -30)");
+
         // filter definition for drop shadows
         var filter =
             d3.select(svg)

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -430,6 +430,12 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
                     parentG.attr("id", chartContainerId);
 
                     g.selectAll(".nv-bar").each(function(bar) {
+                        // If the value is zero, and the chart
+                        // is stacked, don't show any tooltip
+                        if (stacked && parseFloat(bar.y) === 0) {
+                            return;
+                        }
+
                         var b = d3.select(this);
                         var barWidth = b.attr("width");
                         var bgWidth = 40.0;


### PR DESCRIPTION
## The Case of the Double Bug 

It's been a long day solving this mystery. We needed to make sure the charts' `clipPath`s were encompassing the tooltips, but all the charts with spaces in their names had messed up `clipPaths` so the cutoff-tooltip bug only showed up on Evapotranspiration, etc. 

I've removed the spaces from the chart names, and adjusted the `clipPath` so...
- tooltips don't render outside the chart area when you have many scenarios and slide to the right
- tooltips don't get cutoff at the top on maxed out bars

I also added a guard to prevent rendering tooltips on stacked charts with a value of 0.

Connects #2278 

### Demo

Not cutoff and not floating on the left
![screen shot 2017-10-02 at 5 58 19 pm](https://user-images.githubusercontent.com/7633670/31101381-6878dde2-a79b-11e7-9495-34fb2bbd40a0.png)

Not showing for 0.0 valued bar
<img width="541" alt="screen shot 2017-10-02 at 3 58 32 pm" src="https://user-images.githubusercontent.com/7633670/31101380-68769ca8-a79b-11e7-96b8-43c276705195.png">

## Testing Instructions

 * Pull, `bundle`
 * Site-Storm model with scenarios that will let you test
      - the slide control (there should be no tooltips outside the chart area)
      - tooltips that go above the chart scale
      - 0 valued tooltips -- they should appear if the chart isn't stacked, and should _not_ appear if it is 
