### PR TITLE
Use New MultiOperation for MapShed and Sub-basin

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -51,7 +51,7 @@ docker_options: "--storage-driver=aufs"
 geop_host: "localhost"
 geop_port: 8090
 
-geop_version: "3.1.0"
+geop_version: "4.0.0"
 geop_cache_enabled: 1
 
 nginx_cache_dir: "/var/cache/nginx"

--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -18,7 +18,7 @@ def split_into_huc12s(code, id):
     huc_code = table_name.split('_')[1]
 
     sql = '''
-          SELECT boundary_huc12.id,
+          SELECT 'huc12__' || boundary_huc12.id,
                  boundary_huc12.huc12,
                  ST_AsGeoJSON(boundary_huc12.geom_detailed)
           FROM boundary_huc12, {table_name}

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -175,8 +175,8 @@ def multi(self, opname, shapes, stream_lines):
 
     # Get cached results
     for shape in shapes:
+        cached_operations = 0
         if shape['id'] != NOWKAOI:
-            cached_operations = 0
             output[shape['id']] = {}
             for op in data['operations']:
                 key = 'geop_{}__{}'.format(shape['id'], op['label'])
@@ -185,8 +185,8 @@ def multi(self, opname, shapes, stream_lines):
                     output[shape['id']][op['label']] = cached
                     cached_operations += 1
 
-            if cached_operations != operation_count:
-                data['shapes'].append(shape)
+        if cached_operations != operation_count:
+            data['shapes'].append(shape)
 
     # If no un-cached shapes, return cached output
     if not data['shapes']:

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -98,6 +98,7 @@ def run(self, opname, input_data, wkaoi=None, cache_key=''):
 
 
 @shared_task(bind=True, default_retry_delay=1, max_retries=6)
+@statsd.timer(__name__ + '.multi')
 def multi(self, opname, shapes, stream_lines):
     """
     Perform a multi-operation geoprocessing request.

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -164,7 +164,28 @@ def multi(self, opname, shapes, stream_lines):
     we are using the same cache naming scheme as run, any operation cached via
     `multi` can be reused by `run`.
     """
-    pass
+    data = settings.GEOP['json'][opname].copy()
+    data['shapes'] = shapes
+    data['streamLines'] = stream_lines
+
+    output = {}
+
+    try:
+        result = geoprocess('multi', data, self.retry)
+
+        output.update(result)
+
+        return output
+    except Retry as r:
+        raise r
+    except ConnectionError:
+        return {
+            'error': 'Could not reach the geoprocessing service'
+        }
+    except Exception as x:
+        return {
+            'error': str(x)
+        }
 
 
 @statsd.timer(__name__ + '.geop_run')

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import math
+import numpy
 
 from collections import namedtuple
 
@@ -12,6 +13,8 @@ from gwlfe.enums import GrowFlag
 from django_statsd.clients import statsd
 from django.conf import settings
 from django.db import connection
+
+from django.contrib.gis.geos import GEOSGeometry
 
 NRur = settings.GWLFE_DEFAULTS['NRur']
 NUM_WEATHER_STATIONS = settings.GWLFE_CONFIG['NumWeatherStations']
@@ -49,22 +52,31 @@ def day_lengths(geom):
     return [round(l, 1) for l in lengths]
 
 
-def nearest_weather_stations(geom, n=NUM_WEATHER_STATIONS):
 @statsd.timer(__name__ + '.nearest_weather_stations')
+def nearest_weather_stations(shapes, n=NUM_WEATHER_STATIONS):
     """
-    Given a geometry, returns a list of the n closest weather stations to it
+    Given a list of geometries, returns a list of the n closest
+    weather stations to each of them
     """
-    sql = '''
-          SELECT station, location, meanrh, meanwind, meanprecip,
-                 begyear, endyear, eroscoeff, rain_cool, rain_warm,
-                 etadj, grw_start, grw_end
+
+    subquery = '''
+          (SELECT %s watershed_id, station, location, meanrh, meanwind,
+                 meanprecip, begyear, endyear, eroscoeff, rain_cool,
+                 rain_warm, etadj, grw_start, grw_end
           FROM ms_weather_station
           ORDER BY geom <-> ST_SetSRID(ST_GeomFromText(%s), 4326)
-          LIMIT %s;
+          LIMIT %s)
           '''
