### PR TITLE
HydroShare Export Details

### DIFF
--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -164,6 +164,11 @@ def hydroshare(request):
                                'area-of-interest.{}'.format(ext))
         os.remove(filename)
 
+    # Make resource public and shareable
+    endpoint = hs.resource(resource)
+    endpoint.public(True)
+    endpoint.shareable(True)
+
     # Link HydroShareResrouce to Project and save
     hsresource = HydroShareResource.objects.create(
         project=project,

--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -169,6 +169,12 @@ def hydroshare(request):
     endpoint.public(True)
     endpoint.shareable(True)
 
+    # Add geographic coverage
+    endpoint.functions.set_file_type({
+        'file_path': 'area-of-interest.shp',
+        'hs_file_type': 'GeoFeature',
+    })
+
     # Link HydroShareResrouce to Project and save
     hsresource = HydroShareResource.objects.create(
         project=project,


### PR DESCRIPTION
## Overview

Makes the resource in HydroShare public and shareable, so it can be seen and discovered by other users with simple search. Also declares the shapefile as a "GeoFeature" which allows HydroShare to display a bounding box around the area of interest in its UI. This may also be used for geospatial filtering of results.

Connects #2578 

### Demo

![screen shot 2018-01-16 at 3 59 03 pm](https://user-images.githubusercontent.com/1430060/35012381-9dcff2fc-fad7-11e7-83a1-2de862a6abed.png)

## Testing Instructions

* Check out this branch
* Go to [:8000/](http://localhost:8000/)
* Create a new project and export to HydroShare. Open the resource in HydroShare.
* Ensure that the resource is public and shareable, and shows the bounding box of the area of interest.