### PR TITLE
Manage Linked Accounts

### DIFF
--- a/src/mmw/apps/user/templates/user/hydroshare-auth.html
+++ b/src/mmw/apps/user/templates/user/hydroshare-auth.html
@@ -40,8 +40,10 @@
             parent.postMessage(message, window.location.origin);
         });
 
+        {% if error %}
         document.getElementById('hydroshare-cancel').addEventListener('click', function() {
             parent.postMessage('mmw-hydroshare-cancel', window.location.origin);
         });
+        {% endif %}
     </script>
 </body>

--- a/src/mmw/apps/user/urls.py
+++ b/src/mmw/apps/user/urls.py
@@ -16,6 +16,7 @@ from apps.user.views import (login,
                              itsi_auth,
                              hydroshare_login,
                              hydroshare_auth,
+                             hydroshare_logout,
                              )
 
 urlpatterns = patterns(
@@ -25,6 +26,7 @@ urlpatterns = patterns(
     url(r'^itsi/authenticate$', itsi_auth, name='itsi_auth'),
     url(r'^hydroshare/login', hydroshare_login, name='hydroshare_login'),
     url(r'^hydroshare/authorize', hydroshare_auth, name='hydroshare_auth'),
+    url(r'^hydroshare/logout', hydroshare_logout, name='hydroshare_logout'),
     url(r'^login$', login, name='login'),
     url(r'^profile$', profile, name='profile'),
     url(r'^sign_up$', sign_up, name='sign_up'),

--- a/src/mmw/js/src/account/models.js
+++ b/src/mmw/js/src/account/models.js
@@ -5,6 +5,7 @@ var _ = require('lodash'),
 
 var ACCOUNT = 'account';
 var PROFILE = 'profile';
+var LINKED_ACCOUNTS = 'linkedAccounts';
 
 var AccountContainerModel = Backbone.Model.extend({
     defaults: {
@@ -73,6 +74,7 @@ var ApiTokenModel = Backbone.Model.extend({
 module.exports = {
     ACCOUNT: ACCOUNT,
     PROFILE: PROFILE,
+    LINKED_ACCOUNTS: LINKED_ACCOUNTS,
     ApiTokenModel: ApiTokenModel,
     AccountContainerModel: AccountContainerModel
 };

--- a/src/mmw/js/src/account/templates/container.html
+++ b/src/mmw/js/src/account/templates/container.html
@@ -12,6 +12,12 @@
         >
             Account
         </button>
+        <button
+                class="page-toggle-button {{'active' if active_page == 'linkedAccounts' }}"
+                data-action="viewlinkedaccounts"
+        >
+            Linked Accounts
+        </button>
     </div>
     <div class="account-page-column">
         <div class="account-page-container"></div>

--- a/src/mmw/js/src/account/templates/linkedAccounts.html
+++ b/src/mmw/js/src/account/templates/linkedAccounts.html
@@ -1,0 +1,27 @@
+<h2>Linked Accounts</h2>
+
+<section class="linked-account-section">
+    <h3>HydroShare</h3>
+    {% if hydroshare %}
+        <p class="linked-account-status active">
+            <i class="fa fa-check"></i> Linked
+        </p>
+    {% else %}
+        <p class="linked-account-status">Not connected</p>
+    {% endif %}
+
+    <p class="linked-account-description">
+        <a href="https://www.hydroshare.org/" target="_blank">HydroShare</a>
+        is an online collaboration environment for sharing data, models,
+        and code.
+    </p>
+
+    <button class="btn btn-md btn-primary {{ 'hidden' if not hydroshare }}"
+        data-action="unlinkHydroShare">
+        Remove Link
+    </button>
+    <button class="btn btn-md btn-active {{ 'hidden' if hydroshare }}"
+        data-action="linkHydroShare">
+        Link Account
+    </button>
+</section>

--- a/src/mmw/js/src/account/templates/linkedAccounts.html
+++ b/src/mmw/js/src/account/templates/linkedAccounts.html
@@ -1,6 +1,6 @@
 <h2>Linked Accounts</h2>
 
-<section class="linked-account-section">
+<section class="linked-account-section hydroshare">
     <h3>HydroShare</h3>
     {% if hydroshare %}
         <p class="linked-account-status active">
@@ -18,10 +18,12 @@
 
     <button class="btn btn-md btn-primary {{ 'hidden' if not hydroshare }}"
         data-action="unlinkHydroShare">
-        Remove Link
+        Remove link
     </button>
     <button class="btn btn-md btn-active {{ 'hidden' if hydroshare }}"
         data-action="linkHydroShare">
         Link Account
     </button>
+
+    <p class="linked-account-error hidden"></p>
 </section>

--- a/src/mmw/js/src/account/views.js
+++ b/src/mmw/js/src/account/views.js
@@ -19,6 +19,36 @@ var $ = require('jquery'),
 
 var LinkedAccountsView = Marionette.ItemView.extend({
     template: linkedAccountsTmpl,
+
+    ui: {
+        linkHydroShare: '[data-action="linkHydroShare"]',
+    },
+
+    events: {
+        'click @ui.linkHydroShare': 'linkHydroShare',
+    },
+
+    modelEvents: {
+        'change': 'render'
+    },
+
+    linkHydroShare: function() {
+        var self = this,
+            iframe = new modalViews.IframeView({
+                model: new modalModels.IframeModel({
+                    href: '/user/hydroshare/login/',
+                    signalSuccess: 'mmw-hydroshare-success',
+                    signalFailure: 'mmw-hydroshare-failure',
+                    signalCancel: 'mmw-hydroshare-cancel',
+                })
+            });
+
+        iframe.render();
+        iframe.on('success', function() {
+            // Fetch user again to save new HydroShare Access state
+            self.model.fetch();
+        });
+    }
 });
 
 var ProfileView = Marionette.ItemView.extend({

--- a/src/mmw/js/src/account/views.js
+++ b/src/mmw/js/src/account/views.js
@@ -13,8 +13,13 @@ var $ = require('jquery'),
     models = require('./models'),
     settings = require('../core/settings'),
     containerTmpl = require('./templates/container.html'),
+    linkedAccountsTmpl = require('./templates/linkedAccounts.html'),
     profileTmpl = require('./templates/profile.html'),
     accountTmpl = require('./templates/account.html');
+
+var LinkedAccountsView = Marionette.ItemView.extend({
+    template: linkedAccountsTmpl,
+});
 
 var ProfileView = Marionette.ItemView.extend({
     template: profileTmpl,
@@ -170,12 +175,14 @@ var AccountContainerView = Marionette.LayoutView.extend({
 
     ui: {
         profile: '[data-action="viewprofile"]',
-        account: '[data-action="viewaccount"]'
+        account: '[data-action="viewaccount"]',
+        linkedAccounts: '[data-action="viewlinkedaccounts"]',
     },
 
     events: {
         'click @ui.profile': 'viewProfile',
-        'click @ui.account': 'viewAccount'
+        'click @ui.account': 'viewAccount',
+        'click @ui.linkedAccounts': 'viewLinkedAccounts',
     },
 
     modelEvents: {
@@ -195,6 +202,11 @@ var AccountContainerView = Marionette.LayoutView.extend({
         var activePage = this.model.get('active_page');
 
         switch(activePage) {
+            case models.LINKED_ACCOUNTS:
+                this.infoContainer.show(new LinkedAccountsView({
+                    model: App.user
+                }));
+                break;
             case models.PROFILE:
                 this.infoContainer.show(new ProfileView({
                     model: this.profileModel
@@ -221,6 +233,10 @@ var AccountContainerView = Marionette.LayoutView.extend({
 
     viewAccount: function() {
         this.model.set('active_page', models.ACCOUNT);
+    },
+
+    viewLinkedAccounts: function() {
+        this.model.set('active_page', models.LINKED_ACCOUNTS);
     }
 });
 

--- a/src/mmw/sass/pages/_account.scss
+++ b/src/mmw/sass/pages/_account.scss
@@ -12,7 +12,7 @@
     transition: 0.3s ease left, 0.3s ease right;
 
     > .page-toggle-column {
-        width: 100px;
+        width: 200px;
     }
 
     > .account-page-column {
@@ -26,6 +26,7 @@
     display: block;
     font-size: $font-size-h4;
     font-weight: lighter;
+    text-align: left;
 
     &.active {
         font-weight: bolder;
@@ -38,7 +39,7 @@
     padding: 2rem;
     box-sizing: content-box;
     box-shadow: 1px 1px 1px 0px rgba(0, 0, 0, 0.5);
-    margin-left: 8em;
+    margin-left: 1em;
     max-width: 700px;
 
     h2 {
@@ -119,5 +120,32 @@
     .btn-save > .spinner:after {
         top: 16px;
         right: -30px;
+    }
+}
+
+.linked-account-section {
+    border: 1px solid $ui-medium-light;
+    border-radius: 4px;
+    padding: 2rem 1rem;
+    display: inline-block;
+    margin: 1rem 1.25rem 1rem 0;
+
+    @media (min-width: 910px) {
+        width: 47%;
+    }
+
+    .linked-account-status {
+        font-size: 18px;
+        font-style: italic;
+        margin: 1rem 0 0.5rem 0;
+
+        &.active {
+            font-style: normal;
+            color: $brand-primary;
+        }
+    }
+
+    .linked-account-description {
+        margin-bottom: 1.5rem;
     }
 }

--- a/src/mmw/sass/pages/_account.scss
+++ b/src/mmw/sass/pages/_account.scss
@@ -148,4 +148,9 @@
     .linked-account-description {
         margin-bottom: 1.5rem;
     }
+
+    .linked-account-error {
+        margin-top: 1rem;
+        color: $ui-danger;
+    }
 }


### PR DESCRIPTION
## Overview

Adds a "Linked Accounts" section to the "My Account" page, where users can manage various third party applications that they have connected to Model My Watershed. Currently there is only one: HydroShare. From this page they can connect or disconnect their account from HydroShare. If they disconnect their account, any linked projects will be disconnected as well, orphaning the corresponding resources on HydroShare. If they reconnect their account, those projects will have to be setup to export again, and they will export to new resources, not the ones they were previously linked to.

Connects #2597 

### Demo

![2018-01-15 17 04 32](https://user-images.githubusercontent.com/1430060/34963429-66be4f50-fa16-11e7-8d90-fa775efa3b05.gif)

Text of the remove link modal:

![image](https://user-images.githubusercontent.com/1430060/34963435-728e88ae-fa16-11e7-8e87-952b7566388b.png)

Tagging @jfrankl and @ajrobbins for visual review.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and log in
* Go the My Accounts page and see the new Linked Accounts section. Ensure sidebar navigation works correctly.
* Try connecting to HydroShare. Ensure you are able to, and the flow makes sense.
* Make a project or two and export it to HydroShare.
* Try disconnecting from HydroShare. Ensure you are able to, and the flow makes sense.
* Ensure the projects created above are no longer connected to HydroShare, but the resources in HydroShare remain and are not deleted.