+    subqueries, params = [], []
+    for (_, watershed_id, aoi) in shapes:
+        subqueries.append(subquery)
+        geom = GEOSGeometry(aoi, srid=4326)
+        params.extend([watershed_id, geom.wkt, n])
+
+    sql = ' UNION '.join(subqueries) + ';'
 
     with connection.cursor() as cursor:
-        cursor.execute(sql, [geom.wkt, n])
+        cursor.execute(sql, params)
 
         if cursor.rowcount == 0:
             raise Exception("No weather stations found.")
@@ -384,10 +396,10 @@ def point_source_discharge(geom, area, drb=False):
 def weather_data(ws, begyear, endyear):
     """
     Given a list of Weather Stations and beginning and end years, returns two
-    3D arrays, one for average temperature and the other for precipitation,
-    for each day in each month in each year in the range, averaged over all
-    stations in the list, in the format:
-        array[year][month][day] = value
+    dictionaries of 3D arrays keyed by station id,
+    one for average temperature and the other for precipitation,
+    for each day in each month in each year in the range
+        { station: array[year][month][day] = value }
     where `year` 0 corresponds to the first year in the range, 1 to the second,
     and so on; `month` 0 corresponds to January, 1 to February, and so on;
     `day` 0 corresponds to the 1st of the month, 1 to the 2nd, and so on.
@@ -397,31 +409,25 @@ def weather_data(ws, begyear, endyear):
         return (f - 32) * 5.0 / 9.0
 
     temp_sql = '''
-               SELECT year, EXTRACT(MONTH FROM TO_DATE(month, 'MON')) AS month,
-                      AVG("1") AS "1", AVG("2") AS "2", AVG("3") AS "3",
-                      AVG("4") AS "4", AVG("5") AS "5", AVG("6") AS "6",
-                      AVG("7") AS "7", AVG("8") AS "8", AVG("9") AS "9",
-                      AVG("10") AS "10", AVG("11") AS "11", AVG("12") AS "12",
-                      AVG("13") AS "13", AVG("14") AS "14", AVG("15") AS "15",
-                      AVG("16") AS "16", AVG("17") AS "17", AVG("18") AS "18",
-                      AVG("19") AS "19", AVG("20") AS "20", AVG("21") AS "21",
-                      AVG("22") AS "22", AVG("23") AS "23", AVG("24") AS "24",
-                      AVG("25") AS "25", AVG("26") AS "26", AVG("27") AS "27",
-                      AVG("28") AS "28", AVG("29") AS "29", AVG("30") AS "30",
-                      AVG("31") AS "31"
+               SELECT station, year,
+                   EXTRACT(MONTH FROM TO_DATE(month, 'MON')) AS month,
+                    "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9", "10",
+                   "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+                   "21", "22", "23", "24", "25", "26", "27", "28", "29", "30",
+                   "31"
                FROM ms_weather
                WHERE station IN %s
                  AND measure IN ('TMax', 'TMin')
                  AND year BETWEEN %s AND %s
-               GROUP BY year, month
                ORDER BY year, month;
                '''
     prcp_sql = '''
-               SELECT year, EXTRACT(MONTH FROM TO_DATE(month, 'MON')) AS month,
-                     "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9", "10",
-                    "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
-                    "21", "22", "23", "24", "25", "26", "27", "28", "29", "30",
-                    "31"
+               SELECT station, year,
+                   EXTRACT(MONTH FROM TO_DATE(month, 'MON')) AS month,
+                    "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9", "10",
+                   "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+                   "21", "22", "23", "24", "25", "26", "27", "28", "29", "30",
+                   "31"
                FROM ms_weather
                WHERE station IN %s
                  AND measure = 'Prcp'
@@ -431,26 +437,41 @@ def weather_data(ws, begyear, endyear):
 
     year_range = endyear - begyear + 1
     stations = tuple([w.station for w in ws])
-    temps = [[[0] * 31 for m in range(12)] for y in range(year_range)]
-    prcps = [[[0] * 31 for m in range(12)] for y in range(year_range)]
-
+    # For each station id, create a 3D array of 0s
+    # where each 0 is a placeholder for a temperature/precipitation
+    # value on a given year, month, day: array[year][month][day] = 0
+    temps = {station_id: [[[0] * 31 for m in range(12)]
+                          for y in range(year_range)]
+             for station_id in stations}
+    prcps = {station_id: [[[0] * 31 for m in range(12)]
+                          for y in range(year_range)]
+             for station_id in stations}
+    # Query the DB for daily temperatures for each weather station
     with connection.cursor() as cursor:
         cursor.execute(temp_sql, [stations, begyear, endyear])
         for row in cursor.fetchall():
-            year = int(row[0]) - begyear
-            month = int(row[1]) - 1
+            station = int(row[0])
+            year = int(row[1]) - begyear
+            month = int(row[2]) - 1
             for day in range(31):
-                temps[year][month][day] = f_to_c(float(row[day + 2]))
-
+                temps[station][year][month][day] = f_to_c(float(row[day + 3]))
+    # Query the DB for daily precipitation values for each weather station
     with connection.cursor() as cursor:
         cursor.execute(prcp_sql, [stations, begyear, endyear])
         for row in cursor.fetchall():
-            year = int(row[0]) - begyear
-            month = int(row[1]) - 1
+            station = int(row[0])
+            year = int(row[1]) - begyear
+            month = int(row[2]) - 1
             for day in range(31):
-                prcps[year][month][day] = float(row[day + 2]) * CM_PER_INCH
+                prcp = float(row[day + 3]) * CM_PER_INCH
+                prcps[station][year][month][day] = prcp
 
     return temps, prcps
+
+
+def average_weather_data(wd):
+    A = numpy.array(wd)
+    return numpy.mean(A, axis=0).tolist()
 
 
 def curve_number(n_count, ng_count):

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 
 from gwlfe.enums import GrowFlag
 
+from django_statsd.clients import statsd
 from django.conf import settings
 from django.db import connection
 
@@ -49,6 +50,7 @@ def day_lengths(geom):
 
 
 def nearest_weather_stations(geom, n=NUM_WEATHER_STATIONS):
+@statsd.timer(__name__ + '.nearest_weather_stations')
     """
     Given a geometry, returns a list of the n closest weather stations to it
     """
@@ -144,6 +146,7 @@ def kv_coefficient(area_pcts, season):
     return kv
 
 
+@statsd.timer(__name__ + '.animal_enery_units')
 def animal_energy_units(geom):
     """
     Given a geometry, returns the total livestock and poultry AEUs within it
