### PR TITLE
Format SRAT Response Sub-basin

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -95,6 +95,71 @@ def format_for_srat(huc12_id, model_output):
     return formatted
 
 
+def format_subbasin(huc12_gwlfe_results, srat_catchment_results):
+    def empty_source(s):
+        return {'Source': s, 'TotalN': 0, 'TotalP': 0, 'Sediment': 0}
+
+    def add_huc12_source(source, srat_huc12):
+        source_name = source['Source']
+        source_key = settings.SRAT_KEYS[source_name]
+        total_n = srat_huc12.get('tnload_' + source_key, 0)
+        total_p = srat_huc12.get('tpload_' + source_key, 0)
+        sediment = srat_huc12.get('tssload_' + source_key, 0)
+
+        source['TotalN'] += total_n
+        source['TotalP'] += total_p
+        source['Sediment'] += sediment
+
+        return {
+            'Source': source_name,
+            'TotalN': total_n,
+            'TotalP': total_p,
+            'Sediment': sediment
+        }
+
+    def format_catchment(srat_catchment):
+        return {
+            'TotalLoadingRates': {
+                'TotalN': srat_catchment['tnloadrate_total'],
+                'TotalP': srat_catchment['tploadrate_total'],
+                'Sediment': srat_catchment['tssloadrate_total'],
+            },
+            'LoadingRateConcentrations': {
+                'TotalN': srat_catchment['tnloadrate_conc'],
+                'TotalP': srat_catchment['tploadate_conc'],
+                'Sediment': srat_catchment['tssloadrate_conc'],
+            },
+        }
+
+    def add_huc12(srat_huc12, aggregate):
+        area = huc12_gwlfe_results[srat_huc12['huc12']]['AreaTotal']
+        aggregate['AreaTotal'] += area
+        return {
+            'Loads': [add_huc12_source(s, srat_huc12)
+                      for s in aggregate['Loads']],
+            'AreaTotal': area,
+            'Catchments': {comid: format_catchment(result)
+                           for comid, result
+                           in srat_huc12['catchments'].iteritems()}
+        }
+
+    aggregate = {
+        'Loads': [empty_source(source_name)
+                  for source_name in settings.SRAT_KEYS.keys()],
+        'AreaTotal': 0,
+        # All gwlf-e results should have the same inputmod hash,
+        # so grab any of them
+        'inputmod_hash': huc12_gwlfe_results.itervalues()
+                                            .next()['inputmod_hash'],
+    }
+
+    aggregate['HUC-12s'] = {huc12_id: add_huc12(result, aggregate)
+                            for huc12_id, result
+                            in srat_catchment_results['huc12s'].iteritems()}
+
+    return aggregate
+
+
 @shared_task(throws=Exception)
 def nlcd_soil(result):
     if 'error' in result:
@@ -266,12 +331,14 @@ def run_srat(watersheds):
                         (r.status_code, r.text))
 
     try:
-        result = r.json()
+        srat_catchment_result = r.json()
     except ValueError:
         raise Exception('SRAT Catchment API did not return JSON')
 
-    if (r.status_code != 200):
-        logger.error('SRAT Catchment API request failed: %s' % result)
+    try:
+        result = format_subbasin(watersheds, srat_catchment_result)
+    except KeyError as e:
+        raise Exception('SRAT Catchment API returned malformed result: %s' % e)
 
     return result
 

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -126,7 +126,7 @@ def format_subbasin(huc12_gwlfe_results, srat_catchment_results):
             },
             'LoadingRateConcentrations': {
                 'TotalN': srat_catchment['tnloadrate_conc'],
-                'TotalP': srat_catchment['tploadate_conc'],
+                'TotalP': srat_catchment['tploadrate_conc'],
                 'Sediment': srat_catchment['tssloadrate_conc'],
             },
         }

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -250,7 +250,7 @@ def run_srat(watersheds):
     try:
         data = [format_for_srat(id, w) for id, w in watersheds.iteritems()]
     except Exception as e:
-        logger.error('Formatting sub-basin GWLF-E results failed: %s' % e)
+        raise Exception('Formatting sub-basin GWLF-E results failed: %s' % e)
 
     headers = {'x-api-key': settings.SRAT_CATCHMENT_API['api_key']}
 
@@ -259,12 +259,16 @@ def run_srat(watersheds):
                           headers=headers,
                           data=json.dumps(data))
     except Exception as e:
-        logger.error('Request to SRAT Catchment API failed: %s' % e)
+        raise Exception('Request to SRAT Catchment API failed: %s' % e)
+
+    if (r.status_code != 200):
+        raise Exception('SRAT Catchment API request failed: %s %s' %
+                        (r.status_code, r.text))
 
     try:
         result = r.json()
     except ValueError:
-        logger.error('SRAT Catchment API did not return JSON')
+        raise Exception('SRAT Catchment API did not return JSON')
 
     if (r.status_code != 200):
         logger.error('SRAT Catchment API request failed: %s' % result)

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -254,8 +254,8 @@ def _initiate_subbasin_gwlfe_job_chain(model_input, modifications,
 
     return chain(
         group(huc12_jobs) |
-        tasks.subbasin_results_to_dict.s() |
-        tasks.run_srat.s() |
+        tasks.subbasin_results_to_dict.s().set(link_error=errback) |
+        tasks.run_srat.s().set(link_error=errback) |
         save_job_result.s(job_id, model_input)).apply_async()
 
 


### PR DESCRIPTION
## Overview

In sub-basin mode, the SRAT Catchment API returns attenuated GWLF-E results for each HUC-12, along with some summary results for each HUC-12's catchments. We will be displaying the full attenuated results aggregated for the whole AOI, for each huc-12 of the AOI and for huc-12's catchments.

* Sum the HUC-12 level results to find the attenuated results for the entire shape
* Format the SRAT API huc-12 level and catchment level results so they follow the same naming conventions as their unattenuated cousins

@kellyi, this may be useful to lightly review in preparation for the frontend work.
 
Connects #2649 

### Demo

<img width="1280" alt="screen shot 2018-03-23 at 3 11 39 pm" src="https://user-images.githubusercontent.com/7633670/37850352-2dc3197c-2eb1-11e8-9c4f-7c916d2c9a77.png">

Sample Response: 
[subbasin_result.json.txt](https://github.com/WikiWatershed/model-my-watershed/files/1848606/subbasin_result.json.txt)

### Notes
We are still finalizing what we will show in the tables; I've left things out like the `SummaryLoads` while we determine the final data we need. 

## Testing Instructions

 * If you need to rebuild any of your VMs you may need to rebase this off of #2739
 * You will need the `MMW_SRAT_CATCHMENT_API_KEY` set to what's in last pass. Either reprovision your worker VM with the key, or manually edit the env file.

* Turn on subbasin mode: `./scripts/togglefeature.sh  subbasin`
* Model some huc-10s with the multi-year model and confirm results appear in the Water Quality tab. When inspecting the final GWLF-E job payload, you should see a similar `result` as is in the `subbasin_results.json` file attached in the demo section above.

* Delete your `MMW_SRAT_CATCHMENT_API_KEY` and try to subbasin model a HUC-10. Confirm you see an appropriate unauthorized error passed along to the job `error` field.
