### PR TITLE
HydroShare Export: Allow Open With Behavior

### DIFF
--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -33,6 +33,7 @@ hss = HydroShareService()
 HYDROSHARE_BASE_URL = settings.HYDROSHARE['base_url']
 SHAPEFILE_EXTENSIONS = ['cpg', 'dbf', 'prj', 'shp', 'shx']
 DEFAULT_KEYWORDS = {'mmw', 'model-my-watershed'}
+MMW_APP_KEY_FLAG = '{"appkey": "model-my-watershed"}'
 
 
 @decorators.api_view(['GET', 'POST', 'PATCH', 'DELETE'])
@@ -148,7 +149,8 @@ def hydroshare(request):
         'CompositeResource',
         params.get('title', project.name),
         abstract=params.get('abstract', ''),
-        keywords=tuple(DEFAULT_KEYWORDS | keywords)
+        keywords=tuple(DEFAULT_KEYWORDS | keywords),
+        extra_metadata=MMW_APP_KEY_FLAG,
     )
 
     # Files sent from the client


### PR DESCRIPTION
## Overview

To indicate to HydroShare that a given resource can be opened in MMW, add extra metadata to that effect. HydroShare currently does not have this functionality implemented, but we add the metadata all the same in the interim so that when HydroShare is ready it opens it in MMW.

Connects #2558 

### Demo

![image](https://user-images.githubusercontent.com/1430060/36323452-01fe701e-131f-11e8-9c72-71e67e6c2de1.png)

### Notes

HydroShare may ask us to use a different key than `webapp`. I'll update the PR in that case.

## Testing Instructions

* Check out this branch, and go to [:8000/](http://localhost:8000/)
* Export a project to HydroShare
* Go to the resource in HydroShare, scroll down, inspect the Extra Metadata and ensure it has an entry with `webapp` as the key and `model-my-watershed` as the value