@@ -212,6 +215,7 @@ def manure_spread(aeu):
     return [n_spread] * num_land_uses, [p_spread] * num_land_uses
 
 
+@statsd.timer(__name__ + '.ag_ls_c_p')
 def ag_ls_c_p(geom):
     """
     Given a geometry, calculates the area-weighted average value of LS, C, and
@@ -297,6 +301,7 @@ def ls_factor(stream_length, area, avg_slope, m):
         return ls
 
 
+@statsd.timer(__name__ + '.stream_length')
 def stream_length(geom, drb=False):
     """
     Given a geometry, finds the total length of streams in meters within it.
@@ -344,6 +349,7 @@ def get_point_source_table(drb):
     return 'ms_pointsource' + ('_drb' if drb else '')
 
 
+@statsd.timer(__name__ + '.point_source_discharge')
 def point_source_discharge(geom, area, drb=False):
     """
     Given a geometry and its area in square meters, returns three lists,
@@ -374,6 +380,7 @@ def point_source_discharge(geom, area, drb=False):
         return n_load, p_load, discharge
 
 
+@statsd.timer(__name__ + '.weather_data')
 def weather_data(ws, begyear, endyear):
     """
     Given a list of Weather Stations and beginning and end years, returns two

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 
 from celery import shared_task
 from django.conf import settings
