### PR TITLE
Fix rename scenario for Internet Explorer

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -977,20 +977,20 @@ var ScenariosCollection = Backbone.Collection.extend({
     },
 
     /** Validate the new scenario name
-    @param model - the model your trying to rename
+    The value of *this* is the scenario model.
     @param newName the new name string
     @returns If valid, null
              If invalid, a string with the error
     **/
-    validateNewScenarioName: function(model, newName) {
+    validateNewScenarioName: function(newName) {
         var trimmedNewName = newName.trim();
 
         // Bail early if the name actually didn't change.
-        if (model.get('name') === trimmedNewName) {
+        if (this.get('name') === trimmedNewName) {
             return null;
         }
 
-        var match = this.find(function(model) {
+        var match = this.collection.find(function(model) {
             return model.get('name').toLowerCase() === trimmedNewName.toLowerCase();
         });
 

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -921,24 +921,25 @@ describe('Modeling', function() {
             describe('#validateNewScenarioName', function() {
                 it ('returns null if valid rename', function() {
                     var collection = getTestScenarioCollection(),
-                        validationMessage = collection.validateNewScenarioName(collection.at(1),
-                                                'My New Unique Scenario Name');
+                        boundFunc = _.bind(collection.validateNewScenarioName, collection.at(1)),
+                        validationMessage = boundFunc('My New Unique Scenario Name');
 
                     assert.equal(validationMessage, null);
                 });
 
                 it('ignores case when comparing the new name with existing names', function() {
                     var collection = getTestScenarioCollection(),
-                        validationMessage = collection.validateNewScenarioName(collection.at(1),
-                                                'cUrreNt condiTIONS');
+                        boundFunc = _.bind(collection.validateNewScenarioName, collection.at(1)),
+                        validationMessage = boundFunc('cUrreNt condiTIONS');
 
                     assert.notEqual(validationMessage, null);
                 });
 
                 it('will not show error when leaving name as is', function() {
                     var collection = getTestScenarioCollection(),
-                        validationMessage = collection.validateNewScenarioName(collection.at(1),
-                                                'New Scenario 1');
+                        boundFunc = _.bind(collection.validateNewScenarioName, collection.at(1)),
+                        validationMessage = boundFunc('New Scenario 1');
+
                     assert.equal(validationMessage, null);
                 });
             });

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -457,14 +457,13 @@ var ScenarioDropDownMenuOptionsView = Marionette.ItemView.extend({
     renameScenario: function() {
         var self = this,
             collection = self.model.collection,
-            validate = _.bind(collection.validateNewScenarioName, collection),
-            curriedValidationFunction = _.curry(validate)(this.model),
+            validate = _.bind(collection.validateNewScenarioName, self.model),
             rename = new modalViews.InputView({
                 model: new modalModels.InputModel({
                     initial: this.model.get('name'),
                     title: 'Rename Scenario',
                     fieldLabel: 'Scenario Name',
-                    validationFunction: curriedValidationFunction,
+                    validationFunction: validate,
                 })
         });
 


### PR DESCRIPTION
## Overview

Using _.curry appeared to call the validate function before it needed to
be called, which resulted in a JS error and prevented the modal from
being displayed. Keeping the correct scope for the validate function is
slightly reworked here so that _.curry does not need to be used, which
lets things work as expected in IE.

Connects to #2315

### Demo

![mmw2](https://user-images.githubusercontent.com/1042475/31138548-dbd8fd48-a83c-11e7-9db1-c1ace09038ac.gif)

## Testing Instructions

* Create a new project and add a scenario.
* Try to rename the scenario to a valid name. It should work.
* Try to rename the scenario to a name that already exists. It should show an error message.