### PR TITLE
Render layer selector when model attributes change

### DIFF
--- a/src/mmw/js/src/core/layerPicker.js
+++ b/src/mmw/js/src/core/layerPicker.js
@@ -218,6 +218,7 @@ var LayerPickerGroupView = Marionette.LayoutView.extend({
     },
 
     modelEvents: {
+        'change': 'render',
         'toggle:layer': 'addLayerControls',
     },
 


### PR DESCRIPTION
## Overview

This render event was [removed when the climate sub-layer control was added](https://github.com/WikiWatershed/model-my-watershed/commit/48adc9c242917604fe2ab0041499f93c967b969f#diff-fa3796f2e3f8773b7a5d1e15f346e1d9L142) and prevented the Observation tab from reporting "Loading" or updating when layer values were asynchronously added.

Connects #2453 

### Notes

I believe that the render was removed because it was assumed to be superfluous and is not required to be removed for the climate sliders to function.

## Testing Instructions

 * Bundle and click the Observations tab on the layer selector.  The loading text should appear, following by the list of observation layers.
 * Load the app in ?bigcz mode, confirm that the climate layer sliders still function