### PR TITLE
Wait until RWD data has been mounted before starting mmw-rwd upstart service

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
@@ -3,7 +3,7 @@ description "Rapid Watershed Delineation"
 {% if ['development', 'test'] | some_are_in(group_names) -%}
 start on (vagrant-mounted and started docker)
 {% else %}
-start on (filesystem and local-filesystems and started docker)
+start on (filesystem and local-filesystems and started docker and rwd-ready)
 {% endif %}
 stop on stopping docker
 

--- a/deployment/cfn/worker.py
+++ b/deployment/cfn/worker.py
@@ -398,9 +398,6 @@ class Worker(StackNode):
     def get_cloud_config(self):
         return ['#cloud-config\n',
                 '\n',
-                'mounts:\n',
-                '  - [xvdf, /opt/rwd-data, ext4, "defaults,nofail,discard", 0, 2]\n'  # NOQA
-                '\n',
                 'write_files:\n',
                 '  - path: /etc/mmw.d/env/MMW_STACK_COLOR\n',
                 '    permissions: 0750\n',
@@ -417,9 +414,16 @@ class Worker(StackNode):
                 '  - path: /etc/mmw.d/env/ROLLBAR_SERVER_SIDE_ACCESS_TOKEN\n',
                 '    permissions: 0750\n',
                 '    owner: root:mmw\n',
-                '    content: ', self.get_input('RollbarServerSideAccessToken'),  # NOQA
+                '    content: ', self.get_input('RollbarServerSideAccessToken'), '\n',  # NOQA
+                '  - path: /etc/fstab.rwd-data\n',
+                '    permissions: 0644\n',
+                '    owner: root:mmw\n',
+                '    content: |\n',
+                '      /dev/xvdf /opt/rwd-data\text4\tdefaults,nofail,discard\t0 2',  # NOQA
                 '\n',
                 'runcmd:\n',
+                '  - cat /etc/fstab.rwd-data >> /etc/fstab\n',
+                '  - mount -t ext4 /dev/xvdf /opt/rwd-data && initctl emit rwd-ready\n',  # NOQA
                 '  - /opt/model-my-watershed/scripts/aws/ebs-warmer.sh']
 
     def create_cloud_watch_resources(self, worker_auto_scaling_group):


### PR DESCRIPTION
## Overview

Configure the `mmw-rwd` upstart service to wait for an `rwd-ready` event before starting, and configure cloud-init to emit an `rwd-ready` signal after the data volume is mounted. This will prevent the RWD service from starting before the data is availble. 

Connects #2357

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

In order to guarantee that an upstart event wouldn't be emitted until after /opt/rwd-data was mounted, I removed the `mounts` cloud-init configuration and added a `mount` command to the `runcmd` list. I made sure the command to emit the upstart event runs after the `mount` command. 

## Testing Instructions
  * Configure the Upstart service to listen for an `rwd-ready` event in development
```diff
diff --git a/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2 b/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
index 81e69cf9..f8c8fefe 100644
--- a/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
+++ b/deployment/ansible/roles/model-my-watershed.rwd/templates/upstart-mmw-rwd.conf.j2
@@ -1,7 +1,7 @@
 description "Rapid Watershed Delineation"
 
 {% if ['development', 'test'] | some_are_in(group_names) -%}
-start on (vagrant-mounted and started docker)
+start on (vagrant-mounted and started docker and rwd-ready)
 {% else %}
 start on (filesystem and local-filesystems and started docker and rwd-ready)
 {% endif %}
(END)
```

  * Provision the worker VM
  * Restart the worker VM, and confirm that the RWD service isn't running
```bash
$ vagrant provision worker
$ vagrant reload worker
$ vagrant ssh worker -c "sudo service mmw-rwd status"
mmw-rwd stop/waiting
```

  * Modify the worker's shell provisioner to emit `rwd-ready` event, and run the provisioner. Verify that the RWD service is running.
```diff
diff --git a/Vagrantfile b/Vagrantfile
index e604ad6d..ec6731dc 100644
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,7 +119,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     worker.vm.provision "shell" do |shell|
       shell.inline = <<EOF
+      initctl emit rwd-ready
       service celeryd restart >> /dev/null 2>&1
 EOF
     end
```
```bash
$ vagrant provision --provision-with=shell worker
$ vagrant ssh worker -c "sudo service mmw-rwd status"
mmw-rwd start/running, process 2423
```

* I also successfully tested this change on staging. I deployed once without updating the `cloud-config` to emit an upstart event; when I skipped this step `mmw-rwd` never started on the workers. The second time I deployed after modifying cloud-config to emit the upstart event, and  `mmw-rwd` started successfully.
