### PR TITLE
Destroy FilterView from Data Catalog on clicking back button

### DIFF
--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -198,6 +198,10 @@ var FormView = Marionette.ItemView.extend({
         'click @ui.filterToggle': 'onFilterToggle',
     },
 
+    onBeforeDestroy: function() {
+        App.rootView.secondarySidebarRegion.empty();
+    },
+
     initialize: function() {
         var updateFilterSidebar = _.bind(function() {
             if (App.rootView.secondarySidebarRegion.hasView()) {


### PR DESCRIPTION
## Overview

This PR fixes a bug whereby the FilterView wouldn't be re-created if the user hit the back button from a Data Sources page on which it had been shown. I *think* using the `_.bind` function to wrap it for updates in the FormView's initializer may have caused it to lose the usual Marionette life cycle methods. (I wrote up a brief description of how this looks on the DOM in #2367).

Whatever the cause, we fix it by manually emptying the view's region before the FormView unmounts.

Connects #2367 

## Testing Instructions
- get this branch, then `bundle`
- visit bigcz, search for an aoi, then open the data catalog
- open the filter view and hit the back button
- open the data catalog and verify that the filter view now opens correctly
- verify that the filter view otherwise works as expected
