### PR TITLE
HydroShare Export Handle Timeout

### DIFF
--- a/src/mmw/apps/export/hydroshare.py
+++ b/src/mmw/apps/export/hydroshare.py
@@ -121,3 +121,9 @@ class HydroShareClient(HydroShare):
             return True
         except HydroShareNotFound:
             return False
+
+    def get_file_list(self, resource_id):
+        try:
+            return self.getResourceFileList(resource_id)
+        except HydroShareNotFound:
+            return None

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -467,7 +467,13 @@ var ProjectModel = Backbone.Model.extend({
             self.set('hydroshare', result);
             self.set('hydroshare_errors', []);
         }).fail(function(result) {
-            self.set('hydroshare_errors', result.responseJSON.errors);
+            if (result.responseJSON && result.responseJSON.errors) {
+                self.set('hydroshare_errors', result.responseJSON.errors);
+            } else if (result.status === 504) {
+                self.set('hydroshare_errors', ['Server Timeout']);
+            } else {
+                self.set('hydroshare_errors', ['Unknown Server Error']);
+            }
         }) .always(function() {
             self.set('is_exporting', false);
         });


### PR DESCRIPTION
## Overview

Prevents front-end crash from HydroShare export timeouts. Also shortens re-export time by skipping pre-exported analyses.

Connects #2615 

## Testing Instructions

* On `develop`, export a MapShed project to HydroShare. Then add a scenario / make a change. Observe the network tab and the console, and see the timeout and JavaScript error.
* Check out this branch, but only the first commit 532c6605. Update your project and see the timeout now being handled in the front-end.
* Now checkout the second commit 0b54dc18. Update your project and see no timeout.