### PR TITLE
Show drawn modifications only in Modeling tab

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -973,6 +973,7 @@ var ResultsView = Marionette.LayoutView.extend({
                 this.monitorRegion.$el.removeClass('active');
                 this.monitorRegion.currentView.setVisibility(false);
                 this.modelingRegion.$el.removeClass('active');
+                App.getMapView().updateModifications(null);
                 break;
             case utils.MONITOR:
                 if (App.map.get('dataCatalogDetailResult') !== null) {
@@ -984,6 +985,7 @@ var ResultsView = Marionette.LayoutView.extend({
                 this.monitorRegion.$el.addClass('active');
                 this.monitorRegion.currentView.setVisibility(true);
                 this.modelingRegion.$el.removeClass('active');
+                App.getMapView().updateModifications(null);
                 break;
             case utils.MODEL:
                 this.aoiRegion.currentView.$el.addClass('hidden');
@@ -991,6 +993,9 @@ var ResultsView = Marionette.LayoutView.extend({
                 this.monitorRegion.$el.removeClass('active');
                 this.monitorRegion.currentView.setVisibility(false);
                 this.modelingRegion.$el.addClass('active');
+                App.getMapView().updateModifications(
+                    this.model.get('scenarios').getActiveScenario()
+                );
                 break;
         }
     },


### PR DESCRIPTION
## Overview

Hides user-drawn modifications from the Monitor and Analyze tabs, and restores them in the Model tab.

Discovered #2684 during development.

Connects #2676 

### Demo

![2018-02-26 17 16 25](https://user-images.githubusercontent.com/1430060/36698890-189af28c-1b19-11e8-8656-07e4919f6f4b.gif)

## Testing Instructions

 * Check out this branch, and `bundle`
 * Go to [:8000/](http://localhost:8000/) and create a new TR-55 project
 * Once in the modeling stage, add a new scenario and draw some modifications on it
 * Switch to Analyze. Ensure the modifications go away.
 * Switch back to Modeling. Ensure they come back, in the correct order.
 * Switch to Monitor. Ensure they go away. Search for something, wait for results to show up.
 * Switch to Modeling. Ensure search results are hidden, and modifications are shown.
 * Try switching when a map popup is open. Ensure the popup is removed when hiding shapes.
 * Try switching while in Current Conditions. Ensure no shapes are shown when returning to Model tab.
 * Try saving the project to database and refreshing the page. Ensure switching still works correctly.
 * Try a MapShed project to ensure things look good there too.