### PR TITLE
Hide slider on account & project pages

### DIFF
--- a/src/mmw/js/src/account/controllers.js
+++ b/src/mmw/js/src/account/controllers.js
@@ -27,7 +27,7 @@ function showAccountView() {
             model: new models.AccountContainerModel()
         })
     );
-    App.rootView.layerPickerRegion.empty();
+    App.destroyLayerPicker();
 
     App.state.set('active_page', coreUtils.accountPageTitle);
 }

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -96,6 +96,11 @@ var App = new Marionette.Application({
         this.rootView.layerPickerRegion.show(this.layerPickerView);
     },
 
+    destroyLayerPicker: function() {
+        this.rootView.layerPickerRegion.empty();
+        this.rootView.layerPickerSliderRegion.empty();
+    },
+
     getAnalyzeCollection: function() {
         if (!this.analyzeCollection) {
             var aoi = this.map.get('areaOfInterest'),

--- a/src/mmw/js/src/projects/controllers.js
+++ b/src/mmw/js/src/projects/controllers.js
@@ -14,7 +14,7 @@ var ProjectsController = {
             new views.ProjectsView()
         );
 
-        App.rootView.layerPickerRegion.empty();
+        App.destroyLayerPicker();
 
         App.state.set('active_page', coreUtils.projectsPageTitle);
     },


### PR DESCRIPTION
## Overview

This PR ups the z-index for the `#account-container` and `#projects-container` to ensure these display above the climate slider. Previously their z-indices were low enough that the slider showed up.

Connects #2404

### Notes

I considered also reducing the z-index for the slider's container, but I'm not sure what that number's interleaved with so this seemed to be a more reasonable fix.

## Testing Instructions
- get this branch, then `bundle`
- open a climate slider, then visit the accounts page. Verify that the slider's not visible
- repeat with the projects page
