### PR TITLE
BiG-CZ: HydroShare Detail View Updates

### DIFF
--- a/src/mmw/js/src/core/filters.js
+++ b/src/mmw/js/src/core/filters.js
@@ -70,3 +70,27 @@ nunjucks.env.addFilter('split', function(str, splitChar, indexToReturn) {
 
     return items[indexToReturn];
 });
+
+nunjucks.env.addFilter('toFriendlyBytes', function(bytes) {
+    var roundToOneDecimal = function(x) { return Math.round(x * 10) / 10; };
+
+    if (bytes < 1024) {
+        return bytes + '&nbsp;Bytes';
+    }
+
+    bytes /= 1024;
+
+    if (bytes < 1024) {
+        return roundToOneDecimal(bytes) + '&nbsp;KB';
+    }
+
+    bytes /= 1024;
+
+    if (bytes < 1024) {
+        return roundToOneDecimal(bytes) + '&nbsp;MB';
+    }
+
+    bytes /= 1024;
+
+    return roundToOneDecimal(bytes) + '&nbsp;GB';
+});

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsHydroshare.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsHydroshare.html
@@ -4,19 +4,87 @@
             <i class="fa fa-arrow-left black"></i> Back
         </button>
         <h2>
-            {{ title }}
+            Resource: {{ title }}
         </h2>
+        <table class="table-data-detail">
+            <tr>
+                <th>Author</th>
+                <td>
+                    {% for creator in creators %}
+                        {{ creator.name }}{% if creator.organization %}, {{ creator.organization }} {% endif %}<br />
+                    {% endfor %}
+                </td>
+            </tr>
+            <tr>
+                <th>Period</th>
+                <td>
+                    {% if begin_date %}
+                        {{ begin_date|toDateWithoutTime }}&thinsp;&ndash;&thinsp;{{ end_date|toDateWithoutTime }}
+                    {% else %}
+                        Unknown
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <th>Subject</th>
+                <td>
+                    {{ subjects }}
+                </td>
+            </tr>
+            <tr>
+                <th>Resource Type</th>
+                <td>
+                    {{ resource_type }}
+                    <a data-toggle="popover" tabindex="0"
+                       data-html="true" data-container="body" role="button"
+                       data-content="The fundamental unit of digital content in HydroShare is a <strong>Resource</strong>. For more information see <a href='https://help.hydroshare.org/hydroshare-resource-types/' target='_blank' rel='noreferrer noopener'>https://help.hydroshare.org/hydroshare-resource-types/</a>"
+                       data-template="<div class='popover'><div class='pull-right' id='popover-close-button' onclick='closePopover()'><i class='fa fa-times' /></div><div class='popover-content'></div><div class='arrow'></div></div>">
+                        <i class="fa fa-info-circle black"></i>
+                    </a>
+                </td>
+            </tr>
+            <tr>
+                <th>Catalog</th>
+                <td>
+                    CUAHSI HydroShare
+                    <a data-toggle="popover" tabindex="0"
+                       data-html="true" data-container="body" role="button"
+                       data-content="HydroShare is an online collaborative environment for sharing hydrologic data and models. Its goal is to facilitate creation, collaboration around, discovery and access to data and model resources shared by members of the Hydrology community. See <a href='https://www.hydroshare.org/' target='_blank' rel='noreferrer noopener'>https://www.hydroshare.org/</a>"
+                       data-template="<div class='popover'><div class='pull-right' id='popover-close-button' onclick='closePopover()'><i class='fa fa-times' /></div><div class='popover-content'></div><div class='arrow'></div></div>">
+                        <i class="fa fa-info-circle black"></i>
+                    </a>
+                </td>
+            </tr>
+        </table>
     </div>
-    <hr>
-    {% if author %}
-        <p>
-            <i class="fa fa-user"></i>{{ author }}
-        </p>
-    {% endif %}
-        <p>
-            <i class="fa fa-calendar"></i> {{ created_at|toDateFullYear }}
-        </p>
     <p>
