### PR TITLE
MapShed: Update ETAdj, SedNitr Calculations

### DIFF
--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -374,7 +374,7 @@ def soiln(result):
 
     result = parse(result)
 
-    soiln = result.values()[0] * 4.0
+    soiln = result.values()[0] * 7.0
 
     return {
         'soiln': soiln


### PR DESCRIPTION
## Overview

A revision from BME, we now multiply with 7.0 instead of 4.0 for more accurate results. More context can be found here: https://github.com/WikiWatershed/model-my-watershed/issues/2549#issuecomment-350090295

Additionally, update the `ms_weather_station.sql.gz` file on S3 with new values for etadj. The old table is still available at [`ms_weather_station_backup.sql.gz`](https://s3.amazonaws.com/data.mmw.azavea.com/ms_weather_station_backup.sql.gz).

Connects #2549 

### Demo

Old vs New GMS file differences for Little Neshaminy Creek:

![image](https://user-images.githubusercontent.com/1430060/34168578-ddec06ea-e4b2-11e7-829f-5f16ca3d112d.png)

Sample new GMS file: [LittleNeshaminy_Local.gms.txt](https://github.com/WikiWatershed/model-my-watershed/files/1573433/LittleNeshaminy_Local.gms.txt)

### Notes

Previously we mistakenly had 2 of each entry in the `ms_weather_station` table. When we would select the top 2 matching weather stations for any area of interest, we would always get 2 identical stations. I removed the extraneous duplication in the updated script, and now we select 2 actually different stations. This causes new values for weather data.

These values are more accurate than before, but we'll need to do #2561 to make them truly accurate.

## Testing Instructions

* Check out this branch
* Fetch new weather stations table:

      $ vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -f ms_weather_station.sql.gz'

* Clear your geoprocessing cache:

      $ vagrant ssh services -c 'redis-cli -n 1 --raw KEYS ":1:geop*" | xargs redis-cli -n 1 DEL'

* Run MapShed on a familiar shape and generate a GMS file
* Run MapShed on the same shape on Staging or Production and generate a GMS file
* Compare the two files. You should notice differences in the PrcntET(i) values in lines 8-19 position 8, and SedNitr in line 37 position 1. There will also be a large number of incidental weather data changes, as explained in **Notes** above.