### PR TITLE
HydroShare Export Keyword Bubbles

### DIFF
--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -27,6 +27,7 @@ from serializers import HydroShareResourceSerializer
 hss = HydroShareService()
 HYDROSHARE_BASE_URL = settings.HYDROSHARE['base_url']
 SHAPEFILE_EXTENSIONS = ['cpg', 'dbf', 'prj', 'shp', 'shx']
+DEFAULT_KEYWORDS = set(['mmw', 'model-my-watershed'])
 
 
 @decorators.api_view(['GET', 'POST', 'PATCH', 'DELETE'])
@@ -123,17 +124,16 @@ def hydroshare(request):
         serializer = HydroShareResourceSerializer(hsresource)
         return Response(serializer.data)
 
-    # Convert keywords from comma seperated string to tuple of values
+    # Convert keywords from array to set of values
     keywords = params.get('keywords')
-    keywords = \
-        tuple(map(unicode.strip, keywords.split(','))) if keywords else tuple()
+    keywords = set(keywords) if keywords else set()
 
     # POST new resource creates it in HydroShare
     resource = hs.createResource(
         'CompositeResource',
         params.get('title', project.name),
         abstract=params.get('abstract', ''),
-        keywords=('mmw', 'model-my-watershed') + keywords
+        keywords=tuple(DEFAULT_KEYWORDS | keywords)
     )
 
     # TODO Re-enable once hydroshare/hydroshare#2537 is fixed,

--- a/src/mmw/js/src/core/modals/models.js
+++ b/src/mmw/js/src/core/modals/models.js
@@ -43,6 +43,26 @@ var ShareModel = Backbone.Model.extend({
     }
 });
 
