### PR TITLE
Stream Slope

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -110,7 +110,7 @@ fi
 
 if [ "$load_stream" = "true" ] ; then
     # Fetch stream network layer sql files
-    FILES=("nhdflowline.sql.gz")
+    FILES=("nhdflowline_with_slope.sql.gz")
     PATHS=("nhd_streams_v2")
 
     download_and_load $FILES

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -594,10 +594,11 @@ def start_analyze_streams(request, format=None):
 
     ## Response
 
-    You can use the URL provided in the repsonse's `Location` header
+    You can use the URL provided in the response's `Location` header
     to poll for the job's results.
 
     <summary>
+
       **Example of a completed job's `result`**
     </summary>
 
@@ -609,70 +610,81 @@ def start_analyze_streams(request, format=None):
                 "name": "streams",
                 "categories": [
                     {
+                        "lengthkm": 2.598,
+                        "total_weighted_slope": 0.05225867338,
                         "order": 1,
-                        "lengthkm": 30.72,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": 0.020114962809853736
                     },
                     {
+                        "lengthkm": 0,
+                        "total_weighted_slope": null,
                         "order": 2,
-                        "lengthkm": 61.2,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": null
                     },
                     {
-                        "order": 3,
-                        "lengthkm": 21.51,
-                        "slopepct": 0,
-                        "ag_stream_pct": 0.003416856492027335,
+                         lengthkm": 0,
+                         total_weighted_slope": null,
+                         order": 3,
+                         ag_stream_pct": 0.003416856492027335,
+                         avgslope": null
                     },
                     {
+                        "lengthkm": 0,
+                        "total_weighted_slope": null,
                         "order": 4,
-                        "lengthkm": 0,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": null
                     },
                     {
+                        "lengthkm": 0,
+                        "total_weighted_slope": null,
                         "order": 5,
-                        "lengthkm": 0,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": null
                     },
                     {
+                        "lengthkm": 21.228,
+                        "total_weighted_slope": 0.00577236831,
                         "order": 6,
-                        "lengthkm": 44.51,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": 0.0002719223812888637
                     },
                     {
+                        "lengthkm": 0,
+                        "total_weighted_slope": null,
                         "order": 7,
-                        "lengthkm": 0,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": null
                     },
                     {
+                        "lengthkm": 0,
+                        "total_weighted_slope": null,
                         "order": 8,
-                        "lengthkm": 0,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": null
                     },
                     {
+                        "lengthkm": 0,
+                        "total_weighted_slope": null,
                         "order": 9,
-                        "lengthkm": 0,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": null
                     },
                     {
+                        "lengthkm": 0,
+                        "total_weighted_slope": null,
                         "order": 10,
-                        "lengthkm": 0,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": null
                     },
                     {
+                        "lengthkm": 6.085,
+                        "total_weighted_slope": null,
                         "order": 999,
-                        "lengthkm": 0,
-                        "slopepct": 0,
                         "ag_stream_pct": 0.003416856492027335,
+                        "avgslope": null
                     }
                 ]
             }

--- a/src/mmw/js/src/analyze/templates/streamTable.html
+++ b/src/mmw/js/src/analyze/templates/streamTable.html
@@ -7,7 +7,7 @@
             <th class="text-right" data-field="lengthkm" data-sortable="true" data-sorter="window.numericSort">
                 Total Length (km)
             </th>
-            <th class="text-right" data-field="slopepct" data-sortable="true" data-sorter="window.numericSort">
+            <th class="text-right" data-field="avgslope" data-sortable="true" data-sorter="window.noDataSort" data-formatter="window.percentFormatter">
                 Mean Channel Slope (%)
             </th>
         </tr>
@@ -23,7 +23,7 @@
                 {{ totalLength|round(2)|toLocaleString(1) }}
             </th>
             <th class="text-right">
-                {{ avgChannelSlope|round(2)|toLocaleString(1) }}
+                {{ (avgChannelSlope * 100)|round(2)|toLocaleString(1) }}%
             </th>
         </tr>
     </tfoot>

