### PR TITLE
Fix Share modal behavior in project listing

### DIFF
--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -93,7 +93,10 @@ class ProjectListingSerializer(gis_serializers.GeoModelSerializer):
     class Meta:
         model = Project
         fields = ('id', 'name', 'area_of_interest_name', 'is_private',
-                  'model_package', 'created_at', 'modified_at', 'user')
+                  'model_package', 'created_at', 'modified_at', 'user',
+                  'hydroshare')
+
+    hydroshare = HydroShareResourceSerializer(read_only=True)
 
 
 class ProjectUpdateSerializer(gis_serializers.GeoModelSerializer):


### PR DESCRIPTION
## Overview

The Share modal relies on the `project.hydroshare` field, which was missing from the `ProjectListing` serializer. By adding it there, we ensure that the share modal works correctly.

Connects #2611 

### Demo

![2018-01-22 11 17 34](https://user-images.githubusercontent.com/1430060/35231157-0aef357c-ff66-11e7-8cba-f03dbdec1935.gif)

## Testing Instructions

* Check out this branch and `bundle`
* Ensure you have at least one project exported to HydroShare
* Go to the My Projects listing, and click the Share button for any project. Ensure it reflects the correct state of sharing for that project.
* Try sharing a project from the listing page. Ensure it is exported to HydroShare correctly.