### PR TITLE
Analyze Terrain

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -51,7 +51,7 @@ docker_options: "--storage-driver=aufs"
 geop_host: "localhost"
 geop_port: 8090
 
-geop_version: "3.0.0"
+geop_version: "3.1.0"
 geop_cache_enabled: 1
 
 nginx_cache_dir: "/var/cache/nginx"

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -30,6 +30,8 @@ urlpatterns = patterns(
         name='start_analyze_climate'),
     url(r'analyze/streams/$', views.start_analyze_streams,
         name='start_analyze_streams'),
+    url(r'analyze/terrain/$', views.start_analyze_terrain,
+        name='start_analyze_terrain'),
     url(r'jobs/' + uuid_regex, get_job, name='get_job'),
     url(r'watershed/$', views.start_rwd, name='start_rwd'),
 )

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -152,6 +152,13 @@ function createAnalyzeTaskCollection(aoi, wkaoi) {
                 area_of_interest: aoi,
                 wkaoi: wkaoi,
                 taskName: "analyze/streams"
+            },
+            {
+                name: "terrain",
+                displayName: "Terrain",
+                area_of_interest: aoi,
+                wkaoi: wkaoi,
+                taskName: "analyze/terrain"
             }
         );
     }

--- a/src/mmw/js/src/analyze/templates/terrainTable.html
+++ b/src/mmw/js/src/analyze/templates/terrainTable.html
@@ -1,0 +1,15 @@
+<table class="table custom-hover" data-toggle="table">
+    <thead>
+    <tr>
+        <th data-field="type"></th>
+        <th data-field="elevation" class="text-right">
+            Elevation (m)
+        </th>
+        <th data-field="slope" class="text-right">
+            Slope (%)
+        </th>
+    </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>

--- a/src/mmw/js/src/analyze/templates/terrainTableRow.html
+++ b/src/mmw/js/src/analyze/templates/terrainTableRow.html
@@ -1,0 +1,3 @@
+<td>{{ type|capitalize }}</td>
+<td class="strong text-right">{{ elevation|round(1)|toLocaleString(1) }}</td>
+<td class="strong text-right">{{ slope|round(1)|toLocaleString(1) }}</td>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -38,6 +38,8 @@ var $ = require('jquery'),
     pointSourceTableRowTmpl = require('./templates/pointSourceTableRow.html'),
     catchmentWaterQualityTableTmpl = require('./templates/catchmentWaterQualityTable.html'),
     catchmentWaterQualityTableRowTmpl = require('./templates/catchmentWaterQualityTableRow.html'),
+    terrainTableRowTmpl = require('./templates/terrainTableRow.html'),
+    terrainTableTmpl = require('./templates/terrainTable.html'),
     tabPanelTmpl = require('../modeling/templates/resultsTabPanel.html'),
     tabContentTmpl = require('./templates/tabContent.html'),
     barChartTmpl = require('../core/templates/barChart.html'),
@@ -698,6 +700,21 @@ var StreamTableView = Marionette.CompositeView.extend({
     },
 });
 
+var TerrainTableRowView = Marionette.ItemView.extend({
+    tagName: 'tr',
+    template: terrainTableRowTmpl,
+});
+
+var TerrainTableView = Marionette.CompositeView.extend({
+    childView: TerrainTableRowView,
+    childViewContainer: 'tbody',
+    template: terrainTableTmpl,
+
+    onAttach: function() {
+        $('[data-toggle="table"]').bootstrapTable();
+    }
+});
+
 var PageableTableBaseView = Marionette.LayoutView.extend({
     tableView: null, // a View that renders a bootstrap table. Required
 
@@ -1228,6 +1245,18 @@ var CatchmentWaterQualityResultView = AnalyzeResultView.extend({
     }
 });
 
+var TerrainResultView = AnalyzeResultView.extend({
+    onShow: function() {
+        var title = 'Terrain Statisticts',
+            source = 'NHDPlus V2 NEDSnapshot DEM',
+            helpText = 'For more information and data sources, see <a href=\'https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-coverage\' target=\'_blank\' rel=\'noreferrer noopener\'>Model My Watershed Technical Documentation on Coverage Grids</a>',
+            chart = null;
+
+        this.showAnalyzeResults(coreModels.TerrainCensusCollection, TerrainTableView,
+            chart, title, source, helpText);
+    }
+});
+
 var SelectorView = Marionette.ItemView.extend({
     template: selectorTmpl,
 
@@ -1346,6 +1375,7 @@ var AnalyzeResultViews = {
     catchment_water_quality: CatchmentWaterQualityResultView,
     climate: ClimateResultView,
     streams: StreamResultView,
+    terrain: TerrainResultView,
 };
 
 module.exports = {

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -651,6 +651,10 @@ var StreamsCensusCollection = Backbone.Collection.extend({
     comparator: 'order',
 });
 
+var TerrainCensusCollection = Backbone.Collection.extend({
+    comparator: 'name',
+});
+
 var DataCatalogPopoverResultCollection = Backbone.PageableCollection.extend({
     mode: 'client',
     state: { pageSize: 3, firstPage: 1, currentPage: 1 }
@@ -728,6 +732,7 @@ module.exports = {
     CatchmentWaterQualityCensusCollection: CatchmentWaterQualityCensusCollection,
     DataCatalogPopoverResultCollection: DataCatalogPopoverResultCollection,
     StreamsCensusCollection: StreamsCensusCollection,
+    TerrainCensusCollection: TerrainCensusCollection,
     GeoModel: GeoModel,
     AreaOfInterestModel: AreaOfInterestModel,
     AppStateModel: AppStateModel

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -599,6 +599,19 @@ GEOP = {
                 'operationType': 'RasterGroupedAverage',
                 'zoom': 0
             }
+        },
+        'terrain': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'ned-nhdplus-30m-epsg5070',
+                    'us-percent-slope-30m-epsg5070-512',
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterSummary',
+                'zoom': 0
+            }
         }
     }
 }


### PR DESCRIPTION
## Overview

Adds a Terrain tab to the Analyze stage. This uses the new `RasterSummary` operation in the geoprocessing service to get summary statistics for Elevation and Slope rasters.

Connects #2346

### Demo

![image](https://user-images.githubusercontent.com/1430060/34503671-b9691a02-efe7-11e7-831c-ef3dd4633ff4.png)

Also tagging @ajrobbins and @jfrankl for visual review.

### Notes

* There are no related visual layers corresponding to this tab currently
* Can someone confirm the data source name? I took it from the mockup but want to make sure, and add it to the API doc.
* At first I made the transposed table, which felt more natural in my mind:

    ![image](https://user-images.githubusercontent.com/1430060/34502561-ff6d951a-efe1-11e7-8644-3f3d889fb79c.png)

    Later I corrected it according to the mockup. The correction code is in the last two fixups, so can be easily reverted if we like this version better.

## Testing Instructions

* Check out this branch and reprovision worker to install the new geoprocessing service

      vagrant reload worker --provision

* Go to [:8000/](http://localhost:8000/) and select an area of interest. Proceed to Analyze.
* Ensure you see a Terrain tab under Analyze. Ensure it has reasonable values. Ensure its design matches [this mockup](https://docs.google.com/document/d/1-iTJadY2V5uE46Jh4XFQKyiNKOcqVPqJVCM_TkEBkBI/edit#)
