### PR TITLE
Account for origin/ prefix in branch names

### DIFF
--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -751,8 +751,16 @@ describe('Core', function() {
             assert.equal(output.version, 'Unknown');
             assert.equal(output.releaseNotesUrl, latestUrl);
 
+            output = utils.parseVersion('origin/release/1.22.0', gitDescribe);
+            assert.equal(output.version, '1.22.0');
+            assert.equal(output.releaseNotesUrl, taggedUrl);
+
             output = utils.parseVersion('release/1.22.0', gitDescribe);
             assert.equal(output.version, '1.22.0');
+            assert.equal(output.releaseNotesUrl, taggedUrl);
+
+            output = utils.parseVersion('origin/hotfix/1.22.2', gitDescribe);
+            assert.equal(output.version, '1.22.2');
             assert.equal(output.releaseNotesUrl, taggedUrl);
 
             output = utils.parseVersion('hotfix/1.22.2', gitDescribe);

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -638,12 +638,12 @@ var utils = {
             version = 'Unknown';
         } else if (branch === 'local' && gitDescribe === null) {
             version = 'Local';
-        } else if (branch.startsWith('release')) {
-            version = branch.substr(branch.indexOf('/') + 1);
+        } else if (branch.startsWith('release') || branch.startsWith('origin/release')) {
+            version = branch.substr(branch.indexOf('release/') + 8);
             // Use this version for release notes
             url = RELEASE_NOTES_BASE_URL + '/tag/' + version;
-        } else if (branch.startsWith('hotfix')) {
-            version = branch.substr(branch.indexOf('/') + 1);
+        } else if (branch.startsWith('hotfix') || branch.startsWith('origin/hotfix')) {
+            version = branch.substr(branch.indexOf('hotfix/') + 7);
             // Use the original release notes
             url = RELEASE_NOTES_BASE_URL + '/tag/' + version.match(MINOR_MAJOR_REGEX) + '0';
         } else {


### PR DESCRIPTION
## Overview

Observed on staging, branches aren't reported as release/1.22.0, but as origin/release/1.22.0. Now we parse them correctly.

Connects #2711 

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and open the About modal. Ensure you see "Version Local".
* Edit [this line](https://github.com/WikiWatershed/model-my-watershed/blob/3489acc48e0710ef06a55dc6af183e33ca38348d/src/mmw/js/src/app.js#L358) to be `/static/version.txt` instead of `/version.txt`, then edit that file directly:

      $ vagrant ssh app -c 'vim /var/www/mmw/static/version.txt'

  and add something like this:

      origin/release/1.22.0 1.21.0-306-g6484badc1f6ee96ceb54c1020c361b9927224c43

* Bundle and reload [:8000/](http://localhost:8000/). Ensure you see the correct version above.