### PR TITLE
Mandatorily Make Projects Public After HydroShare Export

### DIFF
--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -211,6 +211,10 @@ def hydroshare(request):
     )
     hsresource.save()
 
+    # Make Project public and save
+    project.is_private = False
+    project.save()
+
     # Return newly created HydroShareResource
     serializer = HydroShareResourceSerializer(hsresource)
     return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -7,13 +7,16 @@
             <div class="custom-input-group">
                 <div class="row toggle-row">
                     <h3>Link Sharing</h3>
-                    <label class="pull-right toggle">
+                    <label class="pull-right toggle {{ 'hidden' if hydroshare }}">
                         <input type="checkbox" id="share-enabled" {{ "checked" if not is_private }} />
                         <div class="toggle-switch"></div>
                     </label>
                 </div>
                 {% if not is_private %}
-                    <p>Anyone with this link will be able to view this project</p>
+                    <p>Anyone with this link will be able to view this project.</p>
+                    {% if hydroshare %}
+                        <p>Link sharing is always enabled for a project exported to HydroShare.</p>
+                    {% endif %}
                 {% endif %}
                 <div class="input-group {{ 'hidden' if is_private }}">
                     <input class="form-control" id="share-url" type="text" value="{{  url }}">

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -464,8 +464,12 @@ var ProjectModel = Backbone.Model.extend({
                 mapshed_data: mapshedData,
             }, payload))
         }).done(function(result) {
-            self.set('hydroshare', result);
-            self.set('hydroshare_errors', []);
+            self.set({
+                hydroshare: result,
+                hydroshare_errors: [],
+                is_private: false,
+            });
+            self.saveProjectAndScenarios();
         }).fail(function(result) {
             if (result.responseJSON && result.responseJSON.errors) {
                 self.set('hydroshare_errors', result.responseJSON.errors);

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -467,9 +467,12 @@ var ProjectModel = Backbone.Model.extend({
             self.set({
                 hydroshare: result,
                 hydroshare_errors: [],
+                // Exporting to HydroShare make projects public
+                // in apps.export.views.hydroshare. We manually
+                // make the switch here rather than fetching it
+                // from the server, for efficiency.
                 is_private: false,
             });
-            self.saveProjectAndScenarios();
         }).fail(function(result) {
             if (result.responseJSON && result.responseJSON.errors) {
                 self.set('hydroshare_errors', result.responseJSON.errors);


### PR DESCRIPTION
## Overview

When a project is exported to HydroShare, there may be a link from HydroShare back to the project in MMW. To allow this, we need to make the project public in MMW so that any incoming user can see it.

After a successful export to HydroShare, we update the project's privacy and make it unchangeable from the MultiShareView. We also add a message explaining that any project exported to HydroShare will always have link sharing enabled.

Connects #2638 

### Demo

Once a project has been exported to HydroShare, the modal looks like this:

![image](https://user-images.githubusercontent.com/1430060/36053928-cb491770-0dc1-11e8-963a-583236368b56.png)

For a project not exported to HydroShare, the link sharing can be toggled independently:

![image](https://user-images.githubusercontent.com/1430060/36053944-d94987f6-0dc1-11e8-931c-c3a4c488ec1a.png)

Turning HydroShare off leaves Link Sharing on, but can be toggled independently by the user.

Tagging @ajrobbins and @jfrankl for visual review.

## Testing Instructions

* Check out this branch and `bundle`
* Ensure your VM is setup to work with HydroShare. This essentially involves `vagrant ssh app -c 'sudo vim /etc/mmw.d/env/MMW_HYDROSHARE_SECRET_KEY'` and entering the secret key for HydroShare Beta from LastPass. Restart `mmw-app` after changing that file.
* Go to [:8000/](http://localhost:8000/) and create a project
* Export it to HydroShare. Ensure that if the export fails or is canceled, link sharing remains off.
* Ensure that a successful export turns link sharing off, and that you are unable to turn it off.
* Ensure that removing a project from HydroShare leaves link sharing on, but can be turned off by the user.