### PR TITLE
Fix Geocoder Behaviour When Sidebar Is Collapsed

### DIFF
--- a/src/mmw/js/src/core/sidebarToggleControl.js
+++ b/src/mmw/js/src/core/sidebarToggleControl.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var L = require('leaflet'),
-    $ = require('jquery'),
     Marionette = require('../../shim/backbone.marionette'),
     sidebarToggleControlButtonTmpl = require('./templates/sidebarToggleControlButton.html');
 
@@ -32,20 +31,18 @@ var SidebarToggleControlButton = Marionette.ItemView.extend({
         'click @ui.button': 'toggle'
     },
 
+    modelEvents: {
+        'change:size': 'render',
+    },
+
     templateHelpers: function() {
         return {
-            hidden: this.$sidebar.hasClass('hidden')
+            hidden: this.model.get('size') && !this.model.get('size').hasSidebar
         };
     },
 
-    initialize: function() {
-        this.$sidebar = $('#sidebar');
-    },
-
     toggle: function() {
-        this.$sidebar.toggleClass('hidden');
         this.model.toggleSidebar();
-
         this.render();
     }
 });

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -675,11 +675,13 @@ var MapView = Marionette.ItemView.extend({
     toggleMapSize: function() {
         var self = this,
             size = this.model.get('size'),
-            $container = this.$el.parent();
+            $container = this.$el.parent(),
+            $sidebar = $('#sidebar');
 
         $container.toggleClass('-projectheader', !!size.hasProjectHeader);
         $container.toggleClass('-toolbarheader', !!size.hasToolbarHeader);
         $container.toggleClass('-sidebar', !!size.hasSidebar);
+        $sidebar.toggleClass('hidden', !size.hasSidebar);
         $container.toggleClass('-double', !!size.hasSecondarySidebar);
 
         _.delay(function() {


### PR DESCRIPTION
## Overview

The sidebar toggle control was setting a hidden
class on the sidebar. When a suggestion is selected
from the geocoder, the sidebar was activated again
but the hidden class was never removed. Modify the
toggle control so that it always represents the
map model state (size.hasSidebar) and modify the
`toggleSidebar` control on the map model to handle
hiding the hidden class on the sidebar.


Connects #2716 

### Demo

![fdp0by3ijo](https://user-images.githubusercontent.com/7633670/38274868-0bf01754-375e-11e8-8bbb-7caddcbbee01.gif)

## Testing Instructions

 * Pull and `bundle`
 * Search for stuff with the sidebar open and closed. Be sure to test selecting both locations and boundaries