### PR TITLE
BiG-CZ: WDC Detail Charts

### DIFF
--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -551,8 +551,8 @@ var CuahsiVariable = Backbone.Model.extend({
         // to be either from begin date to end date, or 1 week up to end date,
         // whichever is shorter.
         if (!from || moment(from).isBefore(begin_date)) {
-            if (end_date.diff(begin_date, 'weeks', true) > 1) {
-                params.from_date = end_date.subtract(7, 'days');
+            if (end_date.diff(begin_date, 'months', true) > 1) {
+                params.from_date = moment(end_date).subtract(1, 'months');
             } else {
                 params.from_date = begin_date;
             }

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -598,6 +598,15 @@ var CuahsiVariable = Backbone.Model.extend({
             units: response.variable.units.abbreviation,
             most_recent_value: mrv,
         };
+    },
+
+    getChartData: function() {
+        return this.get('values').map(function(v) {
+            return [
+                moment(v.get('datetime')).valueOf(),
+                parseFloat(v.get('value'))
+            ];
+        });
     }
 });
 

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsi.html
@@ -59,21 +59,12 @@
             <i class="fa fa-globe"></i>&nbsp;Web Services
         </a>
     </p>
-    <div class="spinner {{ "hidden" if not fetching }}"></div>
-    <div class="error {{ "hidden" if not error }}">
-        <i class="fa fa-exclamation-triangle"></i>
-    </div>
+    <div id="cuahsi-status-region"></div>
     <hr />
     <h3>Source Data</h3>
-    <div class="cuahsi-buttons pull-right {{ "hidden" if fetching }}">
-        <button id="cuahsi-button-chart" class="{{ 'active' if mode == 'chart' }}"><i class="fa fa-bar-chart"></i></button>
-        <button id="cuahsi-button-table" class="{{ 'active' if mode == 'table' }}"><i class="fa fa-table"></i></button>
-    </div>
-    <p>
-        Last value collected {{ last_date|toTimeAgo }}
-    </p>
-    <div id="cuahsi-values-region"></div>
-    <!-- TODO Insert Chart https://github.com/WikiWatershed/model-my-watershed/issues/2238 -->
+    <div id="cuahsi-switcher-region"></div>
+    <div id="cuahsi-table-region" class="{{ 'hidden' if mode != 'table' }}"></div>
+    <div id="cuahsi-chart-region" class="{{ 'hidden' if mode != 'chart' }}"></div>
     <hr />
     <h3>Citation</h3>
     <p>{{ service_citation }}</p>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiChart.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiChart.html
@@ -1,0 +1,8 @@
+<select class="cuahsi-variable-select form-control btn btn-small btn-primary">
+    {% for v in variables %}
+        <option value="{{ v.id }}" {{ 'selected' if v.id == selected }}>
+            {{ v.concept_keyword }}
+        </option>
+    {% endfor %}
+</select>
+<div id="cuahsi-variable-chart"></div>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiStatus.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiStatus.html
@@ -1,0 +1,4 @@
+<div class="spinner {{ 'hidden' if not fetching }}"></div>
+<div class="error {{ 'hidden' if not error }}">
+    <i class="fa fa-exclamation-triangle"></i>
+</div>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiSwitcher.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiSwitcher.html
@@ -1,0 +1,7 @@
+<div class="cuahsi-buttons pull-right {{ "hidden" if fetching }}">
+    <button id="cuahsi-button-table" class="{{ 'active' if mode == 'table' }}"><i class="fa fa-table"></i></button>
+    <button id="cuahsi-button-chart" class="{{ 'active' if mode == 'chart' }}"><i class="fa fa-bar-chart"></i></button>
+</div>
+<p>
+    Last value collected {{ last_date|toTimeAgo }}
+</p>

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -22,6 +22,8 @@ var $ = require('jquery'),
     resultDetailsCinergiTmpl = require('./templates/resultDetailsCinergi.html'),
     resultDetailsHydroshareTmpl = require('./templates/resultDetailsHydroshare.html'),
     resultDetailsCuahsiTmpl = require('./templates/resultDetailsCuahsi.html'),
+    resultDetailsCuahsiStatusTmpl = require('./templates/resultDetailsCuahsiStatus.html'),
+    resultDetailsCuahsiSwitcherTmpl = require('./templates/resultDetailsCuahsiSwitcher.html'),
     resultDetailsCuahsiChartTmpl = require('./templates/resultDetailsCuahsiChart.html'),
     resultDetailsCuahsiTableTmpl = require('./templates/resultDetailsCuahsiTable.html'),
     resultDetailsCuahsiTableRowVariableColTmpl = require('./templates/resultDetailsCuahsiTableRowVariableCol.html'),
@@ -484,8 +486,94 @@ var ResultDetailsCuahsiView = ResultDetailsBaseView.extend({
 
     templateHelpers: function() {
         var id = this.model.get('id'),
-            location = id.substring(id.indexOf(':') + 1),
-            fetching = this.model.get('fetching'),
+            location = id.substring(id.indexOf(':') + 1);
+
+        return {
+            location: location,
+        };
+    },
+
+    ui: _.defaults({
+        chartRegion: '#cuahsi-chart-region',
+        tableRegion: '#cuahsi-table-region',
+    }, ResultDetailsBaseView.prototype.ui),
+
+    regions: {
+        statusRegion: '#cuahsi-status-region',
+        switcherRegion: '#cuahsi-switcher-region',
+        chartRegion: '#cuahsi-chart-region',
+        tableRegion: '#cuahsi-table-region',
+    },
+
+    modelEvents: {
+        'change:mode': 'showChartOrTable',
+    },
+
+    initialize: function() {
+        this.model.set('mode', 'table');
+        this.model.fetchCuahsiValues();
+    },
+
+    onShow: function() {
+        var variables = this.model.get('variables');
+
+        this.statusRegion.show(new CuahsiStatusView({ model: this.model }));
+        this.switcherRegion.show(new CuahsiSwitcherView({ model: this.model }));
+        this.tableRegion.show(new CuahsiTableView({ collection: variables }));
+    },
+
+    onDomRefresh: function() {
+        window.closePopover();
+        this.$('[data-toggle="popover"]').popover({
+            placement: 'right',
+            trigger: 'click',
+        });
+    },
+
+    showChartOrTable: function() {
+        if (this.model.get('mode') === 'table') {
+            this.ui.chartRegion.addClass('hidden');
+            this.ui.tableRegion.removeClass('hidden');
+        } else {
+            this.ui.chartRegion.removeClass('hidden');
+            this.ui.tableRegion.addClass('hidden');
+
+            if (!this.chartRegion.hasView()) {
+                this.chartRegion.show(new CuahsiChartView({
+                    collection: this.model.get('variables'),
+                }));
+            }
+        }
+    }
+});
+
+var CuahsiStatusView = Marionette.ItemView.extend({
+    template: resultDetailsCuahsiStatusTmpl,
+
+    modelEvents: {
+        'change:fetching change:error': 'render',
+    },
+});
+
+var CuahsiSwitcherView = Marionette.ItemView.extend({
+    template: resultDetailsCuahsiSwitcherTmpl,
+
+    ui: {
+        chartButton: '#cuahsi-button-chart',
+        tableButton: '#cuahsi-button-table',
+    },
+
+    events: {
+        'click @ui.chartButton': 'setChartMode',
+        'click @ui.tableButton': 'setTableMode',
+    },
+
+    modelEvents: {
+        'change:fetching change:mode': 'render',
+    },
+
+    templateHelpers: function() {
+        var fetching = this.model.get('fetching'),
             error = this.model.get('error'),
             last_date = this.model.get('end_date');
 
@@ -506,72 +594,16 @@ var ResultDetailsCuahsiView = ResultDetailsBaseView.extend({
         }
 
         return {
-            location: location,
             last_date: last_date,
         };
     },
 
-    regions: {
-        valuesRegion: '#cuahsi-values-region',
-    },
-
-    ui: _.defaults({
-        chartButton: '#cuahsi-button-chart',
-        tableButton: '#cuahsi-button-table',
-    }, ResultDetailsBaseView.prototype.ui),
-
-    events: _.defaults({
-        'click @ui.chartButton': 'setChartMode',
-        'click @ui.tableButton': 'setTableMode',
-    }, ResultDetailsBaseView.prototype.events),
-
-    modelEvents: {
-        'change:fetching': 'render',
-        'change:mode': 'showValuesRegion',
-    },
-
-    initialize: function() {
-        this.model.fetchCuahsiValues();
-    },
-
-    onRender: function() {
-        this.showValuesRegion();
-    },
-
-    onDomRefresh: function() {
-        window.closePopover();
-        this.$('[data-toggle="popover"]').popover({
-            placement: 'right',
-            trigger: 'click',
-        });
-    },
-
-    showValuesRegion: function() {
-        if (!this.valuesRegion) {
-            // Don't attempt to display values if this view
-            // has been unloaded.
-            return;
-        }
-
-        var mode = this.model.get('mode'),
-            variables = this.model.get('variables'),
-            view = mode === 'table' ?
-                   new CuahsiTableView({ collection: variables }) :
-                   new CuahsiChartView({ collection: variables });
-
-        this.valuesRegion.show(view);
-    },
-
     setChartMode: function() {
         this.model.set('mode', 'chart');
-        this.ui.chartButton.addClass('active');
-        this.ui.tableButton.removeClass('active');
     },
 
     setTableMode: function() {
         this.model.set('mode', 'table');
-        this.ui.tableButton.addClass('active');
-        this.ui.chartButton.removeClass('active');
     }
 });
 

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -77,6 +77,14 @@
                     }
                 }
             }
