### PR TITLE
BiG-CZ: Fetch and Render CUAHSI Variable Values

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -257,6 +257,10 @@ def get_series_catalog_in_box(box, from_date, to_date, networkIDs):
     try:
         return result['SeriesRecord']
     except KeyError:
+        # Empty object can mean "No results"
+        if not result:
+            return []
+
         # Missing key may indicate a server-side error
         raise ValueError(result)
     except TypeError:

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -68,6 +68,7 @@ var App = new Marionette.Application({
         // Enabling hiding popovers from within them
         window.closePopover = function() {
             $('[data-toggle="popover"]').popover('hide');
+            $('.popover').remove();
         };
     },
 

--- a/src/mmw/js/src/core/filters.js
+++ b/src/mmw/js/src/core/filters.js
@@ -3,6 +3,7 @@
 var nunjucks = require('nunjucks');
 var utils = require('./utils');
 var _ = require('lodash');
+var moment = require('moment');
 
 nunjucks.env = new nunjucks.Environment();
 
@@ -61,30 +62,7 @@ nunjucks.env.addFilter('toDateWithoutTime', function(date) {
 });
 
 nunjucks.env.addFilter('toTimeAgo', function(date) {
-    var diff = Date.now() - (new Date(date)).getTime(),
-        secs = diff / 1000,
-        mins = secs / 60,
-        hrs  = mins / 60,
-        days = hrs  / 24,
-        wks  = days / 7,
-        mths = days / 30,
-        yrs  = days / 365;
-
-    if (yrs > 1) {
-        return Math.floor(yrs) + " years ago";
-    } else if (mths > 1) {
-        return Math.floor(mths) + " months ago";
-    } else if (wks > 1) {
-        return Math.floor(wks) + " weeks ago";
-    } else if (days > 1) {
-        return Math.floor(days) + " days ago";
-    } else if (hrs > 1) {
-        return Math.floor(hrs) + " hours ago";
-    } else if (mins > 1) {
-        return Math.floor(mins) + " minutes ago";
-    } else {
-        return Math.floor(secs) + " seconds ago";
-    }
+    return moment(date).fromNow();
 });
 
 nunjucks.env.addFilter('split', function(str, splitChar, indexToReturn) {

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -320,6 +320,7 @@ var Result = Backbone.Model.extend({
         variables: null,  // CuahsiVariables Collection
         fetching: false,
         error: false,
+        mode: 'table',
     },
 
     initialize: function(attrs) {

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -10,6 +10,8 @@ var REQUEST_TIMED_OUT_CODE = 408;
 var DESCRIPTION_MAX_LENGTH = 100;
 var PAGE_SIZE = settings.get('data_catalog_page_size');
 
+var DATE_FORMAT = 'MM/DD/YYYY';
+
 
 var FilterModel = Backbone.Model.extend({
     defaults: {
@@ -76,22 +78,21 @@ var DateFilter = FilterModel.extend({
     validate: function() {
         // Only need to validate if there are two dates.  Ensure that
         // before is earlier than after
-        var dateFormat = "MM/DD/YYYY",
-            toDate = this.get('toDate'),
+        var toDate = this.get('toDate'),
             fromDate = this.get('fromDate'),
             isValid = true;
 
-        if (toDate && !moment(toDate, dateFormat).isValid()) {
+        if (toDate && !moment(toDate, DATE_FORMAT).isValid()) {
             isValid = false;
         }
 
-        if (fromDate && !moment(fromDate, dateFormat).isValid()) {
+        if (fromDate && !moment(fromDate, DATE_FORMAT).isValid()) {
             isValid = false;
         }
 
         if (toDate && fromDate){
-            isValid = moment(fromDate, dateFormat)
-                .isBefore(moment(toDate, dateFormat));
+            isValid = moment(fromDate, DATE_FORMAT)
+                .isBefore(moment(toDate, DATE_FORMAT));
         }
 
         this.set('isValid', isValid);

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -397,6 +397,22 @@ var PopoverControllerModel = Backbone.Model.extend({
     }
 });
 
+var CuahsiValue = Backbone.Model.extend({
+    defaults: {
+        source_id: '',
+        source_code: '',
+        quality_control_level_code: '',
+        value: null,
+        datetime: '',
+        date_time_utc: '',
+        time_offset: '',
+    }
+});
+
+var CuahsiValues = Backbone.Collection.extend({
+    model: CuahsiValue,
+});
+
 var CuahsiVariable = Backbone.Model.extend({
     url: '/bigcz/values',
 
@@ -414,6 +430,10 @@ var CuahsiVariable = Backbone.Model.extend({
         begin_date: '',
         end_date: '',
         error: null,
+    },
+
+    initialize: function() {
+        this.set('values', new CuahsiValues());
     },
 
     search: function(from, to) {
@@ -496,6 +516,8 @@ module.exports = {
     Results: Results,
     SearchForm: SearchForm,
     PopoverControllerModel: PopoverControllerModel,
+    CuahsiValue: CuahsiValue,
+    CuahsiValues: CuahsiValues,
     CuahsiVariable: CuahsiVariable,
     CuahsiVariables: CuahsiVariables,
 };

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
@@ -1,12 +1,11 @@
 <div class="result">
     <div class="result-detail-header">
+        <button type="button" class="close" aria-label="Close">
+            <i class="fa fa-arrow-left black"></i> Back
+        </button>
         <h2>
             {{ title }}
         </h2>
-        <button type="button" class="close" aria-label="Close">
-            <span aria-hidden="true">×</span>
-        </button>
-        <a href="#"><i class="fa fa-search-plus"></i> Zoom to extent</a>
     </div>
     <hr>
     {% if author %}

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
@@ -47,7 +47,7 @@
     </p>
     <hr />
     <p>
-        Last collected value {{ end_date|toTimeAgo }}:
+        Last value collected {{ end_date|toTimeAgo }}:
     </p>
     <table class="table custom-hover" data-toggle="table">
         <thead>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
@@ -45,28 +45,19 @@
             <i class="fa fa-globe"></i>&nbsp;Web Services
         </a>
     </p>
+    <div class="spinner {{ "hidden" if not fetching }}"></div>
+    <div class="error {{ "hidden" if not error }}">
+        <i class="fa fa-exclamation-triangle"></i>
+    </div>
     <hr />
+    <div class="cuahsi-buttons pull-right {{ "hidden" if fetching }}">
+        <button id="cuahsi-button-chart" class="{{ 'active' if mode == 'chart' }}"><i class="fa fa-bar-chart"></i></button>
+        <button id="cuahsi-button-table" class="{{ 'active' if mode == 'table' }}"><i class="fa fa-table"></i></button>
+    </div>
     <p>
-        Last value collected {{ end_date|toTimeAgo }}:
+        Last value collected {{ last_date|toTimeAgo }}:
     </p>
-    <table class="table custom-hover" data-toggle="table">
-        <thead>
-            <tr>
-                <th>Variable</th>
-                <th class="text-right">Value</th>
-                <th>Units</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for ck in concept_keywords %}
-                <tr>
-                    <td>{{ ck }}</td>
-                    <td class="text-right"><!-- TODO Fetch Values --></td>
-                    <td><!-- TODO Fetch Units --></td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    <div id="cuahsi-values-region"></div>
     <!-- TODO Insert Chart https://github.com/WikiWatershed/model-my-watershed/issues/2238 -->
     <hr />
     <p>Citation: {{ service_citation }}</p>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
@@ -1,7 +1,7 @@
 <div class="result">
     <div class="result-detail-header">
         <button type="button" class="close" aria-label="Close">
-            <span aria-hidden="true">×</span>
+            <i class="fa fa-arrow-left black"></i> Back
         </button>
         <h2>
             Site: {{ location }} {{ title }}
@@ -41,6 +41,10 @@
                     {{ sample_mediums|join(", ") }}
                 </td>
             </tr>
+            <tr>
+                <th>Catalog</th>
+                <td>Water Data Center</td>
+            </tr>
         </table>
     </div>
     <p>
@@ -66,7 +70,7 @@
         <button id="cuahsi-button-table" class="{{ 'active' if mode == 'table' }}"><i class="fa fa-table"></i></button>
     </div>
     <p>
-        Last value collected {{ last_date|toTimeAgo }}:
+        Last value collected {{ last_date|toTimeAgo }}
     </p>
     <div id="cuahsi-values-region"></div>
     <!-- TODO Insert Chart https://github.com/WikiWatershed/model-my-watershed/issues/2238 -->

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
@@ -6,33 +6,43 @@
         <h2>
             Site: {{ location }} {{ title }}
         </h2>
-        <p>
-            Source: {{ service_org }} {{ service_title }}
-            <a data-toggle="popover" tabindex="0"
-               data-html="true" data-container="body" role="button"
-               data-content="{{ description }}"
-               data-template="<div class='popover'><div class='pull-right' id='popover-close-button' onclick='closePopover()'><i class='fa fa-times' /></div><div class='popover-content'></div><div class='arrow'></div></div>">
-                <i class="fa fa-info-circle black"></i>
-            </a>
-        </p>
+        <table class="table-data-detail">
+            <tr>
+                <th>Source</th>
+                <td>{{ service_org }}<br>{{ service_title }}
+                    <a data-toggle="popover" tabindex="0"
+                       data-html="true" data-container="body" role="button"
+                       data-content="{{ description }}"
+                       data-template="<div class='popover'><div class='pull-right' id='popover-close-button' onclick='closePopover()'><i class='fa fa-times' /></div><div class='popover-content'></div><div class='arrow'></div></div>">
+                        <i class="fa fa-info-circle black"></i>
+                    </a>
+                </td>
+            </tr>
+            {% if author %}
+                <tr>
+                    <th>Author</th>
+                    <td>
+                        {{ author }}
+                    </td>
+                </tr>
+            {% endif %}
+            <tr>
+                {% if begin_date == end_date %}
+                    <th>Data collected on</th>
+                    <td>{{ begin_date|toDateWithoutTime }}</td>
+                {% else %}
+                    <th>Data collected between</th>
+                    <td>{{ begin_date|toDateWithoutTime }}&ensp;&ndash;&ensp;{{ end_date|toDateWithoutTime }}</td>
+                {% endif %}
+            </tr>
+            <tr>
+                <th>Medium</th>
+                <td>
+                    {{ sample_mediums|join(", ") }}
+                </td>
+            </tr>
+        </table>
     </div>
-    {% if author %}
-        <p>
-            <i class="fa fa-user"></i>{{ author }}
-        </p>
-    {% endif %}
-    {% if begin_date == end_date %}
-        <p>
-            Data collected on: {{ begin_date|toDateWithoutTime }}
-        </p>
-    {% else %}
-        <p>
-            Data collected between: {{ begin_date|toDateWithoutTime }} - {{ end_date|toDateWithoutTime }}
-        </p>
-    {% endif %}
-    <p>
-        Medium: {{ sample_mediums|join(", ") }}
-    </p>
     <p>
         {% if details_url %}
             <a class="btn btn-secondary" href="{{ details_url }}"
@@ -50,6 +60,7 @@
         <i class="fa fa-exclamation-triangle"></i>
     </div>
     <hr />
+    <h3>Source Data</h3>
     <div class="cuahsi-buttons pull-right {{ "hidden" if fetching }}">
         <button id="cuahsi-button-chart" class="{{ 'active' if mode == 'chart' }}"><i class="fa fa-bar-chart"></i></button>
         <button id="cuahsi-button-table" class="{{ 'active' if mode == 'table' }}"><i class="fa fa-table"></i></button>
@@ -60,5 +71,6 @@
     <div id="cuahsi-values-region"></div>
     <!-- TODO Insert Chart https://github.com/WikiWatershed/model-my-watershed/issues/2238 -->
     <hr />
-    <p>Citation: {{ service_citation }}</p>
+    <h3>Citation</h3>
+    <p>{{ service_citation }}</p>
 </div>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiTable.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiTable.html
@@ -1,0 +1,9 @@
+<thead>
+    <tr>
+        <th>Variable</th>
+        <th class="text-right">Value</th>
+        <th>Units</th>
+    </tr>
+</thead>
+<tbody>
+</tbody>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiTableRowVariableCol.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiTableRowVariableCol.html
@@ -1,0 +1,19 @@
+{{ concept_keyword }}
+{% if name %}
+    <a class="variable-popover" tabindex="0"
+        role="button" data-container="body"
+        data-html="true" data-content="
+            <p>{{ name }}</p>
+            {% if speciation != "Not Applicable" %}
+            <p><strong>Speciation:</strong> {{ speciation }}</p>
+            {% endif %}
+            <p><strong>Medium:</strong> {{ sample_medium }}</p>">
+        <i class="fa fa-info-circle black"></i>
+    </a>
+{% endif %}
+{% if error %}
+    <a class="variable-popover" tabindex="0"
+        role="button" data-content="{{ error }}">
+        <i class="fa fa-exclamation-triangle ui-danger"></i>
+    </a>
+{% endif %}

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsHydroshare.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsHydroshare.html
@@ -1,12 +1,11 @@
 <div class="result">
     <div class="result-detail-header">
+        <button type="button" class="close" aria-label="Close">
+            <i class="fa fa-arrow-left black"></i> Back
+        </button>
         <h2>
             {{ title }}
         </h2>
-        <button type="button" class="close" aria-label="Close">
-            <span aria-hidden="true">×</span>
-        </button>
-        <a href="#"><i class="fa fa-search-plus"></i> Zoom to extent</a>
     </div>
     <hr>
     {% if author %}

--- a/src/mmw/js/src/data_catalog/templates/searchResultCuahsi.html
+++ b/src/mmw/js/src/data_catalog/templates/searchResultCuahsi.html
@@ -9,7 +9,7 @@
     <div class="resource-detail -showall">
         <i class="fa fa-subscript"></i>
         <div class="detail-text">
-            {{ concept_keywords|join("; ") }}
+            {{ concept_keywords }}
         </div>
     </div>
     <div class="resource-detail">

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -396,6 +396,16 @@ var StaticResultView = Marionette.ItemView.extend({
         return CATALOG_RESULT_TEMPLATE[this.options.catalog];
     },
 
+    templateHelpers: function() {
+        if (this.options.catalog === 'cuahsi') {
+            return {
+                'concept_keywords': this.model.get('variables')
+                                              .pluck('concept_keyword')
+                                              .join('; '),
+            };
+        }
+    },
+
     modelEvents: {
         'change:active': 'render'
     },

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -22,6 +22,9 @@ var $ = require('jquery'),
     resultDetailsCinergiTmpl = require('./templates/resultDetailsCinergi.html'),
     resultDetailsHydroshareTmpl = require('./templates/resultDetailsHydroshare.html'),
     resultDetailsCuahsiTmpl = require('./templates/resultDetailsCuahsi.html'),
+    resultDetailsCuahsiChartTmpl = require('./templates/resultDetailsCuahsiChart.html'),
+    resultDetailsCuahsiTableTmpl = require('./templates/resultDetailsCuahsiTable.html'),
+    resultDetailsCuahsiTableRowVariableColTmpl = require('./templates/resultDetailsCuahsiTableRowVariableCol.html'),
     resultsWindowTmpl = require('./templates/resultsWindow.html'),
     resultMapPopoverDetailTmpl = require('./templates/resultMapPopoverDetail.html'),
     resultMapPopoverListTmpl = require('./templates/resultMapPopoverList.html'),
@@ -34,11 +37,6 @@ var ENTER_KEYCODE = 13,
         cinergi: searchResultTmpl,
         hydroshare: searchResultTmpl,
         cuahsi: searchResultCuahsiTmpl,
-    },
-    CATALOG_RESULT_DETAILS_TEMPLATE = {
-        cinergi: resultDetailsCinergiTmpl,
-        hydroshare: resultDetailsHydroshareTmpl,
-        cuahsi: resultDetailsCuahsiTmpl,
     };
 
 var HeaderView = Marionette.LayoutView.extend({
@@ -134,6 +132,7 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
 
     onDetailResultChange: function() {
         var activeCatalog = this.collection.getActiveCatalog(),
+            ResultDetailsView = CATALOG_RESULT_DETAILS_VIEW[activeCatalog.id],
             detailResult = activeCatalog.get('detail_result');
 
         if (!detailResult) {
@@ -447,11 +446,7 @@ var ResultsView = Marionette.CollectionView.extend({
     }
 });
 
-var ResultDetailsView = Marionette.ItemView.extend({
-    getTemplate: function() {
-        return CATALOG_RESULT_DETAILS_TEMPLATE[this.catalog];
-    },
-
+var ResultDetailsBaseView = Marionette.LayoutView.extend({
     ui: {
         closeDetails: '.close'
     },
@@ -469,21 +464,191 @@ var ResultDetailsView = Marionette.ItemView.extend({
             placement: 'right',
             trigger: 'click',
         });
-        this.$('[data-toggle="table"]').bootstrapTable();
-    },
-
-    templateHelpers: function() {
-        var id = this.model.get('id'),
-            location = id.substring(id.indexOf(':') + 1);
-
-        return {
-            location: location,
-        };
     },
 
     closeDetails: function() {
         this.model.collection.closeDetail();
     }
+});
+
+var ResultDetailsCinergiView = ResultDetailsBaseView.extend({
+    template: resultDetailsCinergiTmpl,
+});
+
+var ResultDetailsHydroshareView = ResultDetailsBaseView.extend({
+    template: resultDetailsHydroshareTmpl,
+});
+
+var ResultDetailsCuahsiView = ResultDetailsBaseView.extend({
+    template: resultDetailsCuahsiTmpl,
+
+    templateHelpers: function() {
+        var id = this.model.get('id'),
+            location = id.substring(id.indexOf(':') + 1),
+            fetching = this.model.get('fetching'),
+            error = this.model.get('error'),
+            last_date = this.model.get('end_date');
+
+        if (!fetching && !error) {
+            var variables = this.model.get('variables'),
+                last_dates = variables.map(function(v) {
+                        var values = v.get('values');
+
+                        if (values.length > 0) {
+                            return new Date(values.last().get('datetime'));
+                        } else {
+                            return new Date('07/04/1776');
+                        }
+                    });
+
+            last_dates.push(new Date(last_date));
+            last_date = Math.max.apply(null, last_dates);
+        }
+
+        return {
+            location: location,
+            last_date: last_date,
+        };
+    },
+
+    regions: {
+        valuesRegion: '#cuahsi-values-region',
+    },
+
+    ui: _.defaults({
+        chartButton: '#cuahsi-button-chart',
+        tableButton: '#cuahsi-button-table',
+    }, ResultDetailsBaseView.prototype.ui),
+
+    events: _.defaults({
+        'click @ui.chartButton': 'setChartMode',
+        'click @ui.tableButton': 'setTableMode',
+    }, ResultDetailsBaseView.prototype.events),
+
+    modelEvents: {
+        'change:fetching': 'render',
+        'change:mode': 'showValuesRegion',
+    },
+
+    initialize: function() {
+        this.model.fetchCuahsiValues();
+    },
+
+    onRender: function() {
+        this.showValuesRegion();
+    },
+
+    onDomRefresh: function() {
+        window.closePopover();
+        this.$('[data-toggle="popover"]').popover({
+            placement: 'right',
+            trigger: 'click',
+        });
+    },
+
+    showValuesRegion: function() {
+        if (!this.valuesRegion) {
+            // Don't attempt to display values if this view
+            // has been unloaded.
+            return;
+        }
+
+        var mode = this.model.get('mode'),
+            variables = this.model.get('variables'),
+            view = mode === 'table' ?
+                   new CuahsiTableView({ collection: variables }) :
+                   new CuahsiChartView({ collection: variables });
+
+        this.valuesRegion.show(view);
+    },
+
+    setChartMode: function() {
+        this.model.set('mode', 'chart');
+        this.ui.chartButton.addClass('active');
+        this.ui.tableButton.removeClass('active');
+    },
+
+    setTableMode: function() {
+        this.model.set('mode', 'table');
+        this.ui.tableButton.addClass('active');
+        this.ui.chartButton.removeClass('active');
+    }
+});
+
+var CATALOG_RESULT_DETAILS_VIEW = {
+    cinergi: ResultDetailsCinergiView,
+    hydroshare: ResultDetailsHydroshareView,
+    cuahsi: ResultDetailsCuahsiView,
+};
+
+var CuahsiTableView = Marionette.ItemView.extend({
+    tagName: 'table',
+    className: 'table custom-hover',
+    attributes: {
+        'data-toggle': 'table',
+    },
+    template: resultDetailsCuahsiTableTmpl,
+
+    initialize: function() {
+        var self = this;
+
+        this.variableColumnTmpl = resultDetailsCuahsiTableRowVariableColTmpl;
+
+        this.collection.forEach(function(v, index) {
+            self.listenTo(v, 'change', _.partial(self.onVariableUpdate, index));
+        });
+    },
+
+    onAttach: function() {
+        var data = this.collection.toJSON(),
+            variableColumnFormatter = _.bind(this.variableColumnFormatter, this),
+            enablePopovers = _.bind(this.enablePopovers, this);
+
+        this.$el.bootstrapTable({
+            data: data,
+            columns: [
+                {
+                    field: 'concept_keyword',
+                    formatter: variableColumnFormatter,
+                },
+                {
+                    field: 'most_recent_value',
+                },
+                {
+                    field: 'units',
+                }
+            ],
+            onPostBody: enablePopovers,
+        });
+
+        enablePopovers();
+    },
+
+    enablePopovers: function() {
+        this.$('.variable-popover').popover({
+            placement: 'right',
+            trigger: 'focus',
+        });
+    },
+
+    variableColumnFormatter: function(value, row, index) {
+        return this.variableColumnTmpl.render(
+            this.collection.at(index).toJSON()
+        );
+    },
+
+    onVariableUpdate: function(index) {
+        var row = this.collection.at(index).toJSON();
+
+        this.$el.bootstrapTable('updateRow', {
+            index: index,
+            row: row,
+        });
+    }
+});
+
+var CuahsiChartView = Marionette.ItemView.extend({
+    template: resultDetailsCuahsiChartTmpl,
 });
 
 var ResultMapPopoverDetailView = Marionette.LayoutView.extend({

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -53,7 +53,14 @@
               }
 
               .close {
-                opacity: 0.6;
+                float: none;
+                display: block;
+                opacity: 1;
+                color: #389b9b;
+                text-shadow: none;
+                font-size: 13px;
+                font-weight: 400;
+                padding: 6px 0 2px;
               }
             }
 

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -31,13 +31,13 @@
             }
 
             .spinner:after {
-              top: 44px;
+              top: 22px;
               right: 7px;
             }
 
             .error {
                 position: absolute;
-                top: 33px;
+                top: 11px;
                 right: 10px;
             }
 

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -44,12 +44,16 @@
             .result-detail-header {
               h2 {
                   display: inline-block;
-                  margin: 4px 0;
+                  margin: 10px 0 4px;
                   max-width: 95%;
               }
 
               a.zoom {
                 display: block;
+              }
+
+              .close {
+                opacity: 0.6;
               }
             }
 
@@ -419,5 +423,31 @@
     .data-catalog-validation-msg {
         color: $ui-danger;
         margin-top: 8px;
+    }
+}
+
+.result-details-region {
+    p,
+    .btn {
+        font-size: $font-size-h5;
+    }
+}
+
+.table-data-detail {
+    font-size: $font-size-h5;
+    margin: 14px 0 6px;
+
+    td,
+    th {
+        vertical-align: top;
+        padding-bottom: 10px;
+    }
+
+    td {
+        color: #777;
+    }
+
+    th {
+        padding-right: 20px;
     }
 }

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -30,6 +30,17 @@
                 margin: 5px 0 0 0;
             }
 
+            .spinner:after {
+              top: 44px;
+              right: 7px;
+            }
+
+            .error {
+                position: absolute;
+                top: 33px;
+                right: 10px;
+            }
+
             .result-detail-header {
               h2 {
                   display: inline-block;
@@ -40,6 +51,20 @@
               a.zoom {
                 display: block;
               }
+            }
+
+            .cuahsi-buttons {
+                button {
+                    padding: 1px 4px;
+                    margin-top: -4px;
+                    background-color: transparent;
+                    border: 0;
+
+                    &.active {
+                        color: $paper;
+                        background-color: $black-54;
+                    }
+                }
             }
         }
     }

--- a/src/mmw/sass/utils/_quick-classes.scss
+++ b/src/mmw/sass/utils/_quick-classes.scss
@@ -57,3 +57,7 @@
 .pad-lg{
   padding: 3rem;
 }
+
+.ui-danger {
+  color: $ui-danger;
+}


### PR DESCRIPTION
## Overview

Fetches CUAHSI variable values and populates the UI. The first few commits are cleanup, the later ones do the real fetching and rendering. See commit messages for details.

Also tagging @jfrankl for visual review.

This PR targets the backend branch to minimize the diff, in reality it will target and merge on to `develop`.

Builds on #2353 
Connects #2243 
Connects #2238 

### Demo

![2017-10-09 14 33 07](https://user-images.githubusercontent.com/1430060/31353077-1c82392e-acff-11e7-8979-3b56bf29b6dc.gif)

## Testing Instructions

 * Check out this branch and run `bundle`
   - If you haven't reprovisioned for Ulmo in #2353, reprovision now: `vagrant reload app worker --provision`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz), select a shape and search for something
 * Switch to the WDC tab. Ensure the search results look correct and no fields are missing
 * Click on any result. Ensure you see a spinner in the top right of the search results
 * Ensure that as the values come in, they are populated in the UI
 * Ensure that if there are any failures, there is an error icon where the spinner was
 * Ensure that if there was a failure, re-opening the Details view re-fetches the results
 * Ensure that if the results were successfully fetched, closing the details view and reopening it does not fetch them again
 * Ensure that if the details view is closed while results are fetching, the completion does not cause any JavaScript errors. Ensure that the details view can be re-opened during or after the fetch, and it behaves correctly in all cases
 * Ensure that popovers behave as they should in all cases
 * Ensure you can switch between Chart and Table views in the Details view (there is currently nothing in the Chart view)