### PR TITLE
Throttle Geoprocessing API Requests

### DIFF
--- a/src/mmw/apps/geoprocessing_api/throttling.py
+++ b/src/mmw/apps/geoprocessing_api/throttling.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.conf import settings
+
+from rest_framework.throttling import UserRateThrottle
+
+
+class GeoprocessingApiUserRateThrottle(UserRateThrottle):
+    """ Only throttle "real" users of the API, not the client app"""
+    def allow_request(self, request, view):
+        if request.user and \
+           request.user.username == settings.CLIENT_APP_USERNAME:
+            # If the user is the client app, pass through and
+            # don't attempt any throttling
+            return True
+
+        return UserRateThrottle.allow_request(self, request, view)
+
+
+class BurstRateThrottle(GeoprocessingApiUserRateThrottle):
+    scope = 'burst'
+
+
+class SustainedRateThrottle(GeoprocessingApiUserRateThrottle):
+    scope = 'sustained'

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -26,6 +26,8 @@ from apps.modeling import geoprocessing
 from apps.modeling.views import load_area_of_interest
 from apps.geoprocessing_api import tasks
 from apps.geoprocessing_api.permissions import AuthTokenSerializerAuthentication  # noqa
+from apps.geoprocessing_api.throttling import (BurstRateThrottle,
+                                               SustainedRateThrottle)
 
 
 @decorators.api_view(['POST'])
@@ -84,6 +86,7 @@ def get_auth_token(request, format=None):
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
+@decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
 def start_rwd(request, format=None):
     """
@@ -285,6 +288,7 @@ def start_rwd(request, format=None):
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
+@decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
 def start_analyze_land(request, format=None):
     """
@@ -480,6 +484,7 @@ def start_analyze_land(request, format=None):
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
+@decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
 def start_analyze_soil(request, format=None):
     """
@@ -607,6 +612,7 @@ def start_analyze_soil(request, format=None):
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
+@decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
 def start_analyze_animals(request, format=None):
     """
@@ -718,6 +724,7 @@ def start_analyze_animals(request, format=None):
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
+@decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
 def start_analyze_pointsource(request, format=None):
     """
@@ -808,6 +815,7 @@ def start_analyze_pointsource(request, format=None):
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
+@decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
 def start_analyze_catchment_water_quality(request, format=None):
     """
@@ -927,6 +935,7 @@ def start_analyze_catchment_water_quality(request, format=None):
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
+@decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
 def start_analyze_climate(request, format=None):
     """

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -304,7 +304,11 @@ REST_FRAMEWORK = {
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
-    ]
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'sustained': '5000/day',
+        'burst': '20/min',
+    },
 }
 
 SWAGGER_SETTINGS = {


### PR DESCRIPTION
## Overview

* Add a custom throttle base class to only throttle true users of the
  API and not the client app

* Throttle users at a burst (per minute rate) and a sustained (per day rate). Settings
  are from the [climate-api](https://github.com/azavea/climate-change-api/blob/34a17fa753dd2b1f4d1b20d6b960b347d80733dd/django/climate_change_api/climate_change_api/settings.py#L342). We may need to finetune them at a later date

* Throttle all start-job geoproccessing api endpoints

Connects #2189 

### Demo

```sh
> curl -H "Content-Type: application/json" \
             -H "Authorization: Token f19b20fe829f92ed176d8f90a1606531b445727c" \
             -X POST -d '{ "location": [39.67185812402583,-75.76742706298828] }' \
             localhost:8000/api/watershed/

{"detail":"Request was throttled. Expected available in 59 seconds."}
```
### Notes

I wrote some (admittedly not too useful) tests for this, but they only pass if you run them independently of the other tests (ie `./scripts/manage.sh test apps.geoprocessing_api.tests`). This is because they rely on django's `override_settings` function to adjust the throttle rates, but when there are certain DRF imports before they're called, the settings never get overriden. This is a [known DRF issue](https://github.com/encode/django-rest-framework/issues/2466) which may be somewhat fixed in later releases. Popping the tests here in case the issue is fixed when we upgrade in #2146....

[throttling_test.patch.txt](https://github.com/WikiWatershed/model-my-watershed/files/1407576/throttling_test.patch.txt)


## Testing Instructions
1. Pull this branch
2. Login into the app, go to `/account` and copy your API key
3. Throw the following script into some file like `hitit.sh` (replacing `<your_key>` with your key...)
```sh
#!/bin/bash
for number in {1..21}
do
        curl -H "Content-Type: application/json" \
             -H "Authorization: Token <your_key>" \
             -X POST -d '{ "location": [39.67185812402583,-75.76742706298828] }' \
             localhost:8000/api/watershed/
done
exit 0
```
4. `./hitit.sh | grep throttling` should show only one throttled request, the last one
5. Update the `DEFAULT_THROTTLE_RATES` in `settings/base.py` so that sustained is `10/day`
6. Wait a minute and then run `hitit.sh` again. The last 10 requests should fail
7. Grab the client app's token off of a browser analyze or rwd request. Replace your token with it in `hitit.sh` and confirm all requests succeed