### PR TITLE
Add Monitor Tab

### DIFF
--- a/src/mmw/js/src/analyze/templates/resultsWindow.html
+++ b/src/mmw/js/src/analyze/templates/resultsWindow.html
@@ -1,8 +1,31 @@
+<div class="sidebar-tab-header output-tabs-wrapper" role="tabpanel">
+    <ul class="nav nav-tabs" role="tablist">
+        <li class="active" role="presentation">
+            <a aria-controls="home" aria-expanded="false"
+                               data-toggle="tab" href="#analyze-tab-contents" role="tab">
+                <div class="sidebar-tab-header-label">
+                    Analyze
+                </div>
+            </a>
+        </li>
+        <li role="presentation">
+            <a aria-controls="home" aria-expanded="false"
+               data-toggle="tab" href="#monitor-tab-contents" role="tab">
+                <div class="sidebar-tab-header-label">
+                    Monitor
+                </div>
+            </a>
+        </li>
+    </ul>
+</div>
+
 <div class="tab-contents-region">
     <div class="tab-content">
         <div class="aoi-region"></div>
         <div role="tabpanel" id="analyze-tab-contents"
             class="tab-pane analyze-stage-results-tab-pane"></div>
+        <div role="tabpanel" id="monitor-tab-contents"
+             class="tab-pane"></div>
     </div>
 </div>
 <div class="navigation-footer">

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -19,6 +19,8 @@ var $ = require('jquery'),
     utils = require('../core/utils'),
     pointSourceLayer = require('../core/pointSourceLayer'),
     catchmentWaterQualityLayer = require('../core/catchmentWaterQualityLayer'),
+    dataCatalogModels = require('../data_catalog/models'),
+    monitorViews = require('../monitor/views'),
     windowTmpl = require('./templates/window.html'),
     AnalyzeDescriptionTmpl = require('./templates/analyzeDescription.html'),
     analyzeResultsTmpl = require('./templates/analyzeResults.html'),
