### PR TITLE
Fix IE11 analyze/model tab toggle bug

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -990,6 +990,9 @@ var ResultsView = Marionette.LayoutView.extend({
         } else {
             this.aoiRegion.empty();
         }
+
+        this.analyzeRegion.$el.toggleClass('active');
+        this.modelingRegion.$el.toggleClass('active');
     },
 
     transitionInCss: {


### PR DESCRIPTION
## Overview

This PR fixes a bug whereby the analyze & modeling tab toggle wouldn't adjust the results view in IE11. This was happening because the `.active` class wasn't being toggled correctly in that browser.

To fix it I added some lines to call `.toggleClass('active')` on them explicitly in the `toggleAoiRegion` method of the modeling `ResultsView`.

Connects #2276 

### Demo

IE11:

![ie11-analyze-modeling-tabs](https://user-images.githubusercontent.com/4165523/31347087-24fea292-ace9-11e7-9e58-5ed4fb92d427.gif)

Chrome:

![chrome-analyze-modeling-tab](https://user-images.githubusercontent.com/4165523/31347092-2a28be4c-ace9-11e7-83fe-b2ae2a0cea1e.gif)

## Testing Instructions
- get this branch, then `bundle`
- in Chrome, IE11, FF, and Safari check that you can
    - analyze a new AOI and see the correct tab
    - create new modeling projects for both TR55 and MapShed and then use the toggle to toggle the tabs correctly
    - load saved modeling projects for both TR55 and MapShed and toggle the tabs correctly
