### PR TITLE
Download Area of Interest

### DIFF
--- a/src/mmw/apps/export/urls.py
+++ b/src/mmw/apps/export/urls.py
@@ -5,9 +5,10 @@ from __future__ import division
 
 from django.conf.urls import patterns, url
 
-from apps.export.views import hydroshare
+from apps.export.views import hydroshare, shapefile
 
 urlpatterns = patterns(
     '',
     url(r'^hydroshare/?$', hydroshare, name='hydroshare'),
+    url(r'^shapefile/?$', shapefile, name='shapefile'),
 )

--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -6,10 +6,14 @@ from __future__ import division
 import fiona
 import json
 import os
+import StringIO
+import tempfile
+import zipfile
 
 from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 
@@ -215,3 +219,49 @@ def hydroshare(request):
     # Return newly created HydroShareResource
     serializer = HydroShareResourceSerializer(hsresource)
     return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+@decorators.api_view(['POST'])
+def shapefile(request):
+    """Convert a GeoJSON to a Shapefile"""
+
+    # Extract area of interest into a dictionary
+    params = request.data
+    aoi_json = json.loads(params.get('shape', '{}'))
+    filename = params.get('filename', 'area-of-interest')
+
+    # TODO Validate Shape
+
+    # Configure Shapefile Settings
+    crs = {'no_defs': True, 'proj': 'longlat',
+           'ellps': 'WGS84', 'datum': 'WGS84'}
+    schema = {'geometry': aoi_json['type'], 'properties': {}}
+
+    # Make a temporary directory to save the files in
+    tempdir = tempfile.mkdtemp()
+
+    # Write shapefiles
+    with fiona.open('{}/area-of-interest.shp'.format(tempdir), 'w',
+                    driver='ESRI Shapefile',
+                    crs=crs, schema=schema) as sf:
+        sf.write({'geometry': aoi_json, 'properties': {}})
+
+    shapefiles = ['{}/area-of-interest.{}'.format(tempdir, ext)
+                  for ext in SHAPEFILE_EXTENSIONS]
+
+    # Create a zip file in memory from all the shapefiles
+    stream = StringIO.StringIO()
+    with zipfile.ZipFile(stream, 'w') as zf:
+        for fpath in shapefiles:
+            _, fname = os.path.split(fpath)
+            zf.write(fpath, fname)
+            os.remove(fpath)
+
+    # Delete the temporary directory
+    os.rmdir(tempdir)
+
+    # Return the zip file from memory with appropriate headers
+    resp = HttpResponse(stream.getvalue(), content_type='application/zip')
+    resp['Content-Disposition'] = 'attachment; '\
+                                  'filename="{}.zip"'.format(filename)
+    return resp

--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from apps.modeling.models import Project
+from apps.modeling.serializers import AoiSerializer
 from apps.modeling.tasks import to_gms_file
 
 from hydroshare import HydroShareService
@@ -227,10 +228,13 @@ def shapefile(request):
 
     # Extract area of interest into a dictionary
     params = request.data
-    aoi_json = json.loads(params.get('shape', '{}'))
+    aoi_json = params.get('shape', '{}')
     filename = params.get('filename', 'area-of-interest')
 
-    # TODO Validate Shape
+    # Validate Shape
+    serializer = AoiSerializer(data={'area_of_interest': aoi_json})
+    serializer.is_valid(raise_exception=True)
+    aoi_json = json.loads(serializer.validated_data.get('area_of_interest'))
 
     # Configure Shapefile Settings
     crs = {'no_defs': True, 'proj': 'longlat',

--- a/src/mmw/js/src/analyze/templates/aoiHeader.html
+++ b/src/mmw/js/src/analyze/templates/aoiHeader.html
@@ -1,1 +1,25 @@
+<div class="dropdown">
+    <button type="button" data-toggle="dropdown" class="btn"
+            aria-haspopup="true" aria-expanded="false">
+        <i class="fa fa-download" aria-label="Download"></i>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-right">
+        <li role="presentation">
+            <a role="menuitem" tabindex="-1" id="download-shapefile">
+                Shapefile
+            </a>
+        </li>
+        <li role="presentation">
+            <a role="menuitem" tabindex="-1" id="download-geojson">
+                GeoJSON
+            </a>
+        </li>
+    </ul>
+</div>
+<form id="shapefile-form" method="post" action="/export/shapefile/" target="_blank">
+    <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrftoken }}">
+    <input type="hidden" name="filename" value="{{ place }}">
+    <!-- Put `shape` in single quotes, to keep any unescaped chars from breaking the template -->
+    <input type="hidden" name="shape" value='{{ shape }}' />
+</form>
 <h2>{{ place }}<span class="aoi-area">{{ area|round|toLocaleString }} {{ units }}</span></h2>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -9,6 +9,7 @@ var $ = require('jquery'),
     App = require('../app'),
     router = require('../router').router,
     models = require('./models'),
