### PR TITLE
Add MMW Users to API Logging

### DIFF
--- a/src/mmw/apps/core/decorators.py
+++ b/src/mmw/apps/core/decorators.py
@@ -42,7 +42,9 @@ def log_request(view):
             query_params=request.query_params.dict(),
             method=request.method,
             host=request.get_host(),
-            remote_addr=_get_remote_addr(request))
+            remote_addr=_get_remote_addr(request),
+            referrer=request.META.get('HTTP_REFERER'),
+            api=_is_api_call(request))
         try:
             log.save()
         except Exception:
@@ -66,3 +68,9 @@ def _get_remote_addr(request):
             return [x.strip() for x in ipaddr.split(",")][0]
     else:
         return request.META.get("REMOTE_ADDR", "")
+
+
+def _is_api_call(request):
+    # request.auth is None for SessionAuthentication,
+    # but a Token instance for TokenAuthentication
+    return request.auth is not None

--- a/src/mmw/apps/core/migrations/0003_requestlog_api_referrer.py
+++ b/src/mmw/apps/core/migrations/0003_requestlog_api_referrer.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0002_requestlog'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='requestlog',
+            name='api',
+            field=models.BooleanField(default=True, help_text='Whether this was an API call (true) or MMW UI call (false)'),
+        ),
+        migrations.AddField(
+            model_name='requestlog',
+            name='referrer',
+            field=models.CharField(help_text='The referrer from which the request was sent', max_length=400, null=True),
+        ),
+    ]

--- a/src/mmw/apps/core/models.py
+++ b/src/mmw/apps/core/models.py
@@ -49,6 +49,13 @@ class RequestLog(models.Model):
         help_text='The host from which the request was sent')
     remote_addr = models.GenericIPAddressField(
         help_text='The IP address from which the request was sent')
+    referrer = models.CharField(
+        null=True,
+        max_length=400,
+        help_text='The referrer from which the request was sent')
+    api = models.BooleanField(
+        default=True,
+        help_text='Whether this was an API call (true) or MMW UI call (false)')
 
     def __unicode__(self):
         return self.user + " " + self.path

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -86,7 +86,8 @@ def get_auth_token(request, format=None):
 
 
 @decorators.api_view(['POST'])
-@decorators.authentication_classes((TokenAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
@@ -259,7 +260,8 @@ def start_rwd(request, format=None):
 
 
 @decorators.api_view(['POST'])
-@decorators.authentication_classes((TokenAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
@@ -453,7 +455,8 @@ def start_analyze_land(request, format=None):
 
 
 @decorators.api_view(['POST'])
-@decorators.authentication_classes((TokenAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
@@ -579,7 +582,8 @@ def start_analyze_soil(request, format=None):
 
 
 @decorators.api_view(['POST'])
-@decorators.authentication_classes((TokenAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
@@ -741,7 +745,8 @@ def start_analyze_streams(request, format=None):
 
 
 @decorators.api_view(['POST'])
-@decorators.authentication_classes((TokenAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
@@ -851,7 +856,8 @@ def start_analyze_animals(request, format=None):
 
 
 @decorators.api_view(['POST'])
-@decorators.authentication_classes((TokenAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
@@ -940,7 +946,8 @@ def start_analyze_pointsource(request, format=None):
 
 
 @decorators.api_view(['POST'])
-@decorators.authentication_classes((TokenAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
@@ -1058,7 +1065,8 @@ def start_analyze_catchment_water_quality(request, format=None):
 
 
 @decorators.api_view(['POST'])
-@decorators.authentication_classes((TokenAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
@@ -1169,7 +1177,8 @@ def start_analyze_climate(request, format=None):
 
 
 @decorators.api_view(['POST'])
-@decorators.authentication_classes((TokenAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -165,6 +165,7 @@ def scenario(request, scen_id):
 
 @decorators.api_view(['POST'])
 @decorators.permission_classes((AllowAny, ))
+@log_request
 def start_gwlfe(request, format=None):
     """
     Starts a job to run GWLF-E.
@@ -227,6 +228,7 @@ def _initiate_subbasin_gwlfe_job_chain(model_input, inputmod_hash, job_id):
 
 @decorators.api_view(['POST'])
 @decorators.permission_classes((AllowAny, ))
+@log_request
 def start_mapshed(request, format=None):
     """
     Starts a MapShed job which gathers data from various sources which
@@ -321,6 +323,7 @@ def export_gms(request, format=None):
 
 @decorators.api_view(['POST'])
 @decorators.permission_classes((AllowAny, ))
+@log_request
 def start_tr55(request, format=None):
 
     user = request.user if request.user.is_authenticated() else None

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -462,8 +462,8 @@ def drb_point_sources(request):
 
 
 @decorators.api_view(['GET'])
-@decorators.authentication_classes((TokenAuthentication,
-                                    SessionAuthentication, ))
+@decorators.authentication_classes((SessionAuthentication,
+                                    TokenAuthentication, ))
 @decorators.permission_classes((AllowAny, ))
 @log_request
 def get_job(request, job_uuid, format=None):


### PR DESCRIPTION
## Overview

Adds MMW Users to API request logging by adding `SessionAuthentication` as an option to all API fields, and adding an `api` field to the `RequestLog` table that is `True` when using `TokenAuthentication` and `False` otherwise.

To see all legitimate API requests, run:

```sql
SELECT l.*
FROM core_requestlog l INNER JOIN auth_user u ON l.user_id = u.id
WHERE l.path LIKE '/api%'
  AND u.username <> 'mmw|client_app_user'
  AND l.api = 'true';
```

To see logged-in UI requests for API paths, run:

```sql
SELECT l.*
FROM core_requestlog l INNER JOIN auth_user u ON l.user_id = u.id
WHERE l.path LIKE '/api%'
  AND l.api = 'false';
```

To see anonymous UI requests for API paths, run:

```sql
SELECT l.*
FROM core_requestlog l INNER JOIN auth_user u ON l.user_id = u.id
WHERE l.path LIKE '/api%'
  AND u.username = 'mmw|client_app_user'
  AND l.api = 'true';
```

To see logged-in requests for non-API paths, run:

```sql
SELECT l.*
FROM core_requestlog l
WHERE l.path NOT LIKE '/api%'
  AND l.user_id IS NOT NULL;
```

To see anonymous requests for non-API paths, run:

```sql
SELECT l.*
FROM core_requestlog l
WHERE l.path NOT LIKE '/api%'
  AND l.user_id IS NULL;
```

Connects #2451 

### Notes

The `core_requestlog.api` field is meaningless when the `path` does not begin with `/api`. Going forward, all those requests will have `api=False`, but for all existing rows they will have `api=True`. However, this doesn't matter, as they cannot be accessed via API anyway.

## Testing Instructions

* Check out this branch and run migrations `./scripts/manage.sh migrate`
* Make some requests via the front-end when logged in.
* Make some anonymously.
* Make some via the API.
* Ensure they are all logged according to the description above.