### PR TITLE
Allow sending mapshed job UUID to GWLF-E

### DIFF
--- a/src/mmw/apps/core/migrations/0004_job_uuid_unique_constraint.py
+++ b/src/mmw/apps/core/migrations/0004_job_uuid_unique_constraint.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0003_requestlog_api_referrer'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='job',
+            name='uuid',
+            field=models.UUIDField(unique=True, null=True),
+        ),
+    ]

--- a/src/mmw/apps/core/models.py
+++ b/src/mmw/apps/core/models.py
@@ -10,7 +10,10 @@ AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class Job(models.Model):
     user = models.ForeignKey(AUTH_USER_MODEL, null=True)
-    uuid = models.UUIDField(null=True)
+    uuid = models.UUIDField(
+        null=True,
+        unique=True
+    )
     model_input = models.TextField()
     created_at = models.DateTimeField()
     result = models.TextField()

--- a/src/mmw/apps/modeling/migrations/0027_project_add_mapshed_job_uuids.py
+++ b/src/mmw/apps/modeling/migrations/0027_project_add_mapshed_job_uuids.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0004_job_uuid_unique_constraint'),
+        ('modeling', '0026_delete_hydroshareresource'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='mapshed_job_uuid',
+            field=models.ForeignKey(related_name='mapshed_job', to_field='uuid', to='core.Job', help_text='The job used to calculate the MapShed results. Used for getting the results of that job.', null=True),
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='subbasin_mapshed_job_uuid',
+            field=models.ForeignKey(related_name='subbasin_mapshed_job', to_field='uuid', to='core.Job', help_text='The job used to calculate the MapShed results for each HUC-12 sub-basin of the shape.', null=True),
+        ),
+    ]

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -6,6 +6,8 @@ from __future__ import division
 from django.contrib.gis.db import models
 from django.contrib.auth.models import User
 
+from apps.core.models import Job
+
 
 class Project(models.Model):
     TR55 = 'tr-55'
@@ -43,6 +45,20 @@ class Project(models.Model):
         null=True,
         help_text='Serialized JSON representation of additional'
                   ' data gathering steps, such as MapShed.')
+    mapshed_job_uuid = models.ForeignKey(
+        Job,
+        to_field='uuid',
+        related_name='mapshed_job',
+        null=True,
+        help_text='The job used to calculate the MapShed results.'
+                  ' Used for getting the results of that job.')
+    subbasin_mapshed_job_uuid = models.ForeignKey(
+        Job,
+        to_field='uuid',
+        related_name='subbasin_mapshed_job',
+        null=True,
+        help_text='The job used to calculate the MapShed results'
+                  ' for each HUC-12 sub-basin of the shape.')
     wkaoi = models.CharField(
         null=True,
         max_length=255,

--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -14,6 +14,7 @@ from apps.modeling.models import Project, Scenario
 from apps.modeling.validation import validate_aoi
 from apps.modeling.calcs import get_layer_shape
 from apps.user.serializers import UserSerializer
+from apps.core.models import Job
 
 import json
 
@@ -84,6 +85,16 @@ class ProjectSerializer(gis_serializers.GeoModelSerializer):
 
     user = UserSerializer(default=serializers.CurrentUserDefault())
     gis_data = JsonField(required=False, allow_null=True)
+    mapshed_job_uuid = serializers.SlugRelatedField(
+        slug_field='uuid',
+        queryset=Job.objects.all(),
+        required=False,
+        allow_null=True)
+    subbasin_mapshed_job_uuid = serializers.SlugRelatedField(
+        slug_field='uuid',
+        queryset=Job.objects.all(),
+        required=False,
+        allow_null=True)
     scenarios = ScenarioSerializer(many=True, read_only=True)
     hydroshare = HydroShareResourceSerializer(read_only=True)
 
@@ -109,6 +120,16 @@ class ProjectUpdateSerializer(gis_serializers.GeoModelSerializer):
     user = UserSerializer(default=serializers.CurrentUserDefault(),
                           read_only=True)
     gis_data = JsonField(required=False, allow_null=True)
+    mapshed_job_uuid = serializers.SlugRelatedField(
+        slug_field='uuid',
+        queryset=Job.objects.all(),
+        required=False,
+        allow_null=True)
+    subbasin_mapshed_job_uuid = serializers.SlugRelatedField(
+        slug_field='uuid',
+        queryset=Job.objects.all(),
+        required=False,
+        allow_null=True)
 
 
 class AoiSerializer(serializers.BaseSerializer):

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -546,7 +546,7 @@ var ScenarioDropDownMenuItemView = Marionette.LayoutView.extend({
     },
 
     templateHelpers: function() {
-        var gis_data = this.model.getGisData().model_input,
+        var gis_data = App.currentProject.get('gis_data'),
             is_gwlfe = App.currentProject.get('model_package') === utils.GWLFE &&
                         gis_data !== null &&
                         gis_data !== '{}' &&


### PR DESCRIPTION
## Overview

In subbasin mode, the mapshed GMS payloads can grow to over
5MB (our nginx limit) when an AOI has more than about 20 child
HUC-12s.

Allow sending the MapShed Job UUID to the GWLF-E endpoint so
we don't worry about exceeding the payload size.

Now that the un-modified GMS can come from the job table, burning modifications into the GMS
needs to happen on the backend.

Connects #2543 

### Demo

<img width="445" alt="screen shot 2018-03-13 at 1 48 04 pm" src="https://user-images.githubusercontent.com/7633670/37363071-69f9071c-26cd-11e8-9239-c7e689fdfc9c.png">

### Notes

Using the job UUID to look up MapShed results puts pressure
on maintaining the jobs table which is not necessarily meant for long
term storage. We must now be careful if we ever need to empty
it, and we should consider other places to store the MapShed
results in the future.

## Testing Instructions
[Before pulling this branch make sure you have an old mapshed project.]

Pull, run migrations, and `bundle` the app
```sh
./scripts/manage.sh migrate
```

 **Anonymous user**
* Open your developer tools' network tab
* Model the `City of Philadelphia-Schuylkill River, HUC-12 Subwatershed` with MapShed
* Confirm the water quality results match the screen shot taken from develop below
![screen shot 2018-03-13 at 2 43 32 pm](https://user-images.githubusercontent.com/7633670/37363365-20371668-26ce-11e8-8949-df7cc65ae56f.png)
* Confirm only the `mapshed_job_uuid` is sent, not the `model_input`

* Add a new scenario and add two mods: 3ha of Nutrient Management and 4000ha of Surface Water Retention
* Confirm the new water quality results match the develop screenshot below 
![screen shot 2018-03-13 at 2 43 53 pm](https://user-images.githubusercontent.com/7633670/37363366-205482de-26ce-11e8-9b27-ded61fcae65f.png)

**Logged in user**

* Load a mapshed project you created before this branch. Confirm MapShed runs again to populate the UUID field on the model
* Confirm you can model and reload a model while logged in

**Sub-basin** 
Download [mapshed_model.sh.txt](https://github.com/WikiWatershed/model-my-watershed/files/1808297/mapshed_model.sh.txt) and remove the `.txt` ending. Run it with `SUBBASIN=true`. 

**`model_input`**
Follow the instructions started at `L58` of the above script, and set `SUBBASIN=false`. Call the script again and confirm the gwlf-e endpoint can still work like it did.

