### PR TITLE
Clear analysis results on selecting geocoder shape

### DIFF
--- a/src/mmw/js/src/geocode/views.js
+++ b/src/mmw/js/src/geocode/views.js
@@ -309,6 +309,8 @@ var SearchBoxView = Marionette.LayoutView.extend({
             })
             .done(function() {
                 App.map.set('selectedGeocoderArea', null);
+                App.clearAnalyzeCollection();
+                App.clearDataCatalog();
                 addBoundaryLayer(selectedBoundary, selectedBoundaryShape);
                 router.navigate('/analyze', { trigger: true});
             });


### PR DESCRIPTION
## Overview

This PR clears the analyze results on selecting a shape from the geocoder search bar. We also clear the data catalog, since that seems always to be paired with other similar `clearAnalyzeCollection` method calls.

Connects #2699

## Testing
- get and serve this branch and try to replicate the bug described in #2699 and verify that: you can't