### PR TITLE
Move callback function to options from attributes

### DIFF
--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -145,7 +145,9 @@ var App = new Marionette.Application({
         var loginModalView = new userViews.LoginModalView({
             model: new userModels.LoginFormModel({
                 showItsiButton: settings.get('itsi_enabled'),
-                successCallback:  function(loginResponse) {
+            },
+            {
+                onSuccess:  function(loginResponse) {
                     if (loginResponse.profile_was_skipped || loginResponse.profile_is_complete) {
                         if (onSuccess && _.isFunction(onSuccess)) {
                             onSuccess(loginResponse);
@@ -154,8 +156,8 @@ var App = new Marionette.Application({
                         loginModalView.$el.modal('hide');
                         loginModalView.$el.on('hidden.bs.modal', function() {
                             new userViews.UserProfileModalView({
-                                model: new userModels.UserProfileFormModel({
-                                    successCallback: onSuccess
+                                model: new userModels.UserProfileFormModel({}, {
+                                    onSuccess: onSuccess
                                 }),
                                 app: self
                             }).render();
@@ -169,8 +171,8 @@ var App = new Marionette.Application({
 
     showProfileModal: function (onSuccess) {
         new userViews.UserProfileModalView({
-            model: new userModels.UserProfileFormModel({
-                successCallback: onSuccess
+            model: new userModels.UserProfileFormModel({}, {
+                onSuccess: onSuccess
             }),
             app: this
         }).render();

--- a/src/mmw/js/src/user/models.js
+++ b/src/mmw/js/src/user/models.js
@@ -84,10 +84,17 @@ var LoginFormModel = ModalBaseModel.extend({
     defaults: {
         username: null,
         password: null,
-        successCallback: null
     },
 
     url: '/user/login',
+
+    initialize: function(attrs, opts) {
+        if (opts && opts.onSuccess && _.isFunction(opts.onSuccess)) {
+            this.onSuccess = opts.onSuccess;
+        } else {
+            this.onSuccess = _.noop;
+        }
+    },
 
     validate: function(attrs) {
         var errors = [];
@@ -113,13 +120,6 @@ var LoginFormModel = ModalBaseModel.extend({
             });
         }
     },
-
-    onSuccess: function(response) {
-        var callback = this.get('successCallback');
-        if (callback && _.isFunction(callback)) {
-            callback(response);
-        }
-    }
 });
 
 var UserProfileFormModel = ModalBaseModel.extend({


### PR DESCRIPTION
## Overview

Previously a success callback function was added to a model's attributes, and was being sent to the server during save, causing server side errors.

Now we pass in that callback via options, so it is not added to the list of attributes sent to the server.

This callback is used for showing the profile form after logging in for the first time, but is also used for actions that depend on logging in, such as [showing the projects list](https://github.com/WikiWatershed/model-my-watershed/blob/tt/user-accounts-profile-extra-param/src/mmw/js/src/draw/views.js#L253-L255).

Connects #2460 

### Demo

![2017-11-03 14 53 16](https://user-images.githubusercontent.com/1430060/32391163-755cc21a-c0a7-11e7-816c-c962201e2742.gif)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/](http://localhost:8000/) and make sure you are signed out
 * Click on "Open Projects" and log in. Ensure you are taken to the projects list page
 * Sign up as a new user. Login, and ensure you see the profile form after logging in
 * Ensure saving the profile does not cause any errors