### PR TITLE
Monitor: Update Search Catalog Order, Behavior

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -248,6 +248,16 @@ var ResultsView = Marionette.LayoutView.extend({
 
     onMonitorTabShown: function() {
         this.monitorRegion.currentView.setVisibility(true);
+        // Cache CUAHSI results
+        if (!this.cuahsiResultsHaveBeenCached) {
+            var self = this;
+
+            this.monitorRegion.currentView
+                .cacheCuahsiResults()
+                .done(function() {
+                    self.cuahsiResultsHaveBeenCached = true;
+                });
+        }
         // Hide AoI Region if details open
         if (App.map.get('dataCatalogDetailResult') !== null) {
             this.aoiRegion.currentView.$el.addClass('hidden');

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -891,17 +891,9 @@ function createCatalogCollection() {
 
     return new Catalogs([
         new Catalog({
-            id: 'cinergi',
-            name: 'CINERGI',
-            active: true,
-            results: new Results(null, { catalog: 'cinergi' }),
-            filters: new FilterCollection([
-                dateFilter,
-            ]),
-        }),
-        new Catalog({
             id: 'hydroshare',
             name: 'HydroShare',
+            active: true,
             results: new Results(null, { catalog: 'hydroshare' }),
             filters: new FilterCollection([
                 dateFilter,
@@ -918,6 +910,14 @@ function createCatalogCollection() {
                 dateFilter,
                 new GriddedServicesFilter()
             ])
+        }),
+        new Catalog({
+            id: 'cinergi',
+            name: 'CINERGI',
+            results: new Results(null, { catalog: 'cinergi' }),
+            filters: new FilterCollection([
+                dateFilter,
+            ]),
         })
     ]);
 }

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -232,6 +232,32 @@ var DataCatalogWindow = Marionette.LayoutView.extend({
         }
     },
 
+    // Since CUAHSI server results do not depend on the text, only the
+    // area of interest, this function runs a CUAHSI search for the entire
+    // area of interest, to cache the values for further text searches which
+    // will perform local filtering.
+    cacheCuahsiResults: function() {
+        var cuahsiCatalog = this.collection.findWhere({ id: 'cuahsi' }),
+            query = '',
+            aoiGeoJson = App.map.get('areaOfInterest');
+
+        return cuahsiCatalog
+            .searchIfNeeded(query, aoiGeoJson)
+            .done(function() {
+                // HACK: Text search something fake to set the result
+                // count to 0, since seeing a result count in CUAHSI
+                // without having searched for anything looks odd.
+
+                // But do this only if CUAHSI is not selected. If it is,
+                // the user may have searched for something else, which
+                // we shouldn't override.
+
+                if (!cuahsiCatalog.get('active')) {
+                    cuahsiCatalog.searchIfNeeded('show no results', aoiGeoJson);
+                }
+            });
+    },
+
     // Enables or disables map item visibility
     // For when the DataCatalogWindow is loaded but hidden
     // Such as when showing the Analyze or Model tab instead of Monitor


### PR DESCRIPTION
## Overview

Moves CINERGI to the end of the search catalogs, placing HydroShare first and CUAHSI second. Also searches CUAHSI as soon as the Monitor tab is opened for the first time, to cache the server values and run the local filter quickly afterwards.

Connects #2759 

### Demo

![mmw-monitor-cuahsi-delayed-search](https://user-images.githubusercontent.com/1430060/38830151-558433de-4189-11e8-8786-6e42358d2bc1.gif)

## Testing Instructions

* Check out this branch and `bundle`
* Select a shape and proceed to Analyze
* Open the Network tab in Developer Tools. Click "Monitor". Ensure you see a search query request.
* Type in a search query and go to the CUAHSI tab. Ensure it behaves correctly in all cases:
  - When searching in HydroShare only
  - When searching in CUAHSI after server results are fetched
  - When searching in CUAHSI before server results are fetched
  - When searching CINERGI