### PR TITLE
Hide user endpoints in Swagger API documentation

### DIFF
--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -107,7 +107,7 @@ itsi = ItsiService()
 
 def itsi_login(request):
     redirect_uri = '{0}?next={1}'.format(
-        request.build_absolute_uri(reverse(itsi_auth)),
+        request.build_absolute_uri(reverse('user:itsi_auth')),
         request.GET.get('next', '/')
     )
     params = {'redirect_uri': redirect_uri}

--- a/src/mmw/mmw/urls.py
+++ b/src/mmw/mmw/urls.py
@@ -37,5 +37,6 @@ urlpatterns = patterns(
                                    namespace='mmw')),
     url(r'^api/', include(apps.geoprocessing_api.urls)),
     url(r'^micro/', include(apps.water_balance.urls)),
-    url(r'^user/', include(apps.user.urls))
+    url(r'^user/', include(apps.user.urls,
+                           namespace='user'))
 )


### PR DESCRIPTION
## Overview

The user namespace is added to the user URLs, which, because of our Swagger configuration, prevents the URLs from showing up in the documentation.

This was originally added in #2227, but it broke compatibility with ITSI and was removed in #2377.

The namespace is added here again along with a fix to the ITSI login view. When calling reverse on a URL which is included in a namespace, the namespace must also be added to the reverse parameter. See https://stackoverflow.com/a/38390178/217378.

Connects #2401

### Demo

![bz2](https://user-images.githubusercontent.com/1042475/32020233-87b048da-b99d-11e7-8b57-bf243005764b.gif)

## Testing Instructions

- Make sure your dev environment has been created with the `MMW_ITSI_SECRET_KEY` env var. You can do this by running `MMW_ITSI_SECRET_KEY="***" vagrant up app worker --provision`.
- Attempt to log into ITSI. This should work without error.
- View the API documentation at `/api/docs`. Confirm that the user routes are not shown.