### PR TITLE
Create temperature & precipitation legends

### DIFF
--- a/src/mmw/js/src/core/layerPicker.js
+++ b/src/mmw/js/src/core/layerPicker.js
@@ -10,6 +10,7 @@ var $ = require('jquery'),
     layerPickerGroupTmpl = require('./templates/layerPickerGroup.html'),
     layerPickerLayerTmpl = require('./templates/layerPickerLayer.html'),
     layerPickerLegendTmpl = require('./templates/layerPickerLegend.html'),
+    layerPickerColorRampLegendTmpl = require('./templates/layerPickerColorRampLegendTmpl.html'),
     layerPickerNavTmpl = require('./templates/layerPickerNav.html'),
     opacityControlTmpl = require('./templates/opacityControl.html'),
     timeSliderTmpl = require('./templates/timeSliderControl.html');
@@ -112,6 +113,18 @@ var LayerPickerLegendView = Marionette.ItemView.extend({
     }
 });
 
+var LayerPickerColorRampLegendView = Marionette.ItemView.extend({
+    template: layerPickerColorRampLegendTmpl,
+
+    templateHelpers: function() {
+        return {
+            colorRampId: this.model.get('colorRampId'),
+            legendUnitsLabel: this.model.get('legendUnitsLabel'),
+            legendUnitBreaks: this.model.get('legendUnitBreaks'),
+        };
+    }
+});
+
 /* The individual layers in each layer group */
 var LayerPickerLayerView = Marionette.ItemView.extend({
     template: layerPickerLayerTmpl,
@@ -133,21 +146,24 @@ var LayerPickerLayerView = Marionette.ItemView.extend({
             layerDisplay: this.model.get('display'),
             layerClass: this.model.get('active') ? 'layerpicker-title active' : 'layerpicker-title',
             isDisabled: this.model.get('disabled'),
+            useColorRamp: this.model.get('useColorRamp')
         };
     },
 
     onRender: function() {
+        var legendTooltipContent = this.model.get('useColorRamp') ?
+            new LayerPickerColorRampLegendView({ model: this.model }) :
+            new LayerPickerLegendView({ model: this.model });
+
         this.ui.layerHelpIcon.popover({
             trigger: 'focus',
             viewport: {
                 'selector': '.map-container',
                 'padding': 10
             },
-            content: new LayerPickerLegendView({
-                model: this.model,
-            }).render().el
+            content: legendTooltipContent.render().el
         });
-    },
+    }
 });
 
 /* The list of layers in a layer group */

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -144,6 +144,10 @@ var LayerModel = Backbone.Model.extend({
         legendMapping: null,
         cssClassPrefix: null,
         active: false,
+        useColorRamp: false,
+        colorRampId: null,
+        legendUnitsLabel: null,
+        legendUnitBreaks: null,
     },
 
     buildLayer: function(layerSettings, layerType, initialActive) {
@@ -202,6 +206,10 @@ var LayerModel = Backbone.Model.extend({
             legendMapping: layerSettings.legend_mapping,
             cssClassPrefix: layerSettings.css_class_prefix,
             active: layerSettings.display === initialActive ? true : false,
+            useColorRamp: layerSettings.use_color_ramp || false,
+            colorRampId: layerSettings.color_ramp_id || null,
+            legendUnitsLabel: layerSettings.legend_units_label || null,
+            legendUnitBreaks: layerSettings.legend_unit_breaks || null,
         });
     }
 });

