### PR TITLE
BiG-CZ: Add Variable Data Type in WDC Detail View

### DIFF
--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -508,6 +508,11 @@ var utils = {
                wkaoi.includes('__') &&
                !lodash.startsWith(wkaoi, '__') &&
                !lodash.endsWith(wkaoi, '__');
+    },
+
+    // Array.filter(distinct) to get distinct values
+    distinct: function(value, index, self) {
+        return self.indexOf(value) === index;
     }
 };
 

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -393,6 +393,7 @@ var Result = Backbone.Model.extend({
                             v.set({
                                 'units': info.variable.units.abbreviation,
                                 'speciation': info.variable.speciation,
+                                'data_type': info.variable.data_type,
                                 'sample_medium': info.variable.sample_medium,
                             });
 
@@ -522,6 +523,7 @@ var CuahsiVariable = Backbone.Model.extend({
         name: '',
         units: '',
         concept_keyword: '',
+        data_type: '',
         speciation: '',
         sample_medium: '',
         wsdl: '',
@@ -595,6 +597,7 @@ var CuahsiVariable = Backbone.Model.extend({
 
         return {
             name: response.variable.name,
+            data_type: response.variable.data_type,
             sample_medium: response.variable.sample_medium,
             units: response.variable.units.abbreviation,
             most_recent_value: mrv,

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiChart.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiChart.html
@@ -5,6 +5,9 @@
             {% if v.data_type and v.data_type != 'Unknown' and v.data_type != 'Instantaneous' %}
                 ({{ v.data_type }})
             {% endif %}
+            {% if v.units %}
+                ({{ v.units }})
+            {% endif %}
         </option>
     {% endfor %}
 </select>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiChart.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiChart.html
@@ -2,6 +2,9 @@
     {% for v in variables %}
         <option value="{{ v.id }}" {{ 'selected' if v.id == selected }}>
             {{ v.concept_keyword }}
+            {% if v.data_type and v.data_type != 'Unknown' and v.data_type != 'Instantaneous' %}
+                ({{ v.data_type }})
+            {% endif %}
         </option>
     {% endfor %}
 </select>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiTableRowVariableCol.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCuahsiTableRowVariableCol.html
@@ -1,4 +1,7 @@
 {{ concept_keyword }}
+{% if data_type and data_type != 'Unknown' and data_type != 'Instantaneous' %}
+    ({{ data_type }})
+{% endif %}
 {% if name %}
     <a class="variable-popover" tabindex="0"
         role="button" data-container="body"

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -709,6 +709,7 @@ var CuahsiChartView = Marionette.ItemView.extend({
                     id: v.get('id'),
                     concept_keyword: v.get('concept_keyword'),
                     data_type: v.get('data_type'),
+                    units: v.get('units'),
                 };
             });
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -708,6 +708,7 @@ var CuahsiChartView = Marionette.ItemView.extend({
                 return {
                     id: v.get('id'),
                     concept_keyword: v.get('concept_keyword'),
+                    data_type: v.get('data_type'),
                 };
             });
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -8,6 +8,7 @@ var $ = require('jquery'),
     App = require('../app'),
     analyzeViews = require('../analyze/views.js'),
     settings = require('../core/settings'),
+    utils = require('../core/utils'),
     models = require('./models'),
     errorTmpl = require('./templates/error.html'),
     dateFilterTmpl = require('./templates/dateFilter.html'),
@@ -410,6 +411,7 @@ var StaticResultView = Marionette.ItemView.extend({
             return {
                 'concept_keywords': this.model.get('variables')
                                               .pluck('concept_keyword')
+                                              .filter(utils.distinct)
                                               .join('; '),
             };
         }


### PR DESCRIPTION
## Overview

Adds Variable Data Type in the UI to more easily differentiate the variables in the table. Adds Data Type and Units to the Chart Dropdown to more easily differentiate variables there. Reduces repetition in variable listing in the search result.

There was some initial talk of hiding the Fahrenheit results, but the most recent consensus is to keep them around. See https://github.com/WikiWatershed/model-my-watershed/issues/2406#issuecomment-338018181

Connects #2406 

### Demo

#### Unique values in search results:

![image](https://user-images.githubusercontent.com/1430060/31795170-c90031ce-b4f2-11e7-8f37-52f02c99cb75.png)

vs

![image](https://user-images.githubusercontent.com/1430060/31795194-e6708916-b4f2-11e7-9843-0eb7805fa029.png)

#### Data Type in Table

![image](https://user-images.githubusercontent.com/1430060/31795225-07e751ce-b4f3-11e7-9d7b-31e3a6332066.png)

#### Data Type and Units in Chart Dropdown

![image](https://user-images.githubusercontent.com/1430060/31795254-1dfd1b4c-b4f3-11e7-8774-b0d0b90aa4f2.png)

Also tagging @aufdenkampe for visual review.

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz), select the Philadelphia / Schuylkill HUC-12 and proceed to search
 * Go to the WDC tab. Select NWISDV 01474500 and inspect the results. They should match the screenshots above.
 * Select other results. They should function as expected.