### PR TITLE
Fix Multi-Year modification bug

### DIFF
--- a/src/mmw/apps/modeling/migrations/0024_fix_gwlfe_gis_data.py
+++ b/src/mmw/apps/modeling/migrations/0024_fix_gwlfe_gis_data.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def fix_gis_data_serialization(apps, schema_editor):
+    """
+    Release 1.20.0 introduced a change which let the project "gis_data"
+    field get updated by modifications on a scenario.  This effectively
+    meant that modifications were being applied to all scenarios and that
+    removing them did not actually remove their effect from the gwlf-e
+    input.  For projects that were created and suffered from that bug,
+    clearing out the gis_data on Project and the results on Scenario
+    will force them to be recomputed with the fix applied.
+    """
+
+    Project = apps.get_model('modeling', 'Project')
+    bug_released_date = '2017-10-17'
+
+    # Apply fix to Multi-Year projects created after the release
+    for project in Project.objects.filter(created_at__gte=bug_released_date,
+                                          model_package='gwlfe'):
+        project.gis_data = None
+        for scenario in project.scenarios.all():
+            scenario.results = None
+            scenario.save()
+
+        project.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0023_fix_gis_data_serialization'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_gis_data_serialization,
+                             migrations.RunPython.noop)
+    ]

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -898,7 +898,7 @@ var ScenarioModel = Backbone.Model.extend({
                 // Merge the values that came back from Mapshed with the values
                 // in the modifications from the user.
                 var modifications = self.get('modifications'),
-                    mergedGisData = project.get('gis_data');
+                    mergedGisData = _.cloneDeep(project.get('gis_data'));
 
                 modifications.forEach(function(mod) {
                     _.assign(mergedGisData, mod.get('output'));


### PR DESCRIPTION
## Overview

Release 1.20.0 introduced a change which let the project `gis_data` field get updated by modifications on a scenario.  Since project `gis_data` is the "base" model input, this effectively meant that modifications were being applied to all scenarios and that removing them did not actually remove their effect from the gwlf-e input.  

A migration is provided for projects that were created and suffered from that bug, clearing out the `gis_data` on Project and the results on Scenario will force them to be recomputed with the fix applied.

Connects #2437 

### Notes

For a more technical explanation of the bug, see the commit message.

If applied today on production, the migration would affect 65 records:
```
modelmywatershed=> select count(*) from modeling_project where created_at >= '2017-10-17' and model_package='gwlfe';
 count 
-------
    65
```

## Testing Instructions

 * There are steps for testing that require you to be on `develop`, so hold off checking out this branch
 * Create a Multi-Year project or two that are created and saved in a manner described in #2437: 
    * essentially, have at least one scenario which has had a modification added and then removed
    * this has other manifestations, such as subsequent scenarios inheriting the modifications _impacts_ in the mapshed output (aka, `gis_data`) from other scenarios.
 * One those are created, saved and have had the bugs identified, check out this branch
 * Bundle and run migrations
 * In a refreshed browser (we want the new JS, or they'll just repeat the bug), load your saved projects which had the bugs verified.  They should recalculate (including CC) and not display the bug, since the migration reset the calculated values
 * Make a new Multi-Year project as you did before, and the confirm adding/removing modifications has the right behavior across scenarios.

