### PR TITLE
Add catchment & aoi area != 0 guards

### DIFF
--- a/src/mmw/apps/geoprocessing_api/calcs.py
+++ b/src/mmw/apps/geoprocessing_api/calcs.py
@@ -182,7 +182,13 @@ def catchment_intersects_aoi(aoi, catchment):
     catchment_geom = GEOSGeometry(json.dumps(catchment), srid=4326)
     reprojected_catchment = catchment_geom.transform(5070, clone=True)
 
-    if not reprojected_catchment.valid:
+    if catchment_geom.area == 0:
+        return True
+    elif reprojected_catchment.area == 0:
+        return True
+    elif aoi.area == 0:
+        return False
+    elif not reprojected_catchment.valid:
         return False
 
     aoi_kms = aoi.area / 1000000


### PR DESCRIPTION
## Overview

- add guards to check that catchment & aoi area isn't zero before
  using those values as divisors
- if catchment area is 0, return True (& count the catchment as
  intersecting), since PostGIS has determined that it intersects prior
  to reducing the geometry to an empty list in the simplify operation
- if aoi area is ever 0, return False since there aren't any possible
  intersections

Connects #2472 

### Notes

Made notes on #2472 while investigating this and the problem catchment is `nord` 7870, which is an empty list when simplified in PostGIS. That catchment is including in results on production, but it doesn't have a corresponding mapped polygon (because of the empty coordinates list). It also appears to be the only catchment which has that issue with simplification.

I decided to count catchments with 0 area as `True` and include them in the results since PostGIS had determined that there was an intersection prior to simplifying the shape into geojson.

I also added a guard for the AOI having an area of 0 -- which returns `False` & hence doesn't include catchments. I'm not sure when this would be triggered in practice, but since it's being used as a divisor, too, it felt worthwhile to add.

We may want to change the return value for AOIs with area of 0 to be `True`, btw, but in practice it may not matter except for the API: the smallest shape I'm able to draw using the client is 50 square meters and that value isn't rounded down to zero. 

## Testing Instructions
- get this branch, then bundle and run `./scripts/debugcelery.sh` to ensure the worker gets the new `calcs.py` code
- select "Middle Delaware-Mongaup-Brodhead, HUC-8 Subbasin" as your AOI and verify that it does not throw an error and does return wq catchment results including catchment 7870
- select several other aois and verify that they also return water quality results properly and everything else works as expected