### PR TITLE
Enable ITSI screenshots for compare view

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -155,6 +155,57 @@ function RestAPI() {
     };
 }
 
+function adjustCompareViewBeforeITSIScreenshot() {
+    toggleCompareViewForITSIScreenshot(true);
+}
+
+function adjustCompareViewAfterITSIScreenshot() {
+    toggleCompareViewForITSIScreenshot(false);
+}
+
+function toggleCompareViewForITSIScreenshot(adjustForScreenshot) {
+    var itsiCompareDialog = 'itsi-compare-dialog',
+        itsiCompareModal = 'itsi-compare-modal',
+        itsiCompareRow = 'itsi-compare-row',
+        compareDialog = '#compare-new-dialog',
+        compareModalContent = '.compare-modal-content',
+        compareCloseButton = '.compare-close',
+        compareChartButton = '#compare-input-button-chart',
+        compareTableButton = '#compare-input-button-table',
+        compareChartRow = '.compare-chart-row',
+        compareTableRow = '.compare-table-row',
+        compareScenariosRow = '.compare-scenarios',
+        compareMapsRow = '.compare-scenario-row-content';
+
+    if (adjustForScreenshot) {
+        $(compareDialog).addClass(itsiCompareDialog);
+        $(compareModalContent).addClass(itsiCompareModal);
+        $(compareCloseButton).hide();
+        $(compareChartButton).hide();
+        $(compareTableButton).hide();
+        $(compareScenariosRow).addClass(itsiCompareRow);
+        $(compareMapsRow).addClass(itsiCompareRow);
+        if ($(compareChartRow).length) {
+            $(compareChartRow).addClass(itsiCompareRow);
+        } else if ($(compareTableRow).length) {
+            $(compareTableRow).addClass(itsiCompareRow);
+        }
+    } else {
+        $(compareDialog).removeClass(itsiCompareDialog);
+        $(compareModalContent).removeClass(itsiCompareModal);
+        $(compareCloseButton).show();
+        $(compareChartButton).show();
+        $(compareTableButton).show();
+        $(compareScenariosRow).removeClass(itsiCompareRow);
+        $(compareMapsRow).removeClass(itsiCompareRow);
+        if ($(compareChartRow)) {
+            $(compareChartRow).removeClass(itsiCompareRow);
+        } else if ($(compareTableRow).length) {
+            $(compareTableRow).removeClass(itsiCompareRow);
+        }
+    }
+}
+
 function initializeShutterbug() {
     var googleTileLayerSelector = '#map > .leaflet-google-layer > div > div > div:nth-child(1) > div:nth-child(1)';
 
@@ -187,6 +238,10 @@ function initializeShutterbug() {
             // '/' then to empty string, which leaves a '#' in the URL.
             document.location.hash = '/';
             document.location.hash = '';
+
+            if ($('#compare-new').length) {
+                adjustCompareViewBeforeITSIScreenshot();
+            }
         })
         .on('shutterbug-asyouwere', function() {
             // Reset after screenshot has been taken
@@ -208,6 +263,10 @@ function initializeShutterbug() {
                     left: '',
                     top: '',
                 });
+            }
+
+            if ($('#compare-new').length) {
+                adjustCompareViewAfterITSIScreenshot();
             }
         });
 

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -656,3 +656,24 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
     }
   }
 }
+
+.itsi-compare-modal {
+  max-width: 100% !important;
+  max-height: 100% !important;
+}
+
+.itsi-compare-row {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.itsi-compare-dialog {
+  margin-left: 3% !important;
+  max-width: 70% !important;
+  max-height: 100% !important;
+  width: 70% !important;
+  height: 100% !important;
+}


### PR DESCRIPTION
## Overview

This PR adds some logic to fix the compare view so that the maps, table, and stacked chart will render during an ITSI screenshot.

To accomplish this, I created some ITSI-specific css rules to apply to the compare view rows in the interval when the screenshot's taking place. PhantomJS doesn't fully support flexbox, so some of the new rules here apply supplements.

Others adjust the compare view to position it and also to hide the controls in the top right corner -- the fonts weren't pulling through for those on my local, although this may be superfluous in production.

Connects #2166 

### Demo

![itsi-compare](https://user-images.githubusercontent.com/4165523/31240873-11d6132e-a9d0-11e7-926c-f024032fc1e7.gif)

### Notes

If we want them to work with ITSI screenshots, all the other views using flexbox need to have similar adjustments made OR we need to just add the supplementary rules to the base CSS. We should address this elsewhere.

It's a little unclear how we should handle the scrolling behavior for the compare view screenshot: since PhantomJS renders a new page, it starts scrolled up to the top regardless of what's in the user's viewport. I thought about hiding/showing rows programmatically depending on what was in the viewport, but letting it stick at the top seemed like a decent temporary solution since the stacked chart shows all of the info together.

## Testing Instructions
- get this branch, then `bundle`
- `ngrok http 8000`
- use requestly and add a rule to replace `app.wikiwatershed.org` with your ngrok url
- visit the ITSI portal, create a TR-55 activity, then open the compare view
- take screenshots for the tables and charts for runoff and water quality and verify that you see the compare view in them