### PR TITLE
Make Geocoder Boundary Result Highlightable

### DIFF
--- a/src/mmw/js/src/geocode/templates/search.html
+++ b/src/mmw/js/src/geocode/templates/search.html
@@ -1,9 +1,6 @@
 <input class="search-input" id="geocoder-search" type="text"
-       {%- if selectedSuggestion %}
-           placeholder="{{selectedSuggestion.get('text')}}"
-       {%- else %}
-           placeholder="Jump to location or HUC"
-       {% endif -%}
+       value="{{query or (selectedSuggestion and selectedSuggestion.get('text'))}}"
+       placeholder="Jump to location or HUC"
 >
 <i class="search-icon fa fa-search"></i>
 {% if selectedSuggestion and selectedSuggestion.get('isBoundaryLayer') %}


### PR DESCRIPTION
## Overview

We were displaying the name of the selected
boundary result as the geocoder input's
placeholder. Display it instead as the input's
value so that it can be edit/selected, copied,
etc.

Connects #2571 

### Demo
![ajarcfdeqf](https://user-images.githubusercontent.com/7633670/34879665-f844bfce-f77b-11e7-93e4-a1b6a587efac.gif)


## Testing Instructions

 * Search for a HUC (eg `Brandywine`) and select a result. 
 * Confirm you can edit the result and select it by double clicking
 * Confirm the geocoder searches again if you change the text and that you can select a new result
