### PR TITLE
Branding Updates

### DIFF
--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -2,6 +2,7 @@
     <ul class="global-navigation">
         <li class="global-navigation-item"><button data-url="/">{{ title }}</button></li>
     </ul>
+    <img src="/static/images/stroud-logo.png" alt="Stroud Water Research Center" />
     <div class="navigation">
         <ul class="main">
             <li class="header-link"><a href="#" data-toggle="modal" data-target="#about-modal">About</a></li>

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -4,7 +4,7 @@
     </ul>
     <div class="navigation">
         <ul class="main">
-            <li class="header-link"><a target="_blank" href="{{ aboutLink }}">About</a></li>
+            <li class="header-link"><a href="#" data-toggle="modal" data-target="#about-modal">About</a></li>
             {% if guest %}
                 <li class="header-link"><a class="show-login" href="javascript:void(0);">Login</a></li>
             {% else %}
@@ -40,6 +40,45 @@
         </ul>
     </div>
 </nav>
+
+<div class="modal modal-about fade" id="about-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h2 class="modal-title">Model My Watershed</h2>
+                <p class="version">
+                    <!-- TODO Add Version Number Here -->
+                    <!-- https://github.com/WikiWatershed/model-my-watershed/issues/2591 -->
+                    Version X.XX (<a href="https://github.com/WikiWatershed/model-my-watershed/releases/latest">Release Notes</a>)
+                </p>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Model My Watershed is part of <a href="http://www.stroudcenter.org/" target="_blank">
+                    Stroud Water Research Center</a>'s <a href="https://wikiwatershed.org/" target="_blank">
+                    WikiWatershed</a> initiative. WikiWatershed is a web
+                    toolkit designed to support citizens, conservation
+                    practitioners, municipal decision-makers, researchers,
+                    educators, and students to collaboratively advance
+                    knowledge and stewardship of fresh water.
+                </p>
+                <ul>
+                    <li>Read more <a href="https://wikiwatershed.org/model/" target="_blank">about Model My Watershed</a></li>
+                    <li>Meet <a href="https://wikiwatershed.org/about/" target="_blank">the development team</a></li>
+                </ul>
+                <hr />
+                <h5>With major funding from:</h5>
+                <p>
+                    <a target="_blank" href="http://www.williampennfoundation.org/"><img class="splash-sponsor-logo" src="/static/images/logo-wpf.png" alt="William Penn Foundation Logo" /></a>
+                    <a target="_blank" href="https://www.nsf.gov/"><img class="splash-sponsor-logo" src="/static/images/logo-nsf.png" alt="National Science Foundation Logo" /></a>
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
 
 {% if show_profile_popover %}
 <div class="modal profile-fade-background" tabindex="-1">

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -5,6 +5,7 @@
     <div class="navigation">
         <ul class="main">
             <li class="header-link"><a href="#" data-toggle="modal" data-target="#about-modal">About</a></li>
+            <li class="header-link"><a href="https://wikiwatershed.org/help/" target="_blank">Help</a></li>
             {% if guest %}
                 <li class="header-link"><a class="show-login" href="javascript:void(0);">Login</a></li>
             {% else %}

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -2,11 +2,17 @@
     <ul class="global-navigation">
         <li class="global-navigation-item"><button data-url="/">{{ title }}</button></li>
     </ul>
+    {% if not data_catalog_enabled %}
     <img src="/static/images/stroud-logo.png" alt="Stroud Water Research Center" />
+    {% endif %}
     <div class="navigation">
         <ul class="main">
+            {% if data_catalog_enabled %}
+            <li class="header-link"><a href="http://bigcz.org/" target="_blank">About</a></li>
+            {% else %}
             <li class="header-link"><a href="#" data-toggle="modal" data-target="#about-modal">About</a></li>
             <li class="header-link"><a href="https://wikiwatershed.org/help/" target="_blank">Help</a></li>
