### PR TITLE
Add Google Analytic Events

### DIFF
--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -5,7 +5,8 @@ var $ = require('jquery'),
     Backbone = require('../../shim/backbone'),
     settings = require('../core/settings'),
     utils = require('../core/utils'),
-    coreModels = require('../core/models');
+    coreModels = require('../core/models'),
+    turfArea = require('turf-area');
 
 var LayerModel = Backbone.Model.extend({});
 
@@ -44,6 +45,11 @@ var AnalyzeTaskModel = coreModels.TaskModel.extend({
             result = self.get('result');
 
         if (aoi && !result && self.fetchAnalysisPromise === undefined) {
+            var gaEvent = self.get('name') + '-analyze',
+                gaLabel = utils.isInDrb(aoi) ? 'drb-aoi' : 'national-aoi',
+                gaAoiSize = turfArea(aoi) / 1000000;
+            ga('send', 'event', 'Analyze', gaEvent, gaLabel, parseInt(gaAoiSize));
+
             var isWkaoi = utils.isWKAoIValid(wkaoi),
                 taskHelper = {
                     contentType: 'application/json',

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -48,7 +48,7 @@ var AnalyzeTaskModel = coreModels.TaskModel.extend({
             var gaEvent = self.get('name') + '-analyze',
                 gaLabel = utils.isInDrb(aoi) ? 'drb-aoi' : 'national-aoi',
                 gaAoiSize = turfArea(aoi) / 1000000;
-            ga('send', 'event', 'Analyze', gaEvent, gaLabel, parseInt(gaAoiSize));
+            window.ga('send', 'event', 'Analyze', gaEvent, gaLabel, parseInt(gaAoiSize));
 
             var isWkaoi = utils.isWKAoIValid(wkaoi),
                 taskHelper = {

--- a/src/mmw/js/src/core/testUtils.js
+++ b/src/mmw/js/src/core/testUtils.js
@@ -2,6 +2,9 @@
 
 var $ = require('jquery');
 
+// Mock the Google Analytics function for tests
+window.ga = function() {};
+
 // Should be called after each unit test.
 function resetApp(app) {
     app.map.off();

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -513,6 +513,13 @@ var utils = {
     // Array.filter(distinct) to get distinct values
     distinct: function(value, index, self) {
         return self.indexOf(value) === index;
+    },
+
+    isInDrb: function(geom) {
+        var layers = settings.get('stream_layers'),
+            drb = _.findWhere(layers, {code: 'drb_streams_v2'}).perimeter;
+
+        return !!intersect(geom, drb);
     }
 };
 

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -31,7 +31,8 @@ var selectBoundary = 'selectBoundary',
     delineateWatershed = 'delineateWatershed',
     aoiUpload = 'aoiUpload',
     freeDraw = 'free-draw',
-    squareKm = 'square-km';
+    squareKm = 'square-km',
+    GA_AOI_CATEGORY = 'AoI Creation';
 
 var codeToLayer = {}; // code to layer mapping
 
@@ -419,6 +420,7 @@ var AoIUploadView = Marionette.ItemView.extend({
         var geojson = JSON.parse(jsonString);
 
         this.addPolygonToMap(geojson.features[0]);
+        ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'geojson');
     },
 
     handleShpZip: function(zipfile) {
@@ -432,6 +434,8 @@ var AoIUploadView = Marionette.ItemView.extend({
                 self.reprojectAndAddFeature(shp, prj);
             })
             .catch(_.bind(self.handleShapefileError, self));
+
+        ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'shapefile');
     },
 
     reprojectAndAddFeature: function(shp, prj) {
@@ -664,6 +668,9 @@ var SelectBoundaryView = DrawToolBaseView.extend({
             codeToLayer[layerCode] = ol;
 
             grid.on('click', function(e) {
+                ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'boundary-' + layerCode);
+                ga('send', 'event', GA_AOI_CATEGORY, 'boundary-aoi-create', e.data.name);
+
                 getShapeAndAnalyze(e, self.model, ofg, grid, layerCode, shortDisplay);
             });
 
@@ -776,6 +783,7 @@ var DrawAreaView = DrawToolBaseView.extend({
             .then(function(shape) {
                 addLayer(shape);
                 navigateToAnalyze();
+                ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'freedraw');
             }).fail(function(message) {
                 revertLayer();
                 displayAlert(message, modalModels.AlertTypes.error);
@@ -812,6 +820,7 @@ var DrawAreaView = DrawToolBaseView.extend({
                 return [parseFloat(coord[0]), parseFloat(coord[1])];
             });
 
+            ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'squarekm')
             return box;
         }).then(validateShape).then(function(polygon) {
             addLayer(polygon, '1 Square Km');
@@ -902,6 +911,7 @@ var WatershedDelineationView = DrawToolBaseView.extend({
 
         utils.placeMarker(map)
             .then(function(latlng) {
+                ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'rwd-' + dataSource);
                 return validatePointWithinDataSourceBounds(latlng, dataSource);
             })
             .then(function(latlng) {

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -420,7 +420,7 @@ var AoIUploadView = Marionette.ItemView.extend({
         var geojson = JSON.parse(jsonString);
 
         this.addPolygonToMap(geojson.features[0]);
-        ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'geojson');
+        window.ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'geojson');
     },
 
     handleShpZip: function(zipfile) {
@@ -435,7 +435,7 @@ var AoIUploadView = Marionette.ItemView.extend({
             })
             .catch(_.bind(self.handleShapefileError, self));
 
-        ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'shapefile');
+        window.ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'shapefile');
     },
 
     reprojectAndAddFeature: function(shp, prj) {
@@ -668,8 +668,8 @@ var SelectBoundaryView = DrawToolBaseView.extend({
             codeToLayer[layerCode] = ol;
 
             grid.on('click', function(e) {
-                ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'boundary-' + layerCode);
-                ga('send', 'event', GA_AOI_CATEGORY, 'boundary-aoi-create', e.data.name);
+                window.ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'boundary-' + layerCode);
+                window.ga('send', 'event', GA_AOI_CATEGORY, 'boundary-aoi-create', e.data.name);
 
                 getShapeAndAnalyze(e, self.model, ofg, grid, layerCode, shortDisplay);
             });
@@ -783,7 +783,7 @@ var DrawAreaView = DrawToolBaseView.extend({
             .then(function(shape) {
                 addLayer(shape);
                 navigateToAnalyze();
-                ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'freedraw');
+                window.ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'freedraw');
             }).fail(function(message) {
                 revertLayer();
                 displayAlert(message, modalModels.AlertTypes.error);
@@ -820,7 +820,7 @@ var DrawAreaView = DrawToolBaseView.extend({
                 return [parseFloat(coord[0]), parseFloat(coord[1])];
             });
 
-            ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'squarekm')
+            window.ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'squarekm');
             return box;
         }).then(validateShape).then(function(polygon) {
             addLayer(polygon, '1 Square Km');
@@ -911,7 +911,7 @@ var WatershedDelineationView = DrawToolBaseView.extend({
 
         utils.placeMarker(map)
             .then(function(latlng) {
-                ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'rwd-' + dataSource);
+                window.ga('send', 'event', GA_AOI_CATEGORY, 'aoi-create', 'rwd-' + dataSource);
                 return validatePointWithinDataSourceBounds(latlng, dataSource);
             })
             .then(function(latlng) {

--- a/src/mmw/js/src/modeling/constants.js
+++ b/src/mmw/js/src/modeling/constants.js
@@ -1,0 +1,8 @@
+module.exports = {
+    GA: {
+        MODEL_CATEGORY: "Modeling",
+        MODEL_CREATE_EVENT: "project-create",
+        MODEL_SCENARIO_EVENT: "scenario-create",
+        MODEL_MOD_EVENT: "-modification-create",
+    }
+};

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -4,6 +4,7 @@ var $ = require('jquery'),
     _ = require('lodash'),
     Backbone = require('../../shim/backbone'),
     App = require('../app'),
+    constants = require('./constants.js'),
     settings = require('../core/settings'),
     router = require('../router').router,
     views = require('./views'),
@@ -109,6 +110,8 @@ var ModelingController = {
     },
 
     makeNewProject: function(modelPackage) {
+        window.ga('send', 'event', constants.GA.MODEL_CATEGORY, constants.GA.MODEL_CREATE_EVENT, modelPackage);
+
         var project;
         if (settings.get('itsi_embed')) {
             project = App.currentProject;


### PR DESCRIPTION
## Overview

Adds Event tracking for high profile activity within the app, for the purposes of describing app user behavior to WPF.

* Aoi Creation: Captures the type of aoi creation selected: boundary type, freedraw, squarekm, drb-rwd, nhd-drb, shapefile or geojson
* Analyze: An analyze request for an AoI, one for each type: animals, land, soil, etc.
* Modeling: Captures creating a project, the model type, adding a scenario and adding a modification.  Scenario and Modification events capture the model package as well 

Connects #2450 

### Demo
Events showing up:
![image](https://user-images.githubusercontent.com/1014341/32416771-b12d1792-c21c-11e7-9a14-4f3971a63323.png)

Event requests being sent (Network -> JS)
![image](https://user-images.githubusercontent.com/1014341/32416780-d30978d8-c21c-11e7-981a-c9455b77a3d7.png)


### Notes

There are a large number of potential events to capture, however I chose the top actions that I anticipated WPF may wish to know.  This could be expanded to determine which features are commonly used, but since we don't have explicit funding for that type of analysis, I'm keeping it as simple as possible for now.

## Testing Instructions

 * Application behavior should not have changed at all
 * GA Events take up to 24 hours to register in the dashboard, but Real-Time events can be seen almost immediately.  I can help set up access for you to test.
