### PR TITLE
BiG-CZ: WDC Naïve Free Text Search

### DIFF
--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -46,6 +46,7 @@ var DataCatalogController = {
                 name: 'WDC',
                 is_pageable: false,
                 results: new models.Results(null, { catalog: 'cuahsi' }),
+                serverResults: new models.Results(null, { catalog: 'cuahsi' }),
                 filters: new models.FilterCollection([
                     dateFilter,
                     new models.GriddedServicesFilter()


### PR DESCRIPTION
## Overview

Adds free text search to WDC results. Since the CUAHSI API does not support text filtering, only geometry and date filters, the results must be filtered on the client side.

This is done by add a `serverResults` field to the `Catalog` model, which saves the server results in CUAHSI's case, transferring only those satisfying a `textFilter` to `results`. Since everything else (sidebar entries, map items) are connected to `results`, they all update accordingly.

The search implementation is very simple: for every word in the query (where words are separated by a single space) it searches a set of CUAHSI fields on the result: id, title, citation, service, organization, sample mediums, and concept keywords. For a result to be selected, it must match all the words in the query. There is no support for "OR".

Connects #2389

### Demo

![2017-10-27 17 19 16](https://user-images.githubusercontent.com/1430060/32125868-e7c7ce38-bb3b-11e7-9169-52f46f297e2e.gif)

### Notes

When checking and unchecking the Gridded Services filter, the order of the displayed results changes, even though they remain the same results. I'm going to spin this off into a later card.

## Testing Instructions

 * Check out this branch and `bundle`
 * Select a shape and proceed to search
 * Search for something in WDC. Ensure the results reflect the search term.
 * Try searching for something else. Ensure no server queries are fired.
 * Try switching to another tab and searching for something different there. Ensure that when you return to WDC the new search is performed and the results reflect this.
 * Try the filters in the sidebar and ensure they work correctly with the search terms