### PR TITLE
Monitor Search Fixes

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -23,6 +23,7 @@ from apps.bigcz.clients.cuahsi.models import CuahsiResource
 
 
 SQKM_PER_SQM = 0.000001
+CUAHSI_MAX_SIZE_SQKM = 1500
 CATALOG_NAME = 'cuahsi'
 CATALOG_URL = 'http://hiscentral.cuahsi.org/webservices/hiscentral.asmx?WSDL'
 
@@ -286,6 +287,15 @@ def search(**kwargs):
     if not bbox:
         raise ValidationError({
             'error': 'Required argument: bbox'})
+
+    bbox_area = bbox.area() * SQKM_PER_SQM
+
+    if bbox_area > CUAHSI_MAX_SIZE_SQKM:
+        raise ValidationError({
+            'error': 'The selected area of interest with a bounding box of {} '
+                     'km² is larger than the currently supported maximum size '
+                     'of {} km².'.format(round(bbox_area, 2),
+                                          CUAHSI_MAX_SIZE_SQKM)})
 
     world = BBox(-180, -90, 180, 90)
 

--- a/src/mmw/apps/bigcz/models.py
+++ b/src/mmw/apps/bigcz/models.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from django.contrib.gis.geos import Polygon
+
 
 class ResourceLink(object):
     def __init__(self, type, href):
@@ -40,3 +42,11 @@ class BBox(object):
         self.xmax = xmax
         self.ymin = ymin
         self.ymax = ymax
+
+    def area(self):
+        polygon = Polygon.from_bbox((
+            self.xmin, self.ymin,
+            self.xmax, self.ymax))
+        polygon.set_srid(4326)
+
+        return polygon.transform(5070, clone=True).area

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -4,11 +4,14 @@ var $ = require('jquery'),
     _ = require('lodash'),
     Backbone = require('../../shim/backbone'),
     moment = require('moment'),
-    settings = require('../core/settings');
+    settings = require('../core/settings'),
+    drawUtils = require('../draw/utils'),
+    utils = require('./utils');
 
 var REQUEST_TIMED_OUT_CODE = 408;
 var DESCRIPTION_MAX_LENGTH = 100;
 var PAGE_SIZE = settings.get('data_catalog_page_size');
+var CUAHSI_MAX_SIZE_SQKM = 1500;
 
 var DATE_FORMAT = 'MM/DD/YYYY';
 var WATERML_VARIABLE_TIME_INTERVAL = '{http://www.cuahsi.org/water_ml/1.1/}variable_time_interval';
@@ -201,6 +204,7 @@ var Catalog = Backbone.Model.extend({
             isSameGeom = geom === this.get('geom'),
             isSameSearch = isSameQuery && isSameGeom;
 
+        // Perform local text search for pre-existing CUAHSI results
         if (isCuahsi && isSameGeom && !isSameQuery) {
             this.set({ loading: true });
 
@@ -216,6 +220,23 @@ var Catalog = Backbone.Model.extend({
             return $.when();
         }
 
+        // Check if area of interest is too large for CUAHSI
+        if (isCuahsi) {
+            var area = utils.areaOfBounds(drawUtils.shapeBoundingBox(geom));
+
+            if (area > CUAHSI_MAX_SIZE_SQKM) {
+                this.set('error',
+                    'The selected area of interest with a bounding box of ' +
+                    area.toLocaleString(undefined, { maximumFractionDigits: 2 }) +
+                    ' km² is larger than the currently supported maximum size of ' +
+                    CUAHSI_MAX_SIZE_SQKM.toLocaleString(undefined, { maximumFractionDigits: 2 }) +
+                    ' km² for CUAHSI WDC.');
+
+                return $.Deferred().reject('Area of Interest too large');
+            }
+        }
+
+        // Perform server search
         if (!isSameSearch || stale || error) {
             this.cancelSearch();
             this.searchPromise = this.search(query, geom)

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -256,11 +256,13 @@ var FormView = Marionette.ItemView.extend({
     ui: {
         filterToggle: '.filter-sidebar-toggle',
         searchInput: 'input[type="text"]',
+        searchButton: '.btn-search',
         downloadButton: '#bigcz-catalog-results-download',
     },
 
     events: {
         'keyup @ui.searchInput': 'onSearchInputChanged',
+        'click @ui.searchButton': 'triggerSearch',
         'click @ui.filterToggle': 'onFilterToggle',
         'click @ui.downloadButton': 'downloadResults',
     },


### PR DESCRIPTION
## Overview

Makes it so that clicking the search button searches. Also limits CUAHSI search to areas of interest with a bounding box of 1500 km².

Connects #2687 
Connects #2689 

### Demo

* UI

    ![2018-03-01 13 52 48](https://user-images.githubusercontent.com/1430060/36863535-f3a86810-1d57-11e8-9675-c2b34a6e5d8d.gif)

* API, using [cuahsi-huc10-query.json.txt](https://github.com/WikiWatershed/model-my-watershed/files/1772417/cuahsi-huc10-query.json.txt)

    ```http
    http :8000/bigcz/search < cuahsi-huc10-query.json

    HTTP/1.1 400 BAD REQUEST
    Allow: POST, OPTIONS
    Connection: keep-alive
    Content-Type: application/json
    Date: Thu, 01 Mar 2018 18:49:25 GMT
    Server: nginx
    Transfer-Encoding: chunked
    Vary: Accept, Cookie

    {
        "error": "The selected area of interest with a bounding box of 2297.43 km² is larger than the currently supported maximum size of 1500 km²."
    }
    ```

### Notes

The first attempt at limiting in 7de9bb1 is client side, but then I thought about the server / API being potentially abused (especially since BiG-CZ folks may use it directly in Jupyter Notebooks) so added back the server side check. However, now the logic was duplicated in two places, so in the end I elided the client side check in favor of completely server side that consolidates logic.

## Testing Instructions

* Check out this branch and `bundle`
* Select a HUC-10 and ensure you can search for it with the keyboard and the search button for CINERGI and HydroShare
* Ensure the search fails for CUAHSI
* Select "Change Area" so that the search parameters are reset.
* Select a HUC-12 and ensure you can search it for all catalogs.