### PR TITLE
BiG-CZ: Fetch CUAHSI Values using WaterML and Ulmo

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,7 +1,7 @@
 - src: azavea.ntp
   version: 0.1.1
 - src: azavea.pip
-  version: 0.1.1
+  version: 1.0.0
 - src: azavea.nodejs
   version: 0.3.0
 - src: azavea.git

--- a/src/mmw/apps/bigcz/clients/__init__.py
+++ b/src/mmw/apps/bigcz/clients/__init__.py
@@ -22,6 +22,8 @@ CATALOGS = {
         'model': cuahsi.model,
         'serializer': cuahsi.serializer,
         'search': cuahsi.search,
+        'details': cuahsi.details,
+        'values': cuahsi.values,
         'is_pageable': False,
     },
 }

--- a/src/mmw/apps/bigcz/clients/cuahsi/__init__.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/__init__.py
@@ -8,6 +8,7 @@ from apps.bigcz.clients.cuahsi.serializers import CuahsiResourceSerializer
 
 # Import catalog name and search function, so it can be exported from here
 from apps.bigcz.clients.cuahsi.search import CATALOG_NAME, search  # NOQA
+from apps.bigcz.clients.cuahsi.details import details, values  # NOQA
 
 model = CuahsiResource
 serializer = CuahsiResourceSerializer

--- a/src/mmw/apps/bigcz/clients/cuahsi/details.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/details.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from datetime import date, timedelta
+
+from rest_framework.exceptions import ValidationError
+
+from ulmo.cuahsi import wof
+
+DATE_FORMAT = '%m/%d/%Y'
+
+
+def details(wsdl, site):
+    if not wsdl:
+        raise ValidationError({
+            'error': 'Required argument: wsdl'})
+
+    if not site:
+        raise ValidationError({
+            'error': 'Required argument: site'})
+
+    if not wsdl.upper().endswith('?WSDL'):
+        wsdl += '?WSDL'
+
+    return wof.get_site_info(wsdl, site)
+
+
+def values(wsdl, site, variable, from_date=None, to_date=None):
+    if not wsdl:
+        raise ValidationError({
+            'error': 'Required argument: wsdl'})
+
+    if not site:
+        raise ValidationError({
+            'error': 'Required argument: site'})
+
+    if not variable:
+        raise ValidationError({
+            'error': 'Required argument: variable'})
+
+    if not to_date:
+        # Set to default value of today
+        to_date = date.today().strftime(DATE_FORMAT)
+
+    if not from_date:
+        # Set to default value of one week ago
+        from_date = (date.today() -
+                     timedelta(days=7)).strftime(DATE_FORMAT)
+
+    if not wsdl.upper().endswith('?WSDL'):
+        wsdl += '?WSDL'
+
+    return wof.get_values(wsdl, site, variable, from_date, to_date)

--- a/src/mmw/apps/bigcz/clients/cuahsi/models.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/models.py
@@ -9,15 +9,16 @@ from apps.bigcz.models import Resource
 class CuahsiResource(Resource):
     def __init__(self, id, description, author, links, title,
                  created_at, updated_at, geom, details_url, sample_mediums,
-                 concept_keywords, service_org, service_code, service_url,
-                 service_title, service_citation, begin_date, end_date):
+                 variables, service_org, service_code, service_url,
+                 service_title, service_citation,
+                 begin_date, end_date):
         super(CuahsiResource, self).__init__(id, description, author, links,
                                              title, created_at, updated_at,
                                              geom)
 
         self.details_url = details_url
         self.sample_mediums = sample_mediums
-        self.concept_keywords = concept_keywords
+        self.variables = variables
         self.service_org = service_org
         self.service_code = service_code
         self.service_url = service_url

--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -6,7 +6,7 @@ from __future__ import division
 from datetime import date
 from urllib2 import URLError
 from socket import timeout
-from operator import attrgetter
+from operator import attrgetter, itemgetter
 
 from suds.client import Client
 from suds.sudsobject import asdict
@@ -126,7 +126,7 @@ def parse_record(record, service):
         geom=geom,
         details_url=details_url,
         sample_mediums=record['sample_mediums'],
-        concept_keywords=record['concept_keywords'],
+        variables=record['variables'],
         service_org=service['organization'],
         service_code=record['serv_code'],
         service_url=service['ServiceDescriptionURL'],
@@ -189,6 +189,13 @@ def group_series_by_location(series):
                                for r in group]),
             'end_date': max([parse_date(r['endDate'])
                              for r in group]),
+            'variables': sorted([{
+                'id': r['VarCode'],
+                'name': r['VarName'],
+                'concept_keyword': r['conceptKeyword'],
+                'site': r['location'],
+                'wsdl': r['ServURL'],
+            } for r in group], key=itemgetter('concept_keyword'))
         })
 
     return records

