### PR TITLE
BiG-CZ: HydroShare List View Updates

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -202,8 +202,8 @@ def group_series_by_location(series):
 
 
 def make_request(request, expiry, **kwargs):
-    key = 'bigcz_{}_{}'.format(request.method.name,
-                               hash(frozenset(kwargs.items())))
+    key = 'bigcz_cuahsi_{}_{}'.format(request.method.name,
+                                      hash(frozenset(kwargs.items())))
     cached = cache.get(key)
     if cached:
         return cached

--- a/src/mmw/apps/bigcz/clients/hydroshare/__init__.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/__init__.py
@@ -3,11 +3,10 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from apps.bigcz.models import Resource
-from apps.bigcz.serializers import ResourceSerializer
+from apps.bigcz.clients.hydroshare import models, serializers
 
 # Import catalog name and search function, so it can be exported from here
 from apps.bigcz.clients.hydroshare.search import CATALOG_NAME, search  # NOQA
 
-model = Resource
-serializer = ResourceSerializer
+model = models.HydroshareResource
+serializer = serializers.HydroshareResourceSerializer

--- a/src/mmw/apps/bigcz/clients/hydroshare/models.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/models.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from apps.bigcz.models import Resource
+
+
+class HydroshareResource(Resource):
+    def __init__(self, id, description, author, links, title,
+                 created_at, updated_at, geom, begin_date, end_date):
+        super(HydroshareResource, self).__init__(id, description, author,
+                                                 links, title, created_at,
+                                                 updated_at, geom)
+
+        self.begin_date = begin_date
+        self.end_date = end_date

--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -154,7 +154,7 @@ def search(**kwargs):
         raise ValueError(data)
 
     records = [parse_record(item) for item in data['results']]
