### PR TITLE
Fix Catchment Popup

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -924,7 +924,7 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
                     'nord', data.nord);
         this.catchmentPolygon.addTo(map);
         map.panInsideBounds(this.catchmentPolygon.getBounds());
-        var popUpLocationGeoJSON = utils.findCenterOfShapeIntersection(JSON.parse(geom), App.map.get('areaOfInterest'));
+        var popUpLocationGeoJSON = utils.findCenterOfShapeIntersection(geom, App.map.get('areaOfInterest'));
         this.catchmentPolygon.openPopup(L.GeoJSON.coordsToLatLng(popUpLocationGeoJSON.geometry.coordinates));
     },
 


### PR DESCRIPTION
## Overview

* We were failing to display the water quality catchment
  popup when you click a row in the analyze water quality
  table

* We were still treating the water quality geom as string,
  but it now comes as a regular json object and doesn't
  need to be parsed

Connects #2361 

### Demo

![screen shot 2017-10-11 at 6 20 21 pm](https://user-images.githubusercontent.com/7633670/31469932-bd3528b4-aeb1-11e7-9697-533339614278.png)


## Testing Instructions

Analayze some AoI and confirm you can see the popups when you click one of the Water Quality table rows in analzye.