@@ -220,6 +222,11 @@ var ResultsView = Marionette.LayoutView.extend({
     showDetailsRegion: function() {
         this.analyzeRegion.show(new AnalyzeWindow({
             collection: this.collection
+        }));
+
+        this.monitorRegion.show(new monitorViews.MonitorWindow({
+            model: new dataCatalogModels.SearchForm(),
+            collection: App.getDataCatalogCollection(),
         }));
     },
 

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -190,6 +190,7 @@ var ResultsView = Marionette.LayoutView.extend({
     regions: {
         aoiRegion: '.aoi-region',
         analyzeRegion: '#analyze-tab-contents',
+        monitorRegion: '#monitor-tab-contents',
         nextStageRegion: '#next-stage-navigation-region',
     },
 

--- a/src/mmw/js/src/app.js
+++ b/src/mmw/js/src/app.js
@@ -10,6 +10,7 @@ var $ = require('jquery'),
     settings = require('./core/settings'),
     itsi = require('./core/itsiEmbed'),
     analyzeModels = require('./analyze/models'),
+    dataCatalogModels = require('./data_catalog/models'),
     userModels = require('./user/models'),
     userViews = require('./user/views');
 
@@ -117,6 +118,18 @@ var App = new Marionette.Application({
 
     clearAnalyzeCollection: function() {
         delete this.analyzeCollection;
+    },
+
+    getDataCatalogCollection: function() {
+        if (!this.dataCatalogCollection) {
+            this.dataCatalogCollection = dataCatalogModels.createCatalogCollection();
+        }
+
+        return this.dataCatalogCollection;
+    },
+
+    clearDataCatalogCollection: function() {
+        delete this.dataCatalogCollection;
     },
 
     getMapView: function() {

--- a/src/mmw/js/src/data_catalog/controllers.js
+++ b/src/mmw/js/src/data_catalog/controllers.js
@@ -22,37 +22,8 @@ var DataCatalogController = {
         });
 
         var form = new models.SearchForm();
-        var dateFilter = new models.DateFilter();
 
-        var catalogs = new models.Catalogs([
-            new models.Catalog({
-                id: 'cinergi',
-                name: 'CINERGI',
-                active: true,
-                results: new models.Results(null, { catalog: 'cinergi' }),
-                filters: new models.FilterCollection([dateFilter])
-            }),
-            new models.Catalog({
-                id: 'hydroshare',
-                name: 'HydroShare',
-                results: new models.Results(null, { catalog: 'hydroshare' }),
-                filters: new models.FilterCollection([
-                    dateFilter,
-                    new models.PrivateResourcesFilter(),
-                ]),
-            }),
-            new models.Catalog({
-                id: 'cuahsi',
-                name: 'CUAHSI WDC',
-                is_pageable: false,
-                results: new models.Results(null, { catalog: 'cuahsi' }),
-                serverResults: new models.Results(null, { catalog: 'cuahsi' }),
-                filters: new models.FilterCollection([
-                    dateFilter,
-                    new models.GriddedServicesFilter()
-                ])
-            })
-        ]);
+        var catalogs = App.getDataCatalogCollection();
 
         var resultsWindow = new views.ResultsWindow({
                 model: form,

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -877,6 +877,42 @@ var ExpandableListModel = Backbone.Model.extend({
     }
 });
 
+function createCatalogCollection() {
+    var dateFilter = new DateFilter();
+
+    return new Catalogs([
+        new Catalog({
+            id: 'cinergi',
+            name: 'CINERGI',
+            active: true,
+            results: new Results(null, { catalog: 'cinergi' }),
+            filters: new FilterCollection([
+                dateFilter,
+            ]),
+        }),
+        new Catalog({
+            id: 'hydroshare',
+            name: 'HydroShare',
+            results: new Results(null, { catalog: 'hydroshare' }),
+            filters: new FilterCollection([
+                dateFilter,
+                new PrivateResourcesFilter(),
+            ]),
+        }),
+        new Catalog({
+            id: 'cuahsi',
+            name: 'CUAHSI WDC',
+            is_pageable: false,
+            results: new Results(null, { catalog: 'cuahsi' }),
+            serverResults: new Results(null, { catalog: 'cuahsi' }),
+            filters: new FilterCollection([
+                dateFilter,
+                new GriddedServicesFilter()
+            ])
+        })
+    ]);
+}
+
 module.exports = {
     GriddedServicesFilter: GriddedServicesFilter,
     PrivateResourcesFilter: PrivateResourcesFilter,
@@ -893,4 +929,5 @@ module.exports = {
     CuahsiVariable: CuahsiVariable,
     CuahsiVariables: CuahsiVariables,
     ExpandableListModel: ExpandableListModel,
+    createCatalogCollection: createCatalogCollection,
 };

--- a/src/mmw/js/src/monitor/templates/window.html
+++ b/src/mmw/js/src/monitor/templates/window.html
@@ -1,0 +1,19 @@
+<div class="monitor-search">
+    <div class="search-group">
+        <input type="text" class="form-control" placeholder="Search data sources" />
+        <button class="btn btn-active btn-search" type="button">
+            <i class="fa fa-search"></i>
+        </button>
+    </div>
+    <button class="btn btn-secondary">Filter</button>
+</div>
+
+<div class="intro-text">
+    <p>
+        <strong>Sample search terms: "turbidity", "water" &amp; "MODIS".</strong>
+    </p>
+    <p>
+        Start typing to find some datasets that would be useful
+        for your research. You can add filters if dates are important.
+    </p>
+</div>

--- a/src/mmw/js/src/monitor/views.js
+++ b/src/mmw/js/src/monitor/views.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var Marionette = require('../../shim/backbone.marionette'),
+    windowTmpl = require('./templates/window.html');
+
+var MonitorWindow = Marionette.LayoutView.extend({
+    template: windowTmpl,
+    className: 'monitor-window',
+});
+
+module.exports = {
+    MonitorWindow: MonitorWindow
+};

--- a/src/mmw/sass/components/_tabs.scss
+++ b/src/mmw/sass/components/_tabs.scss
@@ -59,8 +59,9 @@
     // Set a specific height to allow y-scroll:
     // Calc height under the main header (height-lg), aoi region (aoi-header-height),
     // and analyze nav tabs (sidebar-header-height)
-    // and above the next-stage-region (2*height-lg).
-      height: calc(100% - #{$height-lg} * 3 - #{$aoi-header-height} - #{$sidebar-header-height}) !important;
+    // and above the next-stage-region (2*height-lg)
+    // and the Analyze / Monitor tabs (42px);
+      height: calc(100% - #{$height-lg} * 3 - #{$aoi-header-height} - #{$sidebar-header-height} - 42px) !important;
     }
 }
 

--- a/src/mmw/sass/main.scss
+++ b/src/mmw/sass/main.scss
@@ -75,6 +75,7 @@
   "pages/search-map",
   "pages/draw",
   "pages/analyze",
+  "pages/monitor",
   "pages/model",
   "pages/compare",
   "pages/projects",

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -39,8 +39,13 @@
     height: 46px;
 }
 
-.tab-contents-region {
-    background-color: $black-06;
+.sidebar-tab-header {
+  background-color: $black-06;
+
+  .nav-tabs li > a {
+    font-size: 16px;
+    padding: 0 0.7rem;
+  }
 }
 
 .aoi-region {

--- a/src/mmw/sass/pages/_monitor.scss
+++ b/src/mmw/sass/pages/_monitor.scss
@@ -1,0 +1,34 @@
+.monitor-window {
+  padding: 1rem;
+
+  .monitor-search {
+    display: flex;
+
+    button {
+      border-radius: 2px;
+    }
+
+    .search-group {
+      display: flex;
+      flex: 3;
+      padding-right: 5px;
+
+      input[type="text"] {
+        border-radius: 0;
+        box-shadow: none;
+        flex: 1;
+        height: auto;
+      }
+
+      .btn-search {
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
+        margin-left: -1px;
+      }
+    }
+  }
+
+  .intro-text {
+    margin-top: 15px;
+  }
+}


### PR DESCRIPTION
## Overview

Adds Monitor tab to the Analyze stage. Updates styling to match the mockup. The Monitor tab currently has no behavior, which will be added in #2622, mostly by reusing the models and copying a lot of the views from BiG-CZ.

Connects #2620 

### Demo

![2018-01-31 10 48 31](https://user-images.githubusercontent.com/1430060/35632377-80fd852e-0674-11e8-8ab4-f96fee397b36.gif)

### Notes

As part of an earlier attempt I had the full search available in the monitor tab (see https://github.com/WikiWatershed/model-my-watershed/issues/2620#issuecomment-361416979), I ultimately decided against using the BiG-CZ views as is for this. This decision is motivated by two constraints:

1. Existing BiG-CZ behavior should not change at all
2. Monitor tab should fit in well with MMW

There are things we'll need to do for 2 which would contradict 1. For example, in BiG-CZ when switching between the Data and Analyze tabs the map state does not change. Whereas in MMW it will. Another issue is that much of BiG-CZ's search UI is absolutely positioned, which does not readily fit in with the altered sizes in MMW. We should create a UI using flexbox and other more modern methods so that the contents fit and work nicely.

Thus, I created a `/monitor` package in the JavaScript source folder, to be populated with views and templates used in the monitor tab in MMW, and will leave BiG-CZ untouched.

## Testing Instructions

* Checkout this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and draw / select a shape
* Proceed to Analyze. Ensure you see two tabs above, "Analyze" and "Monitor"
* Switch between the tabs and ensure that scroll state is preserved
* Ensure the styling matches the mockups in the original issue
* Ensure that all the specifications in the original issue have been satisfied