### PR TITLE
Add NHDPlus Catchments to DB setup script

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -14,6 +14,7 @@ where: \n
     -d  load/reload DRB stream data\n
     -m  load/reload mapshed data\n
     -p  load/reload DEP data\n
+    -c  load/reload nhdplus catchment data
     -q  load/reload water quality data\n
     -x  purge s3 cache for given path\n
 "
@@ -25,8 +26,9 @@ file_to_load=
 load_stream=false
 load_mapshed=false
 load_water_quality=false
+load_catchment=false
 
-while getopts ":hbsdpmqf:x:" opt; do
+while getopts ":hbsdpmqcf:x:" opt; do
     case $opt in
         h)
             echo -e $usage
@@ -43,6 +45,8 @@ while getopts ":hbsdpmqf:x:" opt; do
             load_mapshed=true ;;
         q)
             load_water_quality=true ;;
+        c)
+            load_catchment=true ;;
         f)
             file_to_load=$OPTARG ;;
         x)
@@ -131,6 +135,12 @@ if [ "$load_mapshed" = "true" ] ; then
     FILES=("ms_weather.sql.gz" "ms_weather_station.sql.gz" "ms_pointsource.sql.gz"
            "ms_pointsource_drb.sql.gz" "ms_county_animals.sql.gz")
 
+    download_and_load $FILES
+fi
+
+if [ "$load_catchment" = "true" ] ; then
+    # Fetch NHDPlus Catchments
+    FILES=("nhdpluscatchment.sql.gz")
     download_and_load $FILES
 fi
 


### PR DESCRIPTION
## Overview

  We received a dump of the NHDPlus catchment data
  from stroud. We'll be using it to display catchment
  boundaries in mapshed subbasin-mode.

  The dump did not include a step to create the
  table, so I created the table on my instance,
  then created a new dump with it. ~I also dropped
  two columns that we won't be using:
 `geom_catch_centroid`, and `geom_stream`~ (added these back in)

  There are `2,647,454` rows. The `comid` column
  relates to `nhdflowlines`, though there are no
  catchments for flowlines of certain `fcodes`,
  for example `ArtificialPath`s, `CanalDitch`s, etc,
  (entries [here](https://nhd.usgs.gov/userGuide/Robohelpfiles/NHD_User_Guide/Feature_Catalog/Hydrography_Dataset/Complete_FCode_List.htm) that are described as having "no
  attributes")


Connects #2522

### Demo

A catchment with its flowline (red) associated by `comid` in wisconsin

![screen shot 2017-12-06 at 1 17 41 pm](https://user-images.githubusercontent.com/7633670/33677782-e5fc7d86-da87-11e7-87d4-ebf72ac578a7.png)


## Notes
I added a new `setupdb.sh` flag `-c`. The existing `-q` flag is related (water **q**uality data exists at the catchment level), but I think it will someday be dropped in favor of the dynamically modeled results. 

## Testing Instructions
Load the table, then in the `dbshell`, confirm there are `2647454` rows.

```sh
vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -c'
```

