### PR TITLE
Harmonize Downloadable Analyze CSV Names With API and Hydroshare

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1158,30 +1158,7 @@ var AnalyzeResultView = Marionette.LayoutView.extend({
         var data = this.model.get('categories'),
             dataName = this.model.get('name'),
             timestamp = new Date().toISOString(),
-            filename = '';
-
-        switch (dataName) {
-            case 'land':
-                filename = 'nlcd_land_cover_';
-                break;
-            case 'soil':
-                filename = 'nlcd_soils_';
-                break;
-            case 'animals':
-                filename = 'animal_estimate_';
-                break;
-            case 'pointsource':
-                filename = 'pointsource_';
-                break;
-            case 'catchment_water_quality':
-                filename = 'catchment_water_quality_';
-                break;
-            default:
-                filename = this.model.get('name');
-                break;
-        }
-
-        filename = filename + timestamp;
+            filename = 'analyze_' + this.model.get('name') + '_' + timestamp;
 
         // Render an unpaginated table for tables that can be paginated.
         if (dataName === 'pointsource' || dataName === 'catchment_water_quality') {


### PR DESCRIPTION
Harmonize the CSVs downloadable from the Analyze view
with the API and Hydroshare exported csv names.

Eg. `/analyze/soil` endpoint --> `analyze_soil_<timestamp>.csv`

Connects #2575


### Demo

![screen shot 2018-02-21 at 3 38 04 pm](https://user-images.githubusercontent.com/7633670/36504458-8e970920-171e-11e8-8d96-bcc351308231.png)

## Testing Instructions

 * Pull and `bundle`
 * Draw a shape and proceed through each tab downloading all CSVs. Confirm the file names are in harmony with those in the [hydroshare resources](https://beta.hydroshare.org/resource/5afe9c7f3f52472fa5efb4f5d492f4a6) and our API