### PR TITLE
Don't show "Add changes" if project was not created by current user

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -388,7 +388,7 @@ var ScenarioItemView = Marionette.ItemView.extend({
             interactiveMode: false,
         });
         mapView.updateAreaOfInterest();
-        mapView.updateModifications(this.model.get('modifications'));
+        mapView.updateModifications(this.model);
         mapView.fitToModificationsOrAoi();
         mapView.render();
     },
@@ -688,7 +688,7 @@ var CompareScenarioView = Marionette.LayoutView.extend({
 
         this.mapView.fitToAoi();
         this.mapView.updateAreaOfInterest();
-        this.mapView.updateModifications(this.model.get('modifications'));
+        this.mapView.updateModifications(this.model);
         this.mapRegion.show(this.mapView);
         this.modelingRegion.show(new CompareModelingView({
             projectModel: this.projectModel,

--- a/src/mmw/js/src/core/templates/modificationPopup.html
+++ b/src/mmw/js/src/core/templates/modificationPopup.html
@@ -9,8 +9,10 @@
         <td class='strong text-right'>{{ effectiveArea|round(2)|toLocaleString(2) }} {{ effectiveUnits }}</td>
     </tr>
 </table>
+{% if editable %}
 <span>
     <button class="btn btn-sm btn-icon dark delete-modification" type="button">
         <i class="fa fa-trash"></i> Remove modification
     </button>
 </span>
+{% endif %}

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -218,13 +218,27 @@ describe('Core', function() {
                         area: 100,
                         units: 'm<sup>2</sup>',
                     }),
-                    view = new views.ModificationPopupView({ model: model });
-
+                    view = new views.ModificationPopupView({ model: model, editable: true});
                 var spy = sinon.spy(model, 'destroy');
 
                 $(sandboxSelector).html(view.render().el);
                 $(sandboxSelector + ' .delete-modification').trigger('click');
                 assert.equal(spy.callCount, 1);
+
+                view.destroy();
+            });
+
+            it('does not show a delete button if the project is not editable', function() {
+                var model = new Backbone.Model({
+                    value: 'developed_low',
+                    shape: {},
+                    area: 100,
+                    units: 'm<sup>2</sup>',
+                }),
+                    view = new views.ModificationPopupView({ model: model, editable: false});
+
+                $(sandboxSelector).html(view.render().el);
+                assert.equal($(sandboxSelector + ' .delete-modification').length, 0, 'Expected no dom elements to have the .delete-modification class.');
 
                 view.destroy();
             });

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -317,7 +317,7 @@ function updateUrl() {
 }
 
 function updateScenario(scenario) {
-    App.getMapView().updateModifications(scenario.get('modifications'));
+    App.getMapView().updateModifications(scenario);
     updateUrl();
 }
 

--- a/src/mmw/js/src/modeling/templates/gwlfeScenarioToolbar.html
+++ b/src/mmw/js/src/modeling/templates/gwlfeScenarioToolbar.html
@@ -39,9 +39,11 @@
                         {% endfor %}
                     </tbody>
                 </table>
+                {% if editable %}
                 <button class="btn btn-sm btn-icon dark delete-modification" type="button">
                     <i class="fa fa-trash"></i>  Remove modification
                 </button>
+                {% endif %}
             </div>
         </div>
     {% endif %}

--- a/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
+++ b/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
@@ -8,7 +8,7 @@
 {% endif %}
 <div class="right-controls-container">
     <div class="tab-content scenario-toolbar-tab-content"></div>
-    {% if isOnlyCurrentConditions %}
+    {% if isOnlyCurrentConditions and editable %}
     <button id="add-changes" class="btn btn-link" type="button" aria-expanded="true">
         <i class="fa fa-plus-circle"></i> Add changes to this area
     </button>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -800,14 +800,15 @@ var GwlfeToolbarView = ScenarioModelToolbarView.extend({
 
     templateHelpers: function() {
         var activeMod = this.getActiveMod(),
-            modifications = this.model.get('modifications').toJSON();
+            modifications = this.model.get('modifications').toJSON(),
+            editable = isEditable(this.model);
 
         activeMod = activeMod ? activeMod.toJSON() : null;
-
         return {
             modifications: modifications,
             activeMod: activeMod,
-            displayNames: gwlfeConfig.displayNames
+            displayNames: gwlfeConfig.displayNames,
+            editable: editable
         };
     }
 });

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -657,8 +657,7 @@ var ScenarioModelToolbarView = Marionette.CompositeView.extend({
 
     updateMap: function() {
         if (this.model.get('active')) {
-            var modificationsColl = this.model.get('modifications');
-            App.getMapView().updateModifications(modificationsColl);
+            App.getMapView().updateModifications(this.model);
         }
     },
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -881,13 +881,15 @@ var ScenarioToolbarView = Marionette.CompositeView.extend({
         var gisData = this.currentConditions.getGisData().model_input,
             isGwlfe = this.modelPackage === utils.GWLFE && !_.isEmpty(gisData),
             isOnlyCurrentConditions = this.collection.length === 1 &&
-                this.collection.first().get('is_current_conditions');
+                this.collection.first().get('is_current_conditions'),
+            editable = isEditable(this.model);
 
         return {
             isOnlyCurrentConditions: isOnlyCurrentConditions,
             isGwlfe: isGwlfe,
             csrftoken: csrf.getToken(),
             gis_data: gisData,
+            editable: editable
         };
     },
 });


### PR DESCRIPTION
## Overview

Users can't save changes to projects they do not own so it is confusing to allow editing.

Connects #2670 

### Demo

<img width="1680" alt="screen shot 2018-02-22 at 8 48 28 am" src="https://user-images.githubusercontent.com/17363/36548637-0e8c1e10-17ae-11e8-9bcc-b7257d5e474f.png">

## Testing Instructions

 * Log in, create a project, run TR-55, and share the project to Hydroshare.
 * Refresh the project page and verify that the "Add changes" button is visible.
 * Copy the project URL.
 * Log in as a different user and browse the project page.
 * Verify that the "Add changes" button is not visible.
