### PR TITLE
Remove scenario badge from TR-55 compare view

### DIFF
--- a/src/mmw/js/src/compare/templates/compareScenarioItem.html
+++ b/src/mmw/js/src/compare/templates/compareScenarioItem.html
@@ -1,2 +1,2 @@
 <div class="compare-map-container" role="button" data-html="true" data-toggle="popover"></div>
-<div class="compare-scenario-title"><span class="scenario-badge"></span> {{ name }}</div>
+<div class="compare-scenario-title">{{ name }}</div>


### PR DESCRIPTION
We were showing a black dot next each scenario
name. These were placeholders for the future
mapshed compare view which will color them in
correspondence with lines on a chart.

Remove them from tr-55 compare view as it
has no use for them.

Connects #2569 

### Demo

![screen shot 2017-12-29 at 11 46 10 am](https://user-images.githubusercontent.com/7633670/34442187-6b121662-ec8e-11e7-8bd1-d547257f3817.png)

## Testing Instructions

 * Pull and `bundle`
* Go to the compare view of the site storm model. Confirm scenario titles don't have dots next them.