### PR TITLE
Allow boundary selection after HUC search

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -236,6 +236,8 @@ var DrawWindow = Marionette.LayoutView.extend({
         this.rwdTaskModel.reset();
         this.model.reset();
 
+        App.map.set('selectedGeocoderArea', null);
+
         utils.cancelDrawing(App.getLeafletMap());
 
         // RWD typically does not clear the AoI generated, even if it

--- a/src/mmw/js/src/geocode/views.js
+++ b/src/mmw/js/src/geocode/views.js
@@ -92,6 +92,10 @@ var SearchBoxView = Marionette.LayoutView.extend({
         'click @ui.selectButton': 'validateShapeAndGoToAnalyze'
     },
 
+    initialize: function() {
+        this.listenTo(App.map, 'change:selectedGeocoderArea', this.resetIfSelectedAreaIsCleared);
+    },
+
     modelEvents: {
         'change:query change:selectedSuggestion': 'render'
     },
@@ -261,6 +265,12 @@ var SearchBoxView = Marionette.LayoutView.extend({
         });
         this.emptyResultsRegion();
         App.map.set('selectedGeocoderArea', null);
+    },
+
+    resetIfSelectedAreaIsCleared: function(model, selectedGeocoderArea) {
+        if (!selectedGeocoderArea) {
+            this.reset();
+        }
     },
 
     dismissAction: function() {


### PR DESCRIPTION
## Overview

When an alternate AoI generation method is selected, and a geocoder HUC result is rendered on the map, clear it and reset the state of the geocoder control. The geocoder result was preventing users from making a selection from the underlying boundary layer.

Connects to #2533

### Demo

![mmw](https://user-images.githubusercontent.com/1042475/34226116-aca0a520-e596-11e7-9815-055847cf0ae0.gif)

## Testing Instructions

- Search for `Brandywine` in the search box
- Select the `Brandywine-Christina` result under the HUC8 header
- Observe that the HUC has been added to the map
- Under the `Select Boundary` option, select the HUC8 layer
- Verify that the geocoder HUC layer was removed from the map
- Try and select the Brandywine HUC from the boundary layer