### PR TITLE
Add CORS Support to Geoprocessing API

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -262,6 +262,7 @@ TEMPLATE_DIRS = (
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#middleware-classes
 MIDDLEWARE_CLASSES = (
     # Default Django middleware.
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'mmw.middleware.BypassMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -298,6 +299,7 @@ THIRD_PARTY_APPS = (
     'rest_framework',
     'rest_framework_swagger',
     'rest_framework.authtoken',
+    'corsheaders',
     'registration',
     'django_celery_results',
 )
@@ -311,6 +313,11 @@ REST_FRAMEWORK = {
         'burst': '20/min',
     },
 }
+
+# cors
+
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/api/.*$'
 
 SWAGGER_SETTINGS = {
     'exclude_namespaces': ['bigcz',

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -10,6 +10,7 @@ python-omgeo==2.0.0
 rauth==0.7.1
 djangorestframework-gis==0.8.2
 django-rest-swagger==0.3.8
+django-cors-headers==2.1.0
 markdown==2.6.9
 tr55==1.3.0
 gwlf-e==0.6.2


### PR DESCRIPTION
## Overview

Add [CORS support plugin](https://github.com/ottoyiu/django-cors-headers) and allow all hosts to access the API.
We may restrict this in the future.

Connects #2452

### Demo

![image](https://user-images.githubusercontent.com/1430060/32396067-3f67ab94-c0ba-11e7-9da4-79f0fb2e647c.png)

## Testing Instructions

 * Check out this branch and reprovision `app`
 * Go to [:8000/](http://localhost:8000/) and open the Network panel of Developer Tools
 * Draw / select a shape and proceed to Analyze. Watch the network requests for analyze submissions.
 * Inspect any such request. The response headers should include

       Access-Control-Allow-Origin: *