### PR TITLE
BiG-CZ: Fix WDC Fetch Errors

### DIFF
--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -732,6 +732,11 @@ var CuahsiVariable = Backbone.Model.extend({
             params.to_date = moment(to);
         }
 
+        if (params.from_date.format(DATE_FORMAT) ===
+            params.to_date.format(DATE_FORMAT)) {
+            params.to_date.add(1, 'days');
+        }
+
         params.from_date = params.from_date.format(DATE_FORMAT);
         params.to_date = params.to_date.format(DATE_FORMAT);
 

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -717,8 +717,8 @@ var CuahsiVariable = Backbone.Model.extend({
         // to be either from begin date to end date, or 1 week up to end date,
         // whichever is shorter.
         if (!from || moment(from).isBefore(begin_date)) {
-            if (end_date.diff(begin_date, 'months', true) > 1) {
-                params.from_date = moment(end_date).subtract(1, 'months');
+            if (end_date.diff(begin_date, 'years', true) > 1) {
+                params.from_date = moment(end_date).subtract(1, 'years');
             } else {
                 params.from_date = begin_date;
             }

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -19,5 +19,5 @@ retry==0.9.1
 python-dateutil==2.6.0
 suds==0.4
 django_celery_results==1.0.1
-ulmo==0.8.4
+git+git://github.com/emiliom/ulmo@wml_values_md#egg=ulmo
 numpy==1.13.0


### PR DESCRIPTION
## Overview

Previously our workflow was to get date range from the `/details` endpoint (which uses ulmo's `get_site_info` call), and use that date to query a month's worth of data from `/values` (which uses ulmo's `get_values` call). Unfortunately, for some service providers, this was erroring out.

To fix this, @emiliom has made a fork of the project which addresses that bug here: https://github.com/emiliom/ulmo/commit/90dbfe31f38a72ea4cee9a52e572cfa8f8484adc. Thus, we switch to using his fork instead of the main distribution.

Another issue was that for some services the `/details` endpoint would return incorrect date ranges, and the true data would be outside of them. To get those values, we now fetch a year's worth of data instead of a month's.

A yet another issue was us incorrectly specifying the same start and end dates for services which had data for only one day. This caused the retrieval of only those values recorded at midnight, and not any recorded at other times during the day. We now specify the end date as one day after the start date to capture all values collected at any time during that day.

Finally, some responses had a lot of "no data" values. The no data value is specified in the API response, thus we now filter it out from those shown in the table and charts.

Note that time spent reviewing this should be billed to WPF, not BiG-CZ.

Connects #2417 
Connects #2413 

### Demo

Demo showing retrieval from CoCoRaHs, ShaleNetworkODM, GHCN, and NWISDV:

![out-final](https://user-images.githubusercontent.com/1430060/32230904-902650b8-be2a-11e7-852a-34497f16256d.gif)

### Notes

In cases of missing data or unaligned time series for different variables, there are errors in the console. This has not changed from the previous implementation. This does not impede the app's functionality in any substantial way, so I'm letting it be for now.

Since we are now fetching a year's worth of values, the NWISUV results will take a little longer to load. However, according to the clients this is an acceptable compromise to get all the rest to work.

## Testing Instructions

 * Check out this branch, and reprovision `app`, and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Select a shape and search for something. Switch to the WDC tab.
 * Ensure all the different kinds of sources work in the details view: they should all have some data in the table, and some data in the chart