### PR TITLE
HydroShare Export Login Frontend

### DIFF
--- a/src/mmw/apps/user/hydroshare.py
+++ b/src/mmw/apps/user/hydroshare.py
@@ -35,8 +35,10 @@ class HydroShareService(OAuth2Service):
     def set_token_from_code(self, code, redirect_uri, user):
         data = {'code': code, 'redirect_uri': redirect_uri,
                 'grant_type': 'authorization_code'}
-        # TODO Add connection error handling
+
         res = self.get_raw_access_token(data=data).json()
+        if 'error' in res:
+            raise RuntimeError(res['error'])
 
         token, _ = HydroShareToken.objects.update_or_create(user=user,
                                                             defaults=res)
@@ -49,8 +51,9 @@ class HydroShareService(OAuth2Service):
         data = {'refresh_token': token.refresh_token,
                 'grant_type': 'refresh_token'}
 
-        # TODO Add connection error handling
         res = self.get_raw_access_token(data=data).json()
+        if 'error' in res:
+            raise RuntimeError(res['error'])
 
         for key, value in res.iteritems():
             setattr(token, key, value)

--- a/src/mmw/apps/user/templates/user/hydroshare-auth.html
+++ b/src/mmw/apps/user/templates/user/hydroshare-auth.html
@@ -1,0 +1,47 @@
+{% include 'head.html' %}
+{% load staticfiles %}
+
+<body>
+    <div style="display:flex; flex-direction: column; height: 100%;
+                justify-content: center; align-items: center;">
+        {% if error %}
+            <h1>
+                <i class="fa fa-times-circle"
+                   style="font-size: 48px; margin-bottom: 24px; color: maroon"></i>
+            </h1>
+            <h1>Error</h1>
+            <p>{{ error }}</p>
+            <p style="margin: 20px;">
+            {% if error = "access_denied" %}
+                Model My Watershed needs to be authorized to post to your
+                HydroShare account in order to export projects.
+            {% else %}
+                There was an error while authorizing Model My Watershed to
+                access your HydroShare account.
+            {% endif %}
+            </p>
+            <a class="btn btn-md btn-block btn-active" href="/user/hydroshare/login/" target="_self">Try Again</a>
+            <button type="button" class="btn btn-md btn-block" id="hydroshare-cancel">Cancel</button>
+        {% else %}
+            <h1>
+                <i class="fa fa-check-circle"
+                   style="font-size: 48px; margin-bottom: 24px; color: teal"></i>
+            </h1>
+            <h1>Success!</h1>
+        {% endif %}
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            {% if error %}
+            var message = 'mmw-hydroshare-failure';
+            {% else %}
+            var message = 'mmw-hydroshare-success';
+            {% endif %}
+            parent.postMessage(message, window.location.origin);
+        });
+
+        document.getElementById('hydroshare-cancel').addEventListener('click', function() {
+            parent.postMessage('mmw-hydroshare-cancel', window.location.origin);
+        });
+    </script>
+</body>

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -22,7 +22,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import (AllowAny,
                                         IsAuthenticated)
 
