### PR TITLE
Add AOI validations to geoprocessing API

### DIFF
--- a/src/mmw/apps/geoprocessing_api/validation.py
+++ b/src/mmw/apps/geoprocessing_api/validation.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import json
+
+from numbers import Number
+
+from django.conf import settings
+from django.contrib.gis.geos import GEOSGeometry
+from rest_framework.exceptions import ValidationError
+
+
+def validate_rwd(location, data_source, snapping, simplify):
+    if not check_location_format(location):
+        error = create_invalid_rwd_location_format_error_msg(location)
+        raise ValidationError(error)
+
+    if not check_rwd_data_source(data_source):
+        error = create_invalid_rwd_data_source_error_msg(data_source)
+        raise ValidationError(error)
+
+    if type(snapping) is not bool:
+        error = create_invalid_rwd_snapping_error_msg(snapping)
+        raise ValidationError(error)
+
+    if not check_rwd_simplify_param_type(simplify):
+        error = create_invalid_rwd_simplify_param_type_error_msg(simplify)
+        raise ValidationError(error)
+
+    pass
+
+
+def validate_aoi(aoi):
+    if not check_analyze_aoi_size_below_max_area(aoi):
+        error = create_excessive_aoi_size_error_msg(aoi)
+        raise ValidationError(error)
+
+    if not check_aoi_does_not_self_intersect(aoi):
+        error = create_invalid_shape_error_msg(aoi)
+        raise ValidationError(error)
+
+    if not check_shape_in_conus(aoi):
+        error = create_shape_exceeds_conus_error_msg(aoi)
+        raise ValidationError(error)
+
+    pass
+
+
+def create_invalid_rwd_location_format_error_msg(loc):
+    return ('Invalid required `location` parameter value `{}`. Must be a '
+            '`[lat, lng] where `lat` and `lng` are numeric.'.format(loc))
+
+
+def check_location_format(loc):
+    if loc is None or type(loc) is not list or len(loc) is not 2:
+        return False
+    else:
+        [lat, lng] = loc
+        return (isinstance(lat, Number) and isinstance(lng, Number) and
+                type(lat) is not bool and type(lng) is not bool)
+
+
+def create_invalid_rwd_data_source_error_msg(source):
+    return ('Invalid optional `dataSource` parameter value `{}`. Must be '
+            '`drb` or `nhd`.'.format(source))
+
+
+def check_rwd_data_source(source):
+    return source in ['drb', 'nhd']
+
+
+def create_invalid_rwd_snapping_error_msg(snapping):
+    return ('Invalid optional `snappingOn` parameter value `{}`. Must be '
+            '`true` or `false`.'.format(snapping))
+
+
+def create_invalid_rwd_simplify_param_type_error_msg(simplify):
+    return ('Invalid optional `simplify` parameter value: `{}`. Must be a '
+            'number.'.format(simplify))
+
+
+def check_rwd_simplify_param_type(simplify):
+    return isinstance(simplify, Number) or simplify is False
+
+
+def get_aoi_sq_km(aoi):
+    geom = GEOSGeometry(aoi, 4326).transform(5070, clone=True)
+    return geom.area / 1000000
+
+
+def create_excessive_aoi_size_error_msg(aoi):
+    return ('Area of interest is too exceeds maximum size: submitted {} sq km '
+            'but the maximum size is {}'.format(get_aoi_sq_km(aoi),
+                                                settings.MMW_MAX_AREA))
+
+
+def check_analyze_aoi_size_below_max_area(aoi):
+    return get_aoi_sq_km(aoi) < settings.MMW_MAX_AREA
+
+
+def create_invalid_shape_error_msg(aoi):
+    return ('Area of interest is invalid: {}'.format(
+            GEOSGeometry(aoi, 4326).valid_reason))
+
+
+def check_aoi_does_not_self_intersect(aoi):
+    return GEOSGeometry(aoi, 4326).valid
+
+
+def create_shape_exceeds_conus_error_msg(aoi):
+    return ('Area of interest boundaries must be within the boundaries of the '
+            'continental United States')
+
+
+def check_shape_in_conus(aoi):
+    conus_boundaries = GEOSGeometry(
+        json.dumps(settings.CONUS_PERIMETER['geometry']), 4326)
+    return conus_boundaries.contains(GEOSGeometry(aoi, 4326))


### PR DESCRIPTION
## Overview

This PR adds some validations on the size & structure of the AOI for the analyze & climate endpoints. I put everything complex into a validations.py file -- including most of the RWD validations from #2386 as well as the functions to generate the error messages.

For the AOI endpoints we now verify that the shape does not exceed 75k sq km and that it passes the `.valid` check from django gis/GEOSGeometry. If it fails the latter, we send back an error message describing what failed.

Note: the second commit here includes the validation to check whether a shape is within the continental US boundaries.

Connects #2340 
Connects #2342 
Connects #2343 

### Notes

I noted this on #2342 but the `.valid` method seems to catch more than just self-intersecting shapes. If we decide we want to filter out only the self-intersecting ones but accept shapes which otherwise fail the `.valid` check, we can update the method just to check on what the error message would be & return a bool from there.

## Testing Instructions
- get this branch, then bundle, and visit the api docs with your api key at the ready
- check the RWD inputs to verify that they still work as described in #2386 
- for the AOI inputs, test out the following three shapes:

1. Invalid because it's 82k sq km:

```json
{
        "type": "MultiPolygon",
        "coordinates": [[
          [
            [
              -83.0950927734375,
              34.99850370014629
            ],
            [
              -83.36975097656249,
              34.728069689872285
            ],
            [
              -81.090087890625,
              32.18026188320708
            ],
            [
              -80.61767578124999,
              32.20350534542368
            ],
            [
              -78.5577392578125,
              33.8247936182649
            ],
            [
              -79.7003173828125,
              34.82282272723702
            ],
            [
              -80.771484375,
              34.80929324176267
            ],
            [
              -81.06262207031249,
              35.16482750605027
            ],
            [
              -82.2601318359375,
              35.21869749632885
            ],
            [
              -83.0950927734375,
              34.99850370014629
            ]
          ]
        ]]
      }
```

2. invalid because it self-intersects:

```json
{
        "type": "MultiPolygon",
        "coordinates": [[
          [
            [
              -75.4376220703125,
              40.14109012528468
            ],
            [
              -75.5364990234375,
              39.609920257000795
            ],
            [
              -74.739990234375,
              40.16208338164617
            ],
            [
              -74.8828125,
              39.69450749856091
            ],
            [
              -75.4376220703125,
              40.14109012528468
            ]
          ]
        ]]
      }
```

3. valid, about 66k sq km:

```json
{
        "type": "MultiPolygon",
        "coordinates": [[
          [
            [
              -80.628662109375,
              40.622291783092706
            ],
            [
              -81.002197265625,
              39.54641191968671
            ],
            [
              -82.529296875,
              38.436379603
            ],
            [
              -82.672119140625,
              38.151837403006766
            ],
            [
              -81.650390625,
              37.07271048132943
            ],
            [
              -80.167236328125,
              37.61423141542417
            ],
            [
              -79.617919921875,
              38.436379603
            ],
            [
              -78.233642578125,
              39.444677580473424
            ],
            [
              -78.75,
              39.631076770083666
            ],
            [
              -79.46411132812499,
              39.2492708462234
            ],
            [
              -79.4970703125,
              39.715638134796336
            ],
            [
              -80.518798828125,
              39.715638134796336
            ],
            [
              -80.5078125,
              40.63896734381723
            ],
            [
              -80.628662109375,
              40.622291783092706
            ]
          ]
        ]]
      }
```
