### PR TITLE
Add MMW Version Number to About Modal

### DIFF
--- a/deployment/packer/driver.py
+++ b/deployment/packer/driver.py
@@ -121,6 +121,7 @@ def run_packer(mmw_config, machine_types, aws_profile):
                                                           get_git_sha())),
                       '-var', 'branch={}'.format(env.get('GIT_BRANCH',
                                                          get_git_branch())),
+                      '-var', 'description={}'.format(get_git_sha()),
                       '-var', 'aws_region={}'.format(region),
                       '-var', 'aws_ubuntu_ami={}'.format(aws_ubuntu_ami),
                       '-var', 'stack_type={}'.format(stack_type)]

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -1,6 +1,7 @@
 {
     "variables": {
         "version": "",
+        "description": "",
         "branch": "",
         "aws_region": "",
         "aws_ubuntu_ami": "",
@@ -113,7 +114,7 @@
                 "sudo apt-get install python-pip python-dev -y",
                 "sudo pip install paramiko==1.16.0",
                 "sudo pip install ansible==2.0.1.0",
-                "sudo /bin/sh -c 'echo {{user `version`}} > /srv/version.txt'"
+                "sudo /bin/sh -c 'echo {{user `branch`}} {{user `description`}} > /srv/version.txt'"
             ]
         },
         {

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -71,6 +71,8 @@ var App = new Marionette.Application({
             $('[data-toggle="popover"]').popover('hide');
             $('.popover').remove();
         };
+
+        fetchVersion();
     },
 
     load: function(data) {
@@ -350,6 +352,29 @@ function initializeShutterbug() {
         });
 
     shutterbug.enable('body');
+}
+
+function fetchVersion() {
+    $.get('/version.txt')
+        .done(function(data) {
+            var versions = data.match(/(\S+)\s+(\S+)/),
+                branch = versions[1],
+                gitDescribe = versions[2];
+
+            settings.set('branch', branch);
+            settings.set('gitDescribe', gitDescribe);
+        })
+        .fail(function(error) {
+            if (error.status === 404) {
+                // No /version.txt found, this could be a development environment
+                settings.set('branch', 'local');
+                settings.set('gitDescribe', null);
+            } else {
+                // Some other error occurred. Could indicate a faulty deployment
+                settings.set('branch', null);
+                settings.set('gitDescribe', null);
+            }
+        });
 }
 
 module.exports = App;

--- a/src/mmw/js/src/core/modals/templates/aboutModal.html
+++ b/src/mmw/js/src/core/modals/templates/aboutModal.html
@@ -1,0 +1,36 @@
+<div class="modal-dialog" role="document">
+    <div class="modal-content">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <h2 class="modal-title">Model My Watershed</h2>
+            <p class="version">
+                <!-- TODO Add Version Number Here -->
+                <!-- https://github.com/WikiWatershed/model-my-watershed/issues/2591 -->
+                Version X.XX (<a href="https://github.com/WikiWatershed/model-my-watershed/releases/latest">Release Notes</a>)
+            </p>
+        </div>
+        <div class="modal-body">
+            <p>
+                Model My Watershed is part of <a href="http://www.stroudcenter.org/" target="_blank">
+                Stroud Water Research Center</a>'s <a href="https://wikiwatershed.org/" target="_blank">
+                WikiWatershed</a> initiative. WikiWatershed is a web
+                toolkit designed to support citizens, conservation
+                practitioners, municipal decision-makers, researchers,
+                educators, and students to collaboratively advance
+                knowledge and stewardship of fresh water.
+            </p>
+            <ul>
+                <li>Read more <a href="https://wikiwatershed.org/model/" target="_blank">about Model My Watershed</a></li>
+                <li>Meet <a href="https://wikiwatershed.org/about/" target="_blank">the development team</a></li>
+            </ul>
+            <hr />
+            <h5>With major funding from:</h5>
+            <p>
+                <a target="_blank" href="http://www.williampennfoundation.org/"><img class="splash-sponsor-logo" src="/static/images/logo-wpf.png" alt="William Penn Foundation Logo" /></a>
+                <a target="_blank" href="https://www.nsf.gov/"><img class="splash-sponsor-logo" src="/static/images/logo-nsf.png" alt="National Science Foundation Logo" /></a>
+            </p>
+        </div>
+    </div>
+</div>

