### PR TITLE
CINERGI Result Detail View

### DIFF
--- a/src/mmw/apps/bigcz/clients/cinergi/models.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/models.py
@@ -9,8 +9,10 @@ from apps.bigcz.models import Resource
 class CinergiResource(Resource):
     def __init__(self, id, description, author, links, title,
                  created_at, updated_at, geom, cinergi_url,
-                 source_name, contact_organizations,
-                 categories, begin_date, end_date):
+                 source_name, contact_organizations, contact_people,
+                 categories, begin_date, end_date,
+                 resource_type, resource_topic_categories,
+                 web_resources, web_services):
         super(CinergiResource, self).__init__(id, description, author, links,
                                               title, created_at, updated_at,
                                               geom)
@@ -18,6 +20,11 @@ class CinergiResource(Resource):
         self.cinergi_url = cinergi_url
         self.source_name = source_name
         self.contact_organizations = contact_organizations
+        self.contact_people = contact_people
         self.categories = categories
         self.begin_date = begin_date
         self.end_date = end_date
+        self.resource_type = resource_type
+        self.resource_topic_categories = resource_topic_categories
+        self.web_resources = web_resources
+        self.web_services = web_services

--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -90,15 +90,15 @@ def parse_cinergi_url(fileid):
     return '{}/geoportal/?filter=%22{}%22'.format(CINERGI_HOST, fileid)
 
 
-def parse_contact_organizations(contact_organizations):
+def parse_string_or_list(string_or_list):
     """
-    Contact organizations can be either a list of strings, or
+    Fields like contact_organizations be either a list of strings, or
     a string. Make it always a list of strings
     """
-    if isinstance(contact_organizations, basestring):
-        return [contact_organizations]
+    if isinstance(string_or_list, basestring):
+        return [string_or_list]
 
-    return contact_organizations
+    return string_or_list
 
 
 def parse_categories(source):
@@ -160,6 +160,37 @@ def parse_description(description):
     return parser.contents[0]
 
 
+def parse_web_resources(raw_resources):
+    if not raw_resources:
+        return []
+
+    resources = raw_resources
+
+    if isinstance(raw_resources, dict):
+        resources = [raw_resources]
+
+    return [{
+        'url': r.get('url_s'),
+        'url_type': r.get('url_type_s')
+    } for r in resources]
+
+
+def parse_web_services(raw_services):
+    if not raw_services:
+        return []
+
+    services = raw_services
+
+    if isinstance(raw_services, dict):
+        services = [raw_services]
+
+    return [{
+        'url': s.get('url_s'),
+        'url_type': s.get('url_type_s'),
+        'url_name': s.get('url_name_s')
+    } for s in services]
+
+
 def parse_record(item):
     source = item['_source']
     geom = parse_geom(source)
@@ -176,11 +207,18 @@ def parse_record(item):
         geom=geom,
         cinergi_url=parse_cinergi_url(source.get('fileid')),
         source_name=source.get('src_source_name_s'),
-        contact_organizations=parse_contact_organizations(
+        contact_organizations=parse_string_or_list(
             source.get('contact_organizations_s')),
+        contact_people=parse_string_or_list(
+            source.get('contact_people_s')),
         categories=parse_categories(source),
         begin_date=parse_date(begin_date),
-        end_date=parse_date(end_date))
+        end_date=parse_date(end_date),
+        resource_type=source.get('apiso_Type_s'),
+        resource_topic_categories=parse_string_or_list(
+            source.get('apiso_TopicCategory_s')),
+        web_resources=parse_web_resources(source.get('resources_nst')),
+        web_services=parse_web_services(source.get('services_nst')))
 
 
 def prepare_bbox(box):

--- a/src/mmw/apps/bigcz/clients/cinergi/serializers.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/serializers.py
@@ -5,9 +5,21 @@ from __future__ import division
 
 from rest_framework.serializers import (CharField,
                                         ListField,
-                                        DateTimeField)
+                                        DateTimeField,
+                                        Serializer)
 
 from apps.bigcz.serializers import ResourceSerializer
