### PR TITLE
Remove RWD point if RWD cancel button is clicked

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -173,7 +173,12 @@ var DrawWindow = Marionette.LayoutView.extend({
 
     onShow: function() {
         var self = this,
-            resetRwdDrawingState = function() {
+            resetRwdDrawingState = function(e) {
+                // If the cancel button was clicked
+                if (e && e.type === 'click') {
+                    self.model.clearRwdClickedPoint(App.getLeafletMap());
+                }
+
                 self.resetDrawingState({
                     clearOnFailure: false
                 });


### PR DESCRIPTION
## Overview

Work in https://github.com/WikiWatershed/model-my-watershed/pull/2171 preserved RWD map layers on failure. A side-effect of this work was that the initial RWD point was also preserved on cancellation.

The point is now explicitly removed when the cancel button is clicked.

Connects to #2447

### Demo

![mmw1](https://user-images.githubusercontent.com/1042475/32295128-bc98c87a-bf1e-11e7-8738-b75976a75375.gif)

### Notes

This is a bit of a quick fix. Initially, I tried to fix this by reworking how `resetDrawingState` worked and making sure that the point was cleared when the job was cancelled (as opposed to when the job failed). However, clicking the cancel button does not always result in a canceled job. I dug into how the `TaskModel` cancels jobs, and decided to not attempt to make any changes there since the `TaskModel` is used extensively throughout the site and this bug is rather small.

## Testing Instructions

- Start the app and activate the RWD tool.
- Before the job completes, attempt to cancel it using the `x` button on the draw UI.
- The clicked point should be removed.
- Select the RWD tool again, and select a point that will generate a very large watershed that can't be analyzed. See https://github.com/WikiWatershed/model-my-watershed/pull/2171#issuecomment-324097881 for an example).
- When the job completes, the AoI and RWD points should remain on the map.