### PR TITLE
Allow Opening MMW Project via HydroShare Resource ID

### DIFF
--- a/src/mmw/apps/home/urls.py
+++ b/src/mmw/apps/home/urls.py
@@ -4,7 +4,13 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.conf.urls import patterns, url
-from apps.home.views import home_page, projects, project, project_clone
+from apps.home.views import (
+    home_page,
+    project,
+    project_clone,
+    project_via_hydroshare,
+    projects,
+)
 
 
 urlpatterns = patterns(
@@ -22,6 +28,8 @@ urlpatterns = patterns(
         project, name='project'),
     url(r'^project/compare/$', project, name='project'),
     url(r'^project/(?P<proj_id>[0-9]+)/compare/$', project, name='project'),
+    url(r'^project/via/hydroshare/(?P<resource>\w+)/?$',
+        project_via_hydroshare, name='project_via_hydroshare'),
     url(r'^analyze$', home_page, name='analyze'),
     url(r'^search$', home_page, name='search'),
     url(r'^error', home_page, name='error'),

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -16,6 +16,7 @@ from django.contrib.auth.models import User
 
 from rest_framework.authtoken.models import Token
 
+from apps.export.models import HydroShareResource
 from apps.modeling.models import Project, Scenario
 from apps.user.models import UserProfile
 from apps.user.countries import COUNTRY_CHOICES
@@ -86,6 +87,14 @@ def project_clone(request, proj_id=None):
         scenario.save()
 
     return redirect('/project/{0}'.format(project.id))
+
+
+def project_via_hydroshare(request, resource):
+    """Redirect to project given a HydroShare resource, if found."""
+
+    hsresource = get_object_or_404(HydroShareResource, resource=resource)
+
+    return redirect('/project/{}/'.format(hsresource.project_id))
 
 
 def get_layer_url(layer):


### PR DESCRIPTION
## Overview

In HydroShare, we can add a "WebApp" Resource, which has a configured URL pattern it uses to open HydroShare Resources. For MMW, we configure it with this:

    /project/via/hydroshare/${HS_RES_ID}/

The HydroShare resource id is matched with an MMW project, and if found a redirect is issued. Else we return a 404.

Connects #2637 

### Demo

![2018-02-12 13 12 38](https://user-images.githubusercontent.com/1430060/36112176-cca98046-0ff6-11e8-8f2c-da9d8210ad8e.gif)

[Here is the web app configuration for Staging on Beta](https://user-images.githubusercontent.com/1430060/36112282-2909c864-0ff7-11e8-95bc-502e57ae79cc.png). The Abstract is taken from the About page in MMW, source and issues taken from GitHub, help taken from WikiWatershed, and icon, app-home, and app-launching URLs from the appropriate MMW environment.

### Notes

In order to get MMW Web App in the top right "Open With" dropdown, it must be blessed by HydroShare. We're in contact with them for this, but that is a separate effort not part of this card.

## Testing Instructions

* Check out this branch
* Go to [:8000/](http://localhost:8000/) and export a project to HydroShare.
* Go to the created HydroShare resource, and scroll all the way down. In the "Web App" tab of the bottom box, click "MMW Local". Ensure your MMW project is opened.
* Go to the created HydroShare resource in a private / logged out window. Scroll down and open with MMW Local. Ensure your MMW project is opened in an uneditable state.