+            {% endif %}
             {% if guest %}
                 <li class="header-link"><a class="show-login" href="javascript:void(0);">Login</a></li>
             {% else %}

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -136,8 +136,7 @@ var HeaderView = Marionette.ItemView.extend({
         return {
             'title': settings.get('title'),
             'itsi_embed': settings.get('itsi_embed'),
-            'aboutLink': settings.get('data_catalog_enabled') ?
-                'https://bigcz.org/' : 'https://wikiwatershed.org/',
+            'data_catalog_enabled': settings.get('data_catalog_enabled'),
         };
     },
 

--- a/src/mmw/js/src/draw/templates/splash.html
+++ b/src/mmw/js/src/draw/templates/splash.html
@@ -90,24 +90,16 @@
 </button>
 {% endif %}
 
+{% if dataCatalogEnabled %}
 <hr/>
 
 <div class="center">
-{% if dataCatalogEnabled %}
 <a target="_blank" href="http://bigcz.org/"><img class="splash-logo" src="/static/images/logo-bigcz.png" alt="BiG CZ Logo" /></a>
-{% else %}
-<a target="_blank" href="http://www.wikiwatershed.org/"><img class="splash-logo" src="/static/images/logo-wikiwatershed.png" alt="WikiWatershed Logo" /></a>
-{% endif %}
 </div>
 
 <p>Supported by:</p>
 
-{% if dataCatalogEnabled %}
 <a target="_blank" href="https://www.nsf.gov/"><img class="splash-sponsor-logo" src="/static/images/logo-nsf.png" alt="National Science Foundation Logo" /></a>
 <a target="_blank" href="http://www.williampennfoundation.org/"><img class="splash-sponsor-logo" src="/static/images/logo-wpf.png" alt="William Penn Foundation Logo" /></a>
-<a target="_blank" href="http://www.stroudcenter.org/"><img class="splash-sponsor-logo" src="/static/images/logo-stroud.png" alt="Stroud Logo" /></a>
-{% else %}
-<a target="_blank" href="http://www.williampennfoundation.org/"><img class="splash-sponsor-logo" src="/static/images/logo-wpf.png" alt="William Penn Foundation Logo" /></a>
-<a target="_blank" href="https://www.nsf.gov/"><img class="splash-sponsor-logo" src="/static/images/logo-nsf.png" alt="National Science Foundation Logo" /></a>
 <a target="_blank" href="http://www.stroudcenter.org/"><img class="splash-sponsor-logo" src="/static/images/logo-stroud.png" alt="Stroud Logo" /></a>
 {% endif %}

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -11,6 +11,7 @@ header {
   background-color: $ui-primary;
   height: $height-lg;
   padding: 0 1rem;
+  text-align: center;
 
   .brand {
     a {
@@ -29,9 +30,9 @@ header {
   }
 
   img {
-    height: 24px;
+    height: 26px;
     position: relative;
-    top: -2px;
+    top: 10px;
   }
 
   .navigation {

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -261,3 +261,41 @@
     margin: 12px;
   }
 }
+
+.modal-about {
+  .modal-content {
+    padding: 2rem;
+  }
+
+  .modal-header {
+    border: none;
+
+    p.version {
+      margin-top: 1rem;
+      font-size: 13px;
+      font-weight: normal;
+      color: $black-39;
+    }
+  }
+
+  .modal-body {
+    p, li {
+      font-size: 15px;
+      font-weight: 400;
+      color: $black-65;
+      line-height: 1.5;
+    }
+
+    li {
+      padding-left: 1rem;
+    }
+
+    p {
+      margin-bottom: 2rem;
+    }
+
+    img.splash-sponsor-logo {
+      height: 100px;
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Updates Model My Watershed splash page branding as follows:

* Removes all the sponsor information from the sidebar
* Turns the About button into a modal launcher instead of a hyperlink. This About modal has text and images of the sponsors.
* Add a Help button that links to the help page.
* Add Stroud logo to the center of the app header
* Adjust code so that none of this affects BiG-CZ

Tagging @caseycesari for code review, and @jfrankl and @ajrobbins for visual review.

Connects #2534 

### Demo

Home / Splash page:

![image](https://user-images.githubusercontent.com/1430060/34587941-765216d2-f178-11e7-9c06-2825e689f3e8.png)

About Modal:

![image](https://user-images.githubusercontent.com/1430060/34587946-819ba7ce-f178-11e7-8a31-f46b06d61e72.png)

BiG-CZ Splash page:

![image](https://user-images.githubusercontent.com/1430060/34587935-6c81f2a8-f178-11e7-86b9-b5991c2cf8db.png)

### Notes

* Do we add Stroud to the "With major funding from" section?
* The WikiWatershed logo is now completely gone. Is that what we want?
* Version number exists as a placeholder. Actual version will be added in #2591. The "Release Notes" link currently points to the "latest" tag in GitHub, but once we have the version number we will point to the specified tag.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and ensure the page matches the content specified in #2534 
* Try out the links in the About modal and ensure they all go to sensible places
* Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and ensure that it looks exactly like the currently deployed version in [production](https://portal.bigcz.org/).