### PR TITLE
Geoprocessing API: /token management endpoint

### DIFF
--- a/src/mmw/apps/geoprocessing_api/permissions.py
+++ b/src/mmw/apps/geoprocessing_api/permissions.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from rest_framework import authentication
+from rest_framework.authtoken.serializers import AuthTokenSerializer
+
+
+class AuthTokenSerializerAuthentication(authentication.BaseAuthentication):
+    def authenticate(self, request):
+
+        # if the user has made no attempt to add
+        # credentials via the request body,
+        # pass through so other authentication
+        # can be tried
+        username = request.data.get('username', None)
+        password = request.data.get('password', None)
+        if not username and not password:
+            return None
+
+        serializer = AuthTokenSerializer(data=request.data,
+                                         context={'request': request})
+        serializer.is_valid(raise_exception=True)
+        user = serializer.validated_data['user']
+
+        return(user, None)

--- a/src/mmw/apps/geoprocessing_api/tests.py
+++ b/src/mmw/apps/geoprocessing_api/tests.py
@@ -3,9 +3,90 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from django.test import TestCase
+import json
+
+from django.test import (Client,
+                         TestCase,
+                         LiveServerTestCase)
+from django.contrib.auth.models import User
+
+from rest_framework.authtoken.models import Token
 
 from apps.geoprocessing_api import tasks
+
+
+class ExerciseManageApiToken(LiveServerTestCase):
+    TOKEN_URL = 'http://localhost:8081/api/token/'
+
+    def setUp(self):
+        User.objects.create_user(username='bob', email='bob@azavea.com',
+                                 password='bob')
+
+        User.objects.create_user(username='nono', email='nono@azavea.com',
+                                 password='nono')
+
+    def get_logged_in_session(self, username, password):
+        c = Client()
+        c.login(username=username,
+                password=password)
+        return c
+
+    def get_api_token(self, username='', password='',
+                      session=None):
+        if not session:
+            session = Client()
+
+        payload = None
+        if username or password:
+            payload = {'username': username,
+                       'password': password}
+
+        return session.post(self.TOKEN_URL,
+                            data=payload)
+
+    def test_get_api_token_no_credentials_returns_400(self):
+        response = self.get_api_token()
+        self.assertEqual(response.status_code, 403,
+                         'Incorrect server response. Expected 403 found %s %s'
+                         % (response.status_code, response.content))
+
+    def test_get_api_token_bad_body_credentials_returns_400(self):
+        response = self.get_api_token('bad', 'bad')
+        self.assertEqual(response.status_code, 400,
+                         'Incorrect server response. Expected 400 found %s %s'
+                         % (response.status_code, response.content))
+
+    def test_get_api_token_good_body_credentials_returns_200(self):
+        response = self.get_api_token('bob', 'bob')
+        self.assertEqual(response.status_code, 200,
+                         'Incorrect server response. Expected 200 found %s %s'
+                         % (response.status_code, response.content))
+
+    def test_get_api_token_good_session_credentials_returns_200(self):
+        s = self.get_logged_in_session('bob', 'bob')
+        response = self.get_api_token(session=s)
+        self.assertEqual(response.status_code, 200,
+                         'Incorrect server response. Expected 200 found %s %s'
+                         % (response.status_code, response.content))
+
+    def test_get_api_token_uses_body_credentials_over_session(self):
+        bob_user = User.objects.get(username='bob')
+        bob_token = Token.objects.get(user=bob_user)
+
+        s = self.get_logged_in_session('nono', 'nono')
+        response = self.get_api_token('bob', 'bob', s)
+
+        self.assertEqual(response.status_code, 200,
+                         'Incorrect server response. Expected 200 found %s %s'
+                         % (response.status_code, response.content))
+
+        response_token = json.loads(response.content)['token']
+
+        self.assertEqual(str(response_token), str(bob_token),
+                         """ Incorrect server response.
+                         Expected to get token for user
+                         given in request body %s, but got %s
+                         """ % (bob_token, response_token))
 
 
 class ExerciseAnalyze(TestCase):

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.conf.urls import include, patterns, url
-import rest_framework.authtoken.views
 
 from apps.modeling.views import get_job
 from apps.modeling.urls import uuid_regex
