### PR TITLE
Adjust modeling view during ITSI screenshots

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -155,6 +155,31 @@ function RestAPI() {
     };
 }
 
+function adjustModelViewBeforeITSIScreenshot() {
+    toggleModelViewForITSIScreenshot(true);
+}
+
+function adjustModelViewAfterITSIScreenshot() {
+    toggleModelViewForITSIScreenshot(false);
+}
+
+function toggleModelViewForITSIScreenshot(adjustForScreenshot) {
+    var modelHeaderProject = '.project',
+        modelHeaderToolbar = '.toolbar',
+        modelToolbarContainer = '.toolbar-container',
+        itsiModelToolbar = 'itsi-model-toolbar';
+
+    if (adjustForScreenshot) {
+        $(modelHeaderProject).addClass(itsiModelToolbar);
+        $(modelHeaderToolbar).addClass(itsiModelToolbar);
+        $(modelToolbarContainer).addClass(itsiModelToolbar);
+    } else {
+        $(modelHeaderProject).removeClass(itsiModelToolbar);
+        $(modelHeaderToolbar).removeClass(itsiModelToolbar);
+        $(modelToolbarContainer).removeClass(itsiModelToolbar);
+    }
+}
+
 function adjustCompareViewBeforeITSIScreenshot() {
     toggleCompareViewForITSIScreenshot(true);
 }
@@ -242,6 +267,10 @@ function initializeShutterbug() {
             if ($('#compare-new').length) {
                 adjustCompareViewBeforeITSIScreenshot();
             }
+
+            if ($('.project')) {
+                adjustModelViewBeforeITSIScreenshot();
+            }
         })
         .on('shutterbug-asyouwere', function() {
             // Reset after screenshot has been taken
@@ -267,6 +296,10 @@ function initializeShutterbug() {
 
             if ($('#compare-new').length) {
                 adjustCompareViewAfterITSIScreenshot();
+            }
+
+            if ($('.project')) {
+                adjustModelViewAfterITSIScreenshot();
             }
         });
 

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -108,3 +108,11 @@
         margin-left: 0;
     }
 }
+
+.itsi-model-toolbar {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: flex !important;
+  -webkit-flex-wrap: nowrap !important;
+  flex-wrap: nowrap !important;
+}


### PR DESCRIPTION
## Overview

This PR applies some supplementary CSS rules to the modeling view during ITSI screenshots.

Connects #2331

### Demo

![screen shot 2017-10-06 at 12 01 55 pm](https://user-images.githubusercontent.com/4165523/31287314-d349139e-aa8e-11e7-8245-4716a5c84137.png)

&

![screen shot 2017-10-06 at 12 03 14 pm](https://user-images.githubusercontent.com/4165523/31287316-d7d9a63a-aa8e-11e7-9b1f-c70bd649730c.png)

## Testing Instructions
- get this branch, then `bundle`
- `ngrok http 8000`
- enable a requestly rule to replace calls to app.wikiwatershed.org with your ngrok url
- visit https://authoring.concord.org/activities/5644/single_page/dec56c68-6170-4e59-b94a-82fb040e8d88 and start a new activity
- select an aoi then model it with TR55 and take a screenshot. Verify that the screenshot works properly
- repeat with MapShed