### PR TITLE
Add NHD Streams analysis task & tab

### DIFF
--- a/src/mmw/apps/geoprocessing_api/tasks.py
+++ b/src/mmw/apps/geoprocessing_api/tasks.py
@@ -22,6 +22,7 @@ from apps.modeling.tr55.utils import aoi_resolution
 from apps.geoprocessing_api.calcs import (animal_population,
                                           point_source_pollution,
                                           catchment_water_quality,
+                                          stream_data,
                                           )
 
 logger = logging.getLogger(__name__)
@@ -71,6 +72,14 @@ def start_rwd_job(location, snapping, simplify, data_source):
         raise Exception(response_json['error'])
 
     return response_json
+
+
+@shared_task
+def analyze_streams(area_of_interest):
+    """
+    Given an area of interest, returns the streams and stream order within it.
+    """
+    return {'survey': stream_data(area_of_interest)}
 
 
 @shared_task

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -28,6 +28,8 @@ urlpatterns = patterns(
         name='start_analyze_catchment_water_quality'),
     url(r'analyze/climate/$', views.start_analyze_climate,
         name='start_analyze_climate'),
+    url(r'analyze/streams/$', views.start_analyze_streams,
+        name='start_analyze_streams'),
     url(r'jobs/' + uuid_regex, get_job, name='get_job'),
     url(r'watershed/$', views.start_rwd, name='start_rwd'),
 )

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -122,6 +122,13 @@ function createAnalyzeTaskCollection(aoi, wkaoi) {
                 area_of_interest: aoi,
                 wkaoi: wkaoi,
                 taskName: "analyze/catchment-water-quality"
+            },
+            {
+                name: "streams",
+                displayName: "Streams",
+                area_of_interest: aoi,
+                wkaoi: wkaoi,
+                taskName: "analyze/streams"
             }
         );
     }

--- a/src/mmw/js/src/analyze/templates/streamTable.html
+++ b/src/mmw/js/src/analyze/templates/streamTable.html
@@ -1,0 +1,39 @@
+<table class="table custom-hover" data-toggle="table">
+    <thead>
+        <tr>
+            <th data-sortable="true" data-field="displayOrder" data-sorter="window.ordinalNumericSort">
+                Stream Order
+            </th>
+            <th class="text-right" data-field="lengthkm" data-sortable="true" data-sorter="window.numericSort">
+                Total Length (km)
+            </th>
+            <th class="text-right" data-field="slopepct" data-sortable="true" data-sorter="window.numericSort">
+                Mean Channel Slope (%)
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>
+                Total
+            </th>
+            <th class="text-right">
+                {{ totalLength|round(2)|toLocaleString(1) }}
+            </th>
+            <th class="text-right">
+                {{ avgChannelSlope|round(2)|toLocaleString(1) }}
+            </th>
+        </tr>
+    </tfoot>
+</table>
+<div id="streams-tab-ag-section">
+    <div class="streams-tab-ag-line-item">
+        Length in Ag (km) = {{ lengthInAg|round(2)|toLocaleString(1) }}
+    </div>
+    <div class="streams-tab-ag-line-item">
+        Length in non-Ag (km) = {{ lengthInNonAg|round(2)|toLocaleString(1) }}
+    </div>
+</div>
+ 

--- a/src/mmw/js/src/analyze/templates/streamTableRow.html
+++ b/src/mmw/js/src/analyze/templates/streamTableRow.html
@@ -1,0 +1,10 @@
+<td>
+    {{ displayOrder }}
+</td>
+<td class="strong text-right">
+    {{ lengthkm|round(2)|toLocaleString(1) }}
+</td>
+<td class="strong text-right">
+    {{ slopepct|round(2)|toLocaleString(1) }}%
+</td>
+

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -647,6 +647,10 @@ var CatchmentWaterQualityCensusCollection = Backbone.PageableCollection.extend({
     state: { pageSize: 6, firstPage: 1 }
 });
 
