### PR TITLE
Chunk Subbasin Gwlfe Tasks

### DIFF
--- a/src/mmw/apps/core/tasks.py
+++ b/src/mmw/apps/core/tasks.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+from django_statsd.clients import statsd
 from django.utils.timezone import now
 from celery import shared_task
 from apps.core.models import Job
@@ -43,6 +44,7 @@ def save_job_error(request, exc, traceback, job_id):
 
 
 @shared_task(bind=True)
+@statsd.timer(__name__ + '.save_job_result')
 def save_job_result(self, result, id, model_input):
     """
     Updates a job row in the database with final results.

--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -31,6 +31,14 @@ def split_into_huc12s(code, id):
         return cursor.fetchall()
 
 
+def apply_gwlfe_modifications(gms, modifications):
+    modified_gms = {}
+    modified_gms.update(gms)
+    for mod in modifications:
+        modified_gms.update(mod)
+    return modified_gms
+
+
 def get_layer_shape(table_code, id):
     """
     Fetch shape of well known area of interest.

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -13,6 +13,7 @@ from StringIO import StringIO
 
 from celery import shared_task
 
+from django_statsd.clients import statsd
 from django.conf import settings
 
 from apps.core.models import Job
@@ -288,6 +289,7 @@ def run_tr55(censuses, aoi, model_input, cached_aoi_census=None):
 
 
 @shared_task
