### PR TITLE
Fix Re-Opening Modification Dropdown

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -282,7 +282,7 @@ var ModificationsView = ControlView.extend({
         function closeDropdownOnOutsideClick(e) {
             var isTargetOutsideDropdown = $(e.target).parents('.dropdown-menu').length === 0;
             if (isTargetOutsideDropdown && self.model.get('dropdownOpen')) {
-                self.closeDropdown();
+                self.model.set('dropdownOpen', false);
             }
         }
 
@@ -318,38 +318,24 @@ var ModificationsView = ControlView.extend({
         modContentRegion: '.mod-content-region'
     },
 
-    toggleDropdown: function() {
-        if (this.model.get('dropdownOpen')) {
-            this.openDropdown();
+    toggleDropdown: function(model, dropdownOpen) {
+        if (dropdownOpen) {
+            this.ui.dropdown.addClass('open');
         } else {
-            this.closeDropdown();
+            this.ui.dropdown.removeClass('open');
+            this.model.set({
+                manualMod: null,
+                output: null
+            });
         }
-    },
-
-    closeDropdown: function() {
-        this.$(this.ui.dropdown).removeClass('open');
-        this.model.set({
-            dropdownOpen: false,
-            manualMod: null,
-            output: null
-        });
-    },
-
-    openDropdown: function() {
-        this.$(this.ui.dropdown).addClass('open');
-        this.model.set('dropdownOpen', true);
     },
 
     onClickDropdownButton: function() {
         var dropdownOpen = this.model.get('dropdownOpen');
-        if (this.model.get('manualMode')) {
-            if (dropdownOpen) {
-                this.closeDropdown();
-            } else {
-                this.openDropdown();
-            }
-        } else if (!dropdownOpen) {
-            this.openDropdown();
+
+        // Toggle dropdown if in manual mode, else just open it
+        if (this.model.get('manualMode') || !dropdownOpen) {
+            this.model.set('dropdownOpen', !dropdownOpen);
         }
     },
 

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -329,7 +329,7 @@ var ModificationsView = ControlView.extend({
     closeDropdown: function() {
         this.$(this.ui.dropdown).removeClass('open');
         this.model.set({
-            dropdown: false,
+            dropdownOpen: false,
             manualMod: null,
             output: null
         });


### PR DESCRIPTION
## Overview

Fixes a bug introduced in 9acb08eb9bc9964a96d9b8300e94337201df7821.

Connects #2684 

### Demo

* TR-55:

    ![2018-02-28 17 46 24](https://user-images.githubusercontent.com/1430060/36817556-87edb8bc-1caf-11e8-8029-61bbf604025f.gif)

* MapShed:

    ![2018-02-28 17 47 35](https://user-images.githubusercontent.com/1430060/36817568-9020710a-1caf-11e8-8092-bc9d68f5b075.gif)

### Notes

The second commit is a refactor that should not affect functionality.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and make a TR-55 project. Ensure that the modification dropdowns and drawing works as expected. Try opening and closing the dropdowns multiple times.
* Create a MapShed project. Ensure that the modification dropdowns work as expected. Note that clicking outside the box should _not_ close the dropdown in MapShed.