### PR TITLE
HydroShare Export Autosync

### DIFF
--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -48,11 +48,19 @@
                 {% if hydroshare %}
                 <p>
                     Your project <a href="{{ hydroshare.url }}" target="_blank">{{ hydroshare.title }}</a>
-                    has been exported to HydroShare. Last exported at {{ hydroshare.exported_at | toFriendlyDate }}.
-                    {% if not is_exporting %}
-                    <a href="#" class="hydroshare-export">Export Again</a>.
-                    {% endif %}
+                    has been exported to HydroShare.
                 </p>
+                <div class="hydroshare-autosync-container">
+                    <h5>Settings</h5>
+                    <label>
+                        <input type="checkbox" id="hydroshare-autosync" {{ 'checked' if hydroshare.autosync }} />
+                        Automatically push changes to HydroShare
+                    </label>
+                    <p>
+                        <span class="hydroshare-timestamp">Last change: {{ hydroshare.exported_at | toFriendlyDate }}</span>
+                        <a href="#" class="hydroshare-export {{ 'hidden' if hydroshare.autosync or is_exporting }}">Export Now</a>
+                    </p>
+                </div>
                 {% endif %}
             </div>
         </div>

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -49,7 +49,9 @@
                 <p>
                     Your project <a href="{{ hydroshare.url }}" target="_blank">{{ hydroshare.title }}</a>
                     has been exported to HydroShare. Last exported at {{ hydroshare.exported_at | toFriendlyDate }}.
+                    {% if not is_exporting %}
                     <a href="#" class="hydroshare-export">Export Again</a>.
+                    {% endif %}
                 </p>
                 {% endif %}
             </div>

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -27,10 +27,12 @@
             <hr />
             <div class="custom-input-group">
                 <div class="row toggle-row">
-                    <i class="hydroshare-spinner fa fa-circle-o-notch fa-spin hidden"></i>
+                    {% if is_exporting %}
+                    <i class="hydroshare-spinner fa fa-circle-o-notch fa-spin"></i>
+                    {% endif %}
                     <h3>HydroShare Export</h3>
                     <label class="pull-right toggle">
-                        <input type="checkbox" id="hydroshare-enabled" {{ 'checked' if hydroshare }} />
+                        <input type="checkbox" id="hydroshare-enabled" {{ 'checked' if hydroshare }} {{ 'disabled' if is_exporting }} />
                         <div class="toggle-switch"></div>
                     </label>
                 </div>

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -222,12 +222,14 @@ var MultiShareView = ModalBaseView.extend({
         'hydroShareNotification': '#hydroshare-notification',
         'hydroShareSpinner': '.hydroshare-spinner',
         'hydroShareExport': '.hydroshare-export',
+        'hydroShareAutosync': '#hydroshare-autosync',
     },
 
     events: _.defaults({
         'click @ui.shareEnabled': 'onLinkToggle',
         'click @ui.hydroShareEnabled': 'connectHydroShare',
         'click @ui.hydroShareExport': 'reExportHydroShare',
+        'click @ui.hydroShareAutosync': 'setHydroShareAutosync',
     }, ModalBaseView.prototype.events),
 
     modelEvents: {
@@ -340,6 +342,10 @@ var MultiShareView = ModalBaseView.extend({
         e.preventDefault();
         this.model.exportToHydroShare();
         return false;
+    },
+
+    setHydroShareAutosync: function(e) {
+        this.model.setHydroShareAutosync(e.target.checked);
     }
 });
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -492,6 +492,37 @@ var ProjectModel = Backbone.Model.extend({
         }).always(function() {
             self.set('is_exporting', false);
         });
+    },
+
+    /**
+     * Sets HydroShare Autosync to given value.
+     *
+     * Returns a promise of the AJAX call.
+     */
+    setHydroShareAutosync: function(autosync) {
+        var self = this,
+            hydroshare = self.get('hydroshare');
+
+        self.set({
+            is_exporting: true,
+            hydroshare: _.defaults({
+                autosync: autosync
+            }, hydroshare),
+        });
+
+        return $.ajax({
+            url: '/export/hydroshare?project=' + self.id,
+            type: 'PATCH',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                autosync: autosync
+            })
+        }).fail(function() {
+            // Restore local state in case update fails
+            self.set('hydroshare', hydroshare);
+        }).always(function() {
+            self.set('is_exporting', false);
+        });
     }
 });
 

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -260,4 +260,27 @@
   .hydroshare-spinner {
     margin: 12px;
   }
+
+  .hydroshare-autosync-container {
+    padding: 10px;
+    border: 1px solid $ui-light;
+    border-radius: 4px;
+
+    label {
+      font-size: 13px;
+      font-weight: normal;
+      margin-bottom: 1rem;
+    }
+
+    .hydroshare-timestamp {
+      color: $ui-grey;
+    }
+
+    .hydroshare-export {
+      display: inline-block;
+      border-left: 1px solid $ui-grey;
+      margin-left: 5px;
+      padding-left: 10px;
+    }
+  }
 }


### PR DESCRIPTION
## Overview

Refactors the network interaction for HydroShare Export into the Project model from the MultiShareModal view. Reuses that functionality in the Scenario save code, triggering on every save if autosync is enabled. Adds backend and frontend support to turn autosync on or off. Updates UI to match the mockups.

Connects #2574 

### Demo

Exporting to HydroShare manually:

![2018-01-04 13 00 26](https://user-images.githubusercontent.com/1430060/34577781-6c56bd4a-f150-11e7-9361-54e3cefb8dc4.gif)

Exporting to HydroShare automatically (on scenario change):

![2018-01-04 13 03 38](https://user-images.githubusercontent.com/1430060/34577796-7a3d473a-f150-11e7-9f6d-0bd5e7c69907.gif)

Tagging @jfrankl and @ajrobbins for visual review.

### Notes

* Exporting to HydroShare takes about ~15-25 seconds. Running a model takes between 1 and 30 seconds. When a change is made to a scenario, we first save the inputs / modifications, then run the model. Once the model results return, we save them to a scenario again. To avoid triggering two exports to HydroShare in quick succession of input / modification change and result save, I added a debounce of 5 seconds to the export. This means that for every save, the export will wait 5 seconds to see if there is another, and will trigger an export only after that time passes.

  I think we can adjust this number going forward, but if you can think of a better initial setting please comment here.

* I'm currently using default styling for the checkbox:

    ![image](https://user-images.githubusercontent.com/1430060/34578041-83984d4c-f151-11e7-9823-3f2baacd10c1.png)

  But can switch to something else if @jfrankl recommends to match the mockup:

  ![ce2c2eaf-ff6e-475c-93e7-438359702a02](https://user-images.githubusercontent.com/1430060/34419905-6e96a9d4-ebd4-11e7-9213-dcc60bdeea33.png)

  Or we can tackle this in the design review card #2579 

* When a scenario is renamed, a GMS file with the old name continues to live in HydroShare, and a new one with the new name is added. This is because we only delete the files we are uploading to overwrite them. An old named scenario file must be deleted by hand on HydroShare.

## Testing Instructions

* Check out this branch and bundle
* Try exporting a MapShed project to HydroShare. Ensure it works.
* Make changes to the project (add a scenario, rename a scenario, add a modification). Ensure they all trigger a HydroShare export.
* Disable autosync. Ensure changing scenarios does not trigger exports anymore.
* Export manually. Ensure it works.