-        {{ description }}
+        {% if details_url %}
+        <a class="btn btn-secondary" href="{{ details_url }}"
+           target="_blank" rel="noreferrer noopener">
+            <i class="fa fa-external-link-square"></i>&nbsp;Source Data
+        </a>
+        {% endif %}
+        <a class="btn btn-secondary" href="https://www.hydroshare.org/hsapi/#/hsapi"
+           target="_blank" rel="noreferrer noopener">
+            <i class="fa fa-globe"></i>&nbsp;Web Services
+        </a>
+    </p>
+    <div class="spinner {{ 'hidden' if not fetching }}"></div>
+    <div class="error {{ 'hidden' if not error }}">
+        <i class="fa fa-exclamation-triangle"></i>
+    </div>
+    <hr />
+    <!-- TODO Add Abstract / File List -->
+    <hr />
+    <h3>Citation</h3>
+    <p>
+        {% set comma = joiner() %}
+        {% for creator in creators %}{{ comma() }} {{ creator.name }}{% endfor %}
+        ({{ updated_at|toDateFullYear }}).
+        {{ title }}, HydroShare,
+        <a href="{{ details_url }}" target="_blank" rel="noreferrer noopener"
+           style="word-wrap: break-word;">
+            {{ details_url }}
+        </a>
     </p>
 </div>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsHydroshare.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsHydroshare.html
@@ -74,7 +74,52 @@
         <i class="fa fa-exclamation-triangle"></i>
     </div>
     <hr />
