### PR TITLE
Remove bottom margin from modals to prevent unneeded scrolling

### DIFF
--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -3,7 +3,7 @@
   background-color: $black-54;
 
   .modal-dialog {
-    margin: 72px auto;
+    margin: 72px auto 0 auto;
   }
 
   .modal-content {


### PR DESCRIPTION
## Overview

Removing the bottom margin prevents the page from scrolling when a modal dialog is completely on screen but less than 72px from the bottom of the browser frame.

Connects #2482

### Demo

<img width="810" alt="screen shot 2017-11-06 at 1 02 09 pm" src="https://user-images.githubusercontent.com/17363/32461472-29598bca-c2f3-11e7-87f4-7e823fb1e381.png">

## Testing Instructions

 * Open a modal
 * Adjust the height of the browser so that the entire modal is visible, but there is only a small space below the modal.
 * Confirm that the page does not scroll.
 * Adjust the height of the browser to that the modal is partially outside the viewport.
 * Confirm that the page is now scrollable.
