### PR TITLE
Fix broken log configuration for geoprocessing service

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.beaver/templates/geoprocessing.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.beaver/templates/geoprocessing.conf.j2
@@ -1,4 +1,3 @@
--[/var/log/upstart/geoprocessing.log]
--multiline_regex_before = ^\s+
--type: geoprocessing
--tags: geoprocessing,beaver
+[/var/log/upstart/geoprocessing.log]
+type: geoprocessing
+tags: geoprocessing,beaver


### PR DESCRIPTION
## Overview

The log routing configuration for the geoprocessing service via Beaver was in a broken state, which was breaking all of the Beaver managed log collection for the application as a whole. This change fixes the geoprocessing configuration, which in turn enables all centralized logging again (Nginx, application, tiler, Celery, Docker, etc.).

### Notes

N/A

## Testing Instructions

First, provision the `app`, `tiler`, and `worker` with the changes in this PR:

```bash
$ vagrant provision app tiler worker
```

Afterwards, ensure that the `services` virtual machine is up-and-running so that you can navigate to http://localhost:5601/. From there, filter messages by `type: geoprocessing` and ensure that there is at least one entry. Also, ensure that logs of other types are also making it into Kibana (e.g., Nginx).