### PR TITLE
BiG-CZ: Reduce Significant Digits for Precipitation

### DIFF
--- a/src/mmw/js/src/analyze/templates/climateTable.html
+++ b/src/mmw/js/src/analyze/templates/climateTable.html
@@ -16,7 +16,7 @@
     <tfoot>
     <tr>
         <th>Annual</th>
-        <th class="text-right">{{ totalPpt|round(2)|toLocaleString(2) }}</th>
+        <th class="text-right">{{ totalPpt|round(1)|toLocaleString(1) }}</th>
         <th class="text-right">{{ avgTmean|round(1)|toLocaleString(1) }}</th>
     </tr>
     </tfoot>

--- a/src/mmw/js/src/analyze/templates/climateTableRow.html
+++ b/src/mmw/js/src/analyze/templates/climateTableRow.html
@@ -1,4 +1,4 @@
 <td>{{ monthidx }}</td>
 <td>{{ month }}</td>
-<td class="strong text-right">{{ ppt|round(2)|toLocaleString(2) }}</td>
+<td class="strong text-right">{{ ppt|round(1)|toLocaleString(1) }}</td>
 <td class="strong text-right">{{ tmean|round(1)|toLocaleString(1) }}</td>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1228,6 +1228,7 @@ var ClimateChartView = ChartView.extend({
                     return monthNames[x];
                 },
                 xTickValues: lodash.range(12),
+                yTickFormat: '0.01f',
             };
 
         $(chartEl).empty();

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -283,7 +283,8 @@ function renderLineChart(chartEl, data, options) {
 
     options = options || {};
     _.defaults(options, {
-        margin: {top: 20, right: 30, bottom: 40, left: 60}
+        margin: {top: 20, right: 30, bottom: 40, left: 60},
+        yTickFormat: '.02f',
     });
 
     nv.addGraph(function() {
@@ -298,7 +299,7 @@ function renderLineChart(chartEl, data, options) {
 
         chart.yAxis
             .axisLabel(options.yAxisLabel)
-            .tickFormat(d3.format('.02f'));
+            .tickFormat(d3.format(options.yTickFormat));
 
         chart.tooltip.valueFormatter(function(d) {
             return chart.yAxis.tickFormat()(d) + ' ' + options.yAxisUnit;


### PR DESCRIPTION
## Overview

Since it is unlikely that the underlying data is accurate down to 1/10th a millimeter, we reduce the significant digits in the output to 0.1 cm.

Connects #2284 

### Demo

![image](https://user-images.githubusercontent.com/1430060/31406212-8ab993ea-adce-11e7-9afa-a036736d7d4e.png)

## Testing Instructions

 * Check out this branch and run `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Pick a shape and Analyze. Switch to the Climate tab. Ensure the table has only one decimal place for all values.
 * Ensure the charts also have only one decimal place for both precipitation and temperature.
