### PR TITLE
Update MapShed Weather Station EtAdj Values

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -132,8 +132,9 @@ fi
 
 if [ "$load_mapshed" = "true" ] ; then
     # Fetch map shed specific vector features
-    FILES=("ms_weather.sql.gz" "ms_weather_station.sql.gz" "ms_pointsource.sql.gz"
-           "ms_pointsource_drb.sql.gz" "ms_county_animals.sql.gz")
+    FILES=("ms_weather.sql.gz" "ms_weather_station_1523624744.sql.gz"
+           "ms_pointsource.sql.gz" "ms_pointsource_drb.sql.gz"
+           "ms_county_animals.sql.gz")
 
     download_and_load $FILES
 fi


### PR DESCRIPTION
## Overview

Now that we're averaging the precipitation values, Barry has provided us with new EtAdj weather station data. Update the `setupdb` script to load the new sql file.

## Checklist

- [x] Read over [data_checklist.md](https://github.com/WikiWatershed/model-my-watershed/tree/develop/doc/data_checklist.md)
- [x] Load or create the data/updates on your local Postgres instance
- [x] Verify the table you are about to dump
- [x] `pg_dump` it!
- [x] Sanity check the `pg_dump` output with `head` and `tail`
- [x] Gzip and upload to data bucket with `./scripts/data/upload_sql_data.sh`
- [x] Update `./scripts/aws/setupdb.sh`, document data processing steps, and commit
- [x] Open a PR
- [ ] Run `./scripts/aws/setupdb.sh ...` on staging
- [x] Create (or add to) an issue on what we need to apply to production (Added to #2732)
- [ ] At the release after next, delete older versions if they exist

Connects #2762 

### Demo
```sql
mmw=# select new_ws.location, new_ws.etadj, ms_weather_station.etadj from new_ws, ms_weather_station where new_ws.station = ms_weather_station.station and new_ws.etadj != ms_weather_station.etadj;
  location   | etadj | etadj
--------------+-------+-------
Alamosa      |  1.80 |   1.9
Lake Charles |  1.08 |  1.23
Shreveport   |  1.00 |  1.07
Baltimore    |  1.05 |  1.25
Tucumcari    |  2.45 |   2.6
Syracuse     |  1.05 |  1.25
Allentown    |  1.05 |  1.16
Bradford     |  1.05 |  1.16
Harrisburg   |  1.00 |   1.1
Philadelphia |  1.00 |  1.05
WB/Scranton  |  0.95 |  1.05
Abilene      |  1.60 |   1.5
(12 rows)
```

## Testing Instructions

 ```bash
# load the new data
 > vagrant ssh app
 > cd /vagrant && ./scripts/aws/setup.db -m
# leave app VM
# check the new values are there
 > ./scripts/manage.sh dbshell
     SELECT * FROM ms_weather_station WHERE location='Alamosa';
  # 1.8
```

* Run mapshed to confirm the table is fine
