### PR TITLE
Display subbasin results view via water quality tab link

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
@@ -11,4 +11,7 @@
         <i class="fa fa-info-circle black"></i>
     </a>
 </p>
+<a data-action="view-subbasin-attenuated-results" id="view-subbasin-results-link">
+    View subbasin attentuated results
+</a>
 <div class="quality-table-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/result.html
@@ -11,7 +11,9 @@
         <i class="fa fa-info-circle black"></i>
     </a>
 </p>
+{% if showSubbasinModelingButton %}
 <a data-action="view-subbasin-attenuated-results" id="view-subbasin-results-link">
     View subbasin attentuated results
 </a>
+{% endif %}
 <div class="quality-table-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/quality/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/quality/views.js
@@ -3,8 +3,10 @@
 var $ = require('jquery'),
     _ = require('underscore'),
     Marionette = require('../../../../shim/backbone.marionette'),
+    App = require('../../../app'),
     resultTmpl = require('./templates/result.html'),
-    tableTmpl = require('./templates/table.html');
+    tableTmpl = require('./templates/table.html'),
+    utils = require('../../../core/utils');
 
 var ResultView = Marionette.LayoutView.extend({
     className: 'tab-pane',
@@ -26,6 +28,13 @@ var ResultView = Marionette.LayoutView.extend({
 
     modelEvents: {
         'change': 'onShow'
+    },
+
+    templateHelpers: function() {
+        return {
+            showSubbasinModelingButton: utils
+                .isWKAoIValidForSubbasinModeling(App.currentProject.get('wkaoi')),
+        };
     },
 
     initialize: function(options) {
@@ -58,7 +67,7 @@ var ResultView = Marionette.LayoutView.extend({
         });
     },
 
-    viewSubbasinResults() {
+    viewSubbasinResults: function() {
         this.options.showSubbasinHotSpotView();
     },
 });

--- a/src/mmw/js/src/modeling/gwlfe/quality/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/quality/views.js
@@ -12,7 +12,12 @@ var ResultView = Marionette.LayoutView.extend({
     template: resultTmpl,
 
     ui: {
-        tooltip: 'a.model-results-tooltip'
+        tooltip: 'a.model-results-tooltip',
+        subbasinResultsLink: '[data-action="view-subbasin-attenuated-results"]',
+    },
+
+    events: {
+        'click @ui.subbasinResultsLink': 'viewSubbasinResults',
     },
 
     regions: {
@@ -51,7 +56,11 @@ var ResultView = Marionette.LayoutView.extend({
             placement: 'top',
             trigger: 'focus'
         });
-    }
+    },
+
+    viewSubbasinResults() {
+        this.options.showSubbasinHotSpotView();
+    },
 });
 
 var TableView = Marionette.CompositeView.extend({

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
@@ -6,4 +6,6 @@
             <i class="fa fa-arrow-left black"></i> Exit subbasin attenuated results
         </a>
     </div>
+    <div class="result-region">
+    </div>
 </div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
@@ -1,0 +1,9 @@
+<div class="result">
+    <div class="result-detail-header">
+        <a type="button" class="close" aria-label="Close"
+           data-action="close-subbasin-view"
+           id="close-subbasin-view">
+            <i class="fa fa-arrow-left black"></i> Exit subbasin attenuated results
+        </a>
+    </div>
+</div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var $ = require('jquery'),
+    _ = require('lodash'),
+    Marionette = require('../../../../shim/backbone.marionette'),
+    resultTmpl = require('./templates/result.html');
+
+var ResultView = Marionette.LayoutView.extend({
+    className: 'tab-pane',
+    template: resultTmpl,
+
+    ui: {
+        'close': '[data-action="close-subbasin-view"]',
+    },
+
+    events: {
+        'click @ui.close': 'handleSubbasinCloseButtonClick',
+    },
+
+    handleSubbasinCloseButtonClick: function() {
+        this.options.hideSubbasinHotSpotView();
+    },
+});
+
+module.exports = {
+    ResultView: ResultView,
+};

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -1,13 +1,18 @@
 "use strict";
 
-var $ = require('jquery'),
-    _ = require('lodash'),
-    Marionette = require('../../../../shim/backbone.marionette'),
+var Marionette = require('../../../../shim/backbone.marionette'),
+    App = require('../../../app'),
+    coreViews = require('../../../core/views'),
+    coreModels = require('../../../core/models'),
     resultTmpl = require('./templates/result.html');
 
 var ResultView = Marionette.LayoutView.extend({
     className: 'tab-pane',
     template: resultTmpl,
+
+    regions: {
+        resultRegion: '.result-region',
+    },
 
     ui: {
         'close': '[data-action="close-subbasin-view"]',
@@ -15,6 +20,26 @@ var ResultView = Marionette.LayoutView.extend({
 
     events: {
         'click @ui.close': 'handleSubbasinCloseButtonClick',
+    },
+
+    onShow: function() {
+        var taskMessageViewModel = new coreModels.TaskMessageViewModel(),
+            polling = true;
+
+        taskMessageViewModel.setWorking(polling ?
+            'Calculating Results': 'Gathering Data');
+
+        this.resultRegion.show(
+            new coreViews.TaskMessageView({
+                model: taskMessageViewModel,
+            })
+        );
+
+        var isSubbasinMode = true;
+
+        App
+            .currentProject
+            .fetchResultsIfNeeded(isSubbasinMode);
     },
 
     handleSubbasinCloseButtonClick: function() {

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -236,7 +236,16 @@ var ResultCollection = Backbone.Collection.extend({
 
     makeFirstActive: function() {
         this.setActive(this.at(0).get('name'));
-    }
+    },
+
+    // Filter subbasin option out of modeling tabs
+    withoutSubbasin: function() {
+        return new ResultCollection(
+            this.filter(function(result) {
+                return result.get('name') !== 'subbasin';
+            })
+        );
+    },
 });
 
 var ProjectModel = Backbone.Model.extend({

--- a/src/mmw/js/src/modeling/templates/resultsDetails.html
+++ b/src/mmw/js/src/modeling/templates/resultsDetails.html
@@ -1,4 +1,5 @@
 <div class="output-tabs-wrapper">
+  <div class="subbasin-region"></div>
   <div role="tabpanel" class="tab-panels-region"></div>
   <div class="tab-contents-region"></div>
 </div>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -38,12 +38,6 @@ var _ = require('lodash'),
     gwlfeQualityViews = require('./gwlfe/quality/views.js'),
     gwlfeSubbasinViews = require('./gwlfe/subbasin/views.js');
 
-// TODO: remove this!
-const mockSubbasinResultsModel = new models.ResultModel({
-    name: 'subbasin',
-    displayName: 'Subbasin',
-});
-
 // The entire modeling header.
 var ModelingHeaderView = Marionette.LayoutView.extend({
     model: models.ProjectModel,
@@ -1039,7 +1033,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
 
     initialize: function(options) {
         this.scenario = options.scenario;
-        this.showHydrologyAndWaterQualityResults = this.showHydrologyAndWaterQualityResults.bind(this);
+        this.showPrimaryModelingResults = this.showPrimaryModelingResults.bind(this);
         this.showSubbasinHotSpotView = this.showSubbasinHotSpotView.bind(this);
         this.hideSubbasinHotSpotView = this.hideSubbasinHotSpotView.bind(this);
     },
@@ -1051,12 +1045,10 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
     },
 
     onShow: function() {
-        // TODO: remove this in favor of real data
-        this.collection.add(mockSubbasinResultsModel);
-        this.showHydrologyAndWaterQualityResults();
+        this.showPrimaryModelingResults();
     },
 
-    showHydrologyAndWaterQualityResults: function() {
+    showPrimaryModelingResults: function() {
         this.panelsRegion.show(new ResultsTabPanelsView({
             collection: this.collection.withoutSubbasin(),
         }));
@@ -1067,27 +1059,21 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
             areaOfInterest: this.options.areaOfInterest,
             showSubbasinHotSpotView: this.showSubbasinHotSpotView,
         }));
-
-        return this;
     },
 
     showSubbasinHotSpotView: function() {
-        this.panelsRegion.empty();
-        this.contentRegion.empty();
+        this.panelsRegion.$el.hide();
+        this.contentRegion.$el.hide();
 
         this.subbasinRegion.show(new gwlfeSubbasinViews.ResultView({
             hideSubbasinHotSpotView: this.hideSubbasinHotSpotView,
-            model: this.collection.findWhere({ name: 'subbasin' }),
         }));
-
-        return this;
     },
 
     hideSubbasinHotSpotView: function() {
         this.subbasinRegion.empty();
-        this.showHydrologyAndWaterQualityResults();
-
-        return this;
+        this.panelsRegion.$el.show();
+        this.contentRegion.$el.show();
     },
 });
 
@@ -1248,7 +1234,7 @@ function getResultView(modelPackage, resultName) {
                 case 'quality':
                     return gwlfeQualityViews.ResultView;
                 case 'subbasin':
-                    console.log('Skipping creating a tab for subbasin results.');
+                    console.log('Skipping creating a tab for SUBBASIN results.');
                     break;
                 default:
                     console.log('Result not supported.');

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -41,6 +41,12 @@
         margin-bottom: 4px;
     }
 
+    #view-subbasin-results-link {
+        font-weight: 800;
+        color: #389b96;
+        cursor: pointer;
+    }
+
     .mean-flow {
       font-size: $font-size-h4;
     }
@@ -115,4 +121,30 @@
   display: flex !important;
   -webkit-flex-wrap: nowrap !important;
   flex-wrap: nowrap !important;
+}
+
+.subbasin-region {
+    .tab-pane {
+        .result {
+            padding: 1rem;
+            background: $paper;
+
+            .result-detail-header {
+                a.zoom {
+                    display: block;
+                }
+
+                .close {
+                    float: none;
+                    display: block;
+                    opacity: 1;
+                    color: #389b96;
+                    text-shadow: none;
+                    font-size: 15px;
+                    font-weight: 450;
+                    padding: 6px 0 2px;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Overview

This PR adds a link to MapShed water quality results for valid WKAOIs to kick off subbasin modeling, along with a new panel which will be used to display subbasin results in #2650.

In this PR we don't add the subbasin results to the new scenario/results/collection, but just log to the console that it's succeeded. However, we do keep the old mapshed results around to afford not having them replaced by the incoming subbasin results.

Connects #2647 

## Demo

![screen shot 2018-04-02 at 6 33 50 pm](https://user-images.githubusercontent.com/4165523/38219623-6ecdd29a-36a4-11e8-8d50-d736c06f6395.png)

![screen shot 2018-04-02 at 6 33 58 pm](https://user-images.githubusercontent.com/4165523/38219626-727c94ee-36a4-11e8-95ba-d4d4686b9621.png)

... and meanwhile, in the console ...

![screen shot 2018-04-02 at 6 27 55 pm](https://user-images.githubusercontent.com/4165523/38219553-1e174868-36a4-11e8-9b6e-a1ff0c2a16b4.png)

## Testing
- get branch, rebuild, etc
- try modeling a non-subbasin-valid-aoi and verify that you don't see the new link
- model a HUC 8 or HUC 10 and verify that you do see the new link, then check that clicking it shows the new view and also commences subbasin modeling, which will be logged to the console and show the correct result from its last network request