### PR TITLE
Analysis & Model Reorders

### DIFF
--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -141,7 +141,7 @@ function createAnalyzeTaskCollection(aoi, wkaoi) {
         },
         {
             name: "pointsource",
-            displayName: "Point Sources",
+            displayName: "Pt Sources",
             area_of_interest: aoi,
             wkaoi: wkaoi,
             taskName: "analyze/pointsource"
@@ -155,7 +155,7 @@ function createAnalyzeTaskCollection(aoi, wkaoi) {
         },
         {
             name: "catchment_water_quality",
-            displayName: "Water Quality",
+            displayName: "Water Qual",
             area_of_interest: aoi,
             wkaoi: wkaoi,
             taskName: "analyze/catchment-water-quality"

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -102,6 +102,13 @@ var AnalyzeTaskCollection = Backbone.Collection.extend({
 function createAnalyzeTaskCollection(aoi, wkaoi) {
     var tasks = [
         {
+            name: "streams",
+            displayName: "Streams",
+            area_of_interest: aoi,
+            wkaoi: wkaoi,
+            taskName: "analyze/streams"
+        },
+        {
             name: "land",
             displayName: "Land",
             area_of_interest: aoi,
@@ -118,19 +125,19 @@ function createAnalyzeTaskCollection(aoi, wkaoi) {
             enabledForCatalogMode: true,
         },
         {
+            name: "terrain",
+            displayName: "Terrain",
+            area_of_interest: aoi,
+            wkaoi: wkaoi,
+            taskName: "analyze/terrain"
+        },
+        {
             name: "climate",
             displayName: "Climate",
             area_of_interest: aoi,
             wkaoi: wkaoi,
             taskName: "analyze/climate",
             enabledForCatalogMode: true,
-        },
-        {
-            name: "animals",
-            displayName: "Animals",
-            area_of_interest: aoi,
-            wkaoi: wkaoi,
-            taskName: "analyze/animals"
         },
         {
             name: "pointsource",
@@ -140,27 +147,20 @@ function createAnalyzeTaskCollection(aoi, wkaoi) {
             taskName: "analyze/pointsource"
         },
         {
+            name: "animals",
+            displayName: "Animals",
+            area_of_interest: aoi,
+            wkaoi: wkaoi,
+            taskName: "analyze/animals"
+        },
+        {
             name: "catchment_water_quality",
             displayName: "Water Quality",
             area_of_interest: aoi,
             wkaoi: wkaoi,
             taskName: "analyze/catchment-water-quality"
         },
-        {
-            name: "streams",
-            displayName: "Streams",
-            area_of_interest: aoi,
-            wkaoi: wkaoi,
-            taskName: "analyze/streams"
-        },
-        {
-            name: "terrain",
-            displayName: "Terrain",
-            area_of_interest: aoi,
-            wkaoi: wkaoi,
-            taskName: "analyze/terrain"
-        }
-    ]
+    ];
 
     // Remove analyses which aren't available for catalog search mode
     if (settings.get('data_catalog_enabled')) {

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -31,7 +31,9 @@ var AnalyzeTaskModel = coreModels.TaskModel.extend({
             wkaoi: null,
             taskName: 'analyze',
             taskType: 'api',
-            token: settings.get('api_token')
+            token: settings.get('api_token'),
+            // Include this task in Catalog Search results (ie, BigCZ)
+            enabledForCatalogMode: false,
         }, coreModels.TaskModel.prototype.defaults
     ),
 
@@ -104,63 +106,65 @@ function createAnalyzeTaskCollection(aoi, wkaoi) {
             displayName: "Land",
             area_of_interest: aoi,
             wkaoi: wkaoi,
-            taskName: "analyze/land"
+            taskName: "analyze/land",
+            enabledForCatalogMode: true,
         },
         {
             name: "soil",
             displayName: "Soil",
             area_of_interest: aoi,
             wkaoi: wkaoi,
-            taskName: "analyze/soil"
+            taskName: "analyze/soil",
+            enabledForCatalogMode: true,
         },
         {
             name: "climate",
             displayName: "Climate",
             area_of_interest: aoi,
             wkaoi: wkaoi,
-            taskName: "analyze/climate"
+            taskName: "analyze/climate",
+            enabledForCatalogMode: true,
         },
-    ];
+        {
+            name: "animals",
+            displayName: "Animals",
+            area_of_interest: aoi,
+            wkaoi: wkaoi,
+            taskName: "analyze/animals"
+        },
+        {
+            name: "pointsource",
+            displayName: "Point Sources",
+            area_of_interest: aoi,
+            wkaoi: wkaoi,
+            taskName: "analyze/pointsource"
+        },
+        {
+            name: "catchment_water_quality",
+            displayName: "Water Quality",
+            area_of_interest: aoi,
+            wkaoi: wkaoi,
+            taskName: "analyze/catchment-water-quality"
+        },
+        {
+            name: "streams",
+            displayName: "Streams",
+            area_of_interest: aoi,
+            wkaoi: wkaoi,
+            taskName: "analyze/streams"
+        },
+        {
+            name: "terrain",
+            displayName: "Terrain",
+            area_of_interest: aoi,
+            wkaoi: wkaoi,
+            taskName: "analyze/terrain"
+        }
+    ]
 
-    if (!settings.get('data_catalog_enabled')) {
-        // MMW Analyses
-        tasks.push(
-            {
-                name: "animals",
-                displayName: "Animals",
-                area_of_interest: aoi,
-                wkaoi: wkaoi,
-                taskName: "analyze/animals"
-            },
-            {
-                name: "pointsource",
-                displayName: "Point Sources",
-                area_of_interest: aoi,
-                wkaoi: wkaoi,
-                taskName: "analyze/pointsource"
-            },
-            {
-                name: "catchment_water_quality",
-                displayName: "Water Quality",
-                area_of_interest: aoi,
-                wkaoi: wkaoi,
-                taskName: "analyze/catchment-water-quality"
-            },
-            {
-                name: "streams",
-                displayName: "Streams",
-                area_of_interest: aoi,
-                wkaoi: wkaoi,
-                taskName: "analyze/streams"
-            },
-            {
-                name: "terrain",
-                displayName: "Terrain",
-                area_of_interest: aoi,
-                wkaoi: wkaoi,
-                taskName: "analyze/terrain"
-            }
-        );
+    // Remove analyses which aren't available for catalog search mode
+    if (settings.get('data_catalog_enabled')) {
+        tasks = _.filter(tasks, { enabledForCatalogMode: true });
     }
 
     return new AnalyzeTaskCollection(tasks);

--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
@@ -36,11 +36,11 @@
 <div class="mean-flow">
     Mean Flow: {{ MeanFlow|round(0)|toLocaleString }} (m<sup>3</sup>/year) and {{ MeanFlowPerSecond|round(2)|toLocaleString }} (m<sup>3</sup>/s)
 </div>
-{{ table(landUseColumns, landUseRows, true, renderPrecision.landUseTable, defaultPrecision.landUseTable, landUseClassName) }}
-<div class="downloadcsv-link" data-action="download-csv-granular">
-    <i class="fa fa-download"></i> Download this data
-</div>
 {{ table(summaryColumns, summaryRows, false, renderPrecision.summaryTable, defaultPrecision.summaryTable, summaryClassName) }}
 <div class="downloadcsv-link" data-action="download-csv-summary">
+    <i class="fa fa-download"></i> Download this data
+</div>
+{{ table(landUseColumns, landUseRows, true, renderPrecision.landUseTable, defaultPrecision.landUseTable, landUseClassName) }}
+<div class="downloadcsv-link" data-action="download-csv-granular">
     <i class="fa fa-download"></i> Download this data
 </div>

--- a/src/mmw/sass/components/_tabs.scss
+++ b/src/mmw/sass/components/_tabs.scss
@@ -93,6 +93,7 @@
     }
 
     li > a {
+      margin-right: 0px;
       color: $ui-secondary;
       padding: 0 0.4rem;
       line-height: 42px;


### PR DESCRIPTION
## Overview

Reorder and renames the Analysis tab labels to better fit on a single line.  Also swaps the positions of the Multi-Year WQ output, based on client preferences. 

A small UI defect is introduced here, where the Water Qual tab is pushed down slightly by the "download AoI" button.  A brief attempt to correct didn't yield results, so I'm deferring in the hopes of better efficiency through a UI cleanup card.

Connects #2648 
Connects #2643 

### Demo

**New Tabs**
![image](https://user-images.githubusercontent.com/1014341/36110425-87656672-0ff0-11e8-8386-e7a959620899.png)

**New Positions**
![image](https://user-images.githubusercontent.com/1014341/36110400-714d8cc0-0ff0-11e8-80e1-ea5227432c25.png)

### Notes

#2643 references a proposed new tab that was not considered here.  This will come about as a new issue when and if it is prioritized.

## Testing Instructions

 * Build and Bundle
 * In MMW mode, ensure the names and order of the tabs match those specified in the issue
 * In BigCZ mode, ensure that the analyze output is still restricted to Land, Soil, Climate - in that order
 * Create a new Mapshed project and confirm that summary table is on top, and that the download csv buttons still correspond to the table they are underneath 