### PR TITLE
Add user profile page content

### DIFF
--- a/src/mmw/apps/user/serializers.py
+++ b/src/mmw/apps/user/serializers.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.contrib.auth.models import User
+from models import UserProfile
 from rest_framework import serializers
 
 
@@ -10,3 +11,32 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'username', 'is_staff')
+
+
+class UserProfileSerializer(serializers.Serializer):
+    user_id = serializers.IntegerField(required=True)
+    organization = serializers.CharField(required=False, allow_blank=True)
+    user_type = serializers.CharField(required=False, allow_blank=True)
+    postal_code = serializers.CharField(required=False, allow_blank=True)
+    country = serializers.CharField(required=False, allow_blank=True)
+    first_name = serializers.CharField(required=False, allow_blank=True)
+    last_name = serializers.CharField(required=False, allow_blank=True)
+    was_skipped = serializers.BooleanField(required=False)
+    is_complete = serializers.BooleanField(required=True)
+
+    def create(self, validated_data):
+        user_id = validated_data.get('user_id', None)
+        if user_id is not None:
+            user = User.objects.filter(id=user_id).first()
+            if user is not None:
+                if 'first_name' in validated_data:
+                    user.first_name = validated_data['first_name']
+                    del validated_data['first_name']
+                if 'last_name' in validated_data:
+                    user.last_name = validated_data['last_name']
+                    del validated_data['last_name']
+                user.save()
+                profile, created = UserProfile.objects.update_or_create(
+                    user_id=user_id,
+                    defaults=validated_data)
+                return profile

--- a/src/mmw/js/src/account/templates/profile.html
+++ b/src/mmw/js/src/account/templates/profile.html
@@ -1,1 +1,79 @@
+{% macro select(value, name, model, field, defaultChoice='', label='') %}
+    <label for="{{ name }}">{{ label }}</label>
+    <select id="{{ name }}" name="{{ name }}" class="selectpicker" data-live-search="true">
+    </select>
+{% endmacro %}
+
 <h2>Profile</h2>