+var HydroShareModel = Backbone.Model.extend({
+    defaults: {
+        title: '',
+        titleError: false,
+        abstract: '',
+        abstractError: false,
+        keywords: [],
+    },
+
+    validate: function() {
+        var title = this.get('title'),
+            abstract = this.get('abstract');
+
+        this.set('titleError', title === '');
+        this.set('abstractError', abstract === '');
+
+        return !(title === '' || abstract === '');
+    }
+});
+
 var IframeModel = Backbone.Model.extend({
     defaults: {
         href: '',
@@ -82,6 +102,7 @@ module.exports = {
     InputModel: InputModel,
     ShareModel: ShareModel,
     IframeModel: IframeModel,
+    HydroShareModel: HydroShareModel,
     AlertTypes: AlertTypes,
     AlertModel: AlertModel
 };

--- a/src/mmw/js/src/core/modals/templates/hydroShareExportModal.html
+++ b/src/mmw/js/src/core/modals/templates/hydroShareExportModal.html
@@ -27,14 +27,14 @@
                 <div class="input-group">
                     <input class="form-control modal-text-input" name="hydroshare-keyword" id="hydroshare-keyword" type="text">
                     <span class="input-group-btn">
-                        <button class="btn btn-active" type="button" id="hydroshare-add-keyword">
+                        <button class="btn btn-active" type="button" id="hydroshare-add-keyword" tabindex="-1">
                             Add keyword
                         </button>
                     </span>
                 </div>
                 <div id="hydroshare-keywords">
                     {% for keyword in keywords %}
-                        <span class="hydroshare-keyword">
+                        <span class="hydroshare-keyword" tabindex="0">
                             {{ keyword }}
                             <i class="fa fa-times hydroshare-keyword-delete" data-keyword="{{ keyword }}"></i>
                         </span>

--- a/src/mmw/js/src/core/modals/templates/hydroShareExportModal.html
+++ b/src/mmw/js/src/core/modals/templates/hydroShareExportModal.html
@@ -10,23 +10,42 @@
             </p>
             <div>
                 <label class="modal-text-input-label" for="hydroshare-title">Title</label>
-                <input class="modal-text-input" name="hydroshare-title" type="text" id="hydroshare-title" required value="{{ name }}">
-                <span class="modal-text-input-error hidden" id="hydroshare-title-error">Title is required.</span>
+                <input class="modal-text-input" name="hydroshare-title" type="text" id="hydroshare-title" required value="{{ title }}">
+                {% if titleError %}
+                    <span class="modal-text-input-error" id="hydroshare-title-error">Title is required.</span>
+                {% endif %}
             </div>
             <div>
                 <label class="modal-text-input-label" for="hydroshare-abstract">Abstract</label>
-                <textarea class="modal-text-input" name="hydroshare-abstract" id="hydroshare-abstract" required rows="4"></textarea>
-                <span class="modal-text-input-error hidden" id="hydroshare-abstract-error">Abstract is required.</span>
+                <textarea class="modal-text-input" name="hydroshare-abstract" id="hydroshare-abstract" required rows="4">{{ abstract }}</textarea>
+                {% if abstractError %}
+                    <span class="modal-text-input-error" id="hydroshare-abstract-error">Abstract is required.</span>
+                {% endif %}
             </div>
             <div>
-                <label class="modal-text-input-label" for="hydroshare-keywords">Keywords <small>(optional)</small></label>
-                <input class="modal-text-input" name="hydroshare-keywords" type="text" id="hydroshare-keywords" placeholder="comma, separated, values">
+                <label class="modal-text-input-label" for="hydroshare-keyword">Keywords <small>(optional)</small></label>
+                <div class="input-group">
+                    <input class="form-control modal-text-input" name="hydroshare-keyword" id="hydroshare-keyword" type="text">
+                    <span class="input-group-btn">
+                        <button class="btn btn-active" type="button" id="hydroshare-add-keyword">
+                            Add keyword
+                        </button>
+                    </span>
+                </div>
+                <div id="hydroshare-keywords">
+                    {% for keyword in keywords %}
+                        <span class="hydroshare-keyword">
+                            {{ keyword }}
+                            <i class="fa fa-times hydroshare-keyword-delete" data-keyword="{{ keyword }}"></i>
+                        </span>
+                    {% endfor %}
+                </div>
             </div>
         </div>
         <div class="modal-footer" style="text-align:right;">
             <div class="footer-content">
                 <button type="button" class="btn btn-md btn-default" data-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-md btn-active">Export</button>
+                <button type="button" class="btn btn-md btn-active" id="hydroshare-export-button">Export</button>
             </div>
         </div>
     </div>

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -443,7 +443,10 @@ var HydroShareView = ModalBaseView.extend({
     },
 
     onKeyUp: function(e) {
-        if (e.keyCode === ENTER_KEYCODE && !this.ui.abstract.is(':focus')) {
+        if (e.keyCode === ENTER_KEYCODE &&
+            !this.ui.abstract.is(':focus') &&
+            !this.ui.export.is(':focus')) {
+
             if (this.ui.keyword.is(':focus')) {
                 this.addKeyword();
             } else {

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -321,6 +321,7 @@ CORS_URLS_REGEX = r'^/api/.*$'
 
 SWAGGER_SETTINGS = {
     'exclude_namespaces': ['bigcz',
+                           'export',
                            'mmw',
                            'user'],
     'doc_expansion': 'list',

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -345,4 +345,30 @@
     border: 1px solid #ccc;
     color: #333;
   }
+
+  .input-group {
+    > input {
+      box-shadow: none;
+      border-radius: 0;
+    }
+
+    button {
+      border-radius: 0 !important;
+      font-weight: normal !important;
+    }
+  }
+
+  .hydroshare-keyword {
+    display: inline-block;
+    color: $ui-light;
+    background: $ui-primary;
+    padding: 0.75rem;
+    margin: 0.25rem 0.1rem;
+    border-radius: 4px;
+
+    .hydroshare-keyword-delete {
+      margin-left: 0.5rem;
+      cursor: pointer;
+    }
+  }
 }


### PR DESCRIPTION
## Overview

Adds a "bubble" UI to the HydroShare Export modal that allows users to add and remove keywords before they submit the page.

Also excludes the "export" URLs from Swagger Docs.

Connects #2576 
Connects #2604 

### Demo

![Demo Gif](https://user-images.githubusercontent.com/1430060/35066582-10baa826-fb9f-11e7-8fec-c338651d4a38.gif)

[Demo Gif](https://user-images.githubusercontent.com/1430060/35066582-10baa826-fb9f-11e7-8fec-c338651d4a38.gif)

Tagging @ajrobbins and @jfrankl for visual review.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and open / create a project
* Export to HydroShare. Ensure that if Title or Abstract are empty you get the appropriate error message
* Add and remove keywords in the modal. Ensure that when you submit the exact list shown is what is submitted
* Ensure you cannot add duplicate keywords or empty keywords
* Ensure interaction works well with both mouse and keyboard