### PR TITLE
BiG-CZ: Hide Reset Button for Default Filters

### DIFF
--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -43,6 +43,12 @@ var FilterModel = Backbone.Model.extend({
         window.console.error("Use of unimplemented function",
                              "FilterModel.isActive");
         return false;
+    },
+
+    isDefault: function() {
+        window.console.error("Use of unimplemented function",
+                             "FilterModel.isDefault");
+        return false;
     }
 });
 
@@ -53,6 +59,10 @@ var SearchOption = FilterModel.extend({
 
     isActive: function() {
         return this.get('active');
+    },
+
+    isDefault: function() {
+        return this.get('active') === this.defaults.active;
     }
 });
 
@@ -75,6 +85,11 @@ var DateFilter = FilterModel.extend({
 
     isActive: function() {
         return this.get('fromDate') || this.get('toDate');
+    },
+
+    isDefault: function() {
+        return _.isEmpty(this.get('fromDate')) &&
+               _.isEmpty(this.get('toDate'));
     },
 
     validate: function() {
@@ -110,6 +125,12 @@ var FilterCollection = Backbone.Collection.extend({
 
         return this.filter(isActive).length;
     },
+
+    isDefault: function() {
+        var isDefault = function(filter) { return filter.isDefault(); };
+
+        return this.every(isDefault);
+    }
 });
 
 var Catalog = Backbone.Model.extend({

--- a/src/mmw/js/src/data_catalog/templates/dateFilter.html
+++ b/src/mmw/js/src/data_catalog/templates/dateFilter.html
@@ -7,7 +7,7 @@
             value="{{fromDate}}"
         />
         {% if fromDate %}
-        <a href="javascript:0;" class="data-catalog-clear-icon" title="Clear">
+        <a href="#" class="data-catalog-clear-icon" title="Clear">
             <i class="fa fa-times"></i>
         </a>
         {% endif %}
@@ -20,7 +20,7 @@
             value="{{toDate}}"
         />
         {% if toDate %}
-        <a href="javascript:0;" class="data-catalog-clear-icon" title="Clear">
+        <a href="#" class="data-catalog-clear-icon" title="Clear">
             <i class="fa fa-times"></i>
         </a>
         {% endif %}

--- a/src/mmw/js/src/data_catalog/templates/filterSidebar.html
+++ b/src/mmw/js/src/data_catalog/templates/filterSidebar.html
@@ -2,7 +2,7 @@
     <h3 class="filter-title">Filters</h3>
     <button
         type="button"
-        class="btn btn-link btn-md btn-reset"
+        class="btn btn-link btn-md btn-reset hidden"
         data-action="reset-filters">
         Reset
     </button>

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -1088,6 +1088,26 @@ var FilterSidebar = Marionette.CompositeView.extend({
         return null;
     },
 
+    initialize: function() {
+        var self = this;
+
+        this.collection.forEach(function(model) {
+            self.listenTo(model, 'change', self.toggleReset);
+        });
+    },
+
+    onRender: function() {
+        this.toggleReset();
+    },
+
+    toggleReset: function() {
+        if (this.collection.isDefault()) {
+            this.ui.reset.addClass('hidden');
+        } else {
+            this.ui.reset.removeClass('hidden');
+        }
+    },
+
     clearFilters: function() {
         this.collection.forEach(function(model) { model.reset(); });
     }

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -374,6 +374,7 @@
 .data-catalog-filter-window > .data-catalog-filters-header {
     display: flex;
     flex-direction: row;
+    height: 44px;
     padding-bottom: 6px;
     > .filter-title {
         line-height: $height-md;


### PR DESCRIPTION
## Overview

In cases when the default filters are currently applied, the Reset button resulted in a no-op. This hides the button when a no-op is expected.

Also fixes an issue where resetting multiple active filters would lead to multiple parallel searches and inconsistent UI state.

Connects #2317

### Demo

![2017-10-18 17 59 20](https://user-images.githubusercontent.com/1430060/31744906-c9cc058e-b42e-11e7-9c28-d779f0794c25.gif)

Tagging @jfrankl and @ajrobbins for visual review.

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and select an area. Move to the Search stage.
 * Expend the Filters sidebar. Test that setting the filters other than defaults shows the Reset button, and restoring them to the default state (either by manipulating the filter directly or by clicking the Reset button) hides the Reset button.
 * Ensure that reseting multiple filters fires a single subsequent search, after all filters have been reset
 * Ensure there are no errors in the console