### PR TITLE
Handle HydroShare Resource Not Found Error

### DIFF
--- a/src/mmw/apps/export/hydroshare.py
+++ b/src/mmw/apps/export/hydroshare.py
@@ -114,3 +114,10 @@ class HydroShareClient(HydroShare):
 
                 # Add the new file
                 self.addResourceFile(resource_id, fio, fname)
+
+    def check_resource_exists(self, resource_id):
+        try:
+            self.getSystemMetadata(resource_id)
+            return True
+        except HydroShareNotFound:
+            return False

--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -60,6 +60,13 @@ def hydroshare(request):
 
     # GET existing resource simply returns it
     if hsresource and request.method == 'GET':
+        if not hs.check_resource_exists(hsresource.resource):
+            return Response(
+                data={
+                    'errors': ['HydroShare could not find requested resource']
+                },
+                status=status.HTTP_404_NOT_FOUND
+            )
         serializer = HydroShareResourceSerializer(hsresource)
         return Response(serializer.data)
 
@@ -78,7 +85,8 @@ def hydroshare(request):
 
     # DELETE existing resource removes it from MMW and HydroShare
     if hsresource and request.method == 'DELETE':
-        hs.deleteResource(hsresource.resource)
+        if hs.check_resource_exists(hsresource.resource):
+            hs.deleteResource(hsresource.resource)
         hsresource.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -88,6 +96,15 @@ def hydroshare(request):
 
     # POST existing resource updates it
     if hsresource and request.method == 'POST':
+        # Make sure resource still exists on hydroshare
+        if not hs.check_resource_exists(hsresource.resource):
+            return Response(
+                data={
+                    'errors': ['HydroShare could not find requested resource']
+                },
+                status=status.HTTP_404_NOT_FOUND
+            )
+
         # Update files
         files = params.get('files', [])
         for md in params.get('mapshed_data', []):

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -30,7 +30,11 @@
                     {% if is_exporting %}
                     <i class="hydroshare-spinner fa fa-circle-o-notch fa-spin"></i>
                     {% elif hydroshare_errors.length > 0 %}
-                    <i class="fa fa-warning hydroshare-warning" title=" {{hydroshare_errors.join('\n')}} "></i>
+                    <a class="error-popover" tabindex="0"
+                       role="button" data-content="{{ hydroshare_errors.join('\n') }}">
+
+                        <i class="fa fa-warning ui-danger hydroshare-warning"></i>
+                    </a>
                     {% endif %}
                     <h3>HydroShare Export</h3>
                     <label class="pull-right toggle">

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -29,6 +29,8 @@
                 <div class="row toggle-row">
                     {% if is_exporting %}
                     <i class="hydroshare-spinner fa fa-circle-o-notch fa-spin"></i>
+                    {% elif hydroshare_errors.length > 0 %}
+                    <i class="fa fa-warning hydroshare-warning" title=" {{hydroshare_errors.join('\n')}} "></i>
                     {% endif %}
                     <h3>HydroShare Export</h3>
                     <label class="pull-right toggle">
@@ -58,7 +60,7 @@
                     </label>
                     <p>
                         <span class="hydroshare-timestamp">Last change: {{ hydroshare.exported_at | toFriendlyDate }}</span>
-                        <a href="#" class="hydroshare-export {{ 'hidden' if hydroshare.autosync or is_exporting }}">Export Now</a>
+                        <a href="#" class="hydroshare-export {{ 'hidden' if hydroshare.autosync or is_exporting or hydroshare_errors.length > 0 }}">Export Now</a>
                     </p>
                 </div>
                 {% endif %}

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -234,7 +234,7 @@ var MultiShareView = ModalBaseView.extend({
     }, ModalBaseView.prototype.events),
 
     modelEvents: {
-        'change:is_private, change:is_exporting': 'render',
+        'change:is_private change:is_exporting change:hydroshare_errors': 'render',
     },
 
     templateHelpers: function() {

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -224,6 +224,7 @@ var MultiShareView = ModalBaseView.extend({
         'hydroShareSpinner': '.hydroshare-spinner',
         'hydroShareExport': '.hydroshare-export',
         'hydroShareAutosync': '#hydroshare-autosync',
+        'hydroShareError': '.error-popover',
     },
 
     events: _.defaults({
@@ -259,6 +260,15 @@ var MultiShareView = ModalBaseView.extend({
 
             this.$el.modal('show');
         }
+
+        this.enablePopovers();
+    },
+
+    enablePopovers: function() {
+        this.ui.hydroShareError.popover({
+            placement: 'top',
+            trigger: 'focus',
+        });
     },
 
     onLinkToggle: function(e) {

--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -81,7 +81,8 @@
 
 <div class="project-right">
     {% if not is_new and editable %}
-    <button class="btn btn-md btn-secondary {{ 'is-exporting' if is_exporting }}" id="share-project">
+    <button class="btn btn-md btn-secondary {{ 'is-exporting' if is_exporting }} {{ 'error' if hydroshare_errors.length > 0 }}"
+            id="share-project">
         Share
     </button>
     {% endif %}

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -257,7 +257,8 @@
     margin-bottom: 1rem !important;
   }
 
-  .hydroshare-spinner {
+  .hydroshare-spinner,
+  .hydroshare-warning {
     margin: 12px;
   }
 


### PR DESCRIPTION
## Overview

It's possible for a user to delete their MMW-linked resource on HydroShare. When this happens, HydroShare will throw a `HydroShareNotFound` exception on any subsequent actions we try to take on the resource. 

~Rather than add catch-blocks for every request type, I've opted to add a check in the beginning for all calls that tries to get metadata off the resource and responds with a 404 if the check fails.~ I've moved the checks into each HTTP Method subsection in `export/views`.

The UI handles the 404 by adding a warning icon to the modal, and a yet-unused error class to the share button.

Connects #2583 

Removing the commas from the `modelEvents` in the share modal incidentally fixed the link-sharing bug where toggling link sharing didn't show/hide the copy section.

Connects #2599 

### Demo

![r6prdgfn9c](https://user-images.githubusercontent.com/7633670/34875878-185f2588-f76d-11e7-98ba-c43a871be1d4.gif)
<img width="402" alt="screen shot 2018-01-12 at 7 26 43 am" src="https://user-images.githubusercontent.com/7633670/34875891-24faf16e-f76d-11e7-9502-ea54c3a2d5aa.png">

@jfrankl, I added `.error` to the share button on error.
<img width="432" alt="screen shot 2018-01-12 at 7 27 14 am" src="https://user-images.githubusercontent.com/7633670/34875892-25176754-f76d-11e7-8639-facab0dde723.png">

_Link share fix_
![dzwp4wdnqy](https://user-images.githubusercontent.com/7633670/34877800-8a091f56-f775-11e7-824c-b6df3f4129ae.gif)


## Testing Instructions

 * Pull this branch, and `bundle`
 * Link a project to hydroshare, then on the hydroshare site, delete the resource
 * Trigger an export either by updating the project if you had autosync on, or by clicking "Export Now" and confirm the share modal displays a warning triangle and the share button adds an "error" class. 
 * Confirm toggling the autosync resets itself and displays the warning triangle
 * Click the warning triangle and confirm there's a popover
 * Switch off the hydroshare connection and confirm you can resync on a new project okay.
* Confirm switching the link sharing on and off shows and hides the link-copy area