### PR TITLE
Adjust BigCZ max area from 1500 -> 8000

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -383,7 +383,7 @@ OMGEO_SETTINGS = [[
 MMW_MAX_AREA = 75000  # Max area in km2, about the size of West Virginia
 
 BIGCZ_HOST = 'portal.bigcz.org'  # BiG-CZ Host, for enabling custom behavior
-BIGCZ_MAX_AREA = 1500  # Max area in km2, limited by CUAHSI
+BIGCZ_MAX_AREA = 8000  # Max area in km2, limited by CUAHSI
 BIGCZ_CLIENT_TIMEOUT = 5  # timeout in seconds
 BIGCZ_CLIENT_PAGE_SIZE = 100
 


### PR DESCRIPTION
## Overview

This PR increases the max analyzable area for BigCZ from 1500 to 8000.

Connects #2388 

### Demo

<img width="527" alt="screen shot 2017-10-19 at 5 05 58 pm" src="https://user-images.githubusercontent.com/4165523/31794296-d5cc3586-b4ef-11e7-89d8-21c67f8395f0.png">

&

![screen shot 2017-10-19 at 5 06 11 pm](https://user-images.githubusercontent.com/4165523/31794302-da2bef7c-b4ef-11e7-9fe2-45d95a66a012.png)

## Testing Instructions
- get this branch, bundle, then visit bigcz
- try to analyze an aoi larger than 1500 but below 8000 sq km & verify that it works
- try to analyze an aoi larger than 8000 sq km & verify that you encounter the guard