+@statsd.timer(__name__ + '.run_gwlfe')
 def run_gwlfe(model_input, inputmod_hash, watershed_id=None):
     """
     Given a model_input resulting from a MapShed run, converts that dictionary
@@ -313,6 +315,7 @@ def run_gwlfe(model_input, inputmod_hash, watershed_id=None):
 
 
 @shared_task
+@statsd.timer(__name__ + '.run_gwlfe_chunks')
 def run_gwlfe_chunks(mapshed_job_uuid, modifications,
                      inputmod_hash, watershed_ids):
     mapshed_job = Job.objects.get(uuid=mapshed_job_uuid)
@@ -325,6 +328,7 @@ def run_gwlfe_chunks(mapshed_job_uuid, modifications,
 
 
 @shared_task
+@statsd.timer(__name__ + '.run_srat')
 def run_srat(watersheds):
     try:
         data = [format_for_srat(id, w) for id, w in watersheds.iteritems()]

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -266,7 +266,7 @@ def _initiate_subbasin_gwlfe_job_chain(model_input, mapshed_job_uuid,
     post_process = \
         tasks.subbasin_results_to_dict.s().set(link_error=errback) | \
         tasks.run_srat.s().set(link_error=errback) | \
-        save_job_result.s(job_id, model_input)
+        save_job_result.s(job_id, mapshed_job_uuid)
 
     return (gwlfe_chunked_group | post_process).apply_async()
 

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -42,6 +42,7 @@ from apps.modeling.serializers import (ProjectSerializer,
                                        ScenarioSerializer,
                                        AoiSerializer)
 from apps.modeling.calcs import (get_layer_shape,
+                                 apply_gwlfe_modifications,
                                  boundary_search_context,
                                  split_into_huc12s)
 
@@ -203,6 +204,7 @@ def start_gwlfe(request, format=None):
 
     if request.query_params.get('subbasin', False) == 'true':
         task_list = _initiate_subbasin_gwlfe_job_chain(model_input,
+                                                       mapshed_job_uuid,
                                                        modifications,
                                                        inputmod_hash,
                                                        job.id)
@@ -223,18 +225,10 @@ def start_gwlfe(request, format=None):
     )
 
 
-def _apply_gwlfe_modifications(gms, modifications):
-    modified_gms = {}
-    modified_gms.update(gms)
-    for mod in modifications:
-        modified_gms.update(mod)
-    return modified_gms
-
-
 def _initiate_gwlfe_job_chain(model_input, modifications,
                               inputmod_hash, job_id):
-    modified_model_input = _apply_gwlfe_modifications(model_input,
-                                                      modifications)
+    modified_model_input = apply_gwlfe_modifications(model_input,
+                                                     modifications)
     chain = (tasks.run_gwlfe.s(modified_model_input, inputmod_hash)
              | save_job_result.s(job_id, modified_model_input))
 
@@ -243,24 +237,38 @@ def _initiate_gwlfe_job_chain(model_input, modifications,
     return chain.apply_async(link_error=errback)
 
 
-def _initiate_subbasin_gwlfe_job_chain(model_input, modifications,
-                                       inputmod_hash, job_id):
-    huc12_jobs = []
+def _initiate_subbasin_gwlfe_job_chain(model_input, mapshed_job_uuid,
+                                       modifications, inputmod_hash,
+                                       job_id, chunk_size=8):
     errback = save_job_error.s(job_id)
 
-    for (id, gms) in model_input.iteritems():
-        # TODO Certain fields need to be weighted for the HUC-12
-        # https://github.com/WikiWatershed/model-my-watershed/issues/2542
-        gms = _apply_gwlfe_modifications(gms, modifications)
-        huc12_jobs.append(
-            tasks.run_gwlfe.s(gms, inputmod_hash, id)
-                 .set(link_error=errback))
+    # Split the sub-basin ids into a list of lists. (We'll refer to
+    # each inner list as a "chunk")
+    watershed_ids = list(model_input.keys())
+    watershed_id_chunks = [watershed_ids[x:x+chunk_size]
+                           for x in range(0, len(watershed_ids), chunk_size)]
 
-    return chain(
-        group(huc12_jobs) |
-        tasks.subbasin_results_to_dict.s().set(link_error=errback) |
-        tasks.run_srat.s().set(link_error=errback) |
-        save_job_result.s(job_id, model_input)).apply_async()
+    # Create a celery group where each task in the group
+    # runs gwlfe synchronously on a chunk of subbasin ids.
+    # This is to keep the number of tasks in the group low. Celery will
+    # not return the aggregate chain's job_id (which we need for the job
+    # submission response) until all tasks have been submitted.
+    # If we don't chunk, a shape that has 60+ subbasins could take >60sec
+    # to generate a response (and thus timeout) because we'll be waiting to
+    # submit one task for each subbasin.
+    gwlfe_chunked_group = group(iter([
+        tasks.run_gwlfe_chunks.s(mapshed_job_uuid,
+                                 modifications,
+                                 inputmod_hash,
+                                 watershed_id_chunk)
+        for watershed_id_chunk in watershed_id_chunks]))
+
+    post_process = \
+        tasks.subbasin_results_to_dict.s().set(link_error=errback) | \
+        tasks.run_srat.s().set(link_error=errback) | \
+        save_job_result.s(job_id, model_input)
+
+    return (gwlfe_chunked_group | post_process).apply_async()
 
 
 @decorators.api_view(['POST'])


### PR DESCRIPTION
## Overview

Previously we were submitting
a group where each task in the
group was `run_gwlfe` on a subbasin.
Celery waits until all these tasks
submit before allowing access to
the whole chain's job id, which is
needed for initial job submission
response. When a subbasin request
was submitted, it was taking longer
the 60s for all subbasin gwlfe tasks
to submit if there were 60+ subbasins
in a shape. To alleviate this problem,
we need to cut down the number of
tasks in the group. We do this by
chunking the subbasin into smaller
groups and then running gwlfe
synchronously inside single task
on that group.

Notes:
* Celery+redis wasn't handling
  the large GMS payloads well, and
  would hang when called with this
  chunked approach. Instead of passing
  the GMSs, read the mapshed result
  for each subbasin inside the task
  itself.

* We tried using the builtin celery
  "chunk" task, but it resulted
  in mysterious hanging not fixed
  by limiting the payload size.

* The chunk size is set to 8 based
  on local trial and error. This value
  needs to be big enough to break up
  large (60-100) sets of subbasins
  into manageble task sets, but not
  so big that the task takes longer
  than the celery hard time limit.

Connects #2758 

## Testing
Pull the branch, and restart celery. 
Get setup to call this script:
[test_subbasin.sh.txt](https://github.com/WikiWatershed/model-my-watershed/files/1896203/test_subbasin.sh.txt)

It may be helpful to set up 2 celery threads to see how the chunk tasks distribute.

* Calling it as is will test the big Schuylkill huc-8 (60+ subbasins) that motivated the changes
* Changing the WKAOI at the top of the script to El Vado Reservoir (huc10__13907) will test the changes with a shape with fewer subbasins than the chunk size
* Changing SUBBASIN to false at the top of the script will test a regular mapshed job submission



