### PR TITLE
Upgrade GWLF-E Package

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -15,7 +15,7 @@ cryptography==2.1.4
 pyOpenSSL==17.4.0
 markdown==2.6.9
 tr55==1.3.0
-gwlf-e==0.6.2
+gwlf-e==0.6.3
 requests[security]==2.9.1
 rollbar==0.13.8
 retry==0.9.1


### PR DESCRIPTION
## Overview

Upgrade GWLF-E to get the fix for
the double underflow exception caused
by HUCs like Elm Fork Red.

Connects #2765 

### Demo

![screen shot 2018-04-17 at 11 04 01 am](https://user-images.githubusercontent.com/7633670/38878636-686e5fe6-422f-11e8-992f-339d644210e1.png)

## Testing Instructions

 Install the new package
```sh
vagrant ssh app
cd /vagrant && sudo pip install -r src/mmw/requirements/base.txt
# ctrl-d
vagrant ssh worker
cd /vagrant && sudo pip install -r src/mmw/requirements/base.txt
# ctrl-d

# restart services
vagrant ssh worker -c "sudo service celeryd restart
vagrant ssh app -c "sudo restart mmw-app"
```

In the app, use the geocoder to search for `Elm Fork Red`. Select the shape to analyze and model with Multi-Year. Confirm the model completes.