### PR TITLE
Increase max size for MapShed AoI processing

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -78,14 +78,15 @@ var ModelSelectionDropdownView = Marionette.ItemView.extend({
         if (modelPackageName === 'gwlfe' && settings.get('mapshed_max_area')) {
             var areaInSqKm = utils.changeOfAreaUnits(aoiModel.get('area'),
                                                      aoiModel.get('units'),
-                                                     'km<sup>2</sup>');
+                                                     'km<sup>2</sup>'),
+                mapshedMaxArea = settings.get('mapshed_max_area');
 
-            if (areaInSqKm > settings.get('mapshed_max_area')) {
+            if (areaInSqKm > mapshedMaxArea) {
                 alertView = new modalViews.AlertView({
                     model: new modalModels.AlertModel({
                         alertMessage: "The selected Area of Interest is too big for " +
                                  "the Watershed Multi-Year Model. The currently " +
-                                 "maximum supported size is 1000 km².",
+                                 "maximum supported size is " + mapshedMaxArea + " km².",
                         alertType: modalModels.AlertTypes.warn
                     })
                 });

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -481,7 +481,7 @@ GWLFE_CONFIG = {
     'SSLDR': 4.4,
     'SSLDM': 2.2,
     'WeatherNull': -99999,  # This value is used to indicate NULL in ms_weather dataset
-    'MaxAoIArea': 1000,  # Maximum allowed area in square kilometers
+    'MaxAoIArea': 5000,  # Maximum allowed area in square kilometers
     'ETGrowCoeff': [
         1.00,  # Hay/Pasture
         0.80,  # Cropland


### PR DESCRIPTION
## Overview

5000 km2 is a minimum threshold client specified target for running
mapshed jobs.  This was verified to run and not time out directly on
staging instances, it's unlikely that a unmodified VM dev environment
will successfully complete regularly.  There are higher thresholds
desired, and potentially better ways to accommodate them by increasing
Worker CPU counts and adjusting Celery concurrency.  To meet a short-term
testing deadline, I'm proposing this modest change as a first step.

Connects #2375 

### Demo

Here's a 3000 km<sup>2</sup> HUC8 in philadelphia that is successfully modeled, even in development:

![screenshot from 2017-10-23 10 19 50](https://user-images.githubusercontent.com/1014341/31894241-ced941ee-b7db-11e7-9b3e-e12144f4d652.png)


## Testing Instructions

* Mapshed areas that previously worked should continue to do so (1000 km<sup>2</sup> and below)
* Areas up to 5000 km<sup>2</sup> will likely only intermittently work in development, but were tested reliably nearing the upper limit of timeout on staging infrastructure (~30s).  You should not be warned about their size.
* Watersheds above 5000 km<sup>2</sup> should still warn and prevent modeling