--- a/src/mmw/js/src/analyze/templates/streamTableRow.html
+++ b/src/mmw/js/src/analyze/templates/streamTableRow.html
@@ -5,6 +5,10 @@
     {{ lengthkm|round(2)|toLocaleString(1) }}
 </td>
 <td class="strong text-right">
-    {{ slopepct|round(2)|toLocaleString(1) }}%
+    {% if avgslope %}
+        {{ (avgslope * 100)|round(2)|toLocaleString(1) }}
+    {% else %}
+        {{ noData }}
+    {% endif %}
 </td>
 

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -664,7 +664,8 @@ var StreamTableRowView = Marionette.ItemView.extend({
         return {
             displayOrder: displayOrder,
             lengthkm: this.model.get('lengthkm'),
-            slopepct: this.model.get('slopepct')
+            avgslope: this.model.get('avgslope'),
+            noData: utils.noData,
         };
     }
 });
@@ -681,7 +682,7 @@ var StreamTableView = Marionette.CompositeView.extend({
     templateHelpers: function() {
         var data = lodash(this.collection.toJSON()),
             totalLength = data.pluck('lengthkm').sum(),
-            avgChannelSlope = data.pluck('slopepct').sum(),
+            avgChannelSlope = data.pluck('total_weighted_slope').sum() / totalLength,
             // Currently we only calculate agricultral percent for the entire
             // set, not per stream order, so we use the first value for total.
             agPercent = data.first().ag_stream_pct,

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -245,15 +245,27 @@ var utils = {
     noData: noData,
 
     noDataSort: function(x, y) {
-        if (x === noData && y !== noData) {
+        var trimmedX = x.trim(),
+            trimmedY = y.trim();
+
+        if (trimmedX === noData && trimmedY !== noData) {
             return -1;
-        } else if (x === noData && y === noData) {
+        } else if (trimmedX === noData && trimmedY === noData) {
             return 0;
-        } else if (x !== noData && y === noData) {
+        } else if (trimmedX !== noData && trimmedY === noData) {
             return 1;
         }
         return utils.numericSort(x, y);
     },
+
+    percentFormatter: function(value) {
+        var trimmedVal = value.trim();
+        if (trimmedVal === noData) {
+            return trimmedVal;
+        }
+        return trimmedVal + '%';
+    },
+
 
     negateString: function(str) {
         // From https://stackoverflow.com/a/5639070

--- a/src/mmw/js/src/main.js
+++ b/src/mmw/js/src/main.js
@@ -37,6 +37,10 @@ window.ordinalNumericSort = utils.ordinalNumericSort;
 // with numeric fields.
 window.noDataSort = utils.noDataSort;
 
+// This formatter appends a "%" to a value if it isn't the no data
+// value
+window.percentFormatter = utils.percentFormatter;
+
 //
 // Expose application so we can interact with it via JS console.
 //


### PR DESCRIPTION
## Overview
- Modify the `nhdflowline` table to include a `slope` column
- Add `avgslope` to the stream info query, excluding null values
- Update UI to display slope as a percent, and No Data where not available

Connects #2532 

### Demo

![screen shot 2017-12-06 at 2 39 12 pm](https://user-images.githubusercontent.com/7633670/33682729-72e8fb12-da96-11e7-83cd-aa21026e3a25.png)

Somewhere Near Veil, CO
![screen shot 2017-12-06 at 2 40 24 pm](https://user-images.githubusercontent.com/7633670/33682730-72fcc5ca-da96-11e7-97d7-9c98ce0fa188.png)


## Testing Instructions

 * `vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -f nhdflowline_with_slope.sql.gz'` 
 * `vagrant ssh worker -c 'sudo service celeryd restart'`
 * `./scripts/bundle.sh`
 * http://localhost:8000/
 * Think of some places  of which you feel like you have a good sense of the elevation level changes, and analyze their streams. Eg, flat philly and the rocky mountains in Veil, CO
