### PR TITLE
HydroShare Export: Properly Include Model Results as CSV

### DIFF
--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -522,6 +522,17 @@ var utils = {
         });
     },
 
+    toRoundedLocaleString: function(val, n) {
+        if (val === undefined || isNaN(val)) {
+            return val;
+        }
+
+        return val.toLocaleString(undefined, {
+            minimumFractionDigits: n,
+            maximumFractionDigits: n,
+        });
+    },
+
     // Convert polygon to MultiPolyon (mutates original argument).
     toMultiPolygon: function toMultiPolygon(polygon) {
         var geom = polygon.geometry ? polygon.geometry : polygon;

--- a/src/mmw/js/src/modeling/templates/projectMenu.html
+++ b/src/mmw/js/src/modeling/templates/projectMenu.html
@@ -91,7 +91,7 @@
     {% if not is_new and editable %}
     <button class="btn btn-md btn-secondary {{ 'is-exporting' if is_exporting }} {{ 'error' if hydroshare_errors.length > 0 }}"
             id="share-project">
-        Share
+        {{ 'Exporting ...' if is_exporting else 'Share' }}
     </button>
     {% endif %}
     <button class="btn btn-md btn-secondary" id="new-project">


### PR DESCRIPTION
## Overview

Converts each result model into the appropriate CSV, identical to the CSV generated in the UI, to export to HydroShare. As opposed to #2688, this is done from the model rather than the UI, thus there is no user penalty. It is also faster, so we can forego much of the promise nesting done there.

Since this export is now being generated independently of the tables, we can make changes here without making changes to the UI (for example, by adding more precision, or changing the column names / order). On the other hand, if we want to keep this export and the UI in sync, we'll have to remember to update this whenever updating the UI.

Currently the UI export still uses the `tableExport` plugin, although it could possibly be switched to use this (since the results are identical or superior, since we include the Totals row in MapShed Hydrology, and the Mean Flow columns in MapShed Water Quality Summary) to satisfy #2673. If deemed worthy, I can include that here, or we can do it at a later date.

Supersedes #2688 
Connects #2666
Connects #2667

### Demo

* Exporting Model Data:

    ![2018-03-05 11 36 13](https://user-images.githubusercontent.com/1430060/36988355-afcf4df8-206c-11e8-8e56-219c5ad15f0a.gif)

* `Share` → `Exporting ...` → `Share`

    ![2018-03-05 11 47 51](https://user-images.githubusercontent.com/1430060/36988387-c3522080-206c-11e8-8107-05812f4c5b00.gif)

Tagging @ajrobbins and @jfrankl for visual review.

## Testing Instructions

* Check out this branch
* Export a TR-55 project. Ensure the CSVs in HydroShare are named correctly and are identical to those generated from the UI
* Export a MapShed project. Ensure the CSVs in HydroShare are named correctly and are identical to those generated from the UI