### PR TITLE
Fix Compare View Header Styling

### DIFF
--- a/src/mmw/js/src/core/modals/templates/inputModal.html
+++ b/src/mmw/js/src/core/modals/templates/inputModal.html
@@ -5,10 +5,8 @@
         </div>
         <div class="modal-body">
             <div class="custom-input-group">
-                <input type="text" required value="{{ initial }}"/>
-                <span class="highlight"></span>
-                <span class="bar"></span>
-                <label>{{ fieldLabel }}</label>
+                <label class="modal-text-input-label">{{ fieldLabel }}</label>
+                <input class="modal-text-input" type="text" required value="{{ initial }}"/>
             </div>
             <label class="error"></label>
         </div>

--- a/src/mmw/js/src/core/modals/templates/shareModal.html
+++ b/src/mmw/js/src/core/modals/templates/shareModal.html
@@ -8,10 +8,8 @@
                 <p>Sorry, only saved {{ text }}s are able to be shared.  Please log in to share your work.</p>
             {% else %}
                 <div class="custom-input-group">
-                  <input id="share-url" type="text" required value="{{ url }}">
-                  <span class="highlight"></span>
-                  <span class="bar"></span>
-                  <label>URL</label>
+                  <label class="modal-text-input-label">URL</label>
+                  <input class="modal-text-input" id="share-url" type="text" required value="{{ url }}">
                 </div>
             {% endif %}
         </div>

--- a/src/mmw/js/src/user/templates/baseModal.html
+++ b/src/mmw/js/src/user/templates/baseModal.html
@@ -1,7 +1,7 @@
 {% macro field(value, name, label='', type='text') %}
     <div>
-        <label for="{{ name }}">{{ label }}</label>
-        <input name="{{ name }}" type="{{ type }}" id="{{ name }}" required value="{{ value }}">
+        <label class="modal-text-input-label" for="{{ name }}">{{ label }}</label>
+        <input class="modal-text-input" name="{{ name }}" type="{{ type }}" id="{{ name }}" required value="{{ value }}">
     </div>
 {% endmacro %}
 

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -11,11 +11,11 @@
     border: 0px solid $black-12;
     box-shadow: 0 0 6px $black-24;
 
-    label {
+    .modal-text-input-label {
         display: block;
     }
 
-    input {
+    .modal-text-input {
         width: 100%;
         padding: 0.75rem 0.5rem;
         margin: 0.5rem 0 2.5rem 0;


### PR DESCRIPTION
## Overview
- Some of the styling updates to the login modals broke the compare modal. Make the styling
 more specific.

- Fixup some of the input modals, which also lost their styling. @jfrankl, are these passable or should I add the old styling back in?

 
Connects #2485

### Demo
<img width="1024" alt="screen shot 2017-11-06 at 3 49 10 pm" src="https://user-images.githubusercontent.com/7633670/32464003-7e0f9966-c30c-11e7-8ae8-66d48f6410a6.png">

Modals 
<img width="469" alt="screen shot 2017-11-06 at 3 59 23 pm" src="https://user-images.githubusercontent.com/7633670/32464000-7dec6568-c30c-11e7-96d3-2ee1dd0f50ab.png">

<img width="478" alt="screen shot 2017-11-06 at 3 59 13 pm" src="https://user-images.githubusercontent.com/7633670/32464001-7df81a0c-c30c-11e7-9804-dce2315319df.png">

<img width="447" alt="screen shot 2017-11-06 at 3 59 02 pm" src="https://user-images.githubusercontent.com/7633670/32464002-7e05e56a-c30c-11e7-80f0-0327d0d4b8a2.png">

## Testing Instructions

 * Pull and `bundle`
 * Go to the compare view and confirm the header is of a regular height
 * Project Dropdown -> Rename Project -- modal should look like screenshot in Demo
 * Project Dropdown -> Share -- copy url modal should look like screenshot in Demo
 * Scenario Dropdown -> Rename Scenario -- modal should look like screenshot in Demo
 * User Form modals should be uneffected