### PR TITLE
Agricultural Streams Length in Analyze

### DIFF
--- a/src/mmw/apps/geoprocessing_api/calcs.py
+++ b/src/mmw/apps/geoprocessing_api/calcs.py
@@ -51,7 +51,7 @@ def animal_population(geojson):
     }
 
 
-def stream_data(geojson):
+def stream_data(results, geojson):
     """
     Given a GeoJSON shape, retreive stream data from the `nhdflowline` table
     to display in the Analyze tab
@@ -86,6 +86,7 @@ def stream_data(geojson):
         str(s['stream_order']): {
             "order": s['stream_order'],
             "lengthkm": s['lengthkm'],
+            "ag_stream_pct": results['ag_stream_pct'],
             # TODO: implement `slopepct`
             "slopepct": 0,
         } for s in streams
@@ -96,6 +97,7 @@ def stream_data(geojson):
         stream_data.setdefault(str(x), {
             "order": x,
             "lengthkm": 0,
+            "ag_stream_pct": results['ag_stream_pct'],
             "slopepct": 0,
         })
 

--- a/src/mmw/apps/geoprocessing_api/tasks.py
+++ b/src/mmw/apps/geoprocessing_api/tasks.py
@@ -75,11 +75,12 @@ def start_rwd_job(location, snapping, simplify, data_source):
 
 
 @shared_task
-def analyze_streams(area_of_interest):
+def analyze_streams(results, area_of_interest):
     """
-    Given an area of interest, returns the streams and stream order within it.
+    Given geoprocessing results with stream data and an area of interest,
+    returns the streams and stream order within it.
     """
-    return {'survey': stream_data(area_of_interest)}
+    return {'survey': stream_data(results, area_of_interest)}
 
 
 @shared_task

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -612,56 +612,67 @@ def start_analyze_streams(request, format=None):
                         "order": 1,
                         "lengthkm": 30.72,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 2,
                         "lengthkm": 61.2,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 3,
                         "lengthkm": 21.51,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 4,
                         "lengthkm": 0,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 5,
                         "lengthkm": 0,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 6,
                         "lengthkm": 44.51,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 7,
                         "lengthkm": 0,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 8,
                         "lengthkm": 0,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 9,
                         "lengthkm": 0,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 10,
                         "lengthkm": 0,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     },
                     {
                         "order": 999,
                         "lengthkm": 0,
                         "slopepct": 0,
+                        "ag_stream_pct": 0.003416856492027335,
                     }
                 ]
             }

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -20,6 +20,8 @@ from apps.core.tasks import (save_job_error,
                              save_job_result)
 from apps.core.decorators import log_request
 from apps.modeling import geoprocessing
+from apps.modeling.mapshed.calcs import streams
+from apps.modeling.mapshed.tasks import nlcd_streams
 from apps.modeling.serializers import AoiSerializer
 
 from apps.geoprocessing_api import tasks
@@ -707,6 +709,10 @@ def start_analyze_streams(request, format=None):
     area_of_interest, wkaoi = _parse_input(request)
 
     return start_celery_job([
+        geoprocessing.run.s('nlcd_streams',
+                            {'polygon': [area_of_interest],
+                             'vector': streams(area_of_interest)}, wkaoi),
+        nlcd_streams.s(),
         tasks.analyze_streams.s(area_of_interest)
     ], area_of_interest, user)
 

--- a/src/mmw/js/src/analyze/templates/streamTable.html
+++ b/src/mmw/js/src/analyze/templates/streamTable.html
@@ -30,10 +30,9 @@
 </table>
 <div id="streams-tab-ag-section">
     <div class="streams-tab-ag-line-item">
-        Length in Ag (km) = {{ lengthInAg|round(2)|toLocaleString(1) }}
+        Length in agricultural areas = {{ lengthInAg|round(2)|toLocaleString(1) }} km
     </div>
     <div class="streams-tab-ag-line-item">
-        Length in non-Ag (km) = {{ lengthInNonAg|round(2)|toLocaleString(1) }}
+        Length in non-agricultural areas = {{ lengthInNonAg|round(2)|toLocaleString(1) }} km
     </div>
 </div>
- 

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -682,8 +682,11 @@ var StreamTableView = Marionette.CompositeView.extend({
         var data = lodash(this.collection.toJSON()),
             totalLength = data.pluck('lengthkm').sum(),
             avgChannelSlope = data.pluck('slopepct').sum(),
-            lengthInAg = 0,
-            lengthInNonAg = 0;
+            // Currently we only calculate agricultral percent for the entire
+            // set, not per stream order, so we use the first value for total.
+            agPercent = data.first().ag_stream_pct,
+            lengthInAg = totalLength * agPercent,
+            lengthInNonAg = totalLength - lengthInAg;
 
         return {
             totalLength: totalLength,


### PR DESCRIPTION
## Overview

Adds length of streams in agricultural and non-agricultural areas in an area of interest to the Analyze tab. This reuses the `nlcd_streams` MapShed geoprocessing task, and also caches it, so if the user runs MapShed after this, the streams bit will be readily available. This does increase the time it takes for the streams tab to load though.

Connects #2528 

### Demo

![image](https://user-images.githubusercontent.com/1430060/33571621-980ba96a-d8fe-11e7-92ec-896fa9ae2489.png)

![2017-12-04 14 14 24](https://user-images.githubusercontent.com/1430060/33571485-1ab3bb06-d8fe-11e7-842e-cb225585abbf.gif)

## Testing Instructions

* Check out this branch and `bundle --debug` and restart Celery

      vagrant ssh worker -c 'sudo service celeryd restart'

* Go to [:8000/](http://localhost:8000/) and choose an urban area of interest.
* Go to the Analyze tab and ensure that the streams length distribution between agricultural and non-agricultural makes sense
* Try out a rural area of interest and ensure the values still seem appropriate