### PR TITLE
Add source data link for NWISUV and NWISGW results

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -96,11 +96,20 @@ def parse_details_url(record):
     Ref: https://github.com/WikiWatershed/model-my-watershed/issues/1931
     """
     location = record['location']
-    if 'NWISDV' in location:
+    if any(code in location for code in ('NWISDV', 'NWISGW', 'NWISUV')):
         parts = location.split(':')
         if len(parts) == 2:
-            _, id = parts
-            return 'https://waterdata.usgs.gov/nwis/uv/?site_no={}'.format(id)
+            code, id = parts
+            if code == 'NWISDV':
+                url = 'https://waterdata.usgs.gov/nwis/uv/?site_no={}'
+                return url.format(id)
+            elif code == 'NWISUV':
+                url = 'https://waterdata.usgs.gov/nwis/dv/?site_no={}'
+                return url.format(id)
+            elif code == 'NWISGW':
+                url = ('https://nwis.waterdata.usgs.gov/' +
+                       'usa/nwis/gwlevels/?site_no={}')
+                return url.format(id)
     return None
 
 


### PR DESCRIPTION
## Overview

Similar to NWISDV, add a link to the source data page for NWISUV and
NWISGW WDC results.

Connects to #2403

### Demo

![bz1](https://user-images.githubusercontent.com/1042475/32009760-f899099e-b97d-11e7-83d5-5cc728ff20b5.gif)

## Testing Instructions

- Launch the site in BIGCZ mode.
- Select or draw an AoI that covers most of Philadelphia.
- Search for "water".
- Activate the WDC tab.
- Find a NWISUV result, and verify there is "source data" button that takes you to the USGS page for the result.
- Do the same for NWISDV and NWISGW.