### PR TITLE
Use correct link template for NWIS sites

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -101,10 +101,10 @@ def parse_details_url(record):
         if len(parts) == 2:
             code, id = parts
             if code == 'NWISDV':
-                url = 'https://waterdata.usgs.gov/nwis/uv/?site_no={}'
+                url = 'https://waterdata.usgs.gov/nwis/dv/?site_no={}'
                 return url.format(id)
             elif code == 'NWISUV':
-                url = 'https://waterdata.usgs.gov/nwis/dv/?site_no={}'
+                url = 'https://waterdata.usgs.gov/nwis/uv/?site_no={}'
                 return url.format(id)
             elif code == 'NWISGW':
                 url = ('https://nwis.waterdata.usgs.gov/' +


### PR DESCRIPTION
## Overview

The url portion `uv` and `dv` were swapped.

Connects #2456 


## Testing Instructions

* Ensure that NWISUV sites have the `uv` link and NWISDV have the `dv` link, similar to https://github.com/WikiWatershed/model-my-watershed/pull/2428