### PR TITLE
Upgrade statsite

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -23,7 +23,7 @@
 - src: azavea.graphite
   version: 0.6.1
 - src: azavea.statsite
-  version: 1.1.0
+  version: 1.1.1
 - src: azavea.phantomjs
   version: 0.1.0
 - src: azavea.relp


### PR DESCRIPTION
## Overview

The upstream package failed to build due to SCons configuration that was upgraded in the most recent version.  This prevented a successful provision of the services VM.

### Notes

This issue was observed and resolved previously within OTM https://github.com/azavea/ansible-statsite/pull/7.  I came across it when needing to set up a new environment, otherwise we'd likely not run into it.

## Testing Instructions

If you run this in your real dev environment, you'll have to reload all of your data.  I suggest you clone the repo into a test directory.

* `git clone git@github.com:WikiWatershed/model-my-watershed.git mmw-statsite-test && cd mmw-statsite-test`
* Check out this branch
* Build the services VM.  `vagrant up services --provision`
* It should succeed
