### PR TITLE
Center header

### DIFF
--- a/src/mmw/js/src/analyze/templates/resultsWindow.html
+++ b/src/mmw/js/src/analyze/templates/resultsWindow.html
@@ -6,7 +6,7 @@
     </div>
 </div>
 <div class="navigation-footer">
-    <button id="change-area-button" class="btn btn-lg" type="button" data-action="change-area">
+    <button id="change-area-button" class="btn btn-lg btn-primary" type="button" data-action="change-area">
         Change area
     </button>
     <div id="next-stage-navigation-region"></div>

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -104,8 +104,13 @@ header {
         display: flex;
       }
       .project-center {
-          margin-left: auto;
-          margin-right: auto;
+          position: absolute;
+          left: 50%;
+          transform: translateX(-50%);
+          margin-left: 0;
+      }
+      .project-left {
+        flex: 1;
       }
       .project-right {
           margin-right: 8px;


### PR DESCRIPTION
## Overview

This PR centers the primary navigation on the project view. Previously, the primary navigation was sometimes centered, but would become uncentered when other elements on the page changed. Now, it should not be dependent on other elements.

The Stroud logo is not centered. That will be removed in a later PR, so I'm ignoring that for now.

Connects #2596

### Demo

![image](https://user-images.githubusercontent.com/1809908/35693123-32818242-074b-11e8-8aa7-c286a669cd39.png)

## Testing Instructions

 * Rebuild CSS
 * Go to project view
 * Make sure the Analyze/Model buttons are centered. Try to change the name of the project. The centered buttons should not move as a result.