### PR TITLE
BiG-CZ: Download JSON

### DIFF
--- a/src/mmw/js/src/data_catalog/templates/form.html
+++ b/src/mmw/js/src/data_catalog/templates/form.html
@@ -18,4 +18,9 @@
     />
 </div>
 
+<button id="bigcz-catalog-results-download" class="{{ 'hidden' if not downloadVisible }}"
+        title="Download Results as JSON">
+    <i class="fa fa-download"></i>
+</button>
+
 <div class="filter-sidebar-region"></div>

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -210,17 +210,17 @@ var FormView = Marionette.ItemView.extend({
     },
 
     initialize: function() {
-        var updateFilterSidebar = _.bind(function() {
-            if (App.rootView.secondarySidebarRegion.hasView()) {
-                this.showFilterSidebar();
-            }
+        var self = this,
+            updateFilterSidebar = function() {
+                if (App.rootView.secondarySidebarRegion.hasView()) {
+                    self.showFilterSidebar();
+                }
 
-            this.render();
-
-        }, this);
+                self.render();
+            };
 
         // Update the filter sidebar when there's a new active catalog
-        this.collection.on('change:active', updateFilterSidebar);
+        this.listenTo(this.collection, 'change:active', updateFilterSidebar);
     },
 
     getFilters: function() {
@@ -270,18 +270,12 @@ var FormView = Marionette.ItemView.extend({
     },
 
     templateHelpers: function() {
-        var filters = this.getFilters();
-
-        if (!filters) {
-            return { filterNumText: '' };
-        }
-
-        var numActiveFilters = filters.countActive();
+        var filters = this.getFilters(),
+            numActiveFilters = filters && filters.countActive(),
+            filterNumText = numActiveFilters ? '(' + numActiveFilters + ')' : '';
 
         return {
-            filterNumText: numActiveFilters > 0 ?
-                '(' + numActiveFilters + ')' :
-                null
+            filterNumText: filterNumText
         };
     }
 });

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -238,8 +238,20 @@ var FormView = Marionette.ItemView.extend({
             return null;
         }
 
-        var json = JSON.stringify(results.toJSON()),
-            blob = new Blob([json], { type: 'data:text/plain;charset=utf-8'}),
+        var data = results.map(function(r) {
+                var exclude = ['show_detail', 'fetching', 'error', 'mode'],
+                    cr = _.clone(_.omit(r.attributes, exclude));
+
+                if (!_.isNull(cr.variables)) {
+                    cr.variables = cr.variables.map(function(v) {
+                        return _.clone(_.omit(v.attributes, ['values', 'error']));
+                    });
+                }
+
+                return cr;
+            }),
+            blob = new Blob([JSON.stringify(data)],
+                            { type: 'data:text/plain;charset=utf-8'}),
             url = URL.createObjectURL(blob),
             a = document.createElement('a'),
             dateString = (new Date()).toJSON()

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -198,6 +198,7 @@ var FormView = Marionette.ItemView.extend({
     ui: {
         filterToggle: '.filter-sidebar-toggle',
         searchInput: '.data-catalog-search-input',
+        downloadButton: '#bigcz-catalog-results-download',
     },
 
     events: {
@@ -221,6 +222,11 @@ var FormView = Marionette.ItemView.extend({
 
         // Update the filter sidebar when there's a new active catalog
         this.listenTo(this.collection, 'change:active', updateFilterSidebar);
+
+        // Update the download button visibility on catalog load events
+        this.collection.forEach(function(catalog) {
+            self.listenTo(catalog, 'change:loading', self.render);
+        });
     },
 
     getFilters: function() {
@@ -272,9 +278,13 @@ var FormView = Marionette.ItemView.extend({
     templateHelpers: function() {
         var filters = this.getFilters(),
             numActiveFilters = filters && filters.countActive(),
-            filterNumText = numActiveFilters ? '(' + numActiveFilters + ')' : '';
+            filterNumText = numActiveFilters ? '(' + numActiveFilters + ')' : '',
+            catalog = this.collection.getActiveCatalog(),
+            results = catalog && catalog.get('results'),
+            downloadVisible = results && results.length > 0;
 
         return {
+            downloadVisible: downloadVisible,
             filterNumText: filterNumText
         };
     }

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -529,3 +529,11 @@
     color: #555;
     padding-left: 0;
 }
+
+#bigcz-catalog-results-download {
+    position: absolute;
+    right: 1.5rem;
+    top: 56px;
+    border: 0;
+    background-color: transparent;
+}


### PR DESCRIPTION
## Overview

Downloads a JSON of the visible results in BiG-CZ. See commit messages for details.

Connects #2412 

### Demo

![2017-10-30 17 32 21](https://user-images.githubusercontent.com/1430060/32196905-9e9349f4-bd98-11e7-9071-c00bfc9ba7dc.gif)

Sample JSON: [bigcz-cinergi-water-2017-10-30-21-32-32.json](https://github.com/WikiWatershed/model-my-watershed/files/1428868/bigcz-cinergi-water-2017-10-30-21-32-32.json.txt)

Tagging @jfrankl for visual review, but given the low amount of funds on this contract I wouldn't want to make many changes if the current placement is acceptable.

### Notes

The format of the JSON is that of the Result Model, and not of the values that came in from the API. Thus, it will have some extraneous fields like loading and error. But in the interest of expediency and minimalism, this is tolerable.

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and choose a shape and search for something
 * When the search completes, you should see a JSON download button. Hovering over the icon should have a more descriptive tooltip.
 * Clicking the button should download the currently visible results
 * Try changing the filters, pages, catalogs to change the visible results. Click the button and ensure the download matches the view.