### PR TITLE
Rename api/rwd -> api/watershed

### DIFF
--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -30,5 +30,5 @@ urlpatterns = patterns(
     url(r'analyze/climate/$', views.start_analyze_climate,
         name='start_analyze_climate'),
     url(r'jobs/' + uuid_regex, get_job, name='get_job'),
-    url(r'rwd/$', views.start_rwd, name='start_rwd'),
+    url(r'watershed/$', views.start_rwd, name='start_rwd'),
 )

--- a/src/mmw/js/src/draw/models.js
+++ b/src/mmw/js/src/draw/models.js
@@ -53,7 +53,7 @@ var ToolbarModel = Backbone.Model.extend({
 // Used for running Rapid Watershed Delineation tasks.
 var RwdTaskModel = coreModels.TaskModel.extend({
     defaults: _.extend( {
-            taskName: 'rwd',
+            taskName: 'watershed',
             taskType: 'api',
             token: settings.get('api_token')
         }, coreModels.TaskModel.prototype.defaults


### PR DESCRIPTION
## Overview

This PR renames the `api/rwd` route to `api/watershed`. I did *not* change the names of the methods backing the routes as it seemed like we should leave those as is.

Connects #2338

### Demo

![screen shot 2017-10-06 at 10 38 31 am](https://user-images.githubusercontent.com/4165523/31283065-91c23c7c-aa82-11e7-844e-47c0690399aa.png)

![screen shot 2017-10-06 at 10 38 49 am](https://user-images.githubusercontent.com/4165523/31283068-958f3c74-aa82-11e7-91e2-e75f2d30e243.png)

## Testing Instructions
- get this branch, then `bundle`
- set up RWD locally
- visit the MMW frontend and verify that you can run both DRB & NHD RWD and that it's using `api/watershed` as the route path
- visit `/api/docs` and verify that RWD has been renamed watershed and that you can still run it via the Swagger docs as before