+
+{% if error %}
+<p class="error">
+    <i class="fa fa-warning account-inline-error-icon" aria-hidden="true"></i>{{error}}
+</p>
+{% endif %}
+
+<section class="user-profile-section">
+    <div class="row">
+        <div class="col-sm-6">
+            <p>
+                <label for="first_name">First Name</label>
+                <input id="first_name"
+                       type="text"
+                       value="{{ first_name }}"
+                >
+            </p>
+        </div>
+        <div class="col-sm-6">
+            <p>
+                <label for="last_name">Last Name</label>
+                <input id="last_name"
+                       type="text"
+                       value="{{ last_name }}"
+                >
+            </p>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <p>
+                <label for="organization">Organization</label>
+                <input id="organization"
+                       type="text"
+                       value="{{ organization }}"
+                >
+            </p>
+        </div>
+        <div class="col-sm-6">
+            <p>
+                {{ select(user_type, 'user_type', 'UserProfile', 'user_type', user_type, 'User Type') }}
+            </p>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <p>
+                {{ select(country, 'country', 'UserProfile', 'country', country, 'Country') }}
+            </p>
+        </div>
+        <div class="col-sm-6">
+            <p>
+                <label for="postal_code">Postal Code</label>
+                <input id="postal_code"
+                       type="text"
+                       value="{{ postal_code }}"
+                >
+            </p>
+        </div>
+    </div>
+    <div class="row">
+        <button class="btn btn-active btn-save"
+                type="button"
+                data-action="save_changes"
+                {{'disabled' if saving}}>
+            Save changes
+            {% if saving %}
+            <div class="spinner"></div>
+            {% endif %}
+        </button>
+    </div>
+</section>

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -143,19 +143,19 @@ var App = new Marionette.Application({
     showLoginModal: function(onSuccess) {
         var self = this,
             promptForProfileIfIncomplete = function(loginResponse) {
-            if (loginResponse.profile_was_skipped || loginResponse.profile_is_complete) {
-                if (onSuccess && _.isFunction(onSuccess)) {
-                    onSuccess(loginResponse);
+                if (loginResponse.profile_was_skipped || loginResponse.profile_is_complete) {
+                    if (onSuccess && _.isFunction(onSuccess)) {
+                        onSuccess(loginResponse);
+                    }
+                } else {
+                    new userViews.UserProfileModalView({
+                        model: new userModels.UserProfileFormModel({
+                            successCallback: onSuccess
+                        }),
+                        app: self
+                    }).render();
                 }
-            } else {
-                new userViews.UserProfileModalView({
-                    model: new userModels.UserProfileFormModel({
-                        successCallback: onSuccess
-                    }),
-                    app: self
-                }).render();
-            }
-        };
+            };
 
         new userViews.LoginModalView({
             model: new userModels.LoginFormModel({

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -59,7 +59,14 @@ var UserModel = Backbone.Model.extend({
 
 var UserProfileModel = Backbone.Model.extend({
     defaults: {
-        was_skipped: false,
+        first_name: '',
+        last_name: '',
+        organization: '',
+        country: '',
+        user_type: '',
+        postal_code: '',
+        error: null,
+        saving: false
     },
 
     url: '/user/profile',
@@ -116,15 +123,6 @@ var LoginFormModel = ModalBaseModel.extend({
 });
 
 var UserProfileFormModel = ModalBaseModel.extend({
-    defaults: {
-        first_name: null,
-        last_name: null,
-        organization: null,
-        user_type: 'Unspecified',
-        country: 'US',
-        was_skipped: false
-    },
-
     url: '/user/profile'
 });
 

--- a/src/mmw/js/src/user/views.js
+++ b/src/mmw/js/src/user/views.js
@@ -314,9 +314,9 @@ var UserProfileModalView = ModalBaseView.extend({
 
     handleSuccess: function(response) {
         this.app.user.set({
-            'show_profile_popover': response.profile_was_skipped,
-            'profile_was_skipped': response.profile_was_skipped,
-            'profile_is_complete': response.profile_is_complete
+            'show_profile_popover': response.was_skipped,
+            'profile_was_skipped': response.was_skipped,
+            'profile_is_complete': response.is_complete
         });
         this.handleServerSuccess(response);
         this.$el.modal('hide');

--- a/src/mmw/sass/pages/_account.scss
+++ b/src/mmw/sass/pages/_account.scss
@@ -47,6 +47,7 @@
 
     .error {
         color: $ui-danger;
+        margin: 1em 0 1em 0;
         > .account-inline-error-icon {
             margin-right: 5px;
         }
@@ -91,5 +92,32 @@
     .btn-copy > .spinner:after {
         top: auto;
         right: auto;
+    }
+}
+
+.user-profile-section {
+    label {
+        color: $text-muted;
+        font-size: $font-size-h5;
+        font-weight: 500;
+        display: block;
+    }
+
+    input {
+        width: 100%;
+        padding: 0.75rem 0.5rem;
+    }
+
+    p {
+        margin: 0 0 2rem 0;
+    }
+
+    .col-sm-6 {
+        padding: 0 8rem 0 0;
+    }
+
+    .btn-save > .spinner:after {
+        top: 16px;
+        right: -30px;
     }
 }


### PR DESCRIPTION
## Overview

This commit adds a form on the "profile" tab of `/account` to display and edit user profile details.

Connects #2365

### Demo

<img width="805" alt="screen shot 2017-10-30 at 3 33 59 pm" src="https://user-images.githubusercontent.com/17363/32198958-cc0e2270-bd87-11e7-9b65-71b8d167b835.png">


### Notes

- I moved the saving of the profile to a Django REST Framework serializer to keep the persistence details out of the view.
- I styled the text fields on the form to match the wireframes but I did not style the bootstrap-select dropdown menus. We will be restyling them across the app in a future commit.

## Testing Instructions

 * Reset your user profile
```
update user_userprofile set was_skipped = 'false', is_complete = 'false', organization = '', user_type = '', country='', postal_code = '' where user_id = (select id from auth_user where username = 'YOUR_USERNAME');
```
 * Log out, log in, and fully complete the profile form
 * Select "My Account" from the user dropdown at the upper right of the app. Verify that all the profile details are correctly displayed.
 * Refresh the page and verity that all the profile details are correct.
 * Change the first name, organization, and country fields and click `Save changed`. Verify that a spinner briefly appears.
 * Refresh the page and verify that the changes persist.
 * Stop the gunicorn server with `vagrant ssh app -c 'sudo stop mmw-app'`
 * Click `Save changes` and verify that an error message is displayed.
