### PR TITLE
Enable downloading compare data to CSV

### DIFF
--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -208,6 +208,7 @@ var WindowModel = Backbone.Model.extend({
         tabs: null,  // TabsCollection
         visibleScenarioIndex: 0, // Index of the first visible scenario
         polling: false,  // If any results are polling
+        projectName: null,
     },
 
     initialize: function() {

--- a/src/mmw/js/src/compare/templates/compareInputs.html
+++ b/src/mmw/js/src/compare/templates/compareInputs.html
@@ -3,3 +3,8 @@
     <button id="compare-input-button-chart" class="{{ 'active' if mode == 'chart' }}"><i class="fa fa-bar-chart"></i></button>
     <button id="compare-input-button-table" class="{{ 'active' if mode == 'table' }}"><i class="fa fa-table"></i></button>
 </div>
+<div class="compare-download compare-input">
+    <button id="compare-input-button-download">
+        <i class="fa fa-download"></i>
+    </button>
+</div>


### PR DESCRIPTION
## Overview

This PR restores & enables the TR-55 compare view's download button, adding a `downloadCSV` method which formats the data for a CSV, transforms it into a blob, then downloads it.

Connects #2313 

## Demo

For this sq km:

![screen shot 2017-10-17 at 3 40 01 pm](https://user-images.githubusercontent.com/4165523/31685601-864fecc2-b351-11e7-9d4c-1d1f26c96a51.png)

Current output data looks like:

```csv
scenario_name	 runoff	 evapotranspiration	 infiltration	 tss_load	 tss_runoff	 tss_loading_rate	 tn_load	 tn_runoff	 tn_loading_rate	 tp_load	 tp_runoff	 tp_loading_rate
Predominantly Forested	0.032306193244325286	0.5257799999999999	1.941913886755675	14.479092616372036	0.032306193244325286	0.14455778895737198	0.33784549438201417	0.032306193244325286	0.0033730150756720125	0.04182848978063032	0.032306193244325286	0.0004176113903212968
Current Conditions	0.04212154065751694	0.524841276465284	1.9330372628771992	24.585768671322167	0.04212154065751694	0.24546181539891856	0.5652460704251255	0.04212154065751694	0.005643359312800157	0.07417454611851056	0.04212154065751694	0.0007405511289902361
New Scenario	0	0.08124225500450855	2.4187578249954917	0	0	0	0	0	0	0	0	0
```

## Notes

Prior to the release, I checked what the old compare view data downloads included and those seemed limited to et, inf, runoff, plus tss, tn, and tp loading rate per scenario. I decided to include all of that data in a single CSV which also includes the names of the scenarios. I left out the precipitation value, but we could also add that as a column if we liked.

I also included tss, tp, and tn values which we don't currently display in the compare view. Happy to drop these if it's unnecessary.

The headers don't currently have units but we can add those, too, if desired.

The download implementation here works in Chrome, FF, IE 11, and Safari, but one quirk with the Safari version is that it doesn't seem to accept the name for the file. I tried to circumvent this in a few ways to no avail.

If we were okay adding a new dependency we could bring in `file-saver` which creates a simpler interface that works across browsers (including Safari) -- basically `fileSaver.saveAs(blob, fileName)` rather than what we've got here. I checked the Bootstrap table downloads and it looks like the export plugin we're using there has `file-saver` as a dependency.

## Testing
- get this branch, `bundle`, then visit localhost:8000 and create a TR-55 project with a few scenarios
- in Chrome, FF, IE11, and Safari click the download button in the compare view and verify that you're able to download the data and that it's accurate wrt to the data shown in the compare view