-from apps.user.models import ItsiUser, UserProfile
+from apps.user.models import ItsiUser, UserProfile, HydroShareToken
 from apps.user.itsi import ItsiService
 from apps.user.hydroshare import HydroShareService
 from apps.user.serializers import (UserProfileSerializer,
@@ -44,6 +44,8 @@ def login(request):
             'result': 'success',
             'username': user.username,
             'itsi': ItsiUser.objects.filter(user_id=user.id).exists(),
+            'hydroshare': HydroShareToken.objects
+                                         .filter(user_id=user.id).exists(),
             'guest': False,
             'id': user.id,
             'profile_was_skipped': profile.was_skipped,

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -1,3 +1,5 @@
+import rollbar
+
 from uuid import uuid1
 
 from django.contrib.auth import (authenticate,
@@ -373,5 +375,9 @@ def hydroshare_auth(request):
             context.update({'token': token.access_token})
         except (IOError, RuntimeError) as e:
             context.update({'error': e.message})
+
+    if context.get('error') == 'invalid_client':
+        rollbar.report_message('HydroShare OAuth credentials '
+                               'possibly misconfigured', 'warning')
 
     return render_to_response('user/hydroshare-auth.html', context)

--- a/src/mmw/js/src/core/modals/models.js
+++ b/src/mmw/js/src/core/modals/models.js
@@ -43,6 +43,15 @@ var ShareModel = Backbone.Model.extend({
     }
 });
 
+var IframeModel = Backbone.Model.extend({
+    defaults: {
+        href: '',
+        signalSuccess: '',
+        signalFailure: '',
+        signalCancel: '',
+    }
+});
+
 var AlertTypes = {
     info: {
         alertHeader: 'Information',
@@ -72,6 +81,7 @@ module.exports = {
     ConfirmModel: ConfirmModel,
     InputModel: InputModel,
     ShareModel: ShareModel,
+    IframeModel: IframeModel,
     AlertTypes: AlertTypes,
     AlertModel: AlertModel
 };

--- a/src/mmw/js/src/core/modals/templates/confirmModalLarge.html
+++ b/src/mmw/js/src/core/modals/templates/confirmModalLarge.html
@@ -1,0 +1,18 @@
+<div class="modal-dialog modal-dialog-sm">
+    <div class="modal-content {{ className }}">
+        <div class="modal-header">
+            <h2 class="light"> {{ titleText }}</h2>
+        </div>
+        <div class="modal-body">
+            {% for q in question %}
+                <p>{{ q }}</p>
+            {% endfor %}
+        </div>
+        <div class="modal-footer" style="text-align: right;">
+            <div class="footer-content">
+                <button type="button" class="btn btn-md btn-default" data-dismiss="modal">{{ cancelLabel }}</button>
+                <button type="button" class="btn btn-md btn-active confirm" data-dismiss="modal">{{ confirmLabel }}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/mmw/js/src/core/modals/templates/iframeModal.html
+++ b/src/mmw/js/src/core/modals/templates/iframeModal.html
@@ -1,0 +1,5 @@
+<div class="modal-dialog modal-dialog-sm">
+    <div class="modal-content">
+        <iframe class="hydroshare" src="{{ href }}" />
+    </div>
+</div>

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -1,4 +1,4 @@
-<div class="modal-dialog modal-dialog-sm">
+<div class="multi-share-modal modal-dialog modal-dialog-sm">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="light">Share your project</h2>
@@ -23,6 +23,22 @@
                         </button>
                     </span>
                 </div>
+            </div>
+            <hr />
+            <div class="custom-input-group">
+                <div class="row toggle-row">
+                    <h3>HydroShare Export</h3>
+                    <label class="pull-right toggle">
+                        <input type="checkbox" id="hydroshare-enabled" />
+                        <div class="toggle-switch"></div>
+                    </label>
+                </div>
+                <p>HydroShare is an online collaboration environment for sharing data, models, and code.</p>
+                <p id="hydroshare-notification" class="{{ 'hidden' if user_has_authorized_hydroshare }}">
+                    You will need to connect your HydroShare account to your
+                    Model My Watershed account, or create a new HydroShare
+                    account.
+                </p>
             </div>
         </div>
         <div class="modal-footer" style="text-align:right;">

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -9,6 +9,7 @@ var _ = require('underscore'),
     moment = require('moment'),
     models = require('./models'),
     modalConfirmTmpl = require('./templates/confirmModal.html'),
+    modalConfirmLargeTmpl = require('./templates/confirmModalLarge.html'),
     modalInputTmpl = require('./templates/inputModal.html'),
     modalPlotTmpl = require('./templates/plotModal.html'),
     modalShareTmpl = require('./templates/shareModal.html'),
@@ -106,6 +107,11 @@ var ConfirmView = ModalBaseView.extend({
     dismissAction: function() {
         this.triggerMethod('deny');
     }
+});
+
+var ConfirmLargeView = ConfirmView.extend({
+    className: LARGE_MODAL_CLASS,
+    template: modalConfirmLargeTmpl,
 });
 
 var InputView = ModalBaseView.extend({
@@ -443,6 +449,7 @@ module.exports = {
     MultiShareView: MultiShareView,
     InputView: InputView,
     ConfirmView: ConfirmView,
+    ConfirmLargeView: ConfirmLargeView,
     PlotView: PlotView,
     AlertView: AlertView
 };

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -250,3 +250,10 @@
       color: $ui-warning;
     }
 }
+
+.multi-share-modal {
+  p {
+    font-size: 13px;
+    margin-bottom: 1rem !important;
+  }
+}

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -50,6 +50,16 @@
     top: 1rem;
     right: 0;
   }
+
+  iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+
+    &.hydroshare {
+      height: 600px;
+    }
+  }
 }
 
 .modal-dialog-sm {

--- a/src/mmw/sass/components/_toggle.scss
+++ b/src/mmw/sass/components/_toggle.scss
@@ -49,9 +49,4 @@ label.toggle {
     margin: 2px 0;
     padding: 7.5px 0;
   }
-
-  + p {
-    font-size: 13px;
-    margin-bottom: 1rem !important;
-  }
 }


### PR DESCRIPTION
## Overview

Adds frontend to handle and facilitate connecting an MMW user to a HydroShare account. This does not actually export the project to HydroShare, but takes care of all the setup necessary for it.

The workflow for this setup is:

 * If a user has already connected to HydroShare, they can turn the export on and off at will
 * If they haven't, they'll be prompted to log in to HydroShare and allow MMW access
 * If the don't have a HydroShare account, they can make one, although the workflow there is confusing as after account creation they aren't led to the OAuth authorization page. They will have to close the popup and try again.
 * Currently the state of the sharing button isn't saved anywhere. That will be recorded in a forthcoming PR.

Connects #2514 

### Demo

![2017-12-08 15 08 26](https://user-images.githubusercontent.com/1430060/33783250-fd3b99fc-dc29-11e7-8337-9018561d5941.gif)

### Notes

All this UI interaction is new, and will probably need some tweaking before it is smooth. For example:

* Currently in case of error, the iframe is shown plainly, without any dismiss button. One has to click outside to dismiss it. Is this too confusing?

    ![image](https://user-images.githubusercontent.com/1430060/33784709-cf9b69d6-dc2f-11e7-95c6-dabef6151c82.png)

## Testing Instructions

* Check out this branch, `bundle`
* Go to [:8000/](http://localhost:8000/) and create or open a TR-55 project.
* Click share and select HydroShare. Login with `HydroShare OAuth MMW Staging` credentials from LastPass. Authorize MMW. Ensure you see an error page.
* Reprovision `app` by initializing `MMW_HYDROSHARE_SECRET_KEY` environment variable using the client secret available in `HydroShare OAuth MMW Staging` on LastPass.

      (bash) $ MMW_HYDROSHARE_SECRET_KEY=*** vagrant reload app --provision
      (fish) > env MMW_HYDROSHARE_SECRET_KEY=*** vagrant reload app --provision

* Attempt to share to HydroShare again. Ensure it works this time.
* Try sharing a new project, or the same project again. You should no longer be prompted to login, but allowed directly.