### PR TITLE
Switch TR-55 Water Quality to Bullet Charts

### DIFF
--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -3,7 +3,8 @@
 var d3 = require('d3'),
     nv = require('../../shim/nv.d3.js'),
     $ = require('jquery'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    utils = require('./utils');
 
 var widthCutoff = 400;
 
@@ -599,26 +600,14 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
 function renderBulletChart(chartEl, title, subtitle, data) {
     var chart = nv.models.bulletChart(),
         svg = makeSvg(chartEl),
+        range = utils.rangeInMagnitude(data),
         datum = {
             title: title,
             subtitle: subtitle,
+            ranges: [range.min, 0, range.max],
             measures: [data],
             color: '#48c5d1',
-        },
-        adjustment = 1;
-
-    // Calculate max range of chart
-    // by rounding up to the next place
-    while (data < 1) {
-        data *= 10;
-        adjustment -= 1;
-    }
-    while (data > 10) {
-        data /= 10;
-        adjustment += 1;
-    }
-
-    datum.ranges = [0, 0, Math.pow(10, adjustment)];
+        };
 
     chart.tooltip.valueFormatter(d3.format('.02f'));
 

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -596,9 +596,45 @@ function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax,
     }, onRenderComplete);
 }
 
+function renderBulletChart(chartEl, title, subtitle, data) {
+    var chart = nv.models.bulletChart(),
+        svg = makeSvg(chartEl),
+        datum = {
+            title: title,
+            subtitle: subtitle,
+            measures: [data],
+            color: '#48c5d1',
+        },
+        adjustment = 1;
+
+    // Calculate max range of chart
+    // by rounding up to the next place
+    while (data < 1) {
+        data *= 10;
+        adjustment -= 1;
+    }
+    while (data > 10) {
+        data /= 10;
+        adjustment += 1;
+    }
+
+    datum.ranges = [0, 0, Math.pow(10, adjustment)];
+
+    chart.tooltip.valueFormatter(d3.format('.02f'));
+
+    d3.select(svg)
+        .datum(datum)
+        .call(chart);
+
+    removeTooltipOnDestroy(chartEl, chart.tooltip);
+
+    return chart;
+}
+
 module.exports = {
     renderHorizontalBarChart: renderHorizontalBarChart,
     renderVerticalBarChart: renderVerticalBarChart,
     renderLineChart: renderLineChart,
-    renderCompareMultibarChart: renderCompareMultibarChart
+    renderCompareMultibarChart: renderCompareMultibarChart,
+    renderBulletChart: renderBulletChart,
 };

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -15,6 +15,7 @@ var $ = require('jquery'),
     models = require('./models'),
     AppRouter = require('../router').AppRouter,
     settings = require('./settings'),
+    utils = require('./utils'),
     testUtils = require('./testUtils');
 
 var TEST_SHAPE = {
@@ -712,6 +713,17 @@ describe('Core', function() {
                 assert.notProperty(this.requests[i].requestHeaders, 'X-Requested-With');
                 assert.notProperty(this.requests[i].requestHeaders, 'X-CSRFToken');
             }
+        });
+    });
+
+    describe('Utils', function() {
+        it('calculates range in magnitude correctly', function() {
+            assert.deepEqual(utils.rangeInMagnitude(50), {min: 0, max: 100});
+            assert.deepEqual(utils.rangeInMagnitude(8), {min: 0, max: 10});
+            assert.deepEqual(utils.rangeInMagnitude(0.314), {min: 0, max: 1});
+            assert.deepEqual(utils.rangeInMagnitude(0), {min: 0, max: 1});
+            assert.deepEqual(utils.rangeInMagnitude(10), {min: 0, max: 10});
+            assert.deepEqual(utils.rangeInMagnitude(-0.005), {min: -0.01, max: 0});
         });
     });
 });

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -520,6 +520,50 @@ var utils = {
             drb = _.findWhere(layers, {code: 'drb_streams_v2'}).perimeter;
 
         return !!intersect(geom, drb);
+    },
+
+    // Calculates a range from 0 to the upper bound
+    // of the order of magnitde of the value. Returns
+    // an object containing min and max.
+    // e.g. rangeInMagnitude(50)    => {min:  0,   max: 100}
+    //      rangeInMagnitude( 5)    => {min:  0,   max:  10}
+    //      rangeInMagnitude( 0.5)  => {min:  0,   max:   1}
+    //      rangeInMagnitude(-0.05) => {min: -0.1, max:   0}
+    rangeInMagnitude: function(value) {
+        var negative = value < 0,
+            exponent = 1,
+            min = 0,
+            max;
+
+        if (negative) {
+            value *= -1;
+        }
+
+        if (value === 0) {
+            return {min: 0, max: 1};
+        }
+
+        while (value < 1) {
+            value *= 10;
+            exponent -= 1;
+        }
+
+        while (value > 10) {
+            value /= 10;
+            exponent += 1;
+        }
+
+        max = Math.pow(10, exponent);
+
+        if (negative) {
+            min = -max;
+            max = 0;
+        }
+
+        return {
+            min: min,
+            max: max
+        };
     }
 };
 

