### PR TITLE
BiG-CZ: Refetch Data On Server Refresh

### DIFF
--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -421,6 +421,7 @@ var Result = Backbone.Model.extend({
             if (variables instanceof CuahsiVariables) {
                 variables.reset(response.variables);
                 delete response.variables;
+                delete this.fetchPromise;
             }
         }
 


### PR DESCRIPTION
## Overview

When a filter changes, all results for a catalog are refetched. It is possible that a filter may include results that were already included. In this case, there isn't a new instance of the result, but the existing instance is refreshed. When this happens, its CuahsiVariables collection is reset, with no detail values.

Previously, if a result details page had been viewed, it had fetched the detail values for said CuahsiVariables, and cached them, using a fetchPromise that would only be resolved once. After fetching them for the first time, we simply returned the fetchPromise so they would not be fetched again.

When the values are reset, the actual detail values are gone, but the cached fetchPromise remains, thus preventing values from being fetched anew. By deleting the fetchPromise when receiving new values, we ensure that when a detail page is opened for a previously fetched and repeatedly filtered result, the values for its CuahsiVariables are refetched.

Connects #2495 

### Demo

![2017-11-08 11 00 26](https://user-images.githubusercontent.com/1430060/32559214-986f4fd6-c474-11e7-992a-e3bc5c5fcec4.gif)

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/?bigcz](http://localhost:8000/?bigcz), select a shape and proceed to search.
 * Search for "water" and switch to the CUAHSI tab. Pick a result and go to the details view. Wait for its values to be fetched.
 * Once the values are in, go back to list view and then go back to the same result's detail view. Ensure that it has cached values and they are not re-fetched.
 * Change the date filter to something that includes the result you picked. Wait for the results to refresh. Then open your result again. Ensure its data is re-fetched.
 * Change the date filter to exclude your result. Change it again to include it. Open its detail view. Ensure its data is refetched.