### PR TITLE
Pre-release UI Cleanup

### DIFF
--- a/src/mmw/js/src/analyze/templates/aoiHeader.html
+++ b/src/mmw/js/src/analyze/templates/aoiHeader.html
@@ -22,4 +22,4 @@
     <!-- Put `shape` in single quotes, to keep any unescaped chars from breaking the template -->
     <input type="hidden" name="shape" value='{{ shape }}' />
 </form>
-<h2>{{ place }}<span class="aoi-area">{{ area|round|toLocaleString }} {{ units }}</span></h2>
+<h2>{{ place }}<span class="aoi-area">{{ area|round|toLocaleString }}&nbsp;{{ units }}</span></h2>

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -65,6 +65,7 @@
     button {
       border: none;
       background: none;
+      padding-bottom: 0;
     }
   }
 


### PR DESCRIPTION
## Overview

Adjusts the UI so that all the Analyze tabs line up, and the AoI area and units stick together.

Connects #2660 
Connects #2682 

### Demo

* Analyze tabs lining up:

    ![image](https://user-images.githubusercontent.com/1430060/36993814-1b6b1faa-207d-11e8-81bc-abcf2cea8a9e.png)

* AoI area and units sticking together:

    ![image](https://user-images.githubusercontent.com/1430060/36993781-fed5bc06-207c-11e8-981c-f1e6757cd037.png)

### Notes

I tried also adding a breaking space between the end of the area of interest name and the area, but I think that looks worse:

![image](https://user-images.githubusercontent.com/1430060/36994245-80ee13a4-207e-11e8-9420-87062265e5b0.png)

So we should keep the name and area sticking to each other.

## Testing Instructions

* Checkout this branch and `bundle`
* Go to Analyze and draw a shape. Ensure that the name of the area of interest is in one line, not two. Ensure the download AoI button does not push any Analyze tab down, and that it continues to work correctly
* Search for and pick the "Cobbs Creek" HUC-12 (there are two of them, pick the 89 km² one), and ensure the area and units are on the same line