+
+from django_statsd.clients import statsd
 from django.contrib.gis.geos import GEOSGeometry
 
 from apps.modeling.geoprocessing import NOWKAOI, multi, run, parse
@@ -512,6 +514,7 @@ def convert_data(payload, wkaoi):
 
 
 @shared_task
+@statsd.timer(__name__ + '.collect_subbasin')
 def collect_subbasin(payload, shapes):
     return [
         collect_data(convert_data(payload, wkaoi), aoi, watershed_id)

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -480,6 +480,14 @@ def multi_mapshed(aoi, wkaoi):
     return multi.s('mapshed', shape, stream_lines)
 
 
+def multi_subbasin(parent_aoi, child_shapes):
+    shapes = [{'id': wkaoi, 'shape': aoi}
+              for (wkaoi, _, aoi) in child_shapes]
+    stream_lines = streams(parent_aoi)[0]
+
+    return multi.s('mapshed', shapes, stream_lines)
+
+
 @shared_task(throws=Exception)
 def convert_data(payload, wkaoi):
     if 'error' in payload:
@@ -500,6 +508,14 @@ def convert_data(payload, wkaoi):
         slope(results['slope']),
         nlcd_kfactor(results['nlcd_kfactor']),
         nlcd_streams(results['nlcd_streams']),
+    ]
+
+
+@shared_task
+def collect_subbasin(payload, shapes):
+    return [
+        collect_data(convert_data(payload, wkaoi), aoi, watershed_id)
+        for (wkaoi, watershed_id, aoi) in shapes
     ]
 
 

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -25,6 +25,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
                                          stream_length,
                                          point_source_discharge,
                                          weather_data,
+                                         average_weather_data,
                                          curve_number,
                                          phosphorus_conc,
                                          groundwater_nitrogen_conc,
@@ -47,7 +48,7 @@ NO_LAND_COVER = 'NO_LAND_COVER'
 
 
 @shared_task
-def collect_data(geop_results, geojson, watershed_id=None):
+def collect_data(geop_results, geojson, watershed_id=None, weather=None):
     geop_result = {k: v for r in geop_results for k, v in r.items()}
 
     geom = GEOSGeometry(geojson, srid=4326)
@@ -62,7 +63,11 @@ def collect_data(geop_results, geojson, watershed_id=None):
     z['DayHrs'] = day_lengths(geom)
 
     # Data from the Weather Stations dataset
-    ws = nearest_weather_stations(geom)
+    if weather is not None:
+        ws, wd = weather
+    else:
+        ws = nearest_weather_stations([(None, watershed_id, geojson)])
+
     z['Grow'] = growing_season(ws)
     z['Acoef'] = erosion_coeff(ws, z['Grow'])
     z['PcntET'] = et_adjustment(ws)
@@ -97,7 +102,13 @@ def collect_data(geop_results, geojson, watershed_id=None):
     z['PointFlow'] = discharge
 
     # Data from National Weather dataset
-    temps, prcps = weather_data(ws, z['WxYrBeg'], z['WxYrEnd'])
+    if weather is None:
+        wd = weather_data(ws, z['WxYrBeg'], z['WxYrEnd'])
+        temps_dict, prcps_dict = wd
+        temps = average_weather_data(temps_dict.values())
+        prcps = average_weather_data(prcps_dict.values())
+    else:
+        temps, prcps = wd
     z['Temp'] = temps
     z['Prec'] = prcps
 
@@ -516,8 +527,29 @@ def convert_data(payload, wkaoi):
 @shared_task
 @statsd.timer(__name__ + '.collect_subbasin')
 def collect_subbasin(payload, shapes):
