### PR TITLE
Add Subbasin Container; Refactor Result Models

### DIFF
--- a/scripts/toggle_feature.sh
+++ b/scripts/toggle_feature.sh
@@ -32,8 +32,9 @@ enableFeature() {
 RESTART_APP=0
 for n; do
     case $n in
-        subbasin)
-            enableFeature subbasin
+        # Replace 'example' with the feature you to be togglable
+        example)
+            enableFeature example
             shift
             ;;
         clear)

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var Backbone = require('../../../../shim/backbone');
+
+var SubbasinTabModel = Backbone.Model.extend({
+    defaults: {
+        displayName: '',
+        name: '',
+    },
+});
+
+var SubbasinTabCollection = Backbone.Collection.extend({
+    model: SubbasinTabModel,
+});
+
+module.exports = {
+    SubbasinTabModel: SubbasinTabModel,
+    SubbasinTabCollection: SubbasinTabCollection,
+};

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
@@ -1,0 +1,1 @@
+<h3>HUC-12 totals here</h3>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
@@ -1,11 +1,3 @@
-<div class="result">
-    <div class="result-detail-header">
-        <a type="button" class="close" aria-label="Close"
-           data-action="close-subbasin-view"
-           id="close-subbasin-view">
-            <i class="fa fa-arrow-left black"></i> Exit subbasin attenuated results
-        </a>
-    </div>
-    <div class="result-region">
-    </div>
+<div>
+    Subbasin results...
 </div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
@@ -1,3 +1,7 @@
-<div>
-    Subbasin results...
+<div class="result-title">
+    {{ aoiDetails }}
 </div>
+<p class="result-description text-muted">
+    Displaying average annual loads from 30-years of fluxes
+</p>
+<div class="subbasin-tab-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
@@ -4,4 +4,6 @@
 <p class="result-description text-muted">
     Displaying average annual loads from 30-years of fluxes
 </p>
-<div class="subbasin-tab-region"></div>
+
+<div role="tabpanel" class="subbasin-tab-panel-region"></div>
+<div class="subbasin-tab-content-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
@@ -1,0 +1,1 @@
+<h3>Source table here</h3>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/tableTabContent.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/tableTabContent.html
@@ -1,0 +1,1 @@
+<div class="table-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/tableTabPanel.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/tableTabPanel.html
@@ -1,0 +1,3 @@
+<a href="#{{ name }}" aria-controls="home" role="tab" data-toggle="tab">
+    <div class="sidebar-tab-header-label">{{ displayName }}</div>
+</a>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -1,10 +1,37 @@
 "use strict";
 
 var Marionette = require('../../../../shim/backbone.marionette'),
