### PR TITLE
Fix HydroShare Login in Internet Explorer

### DIFF
--- a/src/mmw/apps/user/templates/user/hydroshare-auth.html
+++ b/src/mmw/apps/user/templates/user/hydroshare-auth.html
@@ -38,11 +38,27 @@
             var message = 'mmw-hydroshare-success';
             {% endif %}
             parent.postMessage(message, window.location.origin);
+
+            {% if not error %}
+            // Redirect to home if not in iframe and already closed
+            // since iframes are closed after 500ms in core.modals.views.IframeView.
+            setTimeout(function() {
+                window.location.href = window.location.origin + '/account/';
+            }, 750);
+            {% endif %}
         });
 
         {% if error %}
         document.getElementById('hydroshare-cancel').addEventListener('click', function() {
             parent.postMessage('mmw-hydroshare-cancel', window.location.origin);
+
+            // Disable button to prevent double-clicking
+            document.getElementById('hydroshare-cancel').disabled = true;
+            // Redirect to home if not in iframe and already closed
+            // since iframes are closed after 500ms in core.modals.views.IframeView.
+            setTimeout(function() {
+                window.location.href = window.location.origin + '/account/';
+            }, 750);
         });
         {% endif %}
     </script>

--- a/src/mmw/js/src/account/views.js
+++ b/src/mmw/js/src/account/views.js
@@ -12,6 +12,7 @@ var $ = require('jquery'),
     modalModels = require('../core/modals/models'),
     models = require('./models'),
     settings = require('../core/settings'),
+    utils = require('../core/utils'),
     containerTmpl = require('./templates/container.html'),
     pageToggleTmpl = require('./templates/pageToggle.html'),
     linkedAccountsTmpl = require('./templates/linkedAccounts.html'),
@@ -46,6 +47,14 @@ var LinkedAccountsView = Marionette.ItemView.extend({
                     signalCancel: 'mmw-hydroshare-cancel',
                 })
             });
+
+        if (utils.getIEVersion()) {
+            // Special handling for IE which does not support 3rd party
+            // cookies in iframes, which are necessary for the iframe
+            // workflow.
+
+            window.location.href = window.location.origin + '/user/hydroshare/login/';
+        }
 
         iframe.render();
         iframe.on('success', function() {

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -678,6 +678,35 @@ var utils = {
         }
 
         URL.revokeObjectURL(url);
+    },
+
+    // Checks if current browser is Internet Explorer / Edge. If so,
+    // returns its version number. Else, returns false.
+    // Taken from https://codepen.io/gapcode/pen/vEJNZN
+    getIEVersion: function() {
+        var ua = window.navigator.userAgent;
+
+        var msie = ua.indexOf('MSIE ');
+        if (msie > 0) {
+            // IE 10 or older => return version number
+            return parseInt(ua.substring(msie + 5, ua.indexOf('.', msie)), 10);
+        }
+
+        var trident = ua.indexOf('Trident/');
+        if (trident > 0) {
+            // IE 11 => return version number
+            var rv = ua.indexOf('rv:');
+            return parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
+        }
+
+        var edge = ua.indexOf('Edge/');
+        if (edge > 0) {
+            // Edge (IE 12+) => return version number
+            return parseInt(ua.substring(edge + 5, ua.indexOf('.', edge)), 10);
+        }
+
+        // other browser
+        return false;
     }
 };
 


### PR DESCRIPTION
## Overview

Internet Explorer stringently disallows third party cookies, which make logging in to HydroShare via an iframe impossible, since we cannot send the CSRFToken necessary for Django (which HydroShare is written in) to work. Thus, we detect when the browser is running IE, and redirect instead of iframe in that case. Other browsers will continue to work as is.

Connects #2721 

### Demo

![2018-03-13 17 00 46](https://user-images.githubusercontent.com/1430060/37369884-df3701e2-26e0-11e8-8375-d2181b3bb49c.gif)

### Notes

The workflow would be nicer if the "Linked Accounts" section had a URL that we could redirect to, instead of just the "Accounts" home, but that seemed out of scope for this card.

I also tried opening HydroShare in a new tab, which works for the most part, but we need to refresh / refetch the user model from the server to get the new permissions, which we cannot do automatically like we can with the iframe (since `postMessage` does not work outside of iframes). We could have had a message like "please go back to your original tab and refresh it" but this seemed more intuitive.

## Testing Instructions

* Checkout this branch and `bundle`
* Go to "My Account" → "Linked Accounts" in IE. Ensure that when connecting to HydroShare you are redirected there and back success and failure.
* Go to "My Account" → "Linked Accounts" in any other browser. Ensure that you see the iframe and you are not redirected.
* Go to any project and share to HydroShare when your account is not connected in IE. Ensure you are shown a confirmation popup and are redirected to "My Accounts" on clicking it.
* Go to any project and share to HydroShare when your account is not connected in any other browser. Ensure you are shown the iframe and subsequently the HydroShare export modal.