### PR TITLE
Update libpq glob to reflect main PostgreSQL repository

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -25,7 +25,7 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "10.2-*.pgdg14.04+1"
+postgresql_support_libpq_version: "10.3-*.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.7"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"


### PR DESCRIPTION
## Overview

Same as just about every commit [here](https://github.com/WikiWatershed/model-my-watershed/search?q=libpq&type=Commits&utf8=%E2%9C%93)

@tnation14 — something feels wrong that we have to keep doing this. Is there any other repo for this we can use that doesn't require we bump the version every month?

## Testing Instructions

 * Pull branch
 * `vagrant destroy worker` then `vagrant up worker`