+
+
+class CinergiWebResourceSerializer(Serializer):
+    url_type = CharField()
+    url = CharField()
+
+
+class CinergiWebServiceSerializer(Serializer):
+    url_type = CharField()
+    url_name = CharField()
+    url = CharField()
 
 
 class CinergiResourceSerializer(ResourceSerializer):
@@ -16,8 +28,21 @@ class CinergiResourceSerializer(ResourceSerializer):
     contact_organizations = ListField(
         child=CharField()
     )
+    contact_people = ListField(
+        child=CharField()
+    )
     categories = ListField(
         child=CharField()
     )
     begin_date = DateTimeField()
     end_date = DateTimeField()
+    resource_type = CharField()
+    resource_topic_categories = ListField(
+        child=CharField()
+    )
+    web_resources = ListField(
+        child=CinergiWebResourceSerializer()
+    )
+    web_services = ListField(
+        child=CinergiWebServiceSerializer()
+    )

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -355,6 +355,7 @@ var Result = Backbone.Model.extend({
         active: false,
         show_detail: false, // Show this result as the detail view?
         variables: null,  // CuahsiVariables Collection
+        categories: null, // Cinergi categories, [String]
         fetching: false,
         error: false,
         mode: 'table',
@@ -510,6 +511,23 @@ var Result = Backbone.Model.extend({
         var links = this.get('links') || [],
             detailsUrl = _.findWhere(links, { type: 'details' });
         return detailsUrl && detailsUrl.href;
+    },
+
+    topCinergiCategories: function(n) {
+        var categories = _.clone(this.get('categories'));
+
+        if (!categories) {
+            return null;
+        }
+
+        // Truncate if longer than n values
+        if (categories.length > n) {
+            categories = categories.slice(0, n + 1);
+            var lastIdx = categories.length - 1;
+            categories[lastIdx] = categories[lastIdx] + '...';
+        }
+
+        return categories.join('; ');
     },
 
     toJSON: function() {

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -775,6 +775,15 @@ var HydroshareFiles = Backbone.Collection.extend({
     model: HydroshareFile,
 });
 
+var ExpandableListModel = Backbone.Model.extend({
+    defaults: {
+        expanded: false,
+        list_type: '',
+        truncate_at: 2,
+        list: null
+    }
+});
+
 module.exports = {
     GriddedServicesFilter: GriddedServicesFilter,
     PrivateResourcesFilter: PrivateResourcesFilter,
@@ -790,4 +799,5 @@ module.exports = {
     CuahsiValues: CuahsiValues,
     CuahsiVariable: CuahsiVariable,
     CuahsiVariables: CuahsiVariables,
+    ExpandableListModel: ExpandableListModel,
 };

--- a/src/mmw/js/src/data_catalog/templates/expandableTableRow.html
+++ b/src/mmw/js/src/data_catalog/templates/expandableTableRow.html
@@ -1,0 +1,12 @@
+{% if not list %}
+None provided
+{% else %}
+{% for i in range(0, list.length if expanded else truncate_at) %}
+<p>{{ list[i] }}</p>
+{% endfor %}
+{% if not expanded and list.length > truncate_at %}
+<button data-action="expand" class="btn btn-md btn-link expand-list-btn">
+    View {{list.length - truncate_at }} more {{list_type}}
+</button>
+{% endif %}
+{% endif %}

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
@@ -9,23 +9,11 @@
         <table class="table-data-detail">
             <tr>
                 <th>Contacts</th>
-                <td>
-                    {% for contact in contacts %}
-                    <p>{{ contact }}</p>
-                    {% else %}
-                    None provided
-                    {% endfor %}
-                </td>
+                <td data-list-region="contacts"></td>
             </tr>
             <tr>
                 <th>Organizations</th>
-                <td>
-                    {% for org in orgs %}
-                    <p>{{ org }}</p>
-                    {% else %}
-                    None provided
-                    {% endfor %}
-                </td>
+                <td data-list-region="organizations"></td>
             </tr>
             <tr>
                 <th>Data&nbsp;collected&nbsp;between</th>

--- a/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
+++ b/src/mmw/js/src/data_catalog/templates/resultDetailsCinergi.html
@@ -4,27 +4,117 @@
             <i class="fa fa-arrow-left black"></i> Back
         </button>
         <h2>
-            {{ title }}
+            Resource: {{ title }}
         </h2>
+        <table class="table-data-detail">
+            <tr>
+                <th>Contacts</th>
+                <td>
+                    {% for contact in contacts %}
+                    <p>{{ contact }}</p>
+                    {% else %}
+                    None provided
+                    {% endfor %}
+                </td>
+            </tr>
+            <tr>
+                <th>Organizations</th>
+                <td>
+                    {% for org in orgs %}
+                    <p>{{ org }}</p>
+                    {% else %}
+                    None provided
+                    {% endfor %}
+                </td>
+            </tr>
+            <tr>
+                <th>Data&nbsp;collected&nbsp;between</th>
+                <td>
+                    {% if begin_date and begin_date|toDateWithoutTime == end_date|toDateWithoutTime %}
+                    {{ begin_date|toDateWithoutTime }}
+                    {% elif begin_date %}
+                    {{ begin_date|toDateWithoutTime }}&thinsp;&ndash;&thinsp;{{ end_date|toDateWithoutTime }}
+                    {% else %}
+                    Unknown
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <th>Subject</th>
+                <td>
+                    {{ top_categories }}
+                </td>
+            </tr>
+            <tr>
+                <th>Resource&nbsp;Type</th>
+                <td>
+                    {{ resource_type }} / {{ resource_topic_categories_str }}
+                </td>
+            </tr>
+            <tr>
+                <th>Source</th>
+                <td>
+                    {{ source_name }}
+                </td>
+            </tr>
+            <tr>
+                <th>Catalog</th>
+                <td>
+                    CINERGI
+                    <a data-toggle="popover" tabindex="0"
+                       data-html="true" data-container="body" role="button"
+                       data-content="The Community Inventory of EarthCube Resources for Geosciences Interoperability (CINERGI) Data Portal is a catalog of databases, services and data portals developed by numerous organizations representing a diversity of geoscience domains. Explore CINERGI at <a href='http://cinergi.sdsc.edu/' target='_blank' rel='noreferrer noopener'>http://cinergi.sdsc.edu/</a>"
+                       data-template="<div class='popover'><div class='pull-right' id='popover-close-button' onclick='closePopover()'><i class='fa fa-times' /></div><div class='popover-content'></div><div class='arrow'></div></div>">
+                        <i class="fa fa-info-circle black"></i>
+                    </a>
+                </td>
+            </tr>
+        </table>
     </div>
-    <hr>
-    {% if author %}
-        <p>
-            <i class="fa fa-user"></i>{{ author }}
-        </p>
-    {% endif %}
     <p>
-        <i class="fa fa-calendar"></i> {{ created_at|toDateFullYear }}
+        {% if details_url %}
+        <a class="btn btn-secondary" href="{{ details_url }}"
+           target="_blank" rel="noreferrer noopener">
+            <i class="fa fa-external-link-square"></i>&nbsp;Source Data
+        </a>
+        {% endif %}
+        <a class="btn btn-secondary" href="http://cinergi.sdsc.edu/geoportal/"
+           target="_blank" rel="noreferrer noopener">
+            <i class="fa fa-globe"></i>&nbsp;Web Services
+        </a>
     </p>
-    {% if not (description == "REQUIRED FIELD") %}
+
+    <hr/>
+
+    {% if description and not (description == "REQUIRED FIELD") %}
+    <h3>Description</h3>
     <p>
         {{ description }}
     </p>
     {% endif %}
     <p>
-        <a class="btn btn-secondary" href="{{ cinergi_url }}"
-           target="_blank" rel="noreferrer noopener">
-            <i class="fa fa-external-link-square"></i>&nbsp;Repository
-        </a>
+        Last Updated {{ updated_at|toDateWithoutTime }}
     </p>
+
+    {% if web_resources.length > 0 %}
+    <hr/>
+    <h3>Web Resources</h3>
+    {% for resource in web_resources %}
+    <li><a href={{resource.url}}
+       target="_blank" rel="noreferrer noopener">
+        {{resource.url_type}}
+    </a></li>
+    {% endfor %}
+    {% endif %}
+
+    {% if web_services.length > 0 %}
+    <hr/>
+    <h3>Web Services</h3>
+    {% for service in web_services %}
+    <li><a href={{service.url}}
+       target="_blank" rel="noreferrer noopener">
+        {{service.url_name}} ({{service.url_type}})
+    </a></li>
+    {% endfor %}
+    {% endif %}
 </div>

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -486,6 +486,7 @@ var ResultDetailsBaseView = Marionette.LayoutView.extend({
     },
 
     closeDetails: function() {
+        window.closePopover();
         this.model.collection.closeDetail();
     }
 });

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -418,21 +418,8 @@ var StaticResultView = Marionette.ItemView.extend({
         }
 
         if (this.options.catalog === 'cinergi') {
-            var categories = _.clone(this.model.get('categories'));
-
-            if (!categories) {
-                return null;
-            }
-
-            // Truncate if longer than 8 values
-            if (categories.length > 8) {
-                categories = categories.slice(0, 9);
-                var lastIdx = categories.length -1;
-                categories[lastIdx] = categories[lastIdx] + '...';
-            }
-
             return {
-                'top_categories': categories.join('; ')
+                'top_categories': this.model.topCinergiCategories(8)
             };
         }
     },
@@ -505,6 +492,21 @@ var ResultDetailsBaseView = Marionette.LayoutView.extend({
 
 var ResultDetailsCinergiView = ResultDetailsBaseView.extend({
     template: resultDetailsCinergiTmpl,
+
+    templateHelpers: function() {
+        var topicCategories = this.model.get('resource_topic_categories'),
+            contactOrgs = this.model.get('contact_organizations'),
+            contactPeople = this.model.get('contact_people');
+
+        return {
+            'orgs': contactOrgs ? contactOrgs.filter(utils.distinct) : null,
+            'contacts': contactPeople ? contactPeople.filter(utils.distinct) : null,
+            'top_categories': this.model.topCinergiCategories(20),
+            'resource_topic_categories_str': topicCategories ?
+                topicCategories.join(", ") : null,
+            'details_url': this.model.getDetailsUrl()
+        };
+    }
 });
 
 var ResultDetailsHydroshareView = ResultDetailsBaseView.extend({

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -272,6 +272,10 @@
             margin-right: 4px;
         }
     }
+
+    .expand-list-btn {
+        padding: 0;
+    }
 }
 
 .data-catalog-resource-popover {


### PR DESCRIPTION
## Overview

Flesh out the cinergi specific detail view

[Template here](https://docs.google.com/document/d/1k9_I1gp9V8F2ieL-LfN2OYCimrrqyf9IKAGtCSlM8Uw/edit?usp=sharing)

Branched off #2425, commits for this work are f586fa3 and f230751

@jfrankl, here's another you may want to style review

Connects #2393 

### Demo

![screen shot 2017-10-25 at 1 54 32 pm](https://user-images.githubusercontent.com/7633670/32016821-ddac8678-b992-11e7-9fde-adcc4f12a322.png)

![screen shot 2017-10-25 at 1 54 40 pm](https://user-images.githubusercontent.com/7633670/32016839-ec66f2e8-b992-11e7-87a2-6bd3a2355cc7.png)


### Notes
#### Many organizations
There can be more organizations than fit in a single page. Is it useful to display them all, or should they be capped at a certain threshold?
<details>
<summary>pic</summary>

![jauqolzvnr](https://user-images.githubusercontent.com/7633670/32016241-62c6ce4c-b991-11e7-8431-7bf8cf691c18.gif)

</details>

#### Duplicate organizations
<details>
<summary>pic</summary>

<img width="460" alt="screen shot 2017-10-25 at 1 58 15 pm" src="https://user-images.githubusercontent.com/7633670/32016312-979296e2-b991-11e7-9db2-a0547a4b1cee.png">

</details>


## Testing Instructions

 * Pull and `bundle`
 * Use the City Of Philadelphia-Schuylkill river HUC-12 and search "water epa"
 * The `EPA Office of Water (OW) STORET...` result has a complete view with all fields
 * click pretty much any other result and confirm partially filled views render okay, too
