### PR TITLE
Add spatial index to nhdflowline

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -114,7 +114,7 @@ fi
 
 if [ "$load_stream" = "true" ] ; then
     # Fetch stream network layer sql files
-    FILES=("nhdflowline_with_slope.sql.gz")
+    FILES=("nhdflowline_1513899196.sql.gz")
     PATHS=("nhd_streams_v2")
 
     download_and_load $FILES


### PR DESCRIPTION
## Overview

The stream analyze query took about 9sec because
we were scanning all the rows to find the intersecting flowlines.

Add a spatial index to the nhdflowline table so
we don't sequentially scan. Now takes ~230ms

- Streams table already had to be reloaded for production
- We'll need to load the newly dumped table on staging for this to take effect

Connects #2560 

### Demo

![screen shot 2017-12-19 at 2 23 19 pm](https://user-images.githubusercontent.com/7633670/34180542-1ac0ec82-e4dd-11e7-8c0a-d1541d638979.png)

## Testing Instructions

`vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -s`
Run some analyze jobs and confirm the streams tab completes within a few seconds