### PR TITLE
Fix Reverse itsi_auth lookup

### DIFF
--- a/src/mmw/mmw/urls.py
+++ b/src/mmw/mmw/urls.py
@@ -37,6 +37,5 @@ urlpatterns = patterns(
                                    namespace='mmw')),
     url(r'^api/', include(apps.geoprocessing_api.urls)),
     url(r'^micro/', include(apps.water_balance.urls)),
-    url(r'^user/', include(apps.user.urls,
-                           namespace='user'))
+    url(r'^user/', include(apps.user.urls))
 )


### PR DESCRIPTION
## Overview

Fixes ITSI authentication.

### Demo

![2017-10-17 14 19 15](https://user-images.githubusercontent.com/1430060/31681790-3c7e7c9a-b346-11e7-9b31-647d4cf980ed.gif)

### Notes

ITSI Authentication on Staging seems to be broken for a different reason: our OAuth App there seems to not be working any more. Thus, this must be tested with Production credentials.

## Testing Instructions

 * Update your `MMW_ITSI_BASE_URL` environment variable to be https://itsi.portal.concord.org/
 * Restart `mmw-app` service
 * Go to [:8000/](http://localhost:8000/) and try logging in with ITSI credentials. Ensure login is successful and you do not see an error message or error 500 screen.