### PR TITLE
Pin dependency to numpy 1.13

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -20,3 +20,4 @@ python-dateutil==2.6.0
 suds==0.4
 django_celery_results==1.0.1
 ulmo==0.8.4
+numpy==1.13.0


### PR DESCRIPTION
## Overview

Pin `numpy` to version 1.13.0. This ensures that the version of numpy that `ulmo` requires doesn't get overwritten by the (lower) version needed for `gwlf-e`.

Fixes #2441

### Demo

~Optional. Screenshots, `curl` examples, etc.~

### Notes

~Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.~

## Testing Instructions

 * Pull down this branch, reprovision the `app` VM to pull in the new dependencies and restart the app server. 
 * From inside the `app` VM, do `curl http://localhost/health-check/`, ensure that the healthcheck passes. Also, check `/var/log/mmw-app.log` to make sure that service initialization completed with no errors.