### PR TITLE
Add Geoprocessing Request Timeout

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -138,6 +138,12 @@ CELERY_TASK_QUEUES = {
 }
 CELERY_TASK_DEFAULT_EXCHANGE = 'tasks'
 CELERY_TASK_DEFAULT_ROUTING_KEY = "task.%s" % STACK_COLOR
+
+# The longest running tasks contain geoprocessing requests
+# Keep the task and request time limit above, but in the ballpark of
+# https://github.com/WikiWatershed/mmw-geoprocessing/blob/develop/api/src/main/resources/application.conf#L9
+CELERY_TASK_TIME_LIMIT = 90
+TASK_REQUEST_TIMEOUT = CELERY_TASK_TIME_LIMIT - 10
 # END CELERY CONFIGURATION
 
 


### PR DESCRIPTION
## Overview

We've witnessed a state twice on production where the geoprocessing service times out on every response and must be stopped and started to get back into a good state. Because there was no  timeout on the geoprocessing task requests, the tasks would take longer than the `celery` hard task timeout limit (300s).  Exceeding this timeout would put the celery service in its own bad state, and it, too would need a restart (perhaps related celery/celery#2451).

While we are determining the underlying cause of the geoprocessing failures, add a timeout on the geoprocessing request that is less than the celery hard task timeout (request timeouts are probably best practice anyway. There is even a warning specifically about not putting a timeout on I/O ops in a [task in the celery docs](http://docs.celeryproject.org/en/latest/userguide/tasks.html)). This way a rollbar error will notify us of a bad state instead of an email from our client saying all analyze and model runs timeout.

Connects #2738 

### Demo

<img width="660" alt="screen shot 2018-04-02 at 12 40 54 pm" src="https://user-images.githubusercontent.com/7633670/38205577-2362a33c-3675-11e8-9c1c-beea607bb34b.png">
<img width="931" alt="screen shot 2018-04-02 at 12 40 34 pm" src="https://user-images.githubusercontent.com/7633670/38205578-236d913e-3675-11e8-9e7f-8829bb815c94.png">


## Testing Instructions

 * Pull this branch, and `./scripts/debugcelery.sh`
 *  I've add a commit that drops the timeout down to a second. I'll drop this commit before merging so the timeout is 200 seconds. Draw a big shape so the operation isn't cached and it takes the geoprocessing service longer than a second to chew through an analyze task. Confirm you see an error caught in the celery logs

