### PR TITLE
Fix running MapShed on AoIs with no streams

### DIFF
--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -68,6 +68,13 @@ def run(self, opname, input_data, wkaoi=None, cache_key=''):
     data = settings.GEOP['json'][opname].copy()
     data['input'].update(input_data)
 
+    # If no vector data is supplied for vector operation, shortcut to empty
+    if 'vector' in data['input'] and data['input']['vector'] == [None]:
+        result = {}
+        if key:
+            cache.set(key, result, None)
+        return result
+
     try:
         result = geoprocess(data, self.retry)
         if key:


### PR DESCRIPTION
## Overview

Previously, if no streams intersected the area of interest, instead of an array of stringified GeoJSON MultiLines, a singleton array would be sent with the only value being null. This caused parse issues in the geoprocessing service.

Now this case is caught on the Celery task itself, and if so we return an empty object immediately, and do not invoke the geoprocessing service at all. This short circuit makes the feedback faster and removes unnecessary communication.

Connects #2518

### Demo

![2017-12-04 11 57 17](https://user-images.githubusercontent.com/1430060/33565273-ad954a7a-d8ea-11e7-80bb-85c41343dbab.gif)

## Testing Instructions

* Check out this branch and restart Celery

      vagrant ssh worker -c 'sudo service celeryd restart'

* Go to [:8000/](http://localhost:8000/) and turn on the streams overlay
* Draw a shape deliberately avoiding streams
* Model with MapShed. Ensure that it works successfully.
* Download and run this file: [mmw-cli.py.txt](https://github.com/WikiWatershed/model-my-watershed/files/1528038/mmw-cli.py.txt), which has the test shape from the original issue.