-    <!-- TODO Add Abstract / File List -->
+    <div>
+        <ul class="nav hydroshare-nav-tabs nav-tabs" role="tablist">
+            <li role="presentation" class="active">
+                <a href="#hydroshare-abstract" role="tab" data-toggle="tab">
+                    Abstract
+                </a>
+            </li>
+            <li role="presentation">
+                <a href="#hydroshare-content" role="tab" data-toggle="tab">
+                    Content
+                </a>
+            </li>
+        </ul>
+        <div class="hydroshare-tab-content tab-content">
+            <div role="tabpanel" class="tab-pane active" id="hydroshare-abstract">
+                <p>
+                    {{ abstract }}
+                </p>
+            </div>
+            <div role="tabpanel" class="tab-pane" id="hydroshare-content">
+                <p>
+                    Last Updated {{ updated_at|toDateWithoutTime }}
+                </p>
+                <table class="table custom-hover" data-toggle="table">
+                    <thead>
+                    <tr>
+                        <th data-width="75%">File Name</th>
+                        <th>File Size</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                        {% for file in files %}
+                            <tr>
+                                <td>
+                                    {{ file.name }}
+                                </td>
+                                <td>
+                                    {{ file.size|toFriendlyBytes }}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
     <hr />
     <h3>Citation</h3>
     <p>

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -510,9 +510,45 @@ var ResultDetailsCinergiView = ResultDetailsBaseView.extend({
 var ResultDetailsHydroshareView = ResultDetailsBaseView.extend({
     template: resultDetailsHydroshareTmpl,
 
+    modelEvents: {
+        'change:fetching': 'render',
+    },
+
+    templateHelpers: function() {
+        var scimeta = this.model.get('scimeta'),
+            files = this.model.get('files'),
+            details_url = _.find(this.model.get('links'), {'type': 'details'}),
+            helpers = {
+                details_url: details_url ? details_url.href : null,
+                resource_type: '',
+                abstract: '',
+                creators: [],
+                subjects: '',
+                files: files ? files.toJSON() : [],
+            };
+
+        if (scimeta) {
+            var type = scimeta.get('type');
+
+            helpers.resource_type = type.substring(type.lastIndexOf('/') + 1, type.indexOf('Resource'));
+            helpers.creators = scimeta.get('creators').toJSON();
+            helpers.subjects = scimeta.get('subjects').pluck('value').join(', ');
+        }
+
+        return helpers;
+    },
+
     initialize: function() {
         this.model.fetchHydroshareDetails();
-    }
+    },
+
+    onDomRefresh: function() {
+        window.closePopover();
+        this.$('[data-toggle="popover"]').popover({
+            placement: 'right',
+            trigger: 'focus',
+        });
+    },
 });
 
 var ResultDetailsCuahsiView = ResultDetailsBaseView.extend({

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -326,7 +326,7 @@ var ErrorView = Marionette.ItemView.extend({
 });
 
 var TabContentView = Marionette.LayoutView.extend({
-    className: 'tab-pane',
+    className: 'catalog-tab-pane tab-pane',
     id: function() {
         return this.model.id;
     },
@@ -398,7 +398,7 @@ var TabContentView = Marionette.LayoutView.extend({
 });
 
 var TabContentsView = Marionette.CollectionView.extend({
-    className: 'tab-content',
+    className: 'catalog-tab-content tab-content',
     childView: TabContentView
 });
 
@@ -531,6 +531,7 @@ var ResultDetailsHydroshareView = ResultDetailsBaseView.extend({
             var type = scimeta.get('type');
 
             helpers.resource_type = type.substring(type.lastIndexOf('/') + 1, type.indexOf('Resource'));
+            helpers.abstract = scimeta.get('description');
             helpers.creators = scimeta.get('creators').toJSON();
             helpers.subjects = scimeta.get('subjects').pluck('value').join(', ');
         }
@@ -548,6 +549,7 @@ var ResultDetailsHydroshareView = ResultDetailsBaseView.extend({
             placement: 'right',
             trigger: 'focus',
         });
+        this.$('[data-toggle="table"]').bootstrapTable();
     },
 });
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -509,6 +509,10 @@ var ResultDetailsCinergiView = ResultDetailsBaseView.extend({
 
 var ResultDetailsHydroshareView = ResultDetailsBaseView.extend({
     template: resultDetailsHydroshareTmpl,
+
+    initialize: function() {
+        this.model.fetchHydroshareDetails();
+    }
 });
 
 var ResultDetailsCuahsiView = ResultDetailsBaseView.extend({

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -85,6 +85,14 @@
                     margin-bottom: 10px;
                 }
             }
+
+            .hydroshare-nav-tabs > li > a {
+                padding: 10px 15px !important;
+            }
+
+            .hydroshare-tab-content {
+                padding-top: 15px;
+            }
         }
     }
 
@@ -167,14 +175,14 @@
         overflow-y: auto;
     }
 
-    .tab-pane {
+    .catalog-tab-pane {
         position: absolute;
         top: 0;
         bottom: 0;
         width: 100%;
     }
 
-    .tab-content {
+    .catalog-tab-content {
         padding: 0;
         background: #E6E6E6;
         top: 0;


### PR DESCRIPTION
## Overview

Adds values to HydroShare details page given the mockup [here](https://docs.google.com/document/d/1rrrgZYYH_Jc5LN-vYP3sj3YoLcyXOdgfMcEb6v8Mtdg/edit).

Connects #2391 

### Demo

![2017-10-23 16 53 18](https://user-images.githubusercontent.com/1430060/31912761-fbce1ca6-b812-11e7-8d55-eeb33a52b39c.gif)

![image](https://user-images.githubusercontent.com/1430060/31912767-014d8fb8-b813-11e7-8b99-3236cb4f7d70.png)

![image](https://user-images.githubusercontent.com/1430060/31912843-4064907a-b813-11e7-884b-c4d992635a85.png)

Tagging @jfrankl for visual feedback.

### Notes

The mockup suggests capping the abstract to a max-height and making it scrollable beyond that. But that puts a scrollable div within a scrollable div, which is particularly bad looking in platforms that don't have vanishing scrollbars (like Windows). I elected to use the abstract to full height, allowing the user to scroll down to the Citation when needed.

## Testing Instructions

 * Check out this branch and `bundle`
 * Pick the "Cats Creek-Elwha River" HUC-12 (you can search for it), search for "water", open the HydroShare tab
 * Ensure the contents of the details page of "Elwha Observatory- Public" match the mockup
 * Ensure other results behave reasonably