### PR TITLE
Fix HUC-12 Deduplication

### DIFF
--- a/scripts/data/boundary/deduplicate_huc12.sql
+++ b/scripts/data/boundary/deduplicate_huc12.sql
@@ -52,3 +52,8 @@ WHERE boundary_huc12.id=duplicates.id;
 
 -- Create a btree index on the now unique huc12 id
 CREATE UNIQUE INDEX huc12_idx ON boundary_huc12 (huc12);
+
+-- We no longer need the sequence on the 
+-- on the table now that we've inserted
+-- the merged huc12s
+DROP SEQUENCE seq_boundary_huc12_id CASCADE;


### PR DESCRIPTION
**This PR is mostly to document what was done post #2525 to get its resulting pgdump file applied to staging**

For posterity, I updated the script used to deduplicate the HUC-12s to drop a sequence it creates. The sequence wasn't getting created in the pgdump, but was still being referenced in the pgdump's create table.

I manually edited the pgdump file to remove the id column's reference to the sequence, and sent it back up to s3. I was able to load it on staging without issue.

I also cleared the relevant part of the tile cache (the huc12 utf8grids):

```sh
> aws s3 rm --recursive s3://tile-cache.staging.app.wikiwatershed.org --profile mmw-stg --exclude "*" --include "huc12/*.grid.json"
```
On staging, this now works:
![screen shot 2017-11-29 at 5 54 22 pm](https://user-images.githubusercontent.com/7633670/33403690-5dc05cba-d52f-11e7-9264-56c0a36de9ce.png)

Connects #2519 
