### PR TITLE
Adjust bar chart ticks on tab switch

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -300,8 +300,23 @@ var TabPanelView = Marionette.ItemView.extend({
         role: 'presentation'
     },
 
+    ui: {
+        'tabPanelButton': 'a[data-toggle="tab"]',
+    },
+
+    events: {
+        'shown.bs.tab @ui.tabPanelButton': 'onTabShown',
+    },
+
     initialize: function() {
         this.listenTo(this.model, 'change:polling', this.render);
+    },
+
+    onTabShown: function() {
+        var targetId = this.ui.tabPanelButton.attr('href'),
+            chartEl = targetId + ' .bar-chart';
+
+        $(chartEl).trigger('bar-chart:refresh');
     }
 });
 


### PR DESCRIPTION
## Overview

Previously, the updateChart function which adjusts ticks on bar charts to ensure they don't overlap only fired when the browser window was resized. Although there is a listener for a `bar-chart:refresh` event, designed to trigger during a tab switch, this would never fire:

https://github.com/WikiWatershed/model-my-watershed/blob/5b295d7d25b361e4cf452cb7c902f488c9a41bbc/src/mmw/js/src/core/chart.js#L162-L167

By firing that event purposefully when switching tabs, it is ensured that the ticks are always updated accordingly.

Connects #2677 

### Demo

![2018-02-27 13 12 07](https://user-images.githubusercontent.com/1430060/36746315-080a727e-1bc0-11e8-857b-dd21c7a612e7.gif)

![image](https://user-images.githubusercontent.com/1430060/36746292-f50e54b0-1bbf-11e8-977d-39f4a50fe1ff.png)

![image](https://user-images.githubusercontent.com/1430060/36746304-fb84f20e-1bbf-11e8-9654-c3d01d03b034.png)


### Notes

I looked in to firing `updateChart` via the parent view, or the grandparent view, but the nesting was too deep to try and pass that reference around. Triggering this event via a jQuery selector does have some "action at a distance" magic feeling, but was the quickest approach outside a larger refactoring.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and draw a shape. If you have boundaries installed, select the Petty Island Delaware River HUC-12 (as shown in the screenshots).
* In the Analyze stage, ensure that there are no overlapping labels in the bar charts in the Land and Soil tabs.
* Start over, and select a shape. Quickly switch to Land tab before the Analyze populate, and ensure there are no overlaps even if the chart loads when the tab is active.
* Test in various browsers.