### PR TITLE
MapShed Performance Improvements

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -49,7 +49,7 @@ docker_options: "--storage-driver=aufs"
 geop_host: "localhost"
 geop_port: 8090
 
-geop_version: "3.0.0-beta-3"
+geop_version: "3.0.0"
 geop_cache_enabled: 1
 
 nginx_cache_dir: "/var/cache/nginx"

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -10,7 +10,6 @@ from collections import namedtuple
 from gwlfe.enums import GrowFlag
 
 from django.conf import settings
-from django.contrib.gis.geos import GEOSGeometry
 from django.db import connection
 
 NRur = settings.GWLFE_DEFAULTS['NRur']
@@ -321,9 +320,9 @@ def stream_length(geom, drb=False):
         return cursor.fetchone()[0] or 0  # Aggregate query returns singleton
 
 
-def streams(geom, drb=False):
+def streams(geojson, drb=False):
     """
-    Given a geometry, returns a list of GeoJSON objects, either LineStrings or
+    Given a GeoJSON, returns a list of GeoJSON objects, either LineStrings or
     MultiLineStrings, representing the set of streams contained inside the
     geometry, in LatLng. If the drb flag is set, we use the Delaware River
     Basin dataset instead of NHD Flowline.
@@ -331,11 +330,11 @@ def streams(geom, drb=False):
     sql = '''
           WITH clipped_streams AS (
               SELECT ST_Intersection(geom,
-                                     ST_SetSRID(ST_GeomFromText(%s), 4326))
+                                     ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326))
                      AS stream
               FROM {datasource}
               WHERE ST_Intersects(geom,
-                                  ST_SetSRID(ST_GeomFromText(%s), 4326))
+                                  ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326))
           )
           SELECT ST_AsGeoJSON(ST_Force2D(stream))
           FROM clipped_streams
@@ -343,20 +342,9 @@ def streams(geom, drb=False):
           '''.format(datasource='drb_streams_50' if drb else 'nhdflowline')
 
     with connection.cursor() as cursor:
-        cursor.execute(sql, [geom.wkt, geom.wkt])
+        cursor.execute(sql, [geojson, geojson])
 
         return [row[0] for row in cursor.fetchall()]  # List of GeoJSON strings
-
-
-def streams_from_geojson(geojson, drb=False):
-    """
-    Construct geometry from geojson and run streams routine.
-
-    Convenience method for running returning streams within a geometry using
-    GeoJSON as input.
-    """
-    geom = GEOSGeometry(geojson, srid=4326)
-    return streams(geom, drb)
 
 
 def get_point_source_table(drb):

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -19,7 +19,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
                                          ls_factors,
                                          p_factors,
                                          manure_spread,
-                                         streams_from_geojson,
+                                         streams,
                                          stream_length,
                                          point_source_discharge,
                                          weather_data,
@@ -483,7 +483,7 @@ def geoprocessing_chains(aoi, wkaoi, errback):
         ('slope',        slope,        {'polygon': [aoi]}),
         ('nlcd_kfactor', nlcd_kfactor, {'polygon': [aoi]}),
         ('nlcd_streams', nlcd_streams, {'polygon': [aoi],
-                                        'vector': streams_from_geojson(aoi)}),
+                                        'vector': streams(aoi)}),
     ]
 
     return [


### PR DESCRIPTION
## Overview

Removes redundant intersection clause in SQL query to improve performance by two orders of magnitude.

The longest part of the query was intersecting all the streams with the area of interest before sending it to the geoprocessing service, where each stream would be intersected with the tile again for calculating the results. Not only was this redundant, it was also the primary source of latency in the MapShed submission.

By forgoing the extra intersection, and simply collecting all the streams into a single geometry (MultiLineString), the process is sped up by two orders of magnitude. Also, since the intersection is already done in the following step, the calculations do not change.

Connects #2502 

### Demo

For the Schuylkill HUC-08, queried using [mmw-cli.py](https://gist.github.com/rajadain/57d80a1fc5e1c03f87802967dcd57588):

```
> python mmw-cli.py
{"status":"started","job":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
==> Submitted in 0.46099281311s
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"started","started":"2017-11-14T16:54:49.864Z","finished":null,"result":"","error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
{"status":"complete","started":"2017-11-14T16:54:49.864Z","finished":"2017-11-14T16:55:30.956Z","result":{...},"error":"","job_uuid":"65c8c341-b808-4588-8f5f-602b1999b5fc"}
==> Evaluated in 12.608536005s
==> Total time 13.0695288181s
>
```

### Notes

Since the geoprocessing service is already setup to handle an array of MultiLineStrings, by giving it a singleton array of one MultiLineString, we can use the geoprocessing service as is without needing a new version.

For the sake of clarity, however, it would be good to change that parameter to be a single MultiLineString object rather than an array which conventionally has a single item in it.

## Testing Instructions

* Check out this branch
* Make a new folder and download [mmw-cli.py](https://gist.github.com/rajadain/57d80a1fc5e1c03f87802967dcd57588) there.
* `cd` in to that folder. Than create a virtual environment with `virtualenv env` and activate it with `source env/bin/activate`.
* Install `requests` in that virtual environment: `pip install --upgrade pip && pip install requests`
* SSH in to your `app` VM and install `redis-cli` with: `sudo apt-get install redis-tools`
* Run the following to clear your geoprocessing cache: `envdir /etc/mmw.d/env bash -c 'redis-cli -h $MMW_CACHE_HOST -n 1 --raw KEYS ":1:geop*" | xargs redis-cli -h $MMW_CACHE_HOST -n 1 DEL'`
* Log out of app and come back to your `mmw-cli` folder
* As can be seen in the `mmw-cli.py` file, by default it will run using the Schuylkill HUC-08 which has WKAoI of `huc8__1748`. Run it locally with `python mmw-cli.py`. Notice the time for submission and total time for evaluation (shown in blue). Run it again, and notice the times again. The submission time should be the same, and the total time should be much shorter (since now all the geoprocessing values are cached). Copy the green output to a file.
* Edit the `mmw-cli.py` file to use `MMW_STAGING` instead of `MMW_LOCAL` as the `MMW` endpoint to hit.
* Run it again, this time targeting staging. Notice the times reported in blue. The submission time should be significantly more, and as a result so should the total time.
* Run it again with cached values, noticing that while the evaluation time is shortened the submission time is the same.
* Copy the green output to a different file and compare it with that of the local instance. Ensure that all the result values are the same.
* Test the MMW site and anything else you can think of.