### PR TITLE
HydroShare Export Shapefiles into Folder

### DIFF
--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -27,7 +27,7 @@ from serializers import HydroShareResourceSerializer
 hss = HydroShareService()
 HYDROSHARE_BASE_URL = settings.HYDROSHARE['base_url']
 SHAPEFILE_EXTENSIONS = ['cpg', 'dbf', 'prj', 'shp', 'shx']
-DEFAULT_KEYWORDS = set(['mmw', 'model-my-watershed'])
+DEFAULT_KEYWORDS = {'mmw', 'model-my-watershed'}
 
 
 @decorators.api_view(['GET', 'POST', 'PATCH', 'DELETE'])

--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -146,12 +146,6 @@ def hydroshare(request):
         keywords=tuple(DEFAULT_KEYWORDS | keywords)
     )
 
-    # TODO Re-enable once hydroshare/hydroshare#2537 is fixed,
-    #      and export all GeoJSON and Shapefiles in that folder
-
-    # aoi_folder = 'area-of-interest'
-    # hs.createResourceFolder(resource, pathname=aoi_folder)
-
     # Files sent from the client
     files = params.get('files', [])
 


### PR DESCRIPTION
## Overview

Previously there was a separate card and strategy to accomplish this. However, it seems to have been accidentally accomplished as a side effect of #2609. This PR removes instructions to add this feature.

Connects #2572 

## Testing Instructions

* Check out this branch
* Export a project to HydroShare
* Ensure the shapefiles are grouped in a folder in HydroShare