### PR TITLE
Monitor: Throttle EnviroDIY values to 2 weeks

### DIFF
--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -15,8 +15,8 @@ var DATE_FORMAT = 'MM/DD/YYYY';
 var WATERML_VARIABLE_TIME_INTERVAL = '{http://www.cuahsi.org/water_ml/1.1/}variable_time_interval';
 
 var SERVICE_PERIODS = {
-    'NWISUV': 'months',  // For NWISUV sites, fetch 1 month of data
-    '*'     : 'years',   // For all else, fetch 1 year of data
+    'NWISUV':    '1 months', // For NWISUV sites, fetch 1 month of data
+    '*':         '1 years',  // For all else, fetch 1 year of data
 };
 
 
@@ -723,14 +723,16 @@ var CuahsiVariable = Backbone.Model.extend({
                 variable: this.get('id'),
             },
             service = params.site.split(':')[0],
-            duration = SERVICE_PERIODS[service] || 'years';
+            duration = (SERVICE_PERIODS[service] || '1 years').split(' '),
+            duration_amount = parseInt(duration[0]),
+            duration_unit = duration[1];
 
         // If neither from date nor to date is specified, set time interval
-        // to be either from begin date to end date, or 1 `duration` up to end
-        // date, whichever is shorter.
+        // to be either from begin date to end date, or `duration_amount`
+        // `duration_units` up to end date, whichever is shorter.
         if (!from || moment(from).isBefore(begin_date)) {
-            if (end_date.diff(begin_date, duration, true) > 1) {
-                params.from_date = moment(end_date).subtract(1, duration);
+            if (end_date.diff(begin_date, duration_unit, true) > duration_amount) {
+                params.from_date = moment(end_date).subtract(duration_amount, duration_unit);
             } else {
                 params.from_date = begin_date;
             }

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -16,6 +16,7 @@ var WATERML_VARIABLE_TIME_INTERVAL = '{http://www.cuahsi.org/water_ml/1.1/}varia
 
 var SERVICE_PERIODS = {
     'NWISUV':    '1 months', // For NWISUV sites, fetch 1 month of data
+    'EnviroDIY': '2 weeks',  // For EnviroDIY, fetch 2 weeks of data
     '*':         '1 years',  // For all else, fetch 1 year of data
 };
 


### PR DESCRIPTION
## Overview

Fetching 96K values per variable can overload the system. By limiting EnviroDIY to 1 month instead of 1 year, we get a more manageable quantity ~12K values per variable. This was previously done for NWISUV in #2494.

Is this acceptable @ajrobbins @aufdenkampe?

Connects #2709 

### Demo

![image](https://user-images.githubusercontent.com/1430060/37069257-99e3fe7a-2180-11e8-9be8-86f70fa78daf.png)

![image](https://user-images.githubusercontent.com/1430060/37069271-a79f8fde-2180-11e8-81e1-72105af4fc43.png)

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and select a shape in the Philadelphia area. Proceed to Analyze.
* Switch to the Monitor tab and search for EnviroDIY. Switch to the CUAHSI tab.
  - If you don't see any results for EnviroDIY under CUAHSI, clear the cache and try again:

        vagrant ssh services -c 'redis-cli -n 1 --raw KEYS ":1:bigcz*" | xargs redis-cli -n 1 DEL'

* Open the Detail view of any result. Ensure it fetches values correctly and you can see them in the chart. Ensure the chart has 1 month of values.