### PR TITLE
Adjust Analyze height in tabbed view

### DIFF
--- a/src/mmw/sass/components/_tabs.scss
+++ b/src/mmw/sass/components/_tabs.scss
@@ -68,6 +68,12 @@
     .tab-content {
       // Set a specific height to allow y-scroll:
       height: 100% !important;
+
+      &.analyze-tab-content {
+        // Height under the main header (height-lg), the analyze / data bar
+        // header (height-xl) and the tabs (42px)
+        height: calc(100% - #{$height-lg} - #{$height-xl} - 42px) !important;
+      }
     }
 }
 


### PR DESCRIPTION
## Overview

When the Analyze window is in a tab, when both analyze and data are available as tabs, its contents weren't scrolling correctly.

By calculating the height and taking into account other items on the page, we ensure that the container's height is set in a way that allows all content to scroll and be visible.

Connects #2360 

### Demo

![2017-11-01 16 14 31](https://user-images.githubusercontent.com/1430060/32295522-ea41057a-bf1f-11e7-80db-3a16f84aa5e9.gif)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz)
 * Select an area and search for something. Go back to the Analyze tab, ensure you can scroll and see all the contents correctly.
 * Ensure search results scroll correctly and their area hasn't changed.
 * Ensure detail views scroll correctly and their area hasn't changed.
 * Test in various browsers.