### PR TITLE
HydroShare Export Design Tweaks

### DIFF
--- a/src/mmw/js/src/core/modals/templates/hydroShareExportModal.html
+++ b/src/mmw/js/src/core/modals/templates/hydroShareExportModal.html
@@ -11,10 +11,12 @@
             <div>
                 <label class="modal-text-input-label" for="hydroshare-title">Title</label>
                 <input class="modal-text-input" name="hydroshare-title" type="text" id="hydroshare-title" required value="{{ name }}">
+                <span class="modal-text-input-error hidden" id="hydroshare-title-error">Title is required.</span>
             </div>
             <div>
                 <label class="modal-text-input-label" for="hydroshare-abstract">Abstract</label>
                 <textarea class="modal-text-input" name="hydroshare-abstract" id="hydroshare-abstract" required rows="4"></textarea>
+                <span class="modal-text-input-error hidden" id="hydroshare-abstract-error">Abstract is required.</span>
             </div>
             <div>
                 <label class="modal-text-input-label" for="hydroshare-keywords">Keywords <small>(optional)</small></label>

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -356,7 +356,9 @@ var HydroShareView = ModalBaseView.extend({
 
     ui: {
         'title': '#hydroshare-title',
+        'titleError': '#hydroshare-title-error',
         'abstract': '#hydroshare-abstract',
+        'abstractError': '#hydroshare-abstract-error',
         'keywords': '#hydroshare-keywords',
         'export': '.btn-active',
         'cancel': '.btn-default',
@@ -371,6 +373,18 @@ var HydroShareView = ModalBaseView.extend({
         var title = this.ui.title.val().trim(),
             abstract = this.ui.abstract.val().trim(),
             keywords = this.ui.keywords.val().trim();
+
+        if (title === "") {
+            this.ui.titleError.removeClass('hidden');
+        } else {
+            this.ui.titleError.addClass('hidden');
+        }
+
+        if (abstract === "") {
+            this.ui.abstractError.removeClass('hidden');
+        } else {
+            this.ui.abstractError.addClass('hidden');
+        }
 
         if (title === "" || abstract === "") {
             return;

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -324,13 +324,16 @@ var MultiShareView = ModalBaseView.extend({
             onDeny = _.bind(self.render, self),
             confirm = new ConfirmLargeView({
                 model: new models.ConfirmModel({
-                    titleText: 'Unsynchronize Project',
+                    titleText: 'Remove Resource from HydroShare',
                     question: [
-                        'Unsynchronizing your project from HydroShare will ' +
-                        'delete that resource. There is no way to undo this. ' +
-                        'Continue?'
+                        'This will delete the resource in HydroShare. ' +
+                        'If you enable HydroShare Export for this project ' +
+                        'again, it will create a new HydroShare resource. ' +
+                        'Any details added to the resource directly in ' +
+                        'HydroShare will be permanently lost. This cannot ' +
+                        'be undone. Continue?'
                     ],
-                    confirmLabel: 'Unsynchronize',
+                    confirmLabel: 'Remove from HydroShare',
                 })
             });
 

--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -10,11 +10,6 @@
             <ul class="dropdown-menu menu-left" role="menu">
                 {% if not is_new and editable %}
                     <li role="presentation">
-                        <a role="menuitem" tabindex="-1" data-toggle="modal" id="share-project">
-                            Share
-                        </a>
-                    </li>
-                    <li role="presentation">
                         <a role="menuitem" tabindex="-1" data-toggle="modal" id="delete-project">
                             Delete
                         </a>
@@ -85,6 +80,11 @@
 </div>
 
 <div class="project-right">
+    {% if not is_new and editable %}
+    <button class="btn btn-md btn-secondary {{ 'is-exporting' if is_exporting }}" id="share-project">
+        Share
+    </button>
+    {% endif %}
     <button class="btn btn-md btn-secondary" id="new-project">
         New Project
     </button>

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -278,7 +278,6 @@ describe('Modeling', function() {
                     view = new views.ProjectMenuView({ model: project }),
                     projectResponse = '{"id":21,"user":{"id":1,"username":"test","email":"test@azavea.com"},"scenarios":[],"name":"Test Project","area_of_interest":{},"is_private":true,"model_package":"tr-55","created_at":"2015-06-03T20:09:11.988948Z","modified_at":"2015-06-03T20:09:11.988988Z"}',
                     postSaveMenuItems = [
-                        'Share',
                         'Delete',
                         'Rename',
                         '',
@@ -324,7 +323,6 @@ describe('Modeling', function() {
                     view = new views.ProjectMenuView({ model: project }),
                     projectResponse = '{"id":21,"user":{"id":1,"username":"test","email":"test@azavea.com"},"scenarios":[],"name":"Test Project","area_of_interest":{},"is_private":true,"model_package":"tr-55","created_at":"2015-06-03T20:09:11.988948Z","modified_at":"2015-06-03T20:09:11.988988Z"}',
                     postSaveMenuItems = [
-                        'Share',
                         'Delete',
                         'Rename',
                         'Embed in ITSI',

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -109,6 +109,9 @@ header {
       }
       .project-right {
           margin-right: 8px;
+          .btn + .btn {
+            margin-left: 8px;
+          }
       }
 
       .project-title {

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -322,3 +322,26 @@
     }
   }
 }
+
+.hydroshare-modal {
+  .modal-text-input-label {
+    margin-top: 2.5rem;
+  }
+
+  .modal-content .modal-text-input {
+    margin-bottom: 0.5rem;
+  }
+
+  .modal-text-input-error {
+    display: block;
+    padding: 0.75rem;
+    border: 1px solid $ui-danger;
+    color: $ui-danger;
+    background: $ui-danger-18;
+  }
+
+  textarea {
+    border: 1px solid #ccc;
+    color: #333;
+  }
+}

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -19,6 +19,7 @@ $ui-light: #eceff1; /*Light Grey*/
 $ui-medium-light: #BDBDBD; /* Medium Light Grey */
 $ui-grey: #787878 ; /* Output Tab Bar */
 $ui-danger: #e0412d; /*Errors*/
+$ui-danger-18: rgba(224, 65, 45, 0.18); /* Error Background */
 $ui-warning: #e4b72f; /*Warnings*/
 $active: #51dec2; /*Bright*/
 $brand-primary: #389b9b; /*Teal*/


### PR DESCRIPTION
## Overview

Updates language, adds validation, and makes the share button more prominent. Adds an `is-exporting` class to the share button when an export is in progress, to be styled later.

Also tagging @jfrankl for visual review.

Connects #2579 

### Demo

Updated language for disconnecting from HydroShare:

![image](https://user-images.githubusercontent.com/1430060/34798949-de4b237a-f62b-11e7-8c99-70757abbfe8f.png)

New Share button position:

![image](https://user-images.githubusercontent.com/1430060/34798952-e6a065bc-f62b-11e7-9604-a07da90d9f92.png)

Validation Messages:

![image](https://user-images.githubusercontent.com/1430060/34798975-fa55d13c-f62b-11e7-9fb7-bf363c2b88bf.png)

## Testing Instructions

* Checkout this branch and `bundle`
* Go to a project details view. Ensure you see the new Share button. Clicking it should behave identically to previous behavior when it was in the project menu.
* Try exporting something to HydroShare. Leave the abstract blank. Leave the title blank. Leave both blank. Ensure the error messages are shown and hidden appropriately.
* Disconnect from HydroShare. Review the language and suggest changes (if any).