### PR TITLE
HydroShare Export Share Modal

### DIFF
--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -12,6 +12,9 @@
                         <div class="toggle-switch"></div>
                     </label>
                 </div>
+                {% if not is_private %}
+                    <p>Anyone with this link will be able to view this project</p>
+                {% endif %}
                 <div class="input-group {{ 'hidden' if is_private }}">
                     <input class="form-control" id="share-url" type="text" value="{{  url }}">
                     <span class="input-group-btn">

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -1,0 +1,31 @@
+<div class="modal-dialog modal-dialog-sm">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h2 class="light">Share your project</h2>
+        </div>
+        <div class="modal-body">
+            <div class="custom-input-group">
+                <div class="row toggle-row">
+                    <h3>Link Sharing</h3>
+                    <label class="pull-right toggle">
+                        <input type="checkbox" id="share-enabled" {{ "checked" if not is_private }} />
+                        <div class="toggle-switch"></div>
+                    </label>
+                </div>
+                <div class="input-group {{ 'hidden' if is_private }}">
+                    <input class="form-control" id="share-url" type="text" value="{{  url }}">
+                    <span class="input-group-btn">
+                        <button class="btn btn-primary copy" type="button" data-clipboard-target="#share-url">
+                            <i class="fa fa-clipboard"></i> Copy
+                        </button>
+                    </span>
+                </div>
+            </div>
+        </div>
+        <div class="modal-footer" style="text-align:right;">
+            <div class="footer-content">
+                <button type="button" class="btn btn-md btn-active" data-dismiss="modal">Done</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -15,11 +15,6 @@
                         </a>
                     </li>
                     <li role="presentation">
