### PR TITLE
Fix hydroshare resource link in safari

### DIFF
--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -58,7 +58,7 @@
                 </p>
                 {% if hydroshare %}
                 <p>
-                    Your project <a href="{{ hydroshare.url }}" target="_blank">{{ hydroshare.title }}</a>
+                    Your project <a href="{{ hydroshare.url }}" target="_blank" rel="noopener noreferrer">{{ hydroshare.title }}</a>
                     has been exported to HydroShare.
                 </p>
                 <div class="hydroshare-autosync-container">


### PR DESCRIPTION
Hydroshare link was downloading in safari instead of opening in a new tab. We had `target="_blank"` but no `rel="noreferrer noopener"`

<img width="400" alt="screen shot 2018-03-02 at 4 51 18 pm" src="https://user-images.githubusercontent.com/7633670/36923664-f6ecb4bc-1e39-11e8-86db-a20f3e3d9725.png">
<img width="1280" alt="screen shot 2018-03-02 at 4 51 37 pm" src="https://user-images.githubusercontent.com/7633670/36923671-0067092a-1e3a-11e8-9439-192d7c79886f.png">


Connects #2692

## Testing Instructions

 * Create a hydroshare-shared project and open the share modal in safari. Confirm clicking the link to the resource opens it in hydroshare.