+    csrf = require('../core/csrf'),
     settings = require('../core/settings'),
     modalModels = require('../core/modals/models'),
     modalViews = require('../core/modals/views'),
@@ -372,7 +373,34 @@ var TabContentsView = Marionette.CollectionView.extend({
 });
 
 var AoiView = Marionette.ItemView.extend({
-    template: aoiHeaderTmpl
+    template: aoiHeaderTmpl,
+
+    ui: {
+        'shapefileForm': '#shapefile-form',
+        'dlShapefile': '#download-shapefile',
+        'dlGeojson': '#download-geojson',
+    },
+
+    events: {
+        'click @ui.dlShapefile': 'downloadShapefile',
+        'click @ui.dlGeojson': 'downloadGeojson',
+    },
+
+    templateHelpers: function() {
+        return {
+            csrftoken: csrf.getToken(),
+            shape: JSON.stringify(this.model.get('shape'))
+        };
+    },
+
+    downloadShapefile: function() {
+        this.ui.shapefileForm.submit();
+    },
+
+    downloadGeojson: function() {
+        utils.downloadAsFile(this.model.get('shape'),
+                             this.model.get('place') + '.geojson');
+    }
 });
 
 var AnalyzeLayerToggleView = Marionette.ItemView.extend({

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -637,6 +637,30 @@ var utils = {
             version: version,
             releaseNotesUrl: url
         };
+    },
+
+    // Downloads given data as a text file with given filename
+    downloadAsFile: function(data, filename) {
+        var blob = new Blob([JSON.stringify(data)],
+                            { type: 'data:text/plain;charset=utf-8'}),
+            url = URL.createObjectURL(blob),
+            a = document.createElement('a');
+
+        if (navigator.msSaveBlob) {
+            // IE has a nicer interface for saving blobs
+            navigator.msSaveBlob(blob, filename);
+        } else {
+            // Other browsers have to use a hidden link hack
+            a.style.display = 'none';
+            a.setAttribute('download', filename);
+            a.setAttribute('href', url);
+
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+        }
+
+        URL.revokeObjectURL(url);
     }
 };
 

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -250,10 +250,6 @@ var FormView = Marionette.ItemView.extend({
 
                 return cr;
             }),
-            blob = new Blob([JSON.stringify(data)],
-                            { type: 'data:text/plain;charset=utf-8'}),
-            url = URL.createObjectURL(blob),
-            a = document.createElement('a'),
             dateString = (new Date()).toJSON()
                                      .replace(/[T:]/g, '-')
                                      .substr(0, 19),  // YYYY-MM-DD-hh-mm-ss
@@ -264,21 +260,7 @@ var FormView = Marionette.ItemView.extend({
             filename = 'bigcz-' + catalog.id + '-' +
                        dashedQuery + '-' + dateString + '.json';
 
-        if (navigator.msSaveBlob) {
-            // IE has a nicer interface for saving blobs
-            navigator.msSaveBlob(blob, filename);
-        } else {
-            // Other browsers have to use a hidden link hack
-            a.style.display = 'none';
-            a.setAttribute('download', filename);
-            a.setAttribute('href', url);
-
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-        }
-
-        URL.revokeObjectURL(url);
+        utils.downloadAsFile(data, filename);
     },
 
     getFilters: function() {

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -51,6 +51,15 @@
     line-height: $aoi-header-height / 2;
   }
 
+  .dropdown {
+    float: right;
+
+    button {
+      border: none;
+      background: none;
+    }
+  }
+
   &:empty {
       display: none;
   }


### PR DESCRIPTION
## Overview

Adds a button to the Analyze tab which allows downloading the area of interest as a Shapefile or GeoJSON.

Connects #2603 

### Demo

![2018-01-25 10 41 53](https://user-images.githubusercontent.com/1430060/35397157-be22f612-01bc-11e8-85cf-2f1e263fe8ec.gif)

### Notes

Any recommendations on how to validate the shape?

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and select / draw an area of interest. Notice there is a download button on the top right of the Analyze sidebar.
* Click the button to reveal two options: Shapefile and GeoJSON. Click both and inspect the files in Qgis or similar to verify it is the right shape.
* Ensure this works with different styles of area of interest.
* Ensure that this button is available in the Analyze tab when in the Modeling stage.
* Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and select an area of interest. Search for anything, like "Water". Click the download button in the top right and ensure you can still download a JSON of results.