-                        <a role="menuitem" tabindex="-1" data-toggle="modal" id="project-privacy">
-                            {% if is_private %}Make Public{% else %}Make Private{% endif %}
-                        </a>
-                    </li>
-                    <li role="presentation">
                         <a role="menuitem" tabindex="-1" data-toggle="modal" id="delete-project">
                             Delete
                         </a>

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -279,7 +279,6 @@ describe('Modeling', function() {
                     projectResponse = '{"id":21,"user":{"id":1,"username":"test","email":"test@azavea.com"},"scenarios":[],"name":"Test Project","area_of_interest":{},"is_private":true,"model_package":"tr-55","created_at":"2015-06-03T20:09:11.988948Z","modified_at":"2015-06-03T20:09:11.988988Z"}',
                     postSaveMenuItems = [
                         'Share',
-                        'Make Public',
                         'Delete',
                         'Rename',
                         '',
@@ -315,29 +314,6 @@ describe('Modeling', function() {
                 assert.isUndefined($('#project-settings').el);
             });
 
-            it('changes the privacy menu item depending on the is_private attribute of the project', function() {
-                // Make user id same as one on project, so it is considered editable.
-                App.user.set('id', 1);
-
-                var project = getTestProject(),
-                    view = new views.ProjectMenuView({ model: project });
-
-                // Set id attribute so project.isNew() is false.
-                project.set({
-                    id: 5,
-                    is_private: true
-                });
-
-                $(sandboxSelector).html(view.render().el);
-
-                assert.equal($('#sandbox #project-privacy').text().trim(), 'Make Public');
-
-                project.set('is_private', false);
-                $(sandboxSelector).html(view.render().el);
-
-                assert.equal($('#sandbox #project-privacy').text().trim(), 'Make Private');
-            });
-
             it('shows "Embed in ITSI" link only for ITSI users', function() {
                 App.user.set({
                     id: 1,
@@ -349,7 +325,6 @@ describe('Modeling', function() {
                     projectResponse = '{"id":21,"user":{"id":1,"username":"test","email":"test@azavea.com"},"scenarios":[],"name":"Test Project","area_of_interest":{},"is_private":true,"model_package":"tr-55","created_at":"2015-06-03T20:09:11.988948Z","modified_at":"2015-06-03T20:09:11.988988Z"}',
                     postSaveMenuItems = [
                         'Share',
-                        'Make Public',
                         'Delete',
                         'Rename',
                         'Embed in ITSI',

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -121,7 +121,6 @@ var ProjectMenuView = Marionette.ItemView.extend({
         remove: '#delete-project',
         print: '#print-project',
         save: '#save-project',
-        privacy: '#project-privacy',
         itsiClone: '#itsi-clone',
         newProject: '#new-project',
         changeAoI: '#change-aoi',
@@ -136,7 +135,6 @@ var ProjectMenuView = Marionette.ItemView.extend({
         'click @ui.share': 'shareProject',
         'click @ui.print': 'printProject',
         'click @ui.save': 'saveProjectOrLoginUser',
-        'click @ui.privacy': 'setProjectPrivacy',
         'click @ui.itsiClone': 'getItsiEmbedLink',
         'click @ui.newProject': 'createNewProject',
         'click @ui.changeAoI': 'createNewProject',
@@ -264,32 +262,6 @@ var ProjectMenuView = Marionette.ItemView.extend({
         } else {
             this.model.saveProjectAndScenarios();
         }
-    },
-
-    setProjectPrivacy: function() {
-        var self = this,
-            currentSettings = this.model.get('is_private') ? 'private' : 'public',
-            newSettings = currentSettings === 'private' ? 'public' : 'private',
-            primaryText = 'This project is currently ' + currentSettings + '. ' +
-                      'Are you sure you want to make it ' + newSettings + '? ',
-            additionalText = currentSettings === 'private' ?
-                    'Anyone with the URL will be able to access it.' :
-                    'Only you will be able to access it.',
-            question = primaryText + additionalText,
-            modal = new modalViews.ConfirmView({
-                model: new modalModels.ConfirmModel({
-                    question: question,
-                    confirmLabel: 'Confirm',
-                    cancelLabel: 'Cancel'
-                })
-            });
-
-        modal.render();
-
-        modal.on('confirmation', function() {
-            self.model.set('is_private', !self.model.get('is_private'));
-            self.model.saveProjectAndScenarios();
-        });
     },
 
     getItsiEmbedLink: function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -200,14 +200,9 @@ var ProjectMenuView = Marionette.ItemView.extend({
     },
 
     shareProject: function() {
-        var share = new modalViews.ShareView({
-                model: new modalModels.ShareModel({
-                    text: 'Project',
-                    url: window.location.href,
-                    guest: App.user.get('guest'),
-                    is_private: this.model.get('is_private')
-                }),
-                app: App
+        var share = new modalViews.MultiShareView({
+                model: this.model,
+                app: App,
             });
 
         share.render();

--- a/src/mmw/js/src/projects/templates/projectRow.html
+++ b/src/mmw/js/src/projects/templates/projectRow.html
@@ -7,7 +7,6 @@
     <div class="btn-group">
         <button class="btn btn-default btn-rename">Rename</button>
         <button class="btn btn-default btn-share">Share</button>
-        <button class="btn btn-default btn-privacy">Make {{ "Public" if is_private else "Private" }}</button>
         <button class="btn btn-default btn-delete">Delete</button>
     </div>
 </div>

--- a/src/mmw/js/src/projects/views.js
+++ b/src/mmw/js/src/projects/views.js
@@ -99,15 +99,9 @@ var ProjectRowView = Marionette.ItemView.extend({
     },
 
     shareProject: function() {
-        var share = new modalViews.ShareView({
-                model: new modalModels.ShareModel({
-                    text: 'Project',
-                    url: window.location.origin + this.model.getReferenceUrl(),
-                    guest: App.user.get('guest'),
-                    is_private: this.model.get('is_private')
-                }),
+        var share = new modalViews.MultiShareView({
+                model: this.model,
                 app: App,
-                project: this.model
             });
 
         share.render();

--- a/src/mmw/js/src/projects/views.js
+++ b/src/mmw/js/src/projects/views.js
@@ -63,7 +63,6 @@ var ProjectRowView = Marionette.ItemView.extend({
     ui: {
         rename: '.btn-rename',
         share: '.btn-share',
-        privacy: '.btn-privacy',
         remove: '.btn-delete',
         open: '.open-project'
     },
@@ -71,7 +70,6 @@ var ProjectRowView = Marionette.ItemView.extend({
     events: {
         'click @ui.rename': 'renameProject',
         'click @ui.share': 'shareProject',
-        'click @ui.privacy': 'setProjectPrivacy',
         'click @ui.remove': 'deleteProject',
         'click @ui.open': 'openProject'
     },
@@ -105,32 +103,6 @@ var ProjectRowView = Marionette.ItemView.extend({
             });
 
         share.render();
-    },
-
-    setProjectPrivacy: function() {
-        var self = this,
-            currentSettings = this.model.get('is_private') ? 'private' : 'public',
-            newSettings = currentSettings === 'private' ? 'public' : 'private',
-            primaryText = 'This project is currently ' + currentSettings + '. ' +
-                      'Are you sure you want to make it ' + newSettings + '? ',
-            additionalText = currentSettings === 'private' ?
-                    'Anyone with the URL will be able to access it.' :
-                    'Only you will be able to access it.',
-            question = primaryText + additionalText,
-            modal = new modalViews.ConfirmView({
-                model: new modalModels.ConfirmModel({
-                    question: question,
-                    confirmLabel: 'Confirm',
-                    cancelLabel: 'Cancel'
-                })
-            });
-
-        modal.render();
-
-        modal.on('confirmation', function() {
-            self.model.set('is_private', !self.model.get('is_private'));
-            self.model.saveProjectListing();
-        });
     },
 
     deleteProject: function() {

--- a/src/mmw/sass/components/_buttons.scss
+++ b/src/mmw/sass/components/_buttons.scss
@@ -220,3 +220,7 @@
 .go-to-data-catalog-button > .fa-arrow-right {
     margin-left: 0.25rem;
 }
+
+.input-group-btn > button {
+  height: 34px;
+}

--- a/src/mmw/sass/components/_toggle.scss
+++ b/src/mmw/sass/components/_toggle.scss
@@ -1,0 +1,42 @@
+label.toggle {
+  width: 64px;
+  height: 38px;
+  border-radius: 3px;
+  background-color: $ui-medium-light;
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+  font-weight: normal;
+  font-size: 13px;
+  line-height: 3;
+  transition: 0.3s all ease-in-out;
+
+  input {
+    display: none;
+  }
+
+  input:checked + .toggle-switch {
+    background-color: $brand-primary;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  .toggle-switch {
+    background-color: $ui-grey;
+    color: $paper;
+    height: 38px;
+    width: 38px;
+    text-align: center;
+    display: inline-block;
+  }
+
+  input:checked + .toggle-switch:after {
+    content: "On"
+  }
+
+  input + .toggle-switch:after {
+    content: "Off"
+  }
+}

--- a/src/mmw/sass/components/_toggle.scss
+++ b/src/mmw/sass/components/_toggle.scss
@@ -40,3 +40,13 @@ label.toggle {
     content: "Off"
   }
 }
+
+.toggle-row {
+  margin-bottom: 8px !important;
+
+  h3 {
+    float: left;
+    margin: 2px 0;
+    padding: 7.5px 0;
+  }
+}

--- a/src/mmw/sass/components/_toggle.scss
+++ b/src/mmw/sass/components/_toggle.scss
@@ -49,4 +49,9 @@ label.toggle {
     margin: 2px 0;
     padding: 7.5px 0;
   }
+
+  + p {
+    font-size: 13px;
+    margin-bottom: 1rem !important;
+  }
 }

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -65,7 +65,8 @@
   "components/global-navigation",
   "components/layerpicker",
   "components/spinner",
-  "components/slider";
+  "components/slider",
+  "components/toggle";
 
 /**
  * Pages


### PR DESCRIPTION
## Overview

Changes the share modal of a project to match the new mockups. They HydroShare sharing part will come in a forthcoming card.

Connects #2511 

### Demo

![2017-11-30 09 59 45](https://user-images.githubusercontent.com/1430060/33437326-91d49062-d5b5-11e7-87f6-c77a3ea2c91d.gif)

### Notes

The Scenario sharing uses the same modal as before. Should this also be updated? I'm creating a card for follow up discussion: #2538.

The HydroShare parts of the mockup haven't been implemented yet, they will come in a follow up card: #2514.

## Testing Instructions

* Check out this branch and `./scripts/bundle.sh --debug`
* Go to [:8000/](http://localhost:8000/) and sign in.
* Create or open a TR-55 project. In the project menu, select "Share".
* Turn on link sharing for that project. Copy the link and open in a private browser window (where you're not signed in). Ensure the project is viewable.
* Turn off link sharing. Refresh the private browser window. Ensure you get a 404.
* Try turning link sharing on and off a bunch of times. Ensure the copy button works in all cases.