### PR TITLE
Add boundary_huc12 de-duplication script

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -101,7 +101,7 @@ fi
 
 if [ "$load_boundary" = "true" ] ; then
     # Fetch boundary layer sql files
-    FILES=("boundary_county.sql.gz" "boundary_school_district.sql.gz" "boundary_district.sql.gz" "boundary_huc12.sql.gz" "boundary_huc10.sql.gz" "boundary_huc08.sql.gz")
+    FILES=("boundary_county.sql.gz" "boundary_school_district.sql.gz" "boundary_district.sql.gz" "boundary_huc12_deduped.sql.gz" "boundary_huc10.sql.gz" "boundary_huc08.sql.gz")
     PATHS=("county" "district" "huc8" "huc10" "huc12" "school")
 
     download_and_load $FILES

--- a/scripts/data/boundary/deduplicate_huc12.sql
+++ b/scripts/data/boundary/deduplicate_huc12.sql
@@ -1,0 +1,54 @@
+-- Find all huc12s with duplicate
+-- huc12 ids, and store
+-- them in a temp table
+DROP TABLE IF EXISTS duplicates;
+CREATE TEMP TABLE duplicates
+AS SELECT * FROM boundary_huc12
+WITH NO DATA;
+
+WITH duplicate_huc12s AS (
+    SELECT huc12, count(*)
+    FROM boundary_huc12
+    GROUP BY huc12
+    HAVING count(*) > 1
+)
+INSERT INTO duplicates 
+    SELECT boundary_huc12.*
+    FROM boundary_huc12, duplicate_huc12s
+    WHERE duplicate_huc12s.huc12 = boundary_huc12.huc12;
+
+-- Auto increment the id field
+-- so we can insert the merged
+-- rows into the table
+CREATE SEQUENCE seq_boundary_huc12_id;
+SELECT setval('seq_boundary_huc12_id', max(id))
+FROM boundary_huc12; 
+
+ALTER TABLE boundary_huc12 ALTER COLUMN id SET DEFAULT
+nextval('seq_boundary_huc12_id');
+
+-- Merge the duplicates
+WITH merged_duplicates AS (
+    SELECT max(huc12) as huc12, max(hutype) as hutype, max(name) as name,
+        ST_Union(geom) AS geom,
+        ST_Union(geom_detailed) AS geom_detailed
+    FROM duplicates
+    GROUP BY huc12
+)
+INSERT INTO boundary_huc12 (huc12, hutype, name, geom, geom_detailed) 
+SELECT
+    merged_duplicates.huc12,
+    merged_duplicates.hutype,
+    merged_duplicates.name,
+    merged_duplicates.geom,
+    merged_duplicates.geom_detailed 
+FROM merged_duplicates;
+
+-- Delete the duplicates now that we've
+-- inserted the merged ones
+DELETE FROM boundary_huc12
+USING duplicates
+WHERE boundary_huc12.id=duplicates.id;
+
+-- Create a btree index on the now unique huc12 id
+CREATE UNIQUE INDEX huc12_idx ON boundary_huc12 (huc12);


### PR DESCRIPTION
## Overview

* Add a script that finds duplicate huc12 values
  in `boundary_huc12`, merges their geoms and
  creates an index on huc12

* the results of running the script have been pgdumped,
  gzipped, and uploaded to `s3://data.mmw.azavea.com/boundary_huc12_deduped.sql.gz`

```bash
> ./scripts/manage.sh dbshell
$psql \i /vagrant/scripts/data/deduplicate_huc12.sql
$psql \q

> vagrant ssh services
> pg_dump -c --if-exists -O
      -t boundary_huc12 \
      -h localhost -U mmw mmw \
      > boundary_huc12_deduped.sql
> gzip boundary_huc12_deduped.sql
```

Connects #2519 

### Demo

```sql
mmw=# select huc12, count(*) from boundary_huc12 group by huc12 having count(*) > 1;
 huc12 | count
-------+-------
(0 rows)
```

## Testing Instructions
* If you have a lot of time on your hands, run `vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -b'` This should have the same effect as running
`vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -f boundary_huc12_deduped.sql`
* `./scripts/manage.sh dbshell` and confirm there are no more duplicates

```sql
select huc12, count(*) from boundary_huc12 group by huc12 having count(*) > 1;
```
```sql
mmw=# select count(*) from boundary_huc12;
 count
-------
 86018

--- previously 86024
(1 row)
```

* Use the app to search for "Ironwood, MI", and select either of the `Sahwa Creek-Frontal Lake Superior` polygons:
<img width="1280" alt="screen shot 2017-11-20 at 7 03 37 pm" src="https://user-images.githubusercontent.com/7633670/33047811-b3a545de-ce25-11e7-8138-9e0060e22c65.png">