--- a/src/mmw/js/src/core/templates/layerPickerColorRampLegendTmpl.html
+++ b/src/mmw/js/src/core/templates/layerPickerColorRampLegendTmpl.html
@@ -1,0 +1,27 @@
+<div class="climate-legend-tooltip">
+    <div id="{{colorRampId}}">
+    </div>
+    <div class="climate-legend-unit-breaks-labels">
+        <div class="climate-legend-label-ticks">
+            {% for break in legendUnitBreaks %}
+                <div class="climate-legend-label-tick"></div>
+            {% endfor %}
+        </div>
+        <div class="climate-legend-label-values">
+            {% for break in legendUnitBreaks %}
+                {% if loop.last %}
+                    <div class="climate-legend-label-value max">
+                        {{break}}
+                    </div>
+                {% else %}
+                    <div class="climate-legend-label-value">
+                        {{break}}
+                    </div>
+                {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+    <div class="climate-legend-units-label">
+        {{legendUnitsLabel}}
+    </div>
+</div>

--- a/src/mmw/js/src/core/templates/layerPickerLayer.html
+++ b/src/mmw/js/src/core/templates/layerPickerLayer.html
@@ -5,7 +5,7 @@
     >
         {{ layerDisplay }}
     </button>
-    {% if not isDisabled and legendMapping %}
+    {% if not isDisabled and (legendMapping or useColorRamp) %}
         <a
             tabindex="-1"
             role="button"

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -130,7 +130,6 @@ LAYER_GROUPS = {
             'code': 'mean_ppt',
             'display': 'Mean Monthly Precipitation',
             'short_display': 'Mean Precip',
-            'css_class_prefix': 'ppt',
             'helptext': 'PRISM monthly mean precipitation.',
             'url': 'https://{s}.tiles.azavea.com/climate/ppt_{month}/{z}/{x}/{y}.png',  # noqa
             'maxNativeZoom': 10,
@@ -138,12 +137,15 @@ LAYER_GROUPS = {
             'opacity': 0.85,
             'has_opacity_slider': True,
             'time_slider_values': MONTH_CODES,
+            'use_color_ramp': True,
+            'color_ramp_id': 'precipitation-legend',
+            'legend_units_label': 'Precipitation (mm/month)',
+            'legend_unit_breaks': [0, '', 100, '', 200, '', 300, '', 400, '', 500]
         },
         {
             'code': 'mean_temp',
             'display': 'Mean Monthly Temperature',
             'short_display': 'Mean Temp',
-            'css_class_prefix': 'ppt',
             'helptext': 'PRISM monthly mean temperature.',
             'url': 'https://{s}.tiles.azavea.com/climate/tmean_{month}/{z}/{x}/{y}.png',  # noqa
             'maxNativeZoom': 10,
@@ -151,6 +153,10 @@ LAYER_GROUPS = {
             'opacity': 0.85,
             'has_opacity_slider': True,
             'time_slider_values': MONTH_CODES,
+            'use_color_ramp': True,
+            'color_ramp_id': 'temperature-legend',
+            'legend_units_label': u'Air Temperature (\xb0C)',
+            'legend_unit_breaks': [-20, '', -8, '', 4, '', 16, '', 28, '', 40]
         },
         {
             'code': 'urban_areas',

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -8,6 +8,10 @@
   border-radius: 2px;
   box-shadow: 0 0 6px $black-74;
 
+  .popover {
+    max-width: none;
+  }
+
   .popover > .popover-content {
       border: #fff 1px solid;
   }
@@ -19,7 +23,7 @@
   left: 265px;
   bottom: 23px;
   width: 150px;
-  padding: 10px;
+  padding: 8px;
   background-color: #fff;
   box-shadow: 0 0 6px $black-74;
   font-size: 13px;
@@ -204,4 +208,75 @@ span.time-slider-end {
 .layerpicker-loading {
   font-size: 13px;
   padding: 0 0 8px 6px;
+}
+
+#temperature-legend {
+  height: 20px;
+  width: 300px;
+  margin-left: 2px;
+  margin-right: 2px;
+  background: linear-gradient(90deg, rgba(46, 0, 103, 1) 0%, rgba(141, 20, 255, 1) 16.666667%, rgba(165, 15, 245, 1) 20.0%, rgba(189, 10, 235, 1) 23.333333%, rgba(213, 5, 225, 1) 26.666667%, rgba(238, 0, 215, 1) 30.0%, rgba(178, 8, 225, 1) 33.333333%, rgba(119, 16, 235, 1) 36.666667%, rgba(59, 25, 245, 1) 40.0%, rgba(0, 34, 255, 1) 43.333333%, rgba(0, 77, 199, 1) 46.666667%, rgba(0, 121, 143, 1) 50.0%, rgba(0, 164, 86, 1) 53.333333%, rgba(0, 208, 31, 1) 56.666667%, rgba(59, 211, 23, 1) 60.0%, rgba(117, 214, 15, 1) 63.333333%, rgba(176, 217, 7, 1) 66.666667%, rgba(236, 221, 0, 1) 70.0%, rgba(240, 165, 0, 1) 73.333333%, rgba(245, 110, 2, 1) 76.666667%, rgba(250, 55, 2, 1) 80.0%, rgba(255, 0, 4, 1) 83.333333%, rgba(87, 0, 16, 1) 100%);
+}
+
+#precipitation-legend {
+  height: 20px;
+  width: 300px;
+  margin-left: 3px;
+  margin-right: 2px;
+  background: linear-gradient(90deg, rgba(230, 111, 0, 1) 0%, rgba(246, 155, 56, 1) 8%, rgba(62, 178, 189, 1) 16%, rgba(97, 212, 231, 1) 24%, rgba(3, 116, 116, 1) 32%, rgba(0, 49, 96, 1) 100%)
+}
+
+.climate-legend-tooltip {
+  height: 65px;
+}
+
+.climate-legend-unit-breaks-labels {
+  font-size: 0.8em;
+  position: absolute;
+  left: 0px;
+}
+
+.climate-legend-label-ticks {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.climate-legend-label-tick {
+  white-space: nowrap;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  display: table-cell;
+}
+
+.climate-legend-label-tick::after {
+  display: block;
+  text-align: center;
+  content: '|';
+}
+
+.climate-legend-label-values {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.climate-legend-label-value {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0 auto;
+  display: table-cell;
+  text-align: center;
+}
+
+.climate-legend-label-value.max {
+  padding-right: 10px;
+}
+
+.climate-legend-units-label {
+  font-weight: bold;
+  text-align: center;
+  padding-top: 30px;
 }


### PR DESCRIPTION
## Overview

This PR adds temperature and precipitation legend popovers to the layer selector. We decided to stick with continuous values rather than the discrete steps set in the other legends, and it's implemented here using css gradients. Beneath the gradients I set up tick marks and value labels to echo how the source image looked in #2204, and also added a units label for emphasis.

Connects #2204 

## Demo

![climate-legends](https://user-images.githubusercontent.com/4165523/31628426-a3e82318-b27e-11e7-8f57-9ddd9b32ac52.gif)

## Notes

We decided to use horizontal popovers for these, and doing that made it possible for the user to arrange the popover and month slider such that the values were both visible simultaneously. In turn, I opted not to try to reposition the legends for these -- which means it's possible to have the legend appear above the slider, but also fairly easy to adjust to that it doesn't.

The source values lists for these in `layer_settings.py` include some empty string values -- this was done specifically to force additional tick marks but not to display unit values. This also potentially makes it fairly easy to adjust these to change which increments we display.

Lastly, I'm not totally certain that the tick marks and labels appear at exactly the correct place beneath the gradient legend: they seem to be at least mostly correct, but it seems like there's a slight difference between the legend in #2204 and the versions here.

## Testing

- get this branch, then `bundle`
- in FF, Safari, IE11, and Chrome, visit the app and open the precipitation and temperature legends and verify that they appear correctly as pictured in the screenshot above