### PR TITLE
Adjust PostgreSQL versions to fix package installs

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -23,8 +23,8 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "9.6.*.pgdg14.04+1"
-postgresql_support_psycopg2_version: "2.6"
+postgresql_support_libpq_version: "10.0-*.pgdg14.04+1"
+postgresql_support_psycopg2_version: "2.7"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"
 


### PR DESCRIPTION
Applying @hectcastro's https://github.com/WikiWatershed/model-my-watershed/commit/6753ec8098fa2194cadadb9b233cc7fd98e5f9ac to `develop`

> The PostgreSQL 10 release has caused a number of changes to the official APT repositories we depend on. Many of the core packages begin with 10.x. Also, Psycopg2 2.6.x had a bug where it was expecting PostgreSQL version numbers in the 9.x range.