--- a/src/mmw/js/src/core/modals/templates/aboutModal.html
+++ b/src/mmw/js/src/core/modals/templates/aboutModal.html
@@ -6,9 +6,7 @@
             </button>
             <h2 class="modal-title">Model My Watershed</h2>
             <p class="version">
-                <!-- TODO Add Version Number Here -->
-                <!-- https://github.com/WikiWatershed/model-my-watershed/issues/2591 -->
-                Version X.XX (<a href="https://github.com/WikiWatershed/model-my-watershed/releases/latest">Release Notes</a>)
+                Version {{ version }} (<a href="{{ releaseNotesUrl }}">Release Notes</a>)
             </p>
         </div>
         <div class="modal-body">

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -8,6 +8,7 @@ var _ = require('lodash'),
     Clipboard = require('clipboard'),
     moment = require('moment'),
     models = require('./models'),
+    modalAboutTmpl = require('./templates/aboutModal.html'),
     modalConfirmTmpl = require('./templates/confirmModal.html'),
     modalConfirmLargeTmpl = require('./templates/confirmModalLarge.html'),
     modalInputTmpl = require('./templates/inputModal.html'),
@@ -630,7 +631,22 @@ var PlotView = ModalBaseView.extend({
     }
 });
 
+var AboutModal = Marionette.ItemView.extend({
+    className: 'modal modal-about fade',
+    attributes: {
+        'tabindex': '-1',
+        'role': 'dialog',
+    },
+
+    template: modalAboutTmpl,
+
+    onRender: function() {
+        this.$el.modal('show');
+    }
+});
+
 module.exports = {
+    AboutModal: AboutModal,
     ModalBaseView: ModalBaseView,
     ShareView: ShareView,
     MultiShareView: MultiShareView,

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -18,7 +18,7 @@ var _ = require('lodash'),
     modalHydroShareTmpl = require('./templates/hydroShareExportModal.html'),
     modalAlertTmpl = require('./templates/alertModal.html'),
     modalIframeTmpl = require('./templates/iframeModal.html'),
-    vizerUrls = require('../settings').get('vizer_urls'),
+    settings = require('../settings'),
 
     ENTER_KEYCODE = 13,
     ESCAPE_KEYCODE = 27,
@@ -507,7 +507,7 @@ var PlotView = ModalBaseView.extend({
     plotMeasurement: function(varId) {
         var self = this,
             series = self.model.get('seriesMap')[varId],
-            dataUrl = vizerUrls.variable
+            dataUrl = settings.vizerUrls.variable
                .replace(/{{var_id}}/, varId)
                .replace(/{{asset_id}}/, this.model.get('siso_id'));
 
@@ -639,6 +639,12 @@ var AboutModal = Marionette.ItemView.extend({
     },
 
     template: modalAboutTmpl,
+    templateHelpers: function() {
+        return coreUtils.parseVersion(
+            settings.get('branch'),
+            settings.get('gitDescribe')
+        );
+    },
 
     onRender: function() {
         this.$el.modal('show');

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -20,6 +20,8 @@ var defaultSettings = {
     model_packages: [],
     max_area: 75000,
     enabled_features: [],
+    branch: null,
+    gitDescribe: null,
 };
 
 var settings = (function() {

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -10,7 +10,7 @@
             {% if data_catalog_enabled %}
             <li class="header-link"><a href="http://bigcz.org/" target="_blank">About</a></li>
             {% else %}
-            <li class="header-link"><a href="#" data-toggle="modal" data-target="#about-modal">About</a></li>
+            <li class="header-link"><a href="javascript:void(0);" id="about-modal-trigger">About</a></li>
             <li class="header-link"><a href="https://wikiwatershed.org/help/" target="_blank">Help</a></li>
             {% endif %}
             {% if guest %}
@@ -48,45 +48,6 @@
         </ul>
     </div>
 </nav>
-
-<div class="modal modal-about fade" id="about-modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-                <h2 class="modal-title">Model My Watershed</h2>
-                <p class="version">
-                    <!-- TODO Add Version Number Here -->
-                    <!-- https://github.com/WikiWatershed/model-my-watershed/issues/2591 -->
-                    Version X.XX (<a href="https://github.com/WikiWatershed/model-my-watershed/releases/latest">Release Notes</a>)
-                </p>
-            </div>
-            <div class="modal-body">
-                <p>
-                    Model My Watershed is part of <a href="http://www.stroudcenter.org/" target="_blank">
-                    Stroud Water Research Center</a>'s <a href="https://wikiwatershed.org/" target="_blank">
-                    WikiWatershed</a> initiative. WikiWatershed is a web
-                    toolkit designed to support citizens, conservation
-                    practitioners, municipal decision-makers, researchers,
-                    educators, and students to collaboratively advance
-                    knowledge and stewardship of fresh water.
-                </p>
-                <ul>
-                    <li>Read more <a href="https://wikiwatershed.org/model/" target="_blank">about Model My Watershed</a></li>
-                    <li>Meet <a href="https://wikiwatershed.org/about/" target="_blank">the development team</a></li>
-                </ul>
-                <hr />
-                <h5>With major funding from:</h5>
-                <p>
-                    <a target="_blank" href="http://www.williampennfoundation.org/"><img class="splash-sponsor-logo" src="/static/images/logo-wpf.png" alt="William Penn Foundation Logo" /></a>
-                    <a target="_blank" href="https://www.nsf.gov/"><img class="splash-sponsor-logo" src="/static/images/logo-nsf.png" alt="National Science Foundation Logo" /></a>
-                </p>
-            </div>
-        </div>
-    </div>
-</div>
 
 {% if show_profile_popover %}
 <div class="modal profile-fade-background" tabindex="-1">

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -725,6 +725,37 @@ describe('Core', function() {
             assert.deepEqual(utils.rangeInMagnitude(10), {min: 0, max: 10});
             assert.deepEqual(utils.rangeInMagnitude(-0.005), {min: -0.01, max: 0});
         });
+
+        it('parses version numbers correctly', function() {
+            var latestUrl = 'https://github.com/WikiWatershed/model-my-watershed/releases/latest',
+                taggedUrl = 'https://github.com/WikiWatershed/model-my-watershed/releases/tag/1.22.0',
+                gitDescribe = '1.21.0-131-g9e49b30ce4f5b641e41c96f49c0a1509b21261b2',
+                output = null;
+
+            output = utils.parseVersion(null, null);
+            assert.equal(output.version, 'Unknown');
+            assert.equal(output.releaseNotesUrl, latestUrl);
+
+            output = utils.parseVersion('release/1.22.0', gitDescribe);
+            assert.equal(output.version, '1.22.0');
+            assert.equal(output.releaseNotesUrl, taggedUrl);
+
+            output = utils.parseVersion('hotfix/1.22.2', gitDescribe);
+            assert.equal(output.version, '1.22.2');
+            assert.equal(output.releaseNotesUrl, taggedUrl);
+
+            output = utils.parseVersion('develop', gitDescribe);
+            assert.equal(output.version, '1.21.0-131-g9e49b3');
+            assert.equal(output.releaseNotesUrl, latestUrl);
+
+            output = utils.parseVersion('tt/version-number', gitDescribe);
+            assert.equal(output.version, '1.21.0-131-g9e49b3');
+            assert.equal(output.releaseNotesUrl, latestUrl);
+
+            output = utils.parseVersion('local', null);
+            assert.equal(output.version, 'Local');
+            assert.equal(output.releaseNotesUrl, latestUrl);
+        });
     });
 });
 

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -10,6 +10,8 @@ var L = require('leaflet'),
 
 var M2_IN_KM2 = 1000000;
 var noData = 'No Data';
+var RELEASE_NOTES_BASE_URL = 'https://github.com/WikiWatershed/model-my-watershed/releases';
+var MINOR_MAJOR_REGEX = /^[0-9]+\.[0-9]+\./; // Matches strings like 2.22.
 
 var utils = {
     layerGroupZIndices: {
@@ -606,6 +608,34 @@ var utils = {
         return {
             min: min,
             max: max
+        };
+    },
+
+    // Parses version number from branch and git describe output
+    // Outputs version number and release notes URL
+    parseVersion: function(branch, gitDescribe) {
+        var version = 'Unknown',
+            url = RELEASE_NOTES_BASE_URL + '/latest';
+
+        if (branch === null && gitDescribe === null) {
+            version = 'Unknown';
+        } else if (branch === 'local' && gitDescribe === null) {
+            version = 'Local';
+        } else if (branch.startsWith('release')) {
+            version = branch.substr(branch.indexOf('/') + 1);
+            // Use this version for release notes
+            url = RELEASE_NOTES_BASE_URL + '/tag/' + version;
+        } else if (branch.startsWith('hotfix')) {
+            version = branch.substr(branch.indexOf('/') + 1);
+            // Use the original release notes
+            url = RELEASE_NOTES_BASE_URL + '/tag/' + version.match(MINOR_MAJOR_REGEX) + '0';
+        } else {
+            version = gitDescribe.substr(0, 18);
+        }
+
+        return {
+            version: version,
+            releaseNotesUrl: url
         };
     }
 };

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -114,9 +114,11 @@ var HeaderView = Marionette.ItemView.extend({
         logout: '.user-logout',
         cloneProject: '.clone-project',
         skippedProfilePopover: '[data-toggle="popover"]',
+        about: '#about-modal-trigger',
     },
 
     events: {
+        'click @ui.about': 'showAbout',
         'click @ui.login': 'showLogin',
         'click @ui.logout': 'userLogout',
         'click @ui.cloneProject': 'cloneProject'
@@ -138,6 +140,10 @@ var HeaderView = Marionette.ItemView.extend({
             'itsi_embed': settings.get('itsi_embed'),
             'data_catalog_enabled': settings.get('data_catalog_enabled'),
         };
+    },
+
+    showAbout: function() {
+        new modalViews.AboutModal().render();
     },
 
     showLogin: function() {


### PR DESCRIPTION
## Overview

Adds the version number to the about modal, and links to the appropriate Release Notes. This is done by:

* Changing `/version.txt` from just having the SHA to the following format:

      release/1.22.0	1.21.0-126-ga02c1762e398c859703f22b8881af441975450fe

  where the first item is the name of the current branch, then a `tab`, then the output of `git describe --tags --always --dirty --abbrev=40`, which takes the format of `<last tag>-<commits since last tag>-g<current SHA>[-dirty]`. This is more informative, and allows us to present the _next_ version number from the branch name before the _tag_ has been added.

* Fetching and parsing `/version.txt` on app load. This file should _always_ be available on deployed versions (staging, production). In case we get a 404, we assume that this is a local dev environment, and report a "Version Local" instead.

* Move About modal code into its own file. Since the version won't be available until after the above fetch is complete, we move the about modal code out of `header.html`, which is loaded at app load, to its own modal file, which is triggered when someone clicks "About".

* Show version number in the app, with the following rules:

  - If the file is not found, we say "Version Local" and point to the latest release notes
  - If something else goes wrong in the fetch, we say "Version Unknown" and point to the latest release notes
  - If the branch name is `release/X.Y.Z`, we say "Version X.Y.Z" and point to release notes with that tag
  - If the branch name is `hotfix/X.Y.Z`, we say "Version X.Y.Z" and point to release notes with the tag "X.Y.0", since we most often have release notes for minor releases but never for point releases (looking here: https://github.com/WikiWatershed/model-my-watershed/releases)
  - In all other cases, we show the first 18 characters of the git describe output, and point to the latest release

Connects #2591 

### Demo

Local Development:

![image](https://user-images.githubusercontent.com/1430060/34685421-41e7a550-f476-11e7-95e9-37bde0818f03.png)

Release:

![image](https://user-images.githubusercontent.com/1430060/34685578-d1ab4ae8-f476-11e7-8270-1001fab07cd4.png)

Hotfix:

![image](https://user-images.githubusercontent.com/1430060/34685618-f3bf77c6-f476-11e7-8e85-5af185d219e0.png)

Some other branch:

![image](https://user-images.githubusercontent.com/1430060/34685647-15d36390-f477-11e7-9f91-ab6448263949.png)

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and open the About modal. Ensure you see "Version Local".
* Edit [this line](https://github.com/WikiWatershed/model-my-watershed/blob/3489acc48e0710ef06a55dc6af183e33ca38348d/src/mmw/js/src/app.js#L358) to be `/static/version.txt` instead of `/version.txt`, then edit that file directly:

      $ vagrant ssh app -c 'vim /var/www/mmw/static/version.txt'

  and add something like this:

      release/1.22.0	1.21.0-126-ga02c1762e398c859703f22b8881af441975450fe

* Bundle and reload [:8000/](http://localhost:8000/). Ensure you see the correct version above.
* Try other combinations, ensure the output makes sense in every case.