-    results = sorted(records,
+    results = sorted([r for r in records if r.geom],
                      key=nullable_attrgetter('end_date', DATE_MIN),
                      reverse=True)
     count = data['count']

--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -114,6 +114,7 @@ def search(**kwargs):
     from_date = kwargs.get('from_date')
     bbox = kwargs.get('bbox')
     page = kwargs.get('page')
+    exclude_private = 'exclude_private' in kwargs.get('options')
 
     if not query:
         raise ValidationError({
@@ -153,7 +154,11 @@ def search(**kwargs):
     if 'results' not in data:
         raise ValueError(data)
 
-    records = [parse_record(item) for item in data['results']]
+    items = data['results']
+    if exclude_private:
+        items = [item for item in items if item['public']]
+
+    records = [parse_record(item) for item in items]
     results = sorted([r for r in records if r.geom],
                      key=nullable_attrgetter('end_date', DATE_MIN),
                      reverse=True)

--- a/src/mmw/apps/bigcz/clients/hydroshare/search.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/search.py
@@ -125,14 +125,6 @@ def search(**kwargs):
         'full_text_search': query,
     }
 
-    if to_date:
-        params.update({
-            'to_date': prepare_date(to_date)
-        })
-    if from_date:
-        params.update({
-            'from_date': prepare_date(from_date)
-        })
     if bbox:
         params.update(prepare_bbox(bbox))
         params.update({
@@ -170,7 +162,18 @@ def search(**kwargs):
         items = [item for item in items if item['public']]
 
     records = [parse_record(item) for item in items]
-    results = sorted([r for r in records if r.geom],
+    # Include only those with geometries
+    records = [r for r in records if r.geom]
+
+    if from_date:
+        records = [r for r in records
+                   if r.end_date and r.end_date >= from_date]
+
+    if to_date:
+        records = [r for r in records
+                   if r.begin_date and r.begin_date <= to_date]
+
+    results = sorted(records,
                      key=nullable_attrgetter('end_date', DATE_MIN),
                      reverse=True)
     count = data['count']

--- a/src/mmw/apps/bigcz/clients/hydroshare/serializers.py
+++ b/src/mmw/apps/bigcz/clients/hydroshare/serializers.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from rest_framework.serializers import DateTimeField
+
+from apps.bigcz.serializers import ResourceSerializer
+
+
+class HydroshareResourceSerializer(ResourceSerializer):
+    begin_date = DateTimeField()
+    end_date = DateTimeField()

--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -36,7 +36,10 @@ var DataCatalogController = {
                 id: 'hydroshare',
                 name: 'HydroShare',
                 results: new models.Results(null, { catalog: 'hydroshare' }),
-                filters: new models.FilterCollection([dateFilter])
+                filters: new models.FilterCollection([
+                    dateFilter,
+                    new models.PrivateResourcesFilter(),
+                ]),
             }),
             new models.Catalog({
                 id: 'cuahsi',

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -75,6 +75,15 @@ var GriddedServicesFilter = SearchOption.extend({
     }, SearchOption.prototype.defaults)
 });
 
+var PrivateResourcesFilter = SearchOption.extend({
+    defaults: _.defaults({
+        id: 'exclude_private',
+        type: 'checkbox',
+        label: 'Exclude Private Resources',
+        active: true,
+    }, SearchOption.prototype.defaults)
+});
+
 var DateFilter = FilterModel.extend({
     defaults: _.defaults({
         id: 'date',
@@ -647,6 +656,7 @@ var CuahsiVariables = Backbone.Collection.extend({
 
 module.exports = {
     GriddedServicesFilter: GriddedServicesFilter,
+    PrivateResourcesFilter: PrivateResourcesFilter,
     DateFilter: DateFilter,
     FilterCollection: FilterCollection,
     Catalog: Catalog,

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -341,6 +341,8 @@ var Result = Backbone.Model.extend({
         links: null, // Array
         created_at: '',
         updated_at: '',
+        begin_date: '',
+        end_date: '',
         active: false,
         show_detail: false, // Show this result as the detail view?
         variables: null,  // CuahsiVariables Collection

--- a/src/mmw/js/src/data_catalog/templates/searchResultHydroshare.html
+++ b/src/mmw/js/src/data_catalog/templates/searchResultHydroshare.html
@@ -1,0 +1,18 @@
+<div class="resource-wrapper {{ 'active' if active }}">
+    <h3 class="resource-title">
+        {{ title }}
+    </h3>
+    {% if author %}
+        <div class="resource-author">
+            <i class="fa fa-user"></i> {{ author }}
+        </div>
+    {% endif %}
+    <div class="resource-date">
+        <i class="fa fa-calendar"></i>
+        {% if begin_date %}
+            {{ begin_date|toDateWithoutTime }}&thinsp;&ndash;&thinsp;{{ end_date|toDateWithoutTime }}
+        {% else %}
+            Unknown Time Period
+        {% endif %}
+    </div>
+</div>

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -17,6 +17,7 @@ var $ = require('jquery'),
     formTmpl = require('./templates/form.html'),
     pagerTmpl = require('./templates/pager.html'),
     searchResultTmpl = require('./templates/searchResult.html'),
+    searchResultHydroshareTmpl = require('./templates/searchResultHydroshare.html'),
     searchResultCuahsiTmpl = require('./templates/searchResultCuahsi.html'),
     tabContentTmpl = require('./templates/tabContent.html'),
     tabPanelTmpl = require('./templates/tabPanel.html'),
@@ -40,7 +41,7 @@ var ENTER_KEYCODE = 13,
     PAGE_SIZE = settings.get('data_catalog_page_size'),
     CATALOG_RESULT_TEMPLATE = {
         cinergi: searchResultTmpl,
-        hydroshare: searchResultTmpl,
+        hydroshare: searchResultHydroshareTmpl,
         cuahsi: searchResultCuahsiTmpl,
     };
 


### PR DESCRIPTION
## Overview

Updates HydroShare search result list view according to:

 * Show author on the first line, date on the second
 * Instead of creation date, we now show the coverage period range
 * If coverage period range is not available, we say "Unknown Time Period" (which read better than "Time Period Unknown" to me)
 * Results are sorted by descending end of coverage date, so items without coverage dates are at the bottom
 * If a result does not have a geometry (point or box) it is excluded
 * "Private" (`public=false`) results are not shown by default. A "Exclude Private Resources" filter is added which works identically to the "Exclude Gridded" filter
 * HydroShare API requests are cached for fast filter switching

Connects #2390 

### Demo

![2017-10-20 14 27 04](https://user-images.githubusercontent.com/1430060/31836650-0c7c4440-b5a4-11e7-8b63-1aa25341a460.gif)

### Notes

The date filters now operate on a date that is no longer shown in the UI. I'm waiting for feedback on this here: https://github.com/WikiWatershed/model-my-watershed/issues/2390#issuecomment-338290839, which may incur some revision.

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and select a shape, search for anything in HydroShare
 * Ensure that the results match the specs described in the source card