### PR TITLE
Add help text tooltips to stream tab

### DIFF
--- a/src/mmw/js/src/analyze/templates/streamLengthPopover.html
+++ b/src/mmw/js/src/analyze/templates/streamLengthPopover.html
@@ -1,0 +1,8 @@
+<a class="help" data-toggle="popover" tabindex="0"
+   data-html="true" data-container="body" role="button"
+   data-content="Derived using a uniform one-pixel (30m) riparian width for flowlines. <br> See our <a href='https://wikiwatershed.org/documentation/mmw-tech/#analyze-area-of-interest-aoi' target='_blank'>documentation on streams</a>."
+   data-template="<div class='popover'><div class='pull-right'
+     id='popover-close-button'><i class='fa fa-times' /></div><div
+     class='popover-content'></div><div class='arrow'></div></div>">
+   <i class="fa fa-info-circle black"></i>
+</a>

--- a/src/mmw/js/src/analyze/templates/streamTable.html
+++ b/src/mmw/js/src/analyze/templates/streamTable.html
@@ -31,8 +31,10 @@
 <div id="streams-tab-ag-section">
     <div class="streams-tab-ag-line-item">
         Length in agricultural areas = {{ lengthInAg|round(2)|toLocaleString(2) }} km
+        {% include "./streamLengthPopover.html" %}
     </div>
     <div class="streams-tab-ag-line-item">
         Length in non-agricultural areas = {{ lengthInNonAg|round(2)|toLocaleString(2) }} km
+        {% include "./streamLengthPopover.html" %}
     </div>
 </div>

--- a/src/mmw/js/src/analyze/templates/streamTableRow.html
+++ b/src/mmw/js/src/analyze/templates/streamTableRow.html
@@ -1,5 +1,15 @@
 <td>
     {{ displayOrder }}
+    {% if helpText %}
+        <a class="help" data-toggle="popover" tabindex="0"
+           data-html="true" data-container="body" role="button"
+           data-content="{{helpText}}"
+           data-template="<div class='popover'><div class='pull-right'
+             id='popover-close-button'><i class='fa fa-times' /></div><div
+             class='popover-content'></div><div class='arrow'></div></div>">
+           <i class="fa fa-info-circle black"></i>
+        </a>
+    {% endif %}
 </td>
 <td class="strong text-right">
     {{ lengthkm|round(2)|toLocaleString(2) }}

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -669,7 +669,7 @@ var StreamTableRowView = Marionette.ItemView.extend({
             avgslope: this.model.get('avgslope'),
             noData: utils.noData,
         };
-    }
+    },
 });
 
 var StreamTableView = Marionette.CompositeView.extend({
@@ -677,8 +677,18 @@ var StreamTableView = Marionette.CompositeView.extend({
     childViewContainer: 'tbody',
     template: streamTableTmpl,
 
+    ui: {
+        resultsTable: '[data-toggle="table"]',
+    },
+
     onAttach: function() {
-        $('[data-toggle="table"]').bootstrapTable();
+        this.ui.resultsTable.bootstrapTable();
+
+        // In order to select popover toggles rendered in the
+        // child view, select them directly and not via this.ui
+        this.$('[data-toggle="popover"]').popover({
+            trigger: 'focus',
+        });
     },
 
     templateHelpers: function() {
@@ -1360,7 +1370,21 @@ var StreamResultView = AnalyzeResultView.extend({
             source = 'NHDplusV2',
             helpText = 'For more information on the data source, see <a href=\'https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-in-layers-streams\' target=\'_blank\' >MMW Technical Documentation</a>',
             associatedLayerCodes = ['nhd_streams_v2'],
-            chart = null;
+            chart = null,
+            streamOrderHelpText = [
+                {
+                    order: 999, text: 'Contains canals, artificial paths, coastlines, and other flowlines without a flow direction'
+                }
+            ],
+            streamOrders = this.model.get('categories');
+
+        // Merge helptext in with stream order results
+        _.each(streamOrderHelpText, function(help) {
+            var stream = _.findWhere(streamOrders, { order: help.order });
+            if (stream) {
+                stream.helpText = help.text;
+            }
+        });
 
         this.showAnalyzeResults(coreModels.StreamsCensusCollection, StreamTableView,
                                 chart, title,source, helpText, associatedLayerCodes);

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -94,6 +94,8 @@
     }
     padding-bottom: 6px;
 
+}
+.analyze-tab-content {
     .help > i {
       color: #333333;
       width: 15px;


### PR DESCRIPTION
## Overview

Adds static text for stream length popovers and dynamic text for popovers on each stream order row.  Only "Other" has been provided with  text at present.

Connects #2600 

### Demo

Optional. Screenshots, `curl` examples, etc.
![image](https://user-images.githubusercontent.com/1014341/35307564-3bd2a6fe-0071-11e8-909f-722efbdbd39e.png)


## Testing Instructions

 * Analyze any AoI and verify that 3 new tooltips are added for the items listed in the connected issue.
