### PR TITLE
Fix Compare View Modal For IE11

### DIFF
--- a/src/mmw/js/src/compare/templates/compareWindow2.html
+++ b/src/mmw/js/src/compare/templates/compareWindow2.html
@@ -1,22 +1,24 @@
-<div class="compare-scenario-gradient"></div>
-<div class="compare-header">
-    <div class="compare-title">
-        <h1>Compare</h1>
-    </div>
-    <div class="spinner hidden"></div>
-    <div class="compare-close">
-        <button>
-            <i class="fa fa-times"></i>
-        </button>
-    </div>
-    <div class="compare-actions">
-        <div class="compare-tabs">
+<div id="compare-new-dialog" class="modal-dialog">
+    <div class="modal-content compare-modal-content">
+        <div class="compare-header">
+            <div class="compare-title">
+                <h1>Compare</h1>
+            </div>
+            <div class="spinner hidden"></div>
+            <div class="compare-close">
+                <button>
+                    <i class="fa fa-times"></i>
+                </button>
+            </div>
+            <div class="compare-actions">
+                <div class="compare-tabs">
+                </div>
+                <div class="compare-inputs">
+                </div>
+            </div>
         </div>
-        <div class="compare-inputs">
-        </div>
-    </div>
-</div>
-<div class="compare-scenarios">
+        <div class="compare-scenario-gradient"></div>
+        <div class="compare-scenarios">
     <div class="compare-scenario-row-description">
         <h2>Scenarios</h2>
     </div>
@@ -30,6 +32,8 @@
             <i class="fa fa-arrow-right"></i>
         </button>
     </div>
-</div>
-<div class="compare-sections polling">
+        </div>
+        <div class="compare-sections polling">
+        </div>
+    </div>
 </div>

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -59,6 +59,21 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
         sectionsRegion: '.compare-sections',
     },
 
+    initialize: function() {
+        var self = this;
+
+        // Show the scenario row only after the bootstrap
+        // modal has fired its shown event. The map
+        // set up in the scenarios row needs to happen
+        // after it has fully rendered
+        this.$el.on('shown.bs.modal', function() {
+            self.scenariosRegion.show(new ScenariosRowView({
+                model: self.model,
+                collection: self.model.get('scenarios'),
+            }));
+        });
+    },
+
     highlightButtons: function() {
         var i = this.model.get('visibleScenarioIndex'),
             total = this.model.get('scenarios').length,
@@ -95,10 +110,6 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
         this.tabRegion.show(tabPanelsView);
         this.inputsRegion.show(new InputsView({
             model: this.model,
-        }));
-        this.scenariosRegion.show(new ScenariosRowView({
-            model: this.model,
-            collection: this.model.get('scenarios'),
         }));
 
         showSectionsView();

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -287,20 +287,21 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
 }
 
 #compare-new {
-  background-color: #fff;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 8000;
-  display: flex;
-  flex-direction: column;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 20px;
-  max-width: 1200px;
-  max-height: calc(100% - 20px);
-  -webkit-font-smoothing: antialiased;
+    overflow-y: hidden;
+    padding-left: 0 !important;
+}
+
+#compare-new-dialog {
+    z-index: 8000;
+    display: flex;
+    flex-direction: column;
+    margin-left: auto;
+    margin-right: auto;
+    width: auto;
+    height: auto;
+    margin-top: 20px;
+    max-width: 1200px;
+    height: calc(100% - 20px);
 
   @media screen and (max-width: 1300px) {
     max-width: 1000px;
@@ -309,6 +310,14 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
   @media screen and (max-width: 1000px) {
     margin-top: 0;
     max-height: 100%;
+  }
+
+  .compare-modal-content {
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      height: calc(100% - 20px);
+      -webkit-font-smoothing: antialiased;
   }
 
   .compare-actions {
@@ -493,6 +502,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
   }
 
   .compare-header {
+    position: relative;
     padding: $compare-padding $compare-padding 11px;
     background-color: #eee;
     border-bottom: 1px solid #ccc;


### PR DESCRIPTION
## Overview

On IE11 compare view was showing up stuck to the upper left corner of the viewport.

I initially tried using the [PostCSS autoprefixer](https://github.com/postcss/autoprefixer). After finally getting it to run with the project's version of node, it didn't seem to make a difference to the compare view. Inspecting the DOM, I realized we were using the bootstrap modals in a pretty funky way: omitting the `modal-dialog` and `modal-content` classes. Adding these in fixed the issue. 

Connects #2098 
### Demo

<img width="963" alt="screen shot 2017-10-05 at 8 36 39 am" src="https://user-images.githubusercontent.com/7633670/31227611-6dc8d27a-a9a8-11e7-90c2-17e38c72aa4c.png">

### Notes

The original issue also describes some chart problems — #2320 seems to have fixed those.

## Testing Instructions

 * Pull and `bundle`
* Open compare view, and also open compare view on staging
* Confirm compare view matches chrome staging on all supported browsers.