+    App = require('../../../app'),
     resultTmpl = require('./templates/result.html');
 
 var ResultView = Marionette.LayoutView.extend({
     template: resultTmpl,
+
+    regions: {
+        tabRegion: '.subbasin-tab-region',
+    },
+
+    templateHelpers: function() {
+        return {
+            aoiDetails: App.currentProject.get('area_of_interest_name'),
+        };
+    },
+
+    onShow: function() {
+        this.tabRegion.show(new ResultTabs({}));
+    },
+});
+
+var ResultTabs = Marionette.CollectionView.extend({
+    tagName: 'ul',
+    className: 'nav nav-tabs model-nav-tabs',
+    attributes: {
+        role: 'tablist'
+    },
+
+    onRender: function() {
+        this.$el.find('li:first').addClass('active');
+    },
 });
 
 module.exports = {

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -2,13 +2,19 @@
 
 var Marionette = require('../../../../shim/backbone.marionette'),
     App = require('../../../app'),
-    resultTmpl = require('./templates/result.html');
+    models = require('./models'),
+    resultTmpl = require('./templates/result.html'),
+    tableTabContentTmpl = require('./templates/tableTabContent.html'),
+    tableTabPanelTmpl = require('./templates/tableTabPanel.html'),
+    huc12TotalsTableTmpl = require('./templates/huc12TotalsTable.html'),
+    sourcesTableTmpl = require('./templates/sourcesTable.html');
 
 var ResultView = Marionette.LayoutView.extend({
     template: resultTmpl,
 
     regions: {
-        tabRegion: '.subbasin-tab-region',
+        tabPanelRegion: '.subbasin-tab-panel-region',
+        tabContentRegion: '.subbasin-tab-content-region',
     },
 
     templateHelpers: function() {
@@ -18,21 +24,99 @@ var ResultView = Marionette.LayoutView.extend({
     },
 
     onShow: function() {
-        this.tabRegion.show(new ResultTabs({}));
+        var tabCollection = new models.SubbasinTabCollection([
+            new models.SubbasinTabModel({
+                displayName: 'Sources',
+                name: 'aoiSources',
+            }),
+            new models.SubbasinTabModel({
+                displayName: 'HUC-12',
+                name: 'huc12Totals',
+            }),
+        ]);
+        this.tabPanelRegion.show(new TableTabPanelCollectionView({
+            collection: tabCollection,
+        }));
+        this.tabContentRegion.show(new TableTabContentCollectionView({
+            collection: tabCollection,
+        }));
     },
 });
 
-var ResultTabs = Marionette.CollectionView.extend({
+var TableTabPanelView = Marionette.ItemView.extend({
+    // model: SubbasinTabModel
+    tagName: 'li',
+    template: tableTabPanelTmpl,
+    attributes: {
+        role: 'presentation',
+    },
+});
+
+var TableTabPanelCollectionView = Marionette.CollectionView.extend({
+    // collection: SubbasinTabCollection
     tagName: 'ul',
     className: 'nav nav-tabs model-nav-tabs',
     attributes: {
         role: 'tablist'
     },
 
+    childView: TableTabPanelView,
+
     onRender: function() {
         this.$el.find('li:first').addClass('active');
     },
 });
+
+var TableTabContentView = Marionette.LayoutView.extend({
+    // model: SubbasinTabModel
+    template: tableTabContentTmpl,
+    tagName: 'div',
+    className: 'tab-pane',
+    attributes: {
+        role: 'tabpanel',
+    },
+    regions: {
+        tableRegion: '.table-region',
+    },
+
+    onShow: function() {
+        var tableViewKey = this.model.get('name'),
+            TableView = tableViews[tableViewKey];
+        if (!TableView) {
+            console.error('Use of table view key without TableView: ', tableViewKey);
+            return null;
+        }
+
+        this.tableRegion.show(new TableView({}));
+    },
+
+    id: function() {
+        return this.model.get('name');
+    }
+});
+
+var TableTabContentCollectionView = Marionette.CollectionView.extend({
+    // collection: SubbasinTabCollection
+    tagName: 'div',
+    className: 'tab-content model-tab-content',
+    childView: TableTabContentView,
+    onRender: function() {
+        this.$el.find('.tab-pane:first').addClass('active');
+    }
+});
+
+var AoiSourcesTableView = Marionette.ItemView.extend({
+    template: sourcesTableTmpl,
+});
+
+var Huc12TotalsTableView = Marionette.ItemView.extend({
+    template: huc12TotalsTableTmpl,
+});
+
+var tableViews = {
+    aoiSources: AoiSourcesTableView,
+    huc12Totals: Huc12TotalsTableView,
+};
 
 module.exports = {
     ResultView: ResultView,

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -1,50 +1,10 @@
 "use strict";
 
 var Marionette = require('../../../../shim/backbone.marionette'),
-    App = require('../../../app'),
-    coreViews = require('../../../core/views'),
-    coreModels = require('../../../core/models'),
     resultTmpl = require('./templates/result.html');
 
 var ResultView = Marionette.LayoutView.extend({
-    className: 'tab-pane',
     template: resultTmpl,
-
-    regions: {
-        resultRegion: '.result-region',
-    },
-
-    ui: {
-        'close': '[data-action="close-subbasin-view"]',
-    },
-
-    events: {
-        'click @ui.close': 'handleSubbasinCloseButtonClick',
-    },
-
-    onShow: function() {
-        var taskMessageViewModel = new coreModels.TaskMessageViewModel(),
-            polling = true;
-
-        taskMessageViewModel.setWorking(polling ?
-            'Calculating Results': 'Gathering Data');
-
-        this.resultRegion.show(
-            new coreViews.TaskMessageView({
-                model: taskMessageViewModel,
-            })
-        );
-
-        var isSubbasinMode = true;
-
-        App
-            .currentProject
-            .fetchResultsIfNeeded(isSubbasinMode);
-    },
-
-    handleSubbasinCloseButtonClick: function() {
-        this.options.hideSubbasinHotSpotView();
-    },
 });
 
 module.exports = {

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -100,8 +100,16 @@ var ResultModel = Backbone.Model.extend({
         inputmod_hash: null, // MD5 string generated from result
         result: null, // The actual result object
         polling: false, // True if currently polling
+        error: null,
         active: false, // True if currently selected in Compare UI
         activeVar: null // For GWLFE, the currently selected variable in the UI
+    },
+
+    isSubbasin: function() {
+        // Subbasin is a special case, not displayed as
+        // a tab in the UI, but as a secondary GWLFE view
+        // rendered on top of the original results
+        return this.get('name') === 'subbasin';
     },
 
     toTR55RunoffCSV: function(isCurrentConditions, aoiVolumeModel) {
@@ -228,14 +236,20 @@ var ResultModel = Backbone.Model.extend({
 var ResultCollection = Backbone.Collection.extend({
     model: ResultModel,
 
-    setPolling: function(polling) {
-        this.forEach(function(resultModel) {
+    setPolling: function(polling, isSubbasinMode) {
+        this.getFilteredResults(isSubbasinMode).forEach(function(resultModel) {
             resultModel.set('polling', polling);
         });
     },
 
-    setNullResults: function() {
-        this.forEach(function(resultModel) {
+    setError: function(error, isSubbasinMode) {
+        this.getFilteredResults(isSubbasinMode).forEach(function(resultModel) {
+            resultModel.set('error', error);
+        });
+    },
+
+    setNullResults: function(isSubbasinMode) {
+        this.getFilteredResults(isSubbasinMode).forEach(function(resultModel) {
             resultModel.set('result', null);
         });
     },
@@ -259,10 +273,10 @@ var ResultCollection = Backbone.Collection.extend({
     },
 
     // Filter subbasin option out of modeling tabs
-    withoutSubbasin: function() {
+    getFilteredResults: function(isSubbasinMode) {
         return new ResultCollection(
             this.filter(function(result) {
-                return result.get('name') !== 'subbasin';
+                return isSubbasinMode ? result.isSubbasin() : !result.isSubbasin();
             })
         );
     },
@@ -284,6 +298,8 @@ var ProjectModel = Backbone.Model.extend({
         gis_data: null,                    // Additionally gathered data, such as MapShed for GWLF-E
         mapshed_job_uuid: null,            // (GWLF-E) The id of a successful MapShed job
         subbasin_mapshed_job_uuid: null,   // (GWLF-E) The id of a successful sub-basin MapShed job
+        mapshed_job_error: null,           // (GWLF-E) An error on the MapShed job
+        subbasin_mapshed_job_error: null,  // (GWLF-E) An error on the sub-basin MapShed job
         needs_reset: false,                // Should we overwrite project data on next save?
         allow_save: true,                  // Is allowed to save to the server - false in compare mode
         sidebar_mode: utils.MODEL,         // The current mode of the sidebar. ANALYZE, MONITOR, or MODEL.
@@ -545,25 +561,22 @@ var ProjectModel = Backbone.Model.extend({
      */
     fetchGisDataIfNeeded: function(isSubbasinMode) {
         var self = this,
-            saveProjectAndScenarios = _.bind(self.saveProjectAndScenarios, self);
+            saveProjectAndScenarios = _.bind(self.saveProjectAndScenarios, self),
+            mapshedJobUUIDAttribute = isSubbasinMode ? 'subbasin_mapshed_job_uuid' : 'mapshed_job_uuid',
+            mapshedJobErrorAttribute = isSubbasinMode ? 'subbasin_mapshed_job_error' : 'mapshed_job_error';
 
-        if (isSubbasinMode || (self.get('mapshed_job_uuid') === null && self.fetchGisDataPromise === undefined)) {
+        if (self.get(mapshedJobUUIDAttribute) === null && self.fetchGisDataPromise === undefined) {
             self.fetchGisDataPromise = self.fetchGisData(isSubbasinMode);
             self.fetchGisDataPromise
                 .done(function(result, job) {
                     if (result) {
                         self.set('gis_data', result);
-
-                        if (isSubbasinMode) {
-                            self.set('subbasin_mapshed_job_uuid', job);
-                        } else {
-                            self.set('mapshed_job_uuid', job);
-                        }
-
+                        self.set(mapshedJobUUIDAttribute, job);
                         saveProjectAndScenarios();
                     }
-                })
-                .always(function() {
+                }).fail(function(error) {
+                    self.set(mapshedJobErrorAttribute, error);
+                }).always(function() {
                     // Clear promise once it completes, so we start a new one
                     // next time.
                     delete self.fetchGisDataPromise;
@@ -1129,10 +1142,13 @@ var ScenarioModel = Backbone.Model.extend({
         var self = this,
             inputmod_hash = this.get('inputmod_hash'),
             needsResults = this.get('results').some(function(resultModel) {
-                var emptyResults = !resultModel.get('result'),
-                    staleResults = inputmod_hash !== resultModel.get('inputmod_hash');
+                var results = resultModel.get('result'),
+                    isSubbasinModel = resultModel.isSubbasin(),
+                    shouldIncludeModel = isSubbasinMode ? isSubbasinModel : !isSubbasinModel,
+                    emptyResults = !results && shouldIncludeModel,
+                    staleResults = inputmod_hash !== resultModel.get('inputmod_hash') && shouldIncludeModel;
 
-                return emptyResults || staleResults || isSubbasinMode;
+                return emptyResults || staleResults;
             });
 
         if (needsResults && self.fetchResultsPromise === undefined) {
@@ -1155,13 +1171,15 @@ var ScenarioModel = Backbone.Model.extend({
         return self.fetchResultsPromise || $.when();
     },
 
-    setResults: function() {
+    setResults: function(isSubbasinMode) {
         var serverResults = this.get('taskModel').get('result');
 
         if (_.isEmpty(serverResults)) {
-            this.get('results').setNullResults();
+            this.get('results').setNullResults(isSubbasinMode);
         } else {
-            this.get('results').forEach(function(resultModel) {
+            var results = this.get('results').getFilteredResults(isSubbasinMode);
+
+            results.forEach(function(resultModel) {
                 var resultName = resultModel.get('name');
 
                 if (serverResults) {
@@ -1202,42 +1220,30 @@ var ScenarioModel = Backbone.Model.extend({
                     console.log(isSubbasinMode ?
                         'Starting polling for SUBBASIN modeling results' :
                                 'Starting polling for modeling results');
-
-                    if (!isSubbasinMode) {
-                        self.set('poll_error', null);
-                        results.setPolling(true);
-                    }
+                    results.setPolling(true, isSubbasinMode);
                 },
 
                 pollSuccess: function() {
                     console.log(isSubbasinMode ?
                         'Polling for SUBBASIN modeling results succeeded' :
                         'Polling for modeling results succeeded');
-                    if (!isSubbasinMode) {
-                        self.setResults();
-                    } else {
-                        console.log('Received SUBBBASIN results');
-                    }
+                    self.setResults(isSubbasinMode);
                 },
 
                 pollFailure: function(error) {
                     console.log(isSubbasinMode ?
                         'Failed to get SUBBASIN modeling results' :
                         'Failed to get modeling results.');
-                    self.set('poll_error', error);
-                    results.setNullResults();
+                    results.setError(error, isSubbasinMode);
+                    results.setNullResults(isSubbasinMode);
                 },
 
                 pollEnd: function() {
                     console.log(isSubbasinMode ?
                         'Completed polling for SUBBASIN modeling results' :
                         'Completed polling for modeling results');
-                    results.setPolling(false);
-                    if (!isSubbasinMode) {
-                        self.attemptSave();
-                    } else {
-                        console.log('Not saving SUBBASIN results');
-                    }
+                    results.setPolling(false, isSubbasinMode);
+                    self.attemptSave();
                 },
 
                 startFailure: function(response) {
@@ -1251,9 +1257,9 @@ var ScenarioModel = Backbone.Model.extend({
                         console.log(response.responseJSON.error);
                         error = response.responseJSON.error;
                     }
-                    self.set('poll_error', error);
-                    results.setNullResults();
-                    results.setPolling(false);
+                    results.setError(error, isSubbasinMode);
+                    results.setNullResults(isSubbasinMode);
+                    results.setPolling(false, isSubbasinMode);
                 }
             };
 
@@ -1570,7 +1576,11 @@ function createTaskResultCollection(modelPackage) {
                     name: 'quality',
                     displayName: 'Water Quality',
                     result: null
-                }
+                },
+                {
+                    name: 'subbasin',
+                    result: null
+                },
             ]);
     }
     throw 'Model package not supported: ' + modelPackage;

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -277,7 +277,6 @@ var ProjectModel = Backbone.Model.extend({
         area_of_interest: null,            // GeoJSON
         area_of_interest_name: null,       // Human readable string for AOI.
         wkaoi: null,                       // Well Known Area of Interest ID "{code}__{id}"
-        subbasin_modeling: false,          // (GWLFE) Use subbasin modeling
         model_package: utils.TR55_PACKAGE, // Package name
         scenarios: null,                   // ScenariosCollection
         user_id: 0,                        // User that created the project
@@ -293,23 +292,10 @@ var ProjectModel = Backbone.Model.extend({
     },
 
     initialize: function() {
-        var scenarios = this.get('scenarios'),
-            subbasinFeatureOn = settings.featureEnabled('subbasin'),
-            setSubbasinModeling = _.bind(function() {
-                    var wkaoi = this.get('wkaoi'),
-                        shouldModelSubbasins = subbasinFeatureOn &&
-                            utils.isWKAoIValidForSubbasinModeling(wkaoi);
-                    this.set('subbasin_modeling', shouldModelSubbasins);
-                }, this);
+        var scenarios = this.get('scenarios');
 
         if (scenarios === null || typeof scenarios === 'string') {
             this.set('scenarios', new ScenariosCollection());
-        }
-
-        setSubbasinModeling();
-
-        if (subbasinFeatureOn) {
-            this.on('change:wkaoi', setSubbasinModeling);
         }
 
         this.set('user_id', App.user.get('id'));

--- a/src/mmw/js/src/modeling/templates/subbasinResultsTabContent.html
+++ b/src/mmw/js/src/modeling/templates/subbasinResultsTabContent.html
@@ -1,0 +1,10 @@
+<div class="result">
+    <div class="result-detail-header">
+        <a type="button" class="close" aria-label="Close"
+           data-action="close-subbasin-view"
+           id="close-subbasin-view">
+            <i class="fa fa-arrow-left black"></i> Exit subbasin attenuated results
+        </a>
+    </div>
+    <div class="result-content-region"></div>
+</div>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1067,6 +1067,10 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
     showSubbasinHotSpotView: function() {
         this.panelsRegion.$el.hide();
         this.contentRegion.$el.hide();
+        if (this.subbasinRegion.hasView()) {
+            return this.subbasinRegion.$el.show();
+        }
+
         var isSubbasinMode = true;
         App.currentProject.fetchResultsIfNeeded(isSubbasinMode);
 
@@ -1078,7 +1082,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
     },
 
     hideSubbasinHotSpotView: function() {
-        this.subbasinRegion.empty();
+        this.subbasinRegion.$el.hide();
         this.panelsRegion.$el.show();
         this.contentRegion.$el.show();
     },


### PR DESCRIPTION
## Overview

This PR gets the subbasin view ready to display results in the tables. 

The refactoring and changes are described in the commit messages, but most notably this PR

* moves the gwlfe error off of a scenario and on to result models so that subbasin errors don't muddy the regular model views
* adds mapshed error attributes to the scenario so that we can catch when mapshed fails. Previously mapshed failure would make Gathering Data spin forever. Now there will be a proper error.
* Adds the subbasin model to the GWLFE model collection
* Refactor the subbasin container view to reuse the existing polling state/result view set up
* Add AOI info and blank tabs to the subbasin view 

Connects #2650 

### Demo

![xxvv1nc49d](https://user-images.githubusercontent.com/7633670/38645073-c6b046b0-3db0-11e8-8643-5fa538e50214.gif)

## Notes
* Existing mapshed projects won't be subbasin modelable until #2750 

## Testing Instructions

 * Pull and bundle
* Select a HUC-10 and progress it to subbasin modeling. Confirm you end up on a view with the aoi details and empty tabs once the polling completes.

* Put the browser offline or otherwise cause a failure during the mapshed/Gathering data step. Confirm you see an error

* Briefly test TR-55 and confirm there are no regressions