--- a/src/mmw/apps/bigcz/clients/cuahsi/serializers.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/serializers.py
@@ -6,15 +6,24 @@ from __future__ import division
 from rest_framework.serializers import (CharField,
                                         DateTimeField,
                                         ListField,
+                                        Serializer,
                                         )
 
 from apps.bigcz.serializers import ResourceSerializer
 
 
+class CuahsiVariableSetSerializer(Serializer):
+    id = CharField()
+    name = CharField()
+    concept_keyword = CharField()
+    site = CharField()
+    wsdl = CharField()
+
+
 class CuahsiResourceSerializer(ResourceSerializer):
     details_url = CharField()
     sample_mediums = ListField(child=CharField())
-    concept_keywords = ListField(child=CharField())
+    variables = ListField(child=CuahsiVariableSetSerializer())
     service_org = CharField()
     service_code = CharField()
     service_url = CharField()

--- a/src/mmw/apps/bigcz/urls.py
+++ b/src/mmw/apps/bigcz/urls.py
@@ -10,4 +10,6 @@ from apps.bigcz import views
 urlpatterns = patterns(
     '',
     url(r'^search$', views.search, name='bigcz_search'),
+    url(r'^details$', views.details, name='bigcz_details'),
+    url(r'^values$', views.values, name='bigcz_values'),
 )

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -19,3 +19,4 @@ retry==0.9.1
 python-dateutil==2.6.0
 suds==0.4
 django_celery_results==1.0.1
+ulmo==0.8.4


### PR DESCRIPTION
## Overview

