### PR TITLE
Update, don't overwrite, DRF Production Settings

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -300,11 +300,6 @@ THIRD_PARTY_APPS = (
 
 # rest_framework
 REST_FRAMEWORK = {
-    # Use Django's standard `django.contrib.auth` permissions,
-    # or allow read-only access for unauthenticated users.
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
-    ],
     'DEFAULT_THROTTLE_RATES': {
         'sustained': '5000/day',
         'burst': '20/min',

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -59,11 +59,11 @@ ROLLBAR = {
 # END ROLLBAR CONFIGURATION
 
 # Turn off DRF GUI
-REST_FRAMEWORK = {
+REST_FRAMEWORK.update({
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     )
-}
+})
 
 # Django Storages CONFIGURATION
 mac_metadata = instance_metadata['network']['interfaces']['macs']

--- a/src/mmw/mmw/settings/test.py
+++ b/src/mmw/mmw/settings/test.py
@@ -22,11 +22,11 @@ DJANGO_LIVE_TEST_SERVER_ADDRESS = os.environ.get(
     'DJANGO_LIVE_TEST_SERVER_ADDRESS', 'localhost:9001')
 
 # Turn off DRF GUI
-REST_FRAMEWORK = {
+REST_FRAMEWORK.update({
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     )
-}
+})
 
 # API key for testing/development
 GOOGLE_MAPS_API_KEY = 'AIzaSyB0D5gjoIHpmy-xdP2cr_0I-E7K6s_L0k4'


### PR DESCRIPTION
Staging broke because we're overwriting the DRF settings in `settings/production.py` and losing the default throttle rates. 

* Remove `DEFAULT_PERMISSION_CLASSES` from settings/base.py.
  These have never really seen the light of day because of the
  overwriting, and we use specific permissions for each view

* Use update to modify the REST_FRAMEWORK settings in the
  production settings

Connects #2421 


## Testing Instructions

 * `VAGRANT_ENV=TEST vagrant provision app` and confirm the analyze endpoints still work