### PR TITLE
Document and script data upload steps

### DIFF
--- a/doc/data_checklist.md
+++ b/doc/data_checklist.md
@@ -1,0 +1,80 @@
+## Working With Large SQL Data Dumps
+
+Working with large SQL dump files can be a high risk endeavor;
+the size of some files can cause a small mistake early on to 
+trash hours of work dumping, zipping, uploading and importing
+the file. To ensure we are measuring twice and cutting once,
+copy and paste the checklist at the bottom of this list
+into issues that involve loading new SQL data.
+For example, issues like [#1531](https://github.com/WikiWatershed/model-my-watershed/issues/1531), [#2532](https://github.com/WikiWatershed/model-my-watershed/issues/2532), [#1408](https://github.com/WikiWatershed/model-my-watershed/issues/1408).
+
+## Process
+
+1. Load or create the data/updates on your local Postgres instance
+1. Verify the table you are about to dump
+     - Inspect the table and ensure all desired columns and indices are present.
+
+    ```bash
+    ./scripts/manage.sh dbshell
+    mmw>  \d the_table_name
+    ```
+     **Things to consider:**
+     - How many rows are present?
+     - Are there columns that should have unique values, but don't?
+     - What columns will we primarily operate on? Does every row contain a value for these columns? Should they?
+     - Will we be performing joins, spatial or otherwise, with other tables? How performant are these joins? Would they benefit from a new index?
+1. `pg_dump` it!
+     - If you're exporting a table, the command may look like this:
+    ```bash
+    $ vagrant ssh services
+    $ pg_dump -c --if-exists -O
+            -t the_table_name \
+            -h localhost -U mmw mmw \
+        > /vagrant/thedump.sql
+    ```
+1. Sanity check the `pg_dump` output
+    ```bash
+    # The first 40-60 lines will likely contain 
+    # DROP and CREATE_TABLE statements you should verify.
+    head -n 45 thedump.sql
+    
+    # The end of the file will likely create
+    # any required indices.
+    # It should also contain a comment stating the pg_dump
+    # is complete.
+    tail thedump.sql
+    ```
+1. Gzip and upload to data bucket
+    ```bash
+    ./scripts/data/upload_sql_data.sh [-p MMW_STG_AWS_PROFILE] PATH_TO_FILE [DST_FILE_NAME]
+    # eg
+    ./scripts/data/upload_sql_data.sh -p mmw-stg ./data/new_nhdflowlines_with_slope.sql nhdflowline
+    # Will create s3://data.mmw.azavea.com/nhdflowline_1513899196.sql.gz
+    ```
+1. Update `./scripts/aws/setupdb.sh`
+     - Add or edit the new file name to the relevent load command.
+1. Document the data processing
+     - If the changes are small, include in the `setup.sh` script commit
+        what actions were performed to go from source data to final dump.
+     - If the steps were significant, include a script in `./scripts/data/???.sql` by which the processing can be reproduced
+1. Open a PR
+1. When your PR is merged, and the time is right apply changes to staging
+    - Run `./scripts/aws/setupdb.sh ...` on staging
+1. Create (or add to) an issue on what we need to apply to production
+    - When we release to production, we'll need remember to run `./scripts/aws/setup.sh ...` with the relevent data
+1. At the release after next, delete older versions if they exist
+    - Keep the data bucket slim
+
+## Checklist
+
+- [ ] Read over [data_checklist.md](https://github.com/WikiWatershed/model-my-watershed/tree/develop/doc/data_checklist.md)
+- [ ] Load or create the data/updates on your local Postgres instance
+- [ ] Verify the table you are about to dump
+- [ ] `pg_dump` it!
+- [ ] Sanity check the `pg_dump` output with `head` and `tail`
+- [ ] Gzip and upload to data bucket with `./scripts/data/upload_sql_data.sh`
+- [ ] Update `./scripts/aws/setupdb.sh`, document data processing steps, and commit
+- [ ] Open a PR
+- [ ] Run `./scripts/aws/setupdb.sh ...` on staging
+- [ ] Create (or add to) an issue on what we need to apply to production
+- [ ] At the release after next, delete older versions if they exist

--- a/scripts/data/upload_sql_data.sh
+++ b/scripts/data/upload_sql_data.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -e
+
+usage(){
+    echo gzip the provided .sql file, and 
+    echo then upload it to the MMW S3 bucket.
+    echo
+    echo Appends a timestamp to file name before uploading.
+    echo
+    echo ARGS:
+    echo -e "\t [-p MMW_STG_AWS_PROFILE]: Optional, the name of your mmw-stg profile."
+    echo -e "\t\t If not provided, will default to AWS_PROFILE environment"
+    echo -e "\t\t variable."
+    echo -e "\t PATH_TO_FILE: Path to the file to upload"
+    echo -e "\t [DST_FILE_NAME]: Optional, if the uploaded file"
+    echo -e "\t\t needs a different name than input file"
+    echo
+    echo "Usage: upload_sql_data.sh [-p MMW_STG_AWS_PROFILE] PATH_TO_FILE [DST_FILE_NAME]"
+    exit 1
+}
+
+if [[ $# -eq 0 ]] ; then
+    usage
+fi
+
+# Load optional flagged arguments
+while getopts ":p:" opt; do
+    case $opt in
+        p)
+            AWS_PROFILE="$OPTARG" ;;
+        \?)
+            usage
+esac
+done 
+shift $(( OPTIND-1 ))
+
+# Require AWS_PROFILE to be set
+if [ -z ${AWS_PROFILE+x} ]; then
+    echo AWS_PROFILE environment variable must be set to your mmw-stg profile
+    echo or the mmw-stg profile must be passed in as option -p
+    exit;
+fi
+
+FILE_PATH=$1
+# Require FILE_PATH to be a .sql file
+if [[ -z $FILE_PATH || $FILE_PATH != *\.sql ]]; then
+    echo You must provide a .sql file
+    echo
+    usage
+fi
+
+echo gzipping...
+gzip $FILE_PATH
+GZIPPED_FILE_PATH=$FILE_PATH.gz
+
+echo checking integrity of gzip 
+GZIP_FAILURE=$(gzip -t $GZIPPED_FILE_PATH)
+case "$GZIP_FAILURE" in
+    *[!$whitespace]*)
+        echo gzip failed: $GZIP_FAILURE
+        exit 1
+esac
+
+# Get base file name
+# eg if FILE_PATH is ./somewhere/nhdflowline.sql
+# FILE_PATH will be nhdflowline
+FILE_NAME=$(echo $FILE_PATH | \
+            sed 's/.*\///' | \
+            sed 's/\.sql.*//')
+
+DST_NAME=${2-$FILE_NAME}
+DESIRED_FILE_NAME=${DST_NAME}_$(date +%s).sql.gz
+
+echo Creating MD5 checksum
+CHECKSUM=$(openssl md5 -binary $GZIPPED_FILE_PATH | base64)
+
+echo Uploading $DESIRED_FILE_NAME to s3
+aws s3 cp --profile ${AWS_PROFILE} \
+       $GZIPPED_FILE_PATH \
+       s3://data.mmw.azavea.com/$DESIRED_FILE_NAME \
+       --acl public-read \
+       --metadata md5=$CHECKSUM


### PR DESCRIPTION
## Overview

- Add a checklist to solidify the steps
  to add or modify a sql fixture
- Add a script to gzip and upload the file
  to s3 with proper permissions and checksum
  metadata

### Notes
I went with timestamping our sql files rather than renaming the old files to `/backup`. Having a timestamp has the disadvantage of requiring a change to `setupdb.sh`, but I think it is worth it to have an immediately visible "version" on the file, and to have a way to track that version via commit history. 