+    # Gather weather stations and their data
+    # collectively to avoid re-reading stations
+    # that are shared across huc-12s
+    huc12_ws = nearest_weather_stations(shapes)
+    # Find the weather stations unique across all huc12s
+    unique_ws = {w.station: w for w in huc12_ws}.values()
+    begyear = int(max([w.begyear for w in huc12_ws]))
+    endyear = int(min([w.endyear for w in huc12_ws]))
+    # Gather the temp and prcp values for each unique weather stations
+    unique_wd = weather_data(unique_ws, begyear, endyear)
+
+    # Get the stations and averaged tmp/prcp data for a specific huc-12
+    def get_weather(watershed_id):
+        ws = [w for w in huc12_ws if w.watershed_id == watershed_id]
+        stations = [w.station for w in ws]
+        temps_by_station = [unique_wd[0][station] for station in stations]
+        prcps_by_station = [unique_wd[1][station] for station in stations]
+        return (ws, (average_weather_data(temps_by_station),
+                     average_weather_data(prcps_by_station)))
+    # Build the GMS data for each huc-12
     return [
-        collect_data(convert_data(payload, wkaoi), aoi, watershed_id)
+        collect_data(convert_data(payload, wkaoi), aoi, watershed_id,
+                     get_weather(watershed_id))
         for (wkaoi, watershed_id, aoi) in shapes
     ]
 

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -22,6 +22,7 @@ from django.db.models.sql import EmptyResultSet
 from django.http import (HttpResponse,
                          Http404,
                          )
+
 from django.core.servers.basehttp import FileWrapper
 
 from apps.core.models import Job

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -28,10 +28,11 @@ from apps.core.models import Job
 from apps.core.tasks import save_job_error, save_job_result
 from apps.core.decorators import log_request
 from apps.modeling import tasks, geoprocessing
