### PR TITLE
Fix Compare View Predominantly Forested Chart Values

### DIFF
--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -43,16 +43,6 @@ var ChartRowsCollection = Backbone.Collection.extend({
         this.scenarios.forEach(function(scenario) {
             scenario.get('results').on('change', update);
         });
-    },
-
-    getScenarioResults: function(typeKey) {
-        return this.scenarios.map(function(scenario) {
-            var resultKey = coreUtils.getTR55ResultKey(scenario),
-                result = scenario.get('results')
-                                 .findWhere({ name: typeKey })
-                                 .get('result');
-            return result[typeKey][resultKey];
-        });
     }
 });
 
@@ -62,7 +52,7 @@ var Tr55RunoffCharts = ChartRowsCollection.extend({
                                                .get('inputs')
                                                .findWhere({ name: 'precipitation' }),
             precipitation = coreUtils.convertToMetric(precipitationInput.get('value'), 'in'),
-            results = this.getScenarioResults('runoff');
+            results = this.scenarios.map(coreUtils.getTR55RunoffResult, coreUtils);
 
         this.forEach(function(chart) {
             var key = chart.get('key'),
@@ -87,7 +77,7 @@ var Tr55RunoffCharts = ChartRowsCollection.extend({
 var Tr55QualityCharts = ChartRowsCollection.extend({
     update: function() {
         var aoivm = this.aoiVolumeModel,
-            results = this.getScenarioResults('quality');
+            results = this.scenarios.map(coreUtils.getTR55WaterQualityResult, coreUtils);
 
         this.forEach(function(chart) {
             var name = chart.get('name'),
@@ -135,19 +125,10 @@ var TableRowsCollection = Backbone.Collection.extend({
 
 var Tr55RunoffTable = TableRowsCollection.extend({
     update: function() {
-        var results = this.scenarios.map(function(scenario) {
-                return scenario.get('results')
-                               .findWhere({ name: 'runoff' })
-                               .get('result');
-            }),
-            get = function(key) {
-                return function(result) {
-                    return result.runoff.modified[key];
-                };
-            },
-            runoff = _.map(results, get('runoff')),
-            et     = _.map(results, get('et'    )),
-            inf    = _.map(results, get('inf'   )),
+        var results = this.scenarios.map(coreUtils.getTR55RunoffResult, coreUtils),
+            runoff = _.map(results, 'runoff'),
+            et     = _.map(results, 'et'    ),
+            inf    = _.map(results, 'inf'   ),
             rows   = [
                 { name: "Runoff"            , unit: "cm", values: runoff },
                 { name: "Evapotranspiration", unit: "cm", values: et     },
@@ -161,15 +142,10 @@ var Tr55RunoffTable = TableRowsCollection.extend({
 var Tr55QualityTable = TableRowsCollection.extend({
     update: function() {
         var aoivm = this.aoiVolumeModel,
-            results = this.scenarios.map(function(scenario) {
-                return scenario.get('results')
-                               .findWhere({ name: 'quality' })
-                               .get('result');
-            }),
+            results = this.scenarios.map(coreUtils.getTR55WaterQualityResult, coreUtils),
             get = function(key) {
                 return function(result) {
-                    var measures = result.quality.modified,
-                        load = _.find(measures, { measure: key }).load;
+                    var load = _.find(result, { measure: key }).load;
 
                     return aoivm.getLoadingRate(load);
                 };

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -407,13 +407,34 @@ var utils = {
     // }
     // Use the scenario attributes to figure out which subresult should be
     // accessed.
-    getTR55ResultKey: function(scenario) {
+    _getTR55ResultKey: function(scenario) {
         if (scenario.get('is_current_conditions')) {
             return 'unmodified';
         } else if (scenario.get('is_pre_columbian')) {
             return 'pc_unmodified';
         }
         return 'modified';
+    },
+
+    /** Access a scenario's result for a given type
+     *   @param {ScenarioModel} scenario
+     *   @param {string} typeKey: the type of result you want
+     *                            back; 'runoff', 'quality'
+     **/
+    _getTR55ScenarioResult: function(scenario, typeKey) {
+        var resultKey = this._getTR55ResultKey(scenario),
+            result = scenario.get('results')
+                             .findWhere({ name: typeKey})
+                             .get('result');
+        return result[typeKey][resultKey];
+    },
+
+    getTR55WaterQualityResult: function(scenario) {
+        return this._getTR55ScenarioResult(scenario, 'quality');
+    },
+
+    getTR55RunoffResult: function(scenario) {
+        return this._getTR55ScenarioResult(scenario, 'runoff');
     },
 
     // Reverse sorting of a Backbone Collection.

--- a/src/mmw/js/src/modeling/tr55/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/result.html
@@ -1,11 +1,9 @@
-{% if showModelDescription %}
-    <div class="result-title">
-        Total loads delivered in a 24-hour hypothetical storm event
-    </div>
-    <p class="result-description text-muted">
-        Simulated by EPA's STEP-L model algorithms
-    </p>
-{% endif %}
+<div class="result-title">
+    Total loads delivered in a 24-hour hypothetical storm event
+</div>
+<p class="result-description text-muted">
+    Simulated by EPA's STEP-L model algorithms
+</p>
 <div class="quality-chart-region"></div>
 <div class="quality-table-region"></div>
 <div class="downloadcsv-link" data-action="download-csv">

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/result.html
@@ -1,11 +1,9 @@
-{% if showModelDescription %}
-    <div class="result-title">
-        24-hour hypothetical storm event
-    </div>
-    <p class="result-description text-muted">
-        Simulated by SLAMM and TR-55 model algorithms
-    </p>
-{% endif %}
+<div class="result-title">
+    24-hour hypothetical storm event
+</div>
+<p class="result-description text-muted">
+    Simulated by SLAMM and TR-55 model algorithms
+</p>
 <div class="runoff-chart-region"></div>
 <div class="runoff-table-region"></div>
 <div class="downloadcsv-link" data-action="download-csv">

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -664,8 +664,7 @@ var ScenarioModelToolbarView = Marionette.CompositeView.extend({
         'change:active': 'render'
     },
 
-    initialize: function(options) {
-        this.compareMode = options.compareMode;
+    initialize: function() {
         var modificationsColl = this.model.get('modifications');
         this.listenTo(modificationsColl, 'add remove reset', this.render);
     },


### PR DESCRIPTION
## Overview

- Extract helper functions out to handle getting tr-55 results values
- Use the helper functions in the compare charts and now tables, regular tr-55 charts and tables
- Cleanup `tr55/???/views` — still had a a bit of code referencing the old compare view

Connects #2379

### Demo

<img width="912" alt="screen shot 2017-10-18 at 5 43 13 pm" src="https://user-images.githubusercontent.com/7633670/31744184-df1bf762-b42b-11e7-973d-6cb7bd5e61e7.png">
<img width="910" alt="screen shot 2017-10-18 at 5 43 07 pm" src="https://user-images.githubusercontent.com/7633670/31744185-df25b7b6-b42b-11e7-9004-0d531b78a88e.png">

### Notes
`utils` probably isn't the greatest forever home for these helper functions. Someday we may wish to refactor the `ResultModel` or maybe the `ScenarioModel` so it has proper TR-55 and Mapshed subclasses, and then place the helpers on the TR-55 subclass.

## Testing Instructions

 * Pull and `bundle`
 * Create a tr-55 project for an easily findable huc. Give it a few scenarios, and cover one in forest landcover
 * Do the same for the same huc on staging
 * Compare the displayed results between staging and this branch and confirm they're the same
 * Open the compare view on this branch and confirm the chart and table values match when rounding has been accounted for