+
+            #cuahsi-chart-region {
+                margin-top: 20px;
+
+                .cuahsi-variable-select {
+                    margin-bottom: 10px;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

Adds a chart showing the most recent 1 month of values for each variable in a result.

Connects #2333 

### Demo

![2017-10-18 14 25 25](https://user-images.githubusercontent.com/1430060/31736643-55fd4bba-b413-11e7-88a4-eedf4f8d6477.gif)

Note that the dropdown isn't captured correctly in this GIF, but it's there.

### Notes

One thing we may tweak going forward is how much data do we pull in the first step for each variable. Previously it was 7 days, but here I've upped it to 1 month. The wait is around ~30s for the bigger results, but often quicker, and I think users can wait that long. If not, we can make it 2 weeks, and wait around ~22s.

Another thing I tried to capture here at first was a mechanism to pull in more results. However, this needs some UI thought, for which I'll need to pair with @jfrankl, so I'm deferring that to #2380.

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz), select a shape, search for a term, and head to the WDC tab
 * Open a search result near the top of the list (which is ordered by recency). Once the detail values come in, you should see a chart / table switcher. Click the chart button and ensure it renders.
 * Ensure that the chart has about 1 month of data, and shows 2 weeks at a time by default. Ensure tooltips and the y-axis show the right units, and that the timestamps seem correct.
 * Ensure that for results with single observations (such as an NWISGW result), the chart shows a single value
 * Ensure that for results with failing variables (for which the `/values` endpoint fails, such as GHCN), the chart is empty
 * Ensure there are no errors in the console