### PR TITLE
BiG-CZ: Increase Area of Interest Size

### DIFF
--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -8,6 +8,8 @@ var turfArea = require('turf-area'),
     models = require('./models'),
     views = require('./views');
 
+var MAX_UNCAPPED_AOI = 1500000000;  // 1,500 km²
+
 var DataCatalogController = {
     dataCatalogPrepare: function() {
         if (!App.map.get('areaOfInterest')) {
@@ -23,40 +25,40 @@ var DataCatalogController = {
             'active_page': coreUtils.dataCatalogPageTitle,
         });
 
-        var aoiArea = turfArea(App.map.get('areaOfInterest'));
-        var fromDate = aoiArea < 1500000000 ? null :
-                       moment().subtract(5, 'years').format('L');
+        var aoiArea = turfArea(App.map.get('areaOfInterest')),
+            fromDate = aoiArea < MAX_UNCAPPED_AOI ? null :
+                       moment().subtract(5, 'years').format('L'),
 
-        var form = new models.SearchForm();
-        var dateFilter = new models.DateFilter({ fromDate: fromDate });
+            form = new models.SearchForm(),
+            dateFilter = new models.DateFilter({ fromDate: fromDate }),
 
-        var catalogs = new models.Catalogs([
-            new models.Catalog({
-                id: 'cinergi',
-                name: 'CINERGI',
-                active: true,
-                results: new models.Results(null, { catalog: 'cinergi' }),
-                filters: new models.FilterCollection([dateFilter])
-            }),
-            new models.Catalog({
-                id: 'hydroshare',
-                name: 'HydroShare',
-                results: new models.Results(null, { catalog: 'hydroshare' }),
-                filters: new models.FilterCollection([dateFilter])
-            }),
-            new models.Catalog({
-                id: 'cuahsi',
-                name: 'WDC',
-                is_pageable: false,
-                results: new models.Results(null, { catalog: 'cuahsi' }),
-                filters: new models.FilterCollection([
-                    dateFilter,
-                    new models.GriddedServicesFilter()
-                ])
-            })
-        ]);
+            catalogs = new models.Catalogs([
+                new models.Catalog({
+                    id: 'cinergi',
+                    name: 'CINERGI',
+                    active: true,
+                    results: new models.Results(null, { catalog: 'cinergi' }),
+                    filters: new models.FilterCollection([dateFilter])
+                }),
+                new models.Catalog({
+                    id: 'hydroshare',
+                    name: 'HydroShare',
+                    results: new models.Results(null, { catalog: 'hydroshare' }),
+                    filters: new models.FilterCollection([dateFilter])
+                }),
+                new models.Catalog({
+                    id: 'cuahsi',
+                    name: 'WDC',
+                    is_pageable: false,
+                    results: new models.Results(null, { catalog: 'cuahsi' }),
+                    filters: new models.FilterCollection([
+                        dateFilter,
+                        new models.GriddedServicesFilter()
+                    ])
+                })
+            ]),
 
-        var resultsWindow = new views.ResultsWindow({
+            resultsWindow = new views.ResultsWindow({
                 model: form,
                 collection: catalogs
             }),

--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var App = require('../app'),
+var turfArea = require('turf-area'),
+    moment = require('moment'),
+    App = require('../app'),
     router = require('../router').router,
     coreUtils = require('../core/utils'),
     models = require('./models'),
@@ -21,8 +23,12 @@ var DataCatalogController = {
             'active_page': coreUtils.dataCatalogPageTitle,
         });
 
+        var aoiArea = turfArea(App.map.get('areaOfInterest'));
+        var fromDate = aoiArea < 1500000000 ? null :
+                       moment().subtract(5, 'years').format('L');
+
         var form = new models.SearchForm();
-        var dateFilter = new models.DateFilter();
+        var dateFilter = new models.DateFilter({ fromDate: fromDate });
 
         var catalogs = new models.Catalogs([
             new models.Catalog({

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -383,7 +383,7 @@ OMGEO_SETTINGS = [[
 MMW_MAX_AREA = 75000  # Max area in km2, about the size of West Virginia
 
 BIGCZ_HOST = 'portal.bigcz.org'  # BiG-CZ Host, for enabling custom behavior
-BIGCZ_MAX_AREA = 1500  # Max area in km2, limited by CUAHSI
+BIGCZ_MAX_AREA = 8000  # Max area in km2, limited by CUAHSI
 BIGCZ_CLIENT_TIMEOUT = 5  # timeout in seconds
 BIGCZ_CLIENT_PAGE_SIZE = 100
 


### PR DESCRIPTION
## Overview

Increases size of area of interest to 8000. Limits BiG-CZ searches to the last five years by default whenever area of interest is bigger than 1500 km².

The commit 76e0eca alleviates a CPU and RAM utilization issue where a large number of CUAHSI results would fail to serialize to JSON in order to cache. Now we don't cache the CUAHSI results. However, `suds` itself chokes at a certain point (around 800 or so results). Thus the time limit.

Builds on top of #2409 
Connects #2388 

### Notes

Should we consider adding some sort of message that explains this behavior to the user?

## Testing Instructions

 * Test large areas of interest, ensure CINERGI, HydroShare, and WDC all return values and don't error out