+var StreamsCensusCollection = Backbone.Collection.extend({
+    comparator: 'order',
+});
+
 var DataCatalogPopoverResultCollection = Backbone.PageableCollection.extend({
     mode: 'client',
     state: { pageSize: 3, firstPage: 1, currentPage: 1 }
@@ -723,6 +727,7 @@ module.exports = {
     PointSourceCensusCollection: PointSourceCensusCollection,
     CatchmentWaterQualityCensusCollection: CatchmentWaterQualityCensusCollection,
     DataCatalogPopoverResultCollection: DataCatalogPopoverResultCollection,
+    StreamsCensusCollection: StreamsCensusCollection,
     GeoModel: GeoModel,
     AreaOfInterestModel: AreaOfInterestModel,
     AppStateModel: AppStateModel

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -228,6 +228,20 @@ var utils = {
         }
     },
 
+    // A numeric comparator for ordinal numeric strings.
+    ordinalNumericSort: function(x, y) {
+        var other = 'Other';
+
+        if (x.indexOf(other) > -1) {
+            return 1;
+        } else if (y.indexOf(other) > -1) {
+            return -1;
+        }
+
+        return utils.numericSort(x.replace(/[^0-9]/g,''),
+            y.replace(/[^0-9]/g,''));
+    },
+
     noData: noData,
 
     noDataSort: function(x, y) {

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -30,6 +30,9 @@ App.start();
 // is available for use in templates.
 window.numericSort = utils.numericSort;
 
+// This comparator sorts a table of strings which represent ordinal numbers.
+window.ordinalNumericSort = utils.ordinalNumericSort;
+
 // This comparator sorts a table with "no data" fields intermixed
 // with numeric fields.
 window.noDataSort = utils.noDataSort;

--- a/src/mmw/sass/components/_tabs.scss
+++ b/src/mmw/sass/components/_tabs.scss
@@ -93,7 +93,7 @@
 
     li > a {
       color: $ui-secondary;
-      padding: 0 0.7rem;
+      padding: 0 0.4rem;
       line-height: 42px;
       background-color: transparent;
       height: 42px;
@@ -262,4 +262,14 @@
       }
     }
   }
+}
+
+#streams-tab-ag-section {
+    padding-top: 1rem;
+    margin-left: 0.3rem;
+
+    .streams-tab-ag-line-item {
+        font-weight: 800;
+        font-size: 13px;
+    }
 }


### PR DESCRIPTION
## Overview

This PR adds a Celery task & client-side tab for generating & displaying NHD Streams analysis results.

8dab1e3 sets up the Django-side Streams analysis Celery task and adds Swagger documentation to indicate the job's purpose & expected output.

6fb628d adds the Streams analysis tab to MMW, matching the outline linked in #2334.

Currently we're displaying the "Total Length (km)" values in the table -- and using 0 values for "Mean Channel Slope", "Length in Ag", and "Length in non-Ag". See "Notes" below for more on this.

Connects #2334

## Screenshot

![screen shot 2017-11-22 at 11 33 34 am](https://user-images.githubusercontent.com/4165523/33138780-57d0db60-cf79-11e7-9139-77222e6d7e22.png)

## Notes

Slope, length in ag, and length in non-ag aren't available in `nhdflowline`, so we'll need to to update the table for slope and possibly calculate the ag-length values.

I used 0 values as placeholders for all these for now on the Celery side, then mostly configured the client to display whatever's sent back properly. We should handle this stuff in another issue.

I also adjusted the spacing between analyze tab headers to fit the new streams tab. The next tab will require making changes to how it works.

## Testing
- get this branch, bundle, then visit MMW and select and analyze an area of interest
- verify that you see the Streams tab and that it eventually returns results
- download the Streams data and verify that the CSV matches the table
- visit bigcz and verify that you don't see the streams tab