### PR TITLE
Mark Compare View scroll state for ITSI screenshot

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -230,12 +230,16 @@ function toggleCompareViewForITSIScreenshot(adjustForScreenshot) {
         compareCloseButton = '.compare-close',
         compareChartButton = '#compare-input-button-chart',
         compareTableButton = '#compare-input-button-table',
+        compareSections = '.compare-sections',
         compareChartRow = '.compare-chart-row',
         compareTableRow = '.compare-table-row',
         compareScenariosRow = '.compare-scenarios',
         compareMapsRow = '.compare-scenario-row-content';
 
     if (adjustForScreenshot) {
+        $(compareSections + '> div').css('margin-top',
+            '-' + $(compareSections).scrollTop() + 'px'
+        );
         $(compareDialog).addClass(itsiCompareDialog);
         $(compareModalContent).addClass(itsiCompareModal);
         $(compareCloseButton).hide();
@@ -261,6 +265,12 @@ function toggleCompareViewForITSIScreenshot(adjustForScreenshot) {
         } else if ($(compareTableRow).length) {
             $(compareTableRow).removeClass(itsiCompareRow);
         }
+
+        var mtString = $(compareSections + '> div').css('margin-top'),
+            marginTop = parseInt(mtString.substring(1, mtString.length - 2));
+
+        $(compareSections + '> div').css('margin-top', '');
+        $(compareSections).scrollTop(marginTop);
     }
 }
 


### PR DESCRIPTION
## Overview

Previously any scrolling in the compare view would be lost when the screen was scraped for a screenshot. Now we record the current scroll state into the child's margin-top property so that the screenshotting code gets it as part of the HTML.

Connects #2332 

### Demo

While taking a screenshot:

![screen shot 2017-11-01 at 5 31 12 pm](https://user-images.githubusercontent.com/1430060/32299456-0aae8416-bf2c-11e7-8499-60075c61ecfc.png)

The screenshot I took:

![fe58a3015c2d00d56d34998ac2eade5b917e4d9e](https://user-images.githubusercontent.com/1430060/32299462-103cb506-bf2c-11e7-9494-b5b45488e1d6.png)

Page state when the screenshot was taken:

![screen shot 2017-11-01 at 5 31 38 pm](https://user-images.githubusercontent.com/1430060/32299471-165c2584-bf2c-11e7-9c58-c9e0f39adb90.png)

### Notes

There's probably other places in the app where we could apply a similar treatment (modeling sidebar), but none so egregious as this. If we need to do it for the others, we can tackle them similarly at a later date.

## Testing Instructions

 * Check out this branch and `bundle`
 * Have your local stack up and running, maybe via ngrok
 * Go to https://authoring.concord.org/activities/5644/single_page/dec56c68-6170-4e59-b94a-82fb040e8d88 and click on "Start Interactive" for MMW. Then, replace the iframe with your local stack.
 * Open a saved project, or create a new TR-55 one and make a few scenarios
 * Open the compare view. Scroll down a bit.
 * Take a screenshot. Ensure that the screenshot generally reflects the scroll state, and after the screenshot is taken the app behaves correctly.