### PR TITLE
Ensure AWS profile is set for geoprocessing service

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.geoprocessing/templates/upstart-geoprocessing.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.geoprocessing/templates/upstart-geoprocessing.conf.j2
@@ -11,5 +11,8 @@ stop on shutdown
 respawn
 setuid mmw
 chdir {{ geop_home }}
+{% if ['development', 'test'] | some_are_in(group_names) -%}
+env AWS_PROFILE={{ aws_profile }}
+{% endif %}
 
 exec java -jar mmw-geoprocessing-{{ geop_version }}.jar


### PR DESCRIPTION
## Overview

When the geoprocessing service is configured for local development, ensure that the value of the Ansible `aws_profile` variable is set in the service's Upstart configuration.

In the default case, `mmw-stg` is used, which should work fine because the associated credentials are whitelisted for read access on the DataHub AWS account.

Connects #2300 

### Notes

N/A

## Testing Instructions

Switch to this branch and provision the `worker`:

```bash
$ vagrant provision worker
```

From there, issue an analyze job that interacts with the geoprocessing service. It should complete successfully (provided you have all of the data sets loaded in your PostgreSQL database).