### PR TITLE
Clear details geom on leaving DataCatalogWindow

### DIFF
--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -64,6 +64,7 @@ var DataCatalogController = {
         App.map.set({
             dataCatalogResults: null,
             dataCatalogActiveResult: null,
+            dataCatalogDetailResult: null,
         });
         App.rootView.sidebarRegion.currentView.collection.forEach(
             function(catalogModel) {


### PR DESCRIPTION
## Overview

This PR clears the details geometry on unmounting the DataCatalogView component. To accomplish this we set `"dataCatalogDetailResult"` to `null` in the `onBeforeDestroy` method, which gets called before the component's removed from the stack.

Connects #2366

## Testing Instructions
- get this branch, then `bundle`
- visit `localhost:8000?bigcz`, select an AOI including a major river, then search for "water" and open the "WDC" results
- select one of the river gauge results and open its details view. Click back and verify that the details geometry's removed from the map appopriately
- verify that the other geometries work as expected too, and that they don't linger on the map after clicking the back button
