### PR TITLE
BiG-CZ: Throttle NWISUV

### DIFF
--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -13,6 +13,11 @@ var PAGE_SIZE = settings.get('data_catalog_page_size');
 var DATE_FORMAT = 'MM/DD/YYYY';
 var WATERML_VARIABLE_TIME_INTERVAL = '{http://www.cuahsi.org/water_ml/1.1/}variable_time_interval';
 
+var SERVICE_PERIODS = {
+    'NWISUV': 'months',  // For NWISUV sites, fetch 1 month of data
+    '*'     : 'years',   // For all else, fetch 1 year of data
+};
+
 
 var FilterModel = Backbone.Model.extend({
     defaults: {
@@ -709,14 +714,16 @@ var CuahsiVariable = Backbone.Model.extend({
                 wsdl: this.get('wsdl'),
                 site: this.get('site'),
                 variable: this.get('id'),
-            };
+            },
+            service = params.site.split(':')[0],
+            duration = SERVICE_PERIODS[service] || 'years';
 
         // If neither from date nor to date is specified, set time interval
-        // to be either from begin date to end date, or 1 week up to end date,
-        // whichever is shorter.
+        // to be either from begin date to end date, or 1 `duration` up to end
+        // date, whichever is shorter.
         if (!from || moment(from).isBefore(begin_date)) {
-            if (end_date.diff(begin_date, 'years', true) > 1) {
-                params.from_date = moment(end_date).subtract(1, 'years');
+            if (end_date.diff(begin_date, duration, true) > 1) {
+                params.from_date = moment(end_date).subtract(1, duration);
             } else {
                 params.from_date = begin_date;
             }


### PR DESCRIPTION
## Overview

These sites have a lot of data, and fetching one year worth of it can sometimes overutilize the server's resources. We restrict them to 1 month fetches, keeping the rest at 1 year.

Connects #2493

### Demo

![2017-11-07 16 52 03](https://user-images.githubusercontent.com/1430060/32519942-571b3286-c3dc-11e7-8164-a2c99ef9b5b4.gif)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and select the Brandywine HUC-10 shape
 * Search for "water" and switch to the CUAHSI tab
 * Select an NWISUV site and ensure that all the variables load without the server timing out. Ensure the chart only goes back 1 month.
 * Select another, non-NWISUV site and ensure it works too. Ensure their chart goes back 1 year.