### PR TITLE
Add text indicating HydroShare license

### DIFF
--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -44,7 +44,9 @@
                 </div>
                 <p class="{{ 'hidden' if hydroshare }}">
                     HydroShare is an online collaboration environment for
-                    sharing data, models, and code.
+                    sharing data, models, and code. When you export to HydroShare,
+                    your project will be made public under a <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">
+                    Creative Commons 4.0</a> license.
                 </p>
                 <p id="hydroshare-notification" class="{{ 'hidden' if user_has_authorized_hydroshare }}">
                     You will need to connect your HydroShare account to your


### PR DESCRIPTION
## Overview

So that users know that their work on HydroShare won't be "private". The license and visibility can be edited on HydroShare after export, so we only show this message prior to export, not after.

Connects #2626 

### Demo

![2018-01-26 10 08 09](https://user-images.githubusercontent.com/1430060/35446089-aaf2edde-0281-11e8-9b70-0296ede496eb.gif)

Tagging @ajrobbins for visual review.

## Testing Instructions

* Check out this branch and `bundle`
* Open the MultiShareModal for a project that hasn't been exported. Ensure you see the additional text.
* Ensure that the text is not visible post-export.