@@ -14,7 +13,7 @@ from apps.geoprocessing_api import views
 urlpatterns = patterns(
     '',
     url(r'^docs/', include('rest_framework_swagger.urls')),
-    url(r'^api-token-auth/', rest_framework.authtoken.views.obtain_auth_token,
+    url(r'^token/', views.get_auth_token,
         name="authtoken"),
     url(r'analyze/land/$', views.start_analyze_land,
         name='start_analyze_land'),

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -36,6 +36,20 @@ def get_auth_token(request, format=None):
 
     ## Request Body
 
+    **Required**
+
+    `username` (`string`): Your username
+
+    `password` (`string`): Your password
+
+
+    **Optional**
+
+    `regenerate` (`boolean`): Regenerate your API token?
+                              Default is `false`.
+
+    **Example**
+
         {
             "username": "your_username",
             "password": "your_password"
@@ -54,6 +68,11 @@ def get_auth_token(request, format=None):
     produces:
         - application/json
     """
+
+    should_regenerate = request.data.get('regenerate', False)
+    if should_regenerate:
+        Token.objects.filter(user=request.user).delete()
+
     token, created = Token.objects.get_or_create(user=request.user)
     return Response({'token': token.key,
                      'created_at': token.created})

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -6,8 +6,10 @@ from celery import chain, group
 
 from rest_framework.response import Response
 from rest_framework import decorators
-from rest_framework.authentication import TokenAuthentication
+from rest_framework.authentication import (TokenAuthentication,
+                                           SessionAuthentication)
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.authtoken.models import Token
 
 from django.utils.timezone import now
 from django.core.urlresolvers import reverse
@@ -20,6 +22,41 @@ from apps.core.decorators import log_request
 from apps.modeling import geoprocessing
 from apps.modeling.views import load_area_of_interest
 from apps.geoprocessing_api import tasks
+from apps.geoprocessing_api.permissions import AuthTokenSerializerAuthentication  # noqa
+
+
+@decorators.api_view(['POST'])
+@decorators.authentication_classes((AuthTokenSerializerAuthentication,
+                                    SessionAuthentication, ))
+@decorators.permission_classes((IsAuthenticated, ))
+def get_auth_token(request, format=None):
+    """
+    Get your API key
+
+
+    ## Request Body
+
+        {
+            "username": "your_username",
+            "password": "your_password"
+        }
+
+    ## Sample Response
+
+        {
+           "token": "ea467ed7f67c53cfdd313198647a1d187b4d3ab9",
+           "created_at": "2017-09-11T14:50:54.738Z"
+        }
+    ---
+    omit_serializer: true
+    consumes:
+        - application/json
+    produces:
+        - application/json
+    """
+    token, created = Token.objects.get_or_create(user=request.user)
+    return Response({'token': token.key,
+                     'created_at': token.created})
 
 
 @decorators.api_view(['POST'])

--- a/src/mmw/apps/user/tests.py
+++ b/src/mmw/apps/user/tests.py
@@ -6,7 +6,8 @@ from __future__ import division
 import requests
 
 from django.test import LiveServerTestCase
-from django.test import TestCase
+from django.test import (TestCase,
+                         Client)
 from django.contrib.auth.models import User
 from apps.user.views import trim_to_valid_length
 
@@ -19,36 +20,18 @@ class TaskRunnerTestCase(LiveServerTestCase):
         User.objects.create_user(username='bob', email='bob@azavea.com',
                                  password='bob')
 
-    def get_token(self):
-        try:
-            init_response = requests.get(self.HOMEPAGE_URL)
-        except requests.RequestException:
-            init_response = {}
-
-        try:
-            csrf = init_response.cookies['csrftoken']
-        except KeyError:
-            csrf = None
-
-        return csrf
-
     def attempt_login(self, username, password):
-        csrf = self.get_token()
-        try:
-            headers = {'HTTP_X_CSRFTOKEN': csrf}
-            payload = {'username': username, 'password': password}
-            response = requests.post(self.LOGIN_URL, params=payload,
-                                     headers=headers)
-        except requests.RequestException:
-            response = {}
-        return response
-
-    def attempt_login_without_token(self, username, password):
         try:
             payload = {'username': username, 'password': password}
             response = requests.post(self.LOGIN_URL, params=payload)
         except requests.RequestException:
             response = {}
+        return response
+
+    def attempt_login_without_token(self, username, password):
+        c = Client(enforce_csrf_checks=True)
+        payload = {'username': username, 'password': password}
+        response = c.post(self.LOGIN_URL, params=payload)
         return response
 
     def test_no_username_returns_400(self):
@@ -87,12 +70,11 @@ class TaskRunnerTestCase(LiveServerTestCase):
                          'Incorrect server response. Expected 200 found %s'
                          % response.status_code)
 
-    # TODO: commented out because it fails and we don't know why yet.
-    # def test_no_token_good_credentials_returns_400(self):
-    #    response = self.attempt_login_without_token('bob', 'bob')
-    #    self.assertEqual(response.status_code, 400,
-    #                     'Incorrect server response. Expected 400 found %s'
-    #                     % response.status_code)
+    def test_no_token_good_credentials_returns_400(self):
+        response = self.attempt_login_without_token('bob', 'bob')
+        self.assertEqual(response.status_code, 400,
+                         'Incorrect server response. Expected 400 found %s'
+                         % response.status_code)
 
     def test_no_token_bad_credentials_returns_400(self):
         response = self.attempt_login_without_token('badbob', 'badpass')

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -308,7 +308,6 @@ REST_FRAMEWORK = {
 }
 
 SWAGGER_SETTINGS = {
-    'exclude_url_names': ['authtoken'],
     'exclude_namespaces': ['bigcz',
                            'mmw',
                            'user'],


### PR DESCRIPTION
## Overview
The account page will need to be able to view a users API token and be able to regenerate it. To support that, replace the `/api-auth-token` endpoint we were using stock from DRF with a custom `/api/token` one that...
   - allows sending credentials via session (and also via json object like the stock DRF view allowed)
   - exposes a `regenerate` flag to signal that the returned token should be a new one
   - returns the `created_at` time in the response

Connects #2188 

### Bonus
I was basing my tests off of `user/tests.py`, but found they weren't using a csrf_token in their requests like they claimed -- figuring this out and how to get mine to pass uncovered why the commented out test in `user/tests` fails. Added ad783d4 to address

## Demo

![screen shot 2017-10-11 at 3 10 49 pm](https://user-images.githubusercontent.com/7633670/31461091-68f206c0-ae96-11e7-90e3-f7322c1cd592.png)

```http
> http --json POST 'http://localhost:8000/api/token/' username="dog" password="dog"
HTTP/1.1 200 OK
Allow: POST, OPTIONS
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Wed, 11 Oct 2017 19:01:37 GMT
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept

{
    "created_at": "2017-10-09T21:28:05.805Z",
    "token": "971922817efb5532bfe1ade983aab31a2dcf3fc9"
}

```

## Notes

I removed the request body from the swagger UI because it seemed wrong to have people sending their passwords in it...hopefully the example gives enough info for people to use the endpoint elsewhere.

## Testing
* `localhost:8000/api/docs`
* while logged into MMW, you should be able to make the `api/token` request with no body and get a useable token
* You should be able to get the same token via your credentials inserted here:
```
 > http --json POST 'http://localhost:8000/api/token/' username="dog" password="dog"
```

You should see the created_at and token update if you pass `regenerate=true`
```
> http --json POST 'http://localhost:8000/api/token/' username="dog" password="dog regenerate=true"
```