--- a/src/mmw/js/src/modeling/tr55/quality/templates/chart.html
+++ b/src/mmw/js/src/modeling/tr55/quality/templates/chart.html
@@ -1,0 +1,2 @@
+<div class="bullet-charts"></div>
+<div class="chart-units">Loading Rate (kg/ha)</div>

--- a/src/mmw/js/src/modeling/tr55/quality/views.js
+++ b/src/mmw/js/src/modeling/tr55/quality/views.js
@@ -5,7 +5,7 @@ var $ = require('jquery'),
     Marionette = require('../../../../shim/backbone.marionette'),
     AoiVolumeModel = require('../models').AoiVolumeModel,
     chart = require('../../../core/chart.js'),
-    barChartTmpl = require('../../../core/templates/barChart.html'),
+    chartTmpl = require('./templates/chart.html'),
     resultTmpl = require('./templates/result.html'),
     tableRowTmpl = require('./templates/tableRow.html'),
     tableTmpl = require('./templates/table.html'),
@@ -115,32 +115,36 @@ var TableView = Marionette.CompositeView.extend({
     }
 });
 
-var ChartView = Marionette.ItemView.extend({
+var ChartRowView = Marionette.ItemView.extend({
+    template: false,
+
+    className: 'bullet-chart',
+
+    onShow: function() {
+        var chartEl = this.$el,
+            aoiVolumeModel = this.options.aoiVolumeModel,
+            measure = this.model.get('measure'),
+            title = measure.substr(0, measure.indexOf(' ')), // First word
+            subtitle = measure.substr(measure.indexOf(' ')), // All the rest
+            load = this.model.get('load'),
+            data = aoiVolumeModel.getLoadingRate(load);
+
+        chart.renderBulletChart(chartEl, title, subtitle, data);
+    }
+});
+
+var ChartView = Marionette.CompositeView.extend({
     // model ResultModel
-    template: barChartTmpl,
+    template: chartTmpl,
     className: 'chart-container quality-chart-container',
 
-    onAttach: function() {
-        this.addChart();
+    childView: ChartRowView,
+    childViewContainer: '.bullet-charts',
+    childViewOptions: function() {
+        return {
+            aoiVolumeModel: this.options.aoiVolumeModel
+        };
     },
-
-    addChart: function() {
-        var chartEl = this.$el.find('.bar-chart').get(0),
-            aoiVolumeModel = this.options.aoiVolumeModel,
-            data = this.collection.map(function(model) {
-                var load = model.attributes.load;
-                return {
-                    x: model.attributes.measure,
-                    y: aoiVolumeModel.getLoadingRate(load)
-                };
-            }),
-            chartOptions = {
-                yAxisLabel: 'Loading Rate (kg/ha)',
-                abbreviateTicks: true
-            };
-
-        chart.renderHorizontalBarChart(chartEl, data, chartOptions);
-    }
 });
 
 module.exports = {

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -37,3 +37,27 @@
     height: 300px;
   }
 }
+
+.quality-chart-container {
+  .bullet-charts {
+    .bullet-chart {
+      width: 100%;
+      height: 60px;
+
+      svg {
+        width: $sidebar-width - 25px;
+        height: 60px;
+      }
+
+      .nv-tick line {
+        stroke: #bababa;
+        stroke-width: 0.5px;
+      }
+    }
+  }
+
+  .chart-units {
+    font-size: 12px;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Overview

Previously the water quality data was represented as a horizontal bar chart, with one bar for each type of observation. Unfortunately, the values of the three observations was quite disparate in scale, making the smallest bar insignificantly small.

To help bring each value to first class citizenship, we switch to using three bullet charts. Each chart is scaled to suit the value thereof, and thus shows real, actionable information.

Connects #2165 

### Demo

![image](https://user-images.githubusercontent.com/1430060/32628923-7a931faa-c565-11e7-8697-c2131670c8f1.png)

Tagging @jfrankl and @ajrobbins for visual review.

### Notes

The chart labels in the mock-up are left-aligned, but I couldn't figure out how to left-align the text easily here. Is the right alignment (default design for bullet charts) good enough?

The actual value isn't shown on the chart, but in the tooltip, which looks like this:

![image](https://user-images.githubusercontent.com/1430060/32629397-0d43da28-c567-11e7-9ce1-5ee23312628b.png)

But enabling that tooltip also enables this one:

![image](https://user-images.githubusercontent.com/1430060/32629420-22bcf628-c567-11e7-92a0-23a823f18cf9.png)

and I couldn't figure out a way to have one and not the other.

## Testing Instructions

 * Check out this branch and `bundle`
 * Go to [:8000/](http://localhost:8000/) and create or open a TR-55 project
 * Go to the Water Quality tab. Ensure the new chart is there, and the values correspond to the table.