### PR TITLE
Update default Scenario names, titles in Compare

### DIFF
--- a/src/mmw/js/src/compare/controllers.js
+++ b/src/mmw/js/src/compare/controllers.js
@@ -116,14 +116,14 @@ function copyProject(project, aoi_census) {
     });
 }
 
-// Adds special 100% Forest Cover Scenario for the Compare View
+// Adds special Predominantly Forested Scenario for the Compare View
 function addForestCoverScenario(aoi_census) {
     var project = App.currentProject,
         forestCoverScenario = new modelingModels.ScenarioModel({}),
         currentConditions = project.get('scenarios').findWhere({ is_current_conditions: true });
 
     forestCoverScenario.set({
-        name: '100% Forest Cover',
+        name: 'Predominantly Forested',
         is_current_conditions: false,
         is_pre_columbian: true,
         modifications: currentConditions.get('modifications'),

--- a/src/mmw/js/src/compare/templates/compareDescriptionPopover.html
+++ b/src/mmw/js/src/compare/templates/compareDescriptionPopover.html
@@ -1,16 +1,16 @@
 {% if is_pre_columbian %}
     <h3 class="compare-no-mod-title">{{name}}</h3>
     <p>
-        Lorem ipsum this scenario shows the tr55 model results under pre columbian conditions...
+        Model simulation of a pre-development landscape, where forest replaces all agricultural and urban landcover.
     </p>
 {% elif is_current_conditions %}
     <h3 class="compare-no-mod-title">{{name}}</h3>
     <p>
-        Lorem ipsum this is the model run under current conditions
+        Model results based on 2011 NLCD land and 2016 gSSURGO soil datasets.
     </p>
 {% else %}
     <h3 class="compare-no-mod-title">No modifications</h3>
     <p>
-        To add modifications, close this modal and select "Land cover" or "Conservation practices" lorem ipsum dolor sit
+        To add modifications, close this modal and select "Land cover" or "Conservation practices".
     </p>
 {% endif %}

--- a/src/mmw/js/src/compare/tests.js
+++ b/src/mmw/js/src/compare/tests.js
@@ -38,7 +38,7 @@ describe('Compare', function() {
             });
 
             describe('#update', function() {
-                it('uses precolumbian results for 100% forest cover scenario',
+                it('uses precolumbian results for Predominantly Forested scenario',
                    function() {
                        var precolumbianResult =
                                this.scenarios
@@ -125,7 +125,7 @@ describe('Compare', function() {
             });
 
             describe('#update', function() {
-                it('uses precolumbian results for 100% forest cover scenario',
+                it('uses precolumbian results for Predominantly Forested scenario',
                    function() {
                        var precolumbianResult =
                                this.scenarios
@@ -221,13 +221,13 @@ function getTestScenarioCollection() {
     });
 
     forestCover.set({
-        name: '100% Forest Cover',
+        name: 'Predominantly Forested',
         id: 2,
         is_pre_columbian: true,
         is_current_conditions: false,
     });
 
-    // Tests assume [0] == 100% forest cover
+    // Tests assume [0] == Predominantly Forested
     //              [1] == current conditions
     //              [2] == user's scenario
     return new modelingModels.ScenariosCollection([

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -911,11 +911,11 @@ function getCompareScenarios(isTr55) {
         aoi_census = ccScenario.get('aoi_census');
 
     if (isTr55) {
-        // Add 100% Forest Cover scenario
+        // Add Predominantly Forested scenario
         var forestScenario = copyScenario(ccScenario, aoi_census);
 
         forestScenario.set({
-            name: '100% Forest Cover',
+            name: 'Predominantly Forested',
             is_current_conditions: false,
             is_pre_columbian: true,
         });


### PR DESCRIPTION
## Overview

 * "100% Forest Cover" → "Predominantly Forested"
 * Replace Lorem Ipsum with real copy for Predominantly Forested and Current Conditions scenarios

Connects #2325

### Demo

![image](https://user-images.githubusercontent.com/1430060/31451722-d44285ec-ae7a-11e7-9564-5d27c39693bf.png)

![image](https://user-images.githubusercontent.com/1430060/31451729-d88acd1c-ae7a-11e7-908b-2c2adf145519.png)

![image](https://user-images.githubusercontent.com/1430060/31451735-ddf6c990-ae7a-11e7-932f-8f5cc2854199.png)

![image](https://user-images.githubusercontent.com/1430060/31451817-21b79b1e-ae7b-11e7-87b9-ffbe37b00a26.png)

![image](https://user-images.githubusercontent.com/1430060/31451822-261c925e-ae7b-11e7-9cf8-7149907114b1.png)

## Testing Instructions

 * Check out this branch, and `bundle`
 * Create or load a TR-55 project with multiple scenarios
 * Open the Compare View, hover over each scenario type and ensure that the text matches copy specified in #2325