### PR TITLE
Upgrade RWD to 1.2.3

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -2,7 +2,7 @@
 rwd_data_path: "/opt/rwd-data"
 rwd_host: "localhost"
 rwd_port: 5000
-rwd_docker_image: "quay.io/wikiwatershed/rwd:1.2.2"
+rwd_docker_image: "quay.io/wikiwatershed/rwd:1.2.3"
 
 app_config:
     RWD_HOST: "{{ rwd_host }}"


### PR DESCRIPTION
## Overview

This PR upgrades RWD to version 1.2.3 which now rounds watershed latlngs to 6 trailing decimal places.

Connects #2339 

## Testing Instructions
- get this branch, then set up rwd data and the RWD_DATA export and `vagrant reload worker --provision`
- ssh in and `sudo restart mmw-rwd`
- visit the client in the browser and verify that you can run RWD for both NHD and DRB
- visit `/api/docs` and verify that you can run RWD through the Swagger docs and that the resulting watershed latlngs are rounded to 6 places