### PR TITLE
Update OpenJDK

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.geoprocessing/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.geoprocessing/meta/main.yml
@@ -3,7 +3,7 @@ dependencies:
   - {
       role: "azavea.java",
       java_major_version: "8",
-      java_version: "8u141*"
+      java_version: "8u162*"
     }
   - { role: "model-my-watershed.base" }
   - { role: "model-my-watershed.nginx" }


### PR DESCRIPTION
Our openJDK version was out of date, preventing rebuilding the worker VM.

## Testing Instructions
 * Pull this branch
 * Confirm you can provision your `worker`
  `vagrant reload worker --provision`