-from apps.modeling.mapshed.tasks import (geoprocessing_chains,
+from apps.modeling.mapshed.tasks import (multi_subbasin,
                                          multi_mapshed,
                                          convert_data,
                                          collect_data,
+                                         collect_subbasin,
                                          )
 from apps.modeling.models import Project, Scenario
 from apps.modeling.serializers import (ProjectSerializer,
@@ -314,16 +315,12 @@ def _initiate_subbasin_mapshed_job_chain(mapshed_input, job_id):
     if not huc12s:
         raise EmptyResultSet('No subbasins found')
 
-    huc12_job_chains = []
-    for (huc12_id, huc12, huc12_aoi) in huc12s:
-        huc12_wkaoi = 'huc12__{id}'.format(id=huc12_id)
-        huc12_job_chains.append(chain((
-            group(geoprocessing_chains(huc12_aoi, huc12_wkaoi, errback)) |
-            collect_data.s(huc12_aoi, huc12).set(link_error=errback))))
-
-    return chain(group(huc12_job_chains) |
+    job_chain = (multi_subbasin(area_of_interest, huc12s) |
+                 collect_subbasin.s(huc12s) |
                  tasks.subbasin_results_to_dict.s() |
-                 save_job_result.s(job_id, mapshed_input)).apply_async()
+                 save_job_result.s(job_id, mapshed_input))
+
+    return job_chain.apply_async(link_error=errback)
 
 
 def _initiate_mapshed_job_chain(mapshed_input, job_id):

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -622,6 +622,85 @@ GEOP = {
                 'operationType': 'RasterSummary',
                 'zoom': 0
             }
+        },
+        'mapshed': {
+            'shapes': [],
+            'streamLines': '',
+            'operations': [
+                {
+                    'name': 'RasterGroupedCount',
+                    'label': 'nlcd_soil',
+                    'rasters': [
+                        'nlcd-2011-30m-epsg5070-512-int8',
+                        'ssurgo-hydro-groups-30m-epsg5070-512-int8'
+                    ]
+                },
+                {
+                    'name': 'RasterLinesJoin',
+                    'label': 'nlcd_streams',
+                    'rasters': [
+                        'nlcd-2011-30m-epsg5070-512-int8'
+                    ]
+                },
+                {
+                    'name': 'RasterGroupedCount',
+                    'label': 'gwn',
+                    'rasters': [
+                        'us-groundwater-nitrogen-30m-epsg5070-512'
+                    ]
+                },
+                {
+                    'name': 'RasterGroupedAverage',
+                    'label': 'avg_awc',
+                    'targetRaster': 'us-ssurgo-aws100-30m-epsg5070-512',
+                    'rasters': [
+                        'us-groundwater-nitrogen-30m-epsg5070-512'
+                    ]
+                },
+                {
+                    'name': 'RasterGroupedCount',
+                    'label': 'nlcd_slope',
+                    'rasters': [
+                        'nlcd-2011-30m-epsg5070-512-int8',
+                        'us-percent-slope-30m-epsg5070-512'
+                    ]
+                },
+                {
+                    'name': 'RasterGroupedAverage',
+                    'label': 'slope',
+                    'targetRaster': 'us-percent-slope-30m-epsg5070-512',
+                    'rasters': []
+                },
+                {
+                    'name': 'RasterGroupedAverage',
+                    'label': 'nlcd_kfactor',
+                    'targetRaster': 'us-ssugro-kfactor-30m-epsg5070-512',
+                    'rasters': [
+                        'nlcd-2011-30m-epsg5070-512-int8'
+                    ]
+                },
+                {
+                    'name': 'RasterGroupedAverage',
+                    'label': 'soiln',
+                    'targetRaster': 'soiln-epsg5070',
+                    'rasters': [],
+                    'pixelIsArea': True
+                },
+                {
+                    'name': 'RasterGroupedAverage',
+                    'label': 'soilp',
+                    'targetRaster': 'soilpallland2-epsg5070',
+                    'rasters': [],
+                    'pixelIsArea': True
+                },
+                {
+                    'name': 'RasterGroupedAverage',
+                    'label': 'recess_coef',
+                    'targetRaster': 'bfi48grd-epsg5070',
+                    'rasters': [],
+                    'pixelIsArea': True
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
## Overview

Switches MapShed and Sub-basin to use the new MultiOperation endpoint of the geoprocessing service introduced in https://github.com/WikiWatershed/mmw-geoprocessing/pull/85.

Connects #2657 

### Demo

The result of `debugcelery` for MapShed on this branch:

```
[2018-03-22 13:33:11,673: INFO/MainProcess] Received task: apps.modeling.geoprocessing.multi[6c735c63-3e1c-4c5f-ae9c-0ede5a23d567]
[2018-03-22 13:33:32,585: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.convert_data[7b92c891-7096-4851-9d63-1fb2d95ea5c3]
[2018-03-22 13:33:32,599: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.collect_data[9536ec97-e0be-47c1-9270-c7b0761e64fc]
[2018-03-22 13:33:33,100: INFO/MainProcess] Received task: apps.core.tasks.save_job_result[c1e63a96-8a1d-4c01-8e97-cb10453a9300]
```

as opposed to `develop`:

```
[2018-03-22 13:34:44,476: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[18856b80-89a3-4d73-a62d-25a3701e7456]
[2018-03-22 13:34:44,492: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[c0f7c1e6-3ab3-4295-9f11-f5929ed6d193]
[2018-03-22 13:34:44,500: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[7a2d54cd-0894-4a00-9410-563a6e1dcc9e]
[2018-03-22 13:34:44,513: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[78f5cdb3-ef07-4a27-beda-3ca95e6830e2]
[2018-03-22 13:34:44,532: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[a5caf95c-96c1-4f36-b541-0f727dfa9f1b]
[2018-03-22 13:34:44,573: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[769b1756-a480-4881-8b5d-5116dc24872f]
[2018-03-22 13:34:44,595: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[403a96b3-1571-4da9-9d68-5e4a6a09ae8a]
[2018-03-22 13:34:44,615: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[c375c572-21a9-4c9b-8703-d97dbcc49995]
[2018-03-22 13:34:44,636: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[8007fa43-7a4c-4fd6-9971-71ab12846a93]
[2018-03-22 13:34:44,651: INFO/MainProcess] Received task: apps.modeling.geoprocessing.run[a452f16a-ff6f-4904-bb51-ea0a391cd6f1]
[2018-03-22 13:34:44,666: INFO/MainProcess] Received task: celery.chord_unlock[4061869b-edc9-4f89-a168-a9fc2abe7e59]  ETA:[2018-03-22 17:34:45.442711+00:00]
[2018-03-22 13:34:44,677: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.nlcd_soil[83b30081-e83a-41c3-bcb9-930ed21a09ae]
[2018-03-22 13:34:44,690: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.soiln[2b5736ff-f117-45a1-96c7-ef6586278032]
[2018-03-22 13:34:44,700: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.soilp[4c051f5a-6011-4740-adb2-2483cf07378e]
[2018-03-22 13:34:44,715: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.recess_coef[dd9c4202-02a7-4ac2-8375-0fdbcc51c4ec]
[2018-03-22 13:34:44,725: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.gwn[27e24669-d645-4c5d-afab-2c8ade6cf965]
[2018-03-22 13:34:44,731: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.avg_awc[44d9d256-fa72-4f5c-af4a-7f17548efee1]
[2018-03-22 13:34:44,741: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.nlcd_slope[875f3c88-804e-4442-8591-b686a414bb6b]
[2018-03-22 13:34:44,748: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.slope[9ef9cd12-a45a-4869-b796-7a47b61e1273]
[2018-03-22 13:34:44,756: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.nlcd_kfactor[a22e0ef3-7af0-44cf-ba95-4b0a4e067175]
[2018-03-22 13:34:44,769: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.nlcd_streams[6030f3fa-3c34-42ea-8fe0-480654296ad7]
[2018-03-22 13:34:46,312: INFO/MainProcess] Received task: apps.modeling.mapshed.tasks.collect_data[e69c7324-b760-43fc-8a00-1c6763a51e7f]
[2018-03-22 13:34:46,835: INFO/MainProcess] Received task: apps.core.tasks.save_job_result[35a601b0-926e-4a2a-8f7d-f93bddda961d]
```

### Notes

We should make a follow up card to remove all the methods (such as `geoprocessing_chains`) that are not used anymore. All the individual callbacks (such as `slope`, `nlcd_kfactor`, etc) no longer need to be tasks and can have their `shared_task` decorators removed.

For sub-basin, we could have gone with the following workflow:

```
  chain(
    task0
    group(
      chain(task1, task2),
      chain(task3, task4))
    task5
    task6
  )
```

but because of celery/celery#4244 which does not give the first task in a chain in a group (task1 and task3 above) the result of the preceding task (task0 above), we couldn't have a setup like this:

```
  chain(
    multi_subbasin(huc12s)
    group(
      [convert_data(wkaoi) | collect_data(aoi, watershed_id)
       for (wkaoi, watershed_id, aoi) in huc12s])
    subbasin_results_to_dict
    save_job_result
  )
```

Instead we use `collect_subbasin` in place of the group for the same thing. If this part can be parallelized, it could lead to significant performance gains.

## Testing Instructions

* Check out this branch and reprovision `worker`
* Run `debugcelery`
* Make a MapShed project and observe the Celery logs. Ensure you see one `multi` instead of several `run` tasks. Ensure the values are the same for the same shape on `develop` / staging.
* Make a Sub-basin project and observe the Celery logs. Ensure you see one `multi` instead of several `run` tasks. Ensure the values are the same for the same shape on `develop` / staging.
* Try clearing the cache and running the above again to ensure it works without cached shapes:

    ```
    $ vagrant ssh services -c 'redis-cli -n 1 --raw KEYS ":1:geop_*" | xargs redis-cli -n 1 DEL'
    ```

* Try running the above again to ensure it works with cached shapes.