Adds [Ulmo](https://github.com/ulmo-dev/ulmo/), and uses it in Django endpoints for fetching CUAHSI details and values.

The expected usage is:

 1. Query `/bigcz/details` to fetch general information about all variables in a site
 2. Query `/bigcz/values` for each variable to fetch its values

UI for this is coming in a following PR. The UI may be broken until that next PR is merged.

See commit messages for details.

Connects #2243 
Connects #2238 

### Demo

* **Details**

    ```http
    http --print HhBb :8000/bigcz/details catalog==cuahsi wsdl=="http://hydroportal.cuahsi.org/nwisgw/cuahsi_1_1.asmx" site=="NWISGW:395801075101601"

    GET /bigcz/details?catalog=cuahsi&wsdl=http%3A%2F%2Fhydroportal.cuahsi.org%2Fnwisgw%2Fcuahsi_1_1.asmx&site=NWISGW%3A395801075101601 HTTP/1.1
    Accept: */*
    Accept-Encoding: gzip, deflate
    Connection: keep-alive
    Host: localhost:8000
    User-Agent: HTTPie/0.9.9



    HTTP/1.1 200 OK
    Allow: OPTIONS, GET
    Connection: keep-alive
    Content-Encoding: gzip
    Content-Type: application/json
    Date: Mon, 09 Oct 2017 17:29:25 GMT
    Server: nginx
    Transfer-Encoding: chunked
    Vary: Accept-Encoding
    Vary: Accept, Cookie

    {
        "code": "395801075101601",
        "elevation_m": "90",
        "location": {
            "latitude": "39.96705715",
            "longitude": "-75.17073369",
            "srs": "EPSG:4269"
        },
        "name": "PH   486",
        "network": "NWISGW",
        "series": {
            "NWISGW:72019": {
                "variable": {
                    "code": "72019",
                    "data_type": "unknown",
                    "general_category": "Hydrology",
                    "id": "3017",
                    "name": "Depth to water level, feet below land surface",
                    "no_data_value": "-999999",
                    "sample_medium": "Groundwater",
                    "speciation": "Not Applicable",
                    "time": {
                        "interval": "0",
                        "is_regular": true,
                        "units": {
                            "code": "103",
                            "name": "hour",
                            "type": "Time"
                        }
                    },
                    "units": {
                        "abbreviation": "ft"
                    },
                    "value_type": "Field Observation",
                    "vocabulary": "NWISGW"
                },
                "{http://www.cuahsi.org/water_ml/1.1/}method": {
                    "method_description": "No method specified",
                    "method_id": "0"
                },
                "{http://www.cuahsi.org/water_ml/1.1/}quality_control_level": {
                    "definition": "Unknown",
                    "quality_control_level_code": "-9999",
                    "quality_control_level_id": "-9999"
                },
                "{http://www.cuahsi.org/water_ml/1.1/}source": {
                    "citation": "http://waterservices.usgs.gov",
                    "organization": "U.S. Geological Survey (USGS)",
                    "source_description": "historical manually-recorded groundwater levels from hydrologic sites served by the USGS",
                    "source_id": "2"
                },
                "{http://www.cuahsi.org/water_ml/1.1/}value_count": {
                    "value_count": "1"
                },
                "{http://www.cuahsi.org/water_ml/1.1/}variable_time_interval": {
                    "begin_date_time": "1954-06-09T00:00:00",
                    "begin_date_time_utc": "1954-06-09T04:00:00",
                    "end_date_time": "1954-06-09T00:00:00",
                    "end_date_time_utc": "1954-06-09T04:00:00",
                    "variable_time_interval_type": "TimeIntervalType"
                }
            }
        },
        "site_property": {
            "pos_accuracy_m": "10",
            "site_comments": "02040203",
            "state": "PA"
        }
    }
    ```

 * **Values**

    ```http
    http --print HhBb :8000/bigcz/values catalog==cuahsi wsdl=="http://hydroportal.cuahsi.org/nwisgw/cuahsi_1_1.asmx" site=="NWISGW:395801075101601" variable=="NWISGW:72019" from_date=="06/09/1954" to_date=="06/09/1954"

    GET /bigcz/values?catalog=cuahsi&wsdl=http%3A%2F%2Fhydroportal.cuahsi.org%2Fnwisgw%2Fcuahsi_1_1.asmx&site=NWISGW%3A395801075101601&variable=NWISGW%3A72019&from_date=06%2F09%2F1954&to_date=06%2F09%2F1954 HTTP/1.1
    Accept: */*
    Accept-Encoding: gzip, deflate
    Connection: keep-alive
    Host: localhost:8000
    User-Agent: HTTPie/0.9.9



    HTTP/1.1 200 OK
    Allow: OPTIONS, GET
    Connection: keep-alive
    Content-Encoding: gzip
    Content-Type: application/json
    Date: Mon, 09 Oct 2017 17:33:12 GMT
    Server: nginx
    Transfer-Encoding: chunked
    Vary: Accept-Encoding
    Vary: Accept, Cookie

    {
        "site": {
            "agency": "USGS",
            "code": "395801075101601",
            "location": {
                "latitude": "39.96705715",
                "longitude": "-75.17073369"
            },
            "name": "PH   486",
            "network": "NWISGW",
            "notes": {
                "county_cd": "42101",
                "huc_cd": "02040203",
                "site_type_cd": "GW",
                "state_cd": "42"
            },
            "timezone_info": {
                "default_tz": {
                    "abbreviation": "EST",
                    "offset": "-05:00"
                },
                "dst_tz": {
                    "abbreviation": "EDT",
                    "offset": "-04:00"
                },
                "uses_dst": false
            }
        },
        "values": [
            {
                "datetime": "1954-06-09T12:00:00",
                "value": "3.60"
            }
        ],
        "variable": {
            "code": "72019",
            "description": "Depth to water level, ft below land surface",
            "id": null,
            "name": "Depth to water level, feet below land surface",
            "network": "NWISGW",
            "no_data_value": "-999999",
            "oid": "52331280",
            "sample_medium": "Surface Water Observation",
            "statistic": {
                "code": "00000",
                "name": null
            },
            "time": {},
            "units": {
                "abbreviation": "ft"
            },
            "value_type": "Derived Value",
            "vocabulary": "NWISGW"
        }
    }
    ```

### Notes

The WaterML objects themselves are complex and elaborate, with many nested keys and arrays. Fortunately, we don't need to write our own serializers for them, because that is all taken care of within Ulmo. Furthermore, because of WaterML being an underlying standard, we can reasonably expect the data to follow a certain shape, and exercise this assumption all the way on the client side, without having to verify it on the server.

Ulmo uses suds under the hood to make SOAP requests, and by default uses the suds cache, which is distinct from the redis cache used elsewhere in the app (for Geoprocessing, etc). I have not looked into changing this default behavior, leaving it to a future investigation should the need arise.

## Testing Instructions

 * Check out this branch, and reprovision `app` and `worker`:

       vagrant reload app worker --provision

 * Go to a [sample details endpoint](http://localhost:8000/bigcz/details?catalog=cuahsi&wsdl=http%3A%2F%2Fhydroportal.cuahsi.org%2Fnwisgw%2Fcuahsi_1_1.asmx&site=NWISGW%3A395801075101601) and ensure it populates
 * Go to a [sample values endpoint](http://localhost:8000/bigcz/values?catalog=cuahsi&wsdl=http%3A%2F%2Fhydroportal.cuahsi.org%2Fnwisgw%2Fcuahsi_1_1.asmx&site=NWISGW%3A395801075101601&variable=NWISGW%3A72019&from_date=06%2F09%2F1954&to_date=06%2F09%2F1954) and ensure it populates