### PR TITLE
Add Subbasin HUC-12 Totals Table

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -182,7 +182,7 @@ def format_subbasin(huc12_gwlfe_results, srat_catchment_results, gmss):
             'SummaryLoads': summary_loads,
             'Catchments': {comid: format_catchment(result)
                            for comid, result
-                           in srat_huc12['catchments'].iteritems()}
+                           in srat_huc12['catchments'].iteritems()},
         }
 
     aggregate = {

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -195,9 +195,9 @@ def format_subbasin(huc12_gwlfe_results, srat_catchment_results, gmss):
                                             .next()['inputmod_hash'],
     }
 
-    aggregate['HUC-12s'] = {huc12_id: add_huc12(result, aggregate)
-                            for huc12_id, result
-                            in srat_catchment_results['huc12s'].iteritems()}
+    aggregate['HUC12s'] = {huc12_id: add_huc12(result, aggregate)
+                           for huc12_id, result
+                           in srat_catchment_results['huc12s'].iteritems()}
 
     return aggregate
 

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -25,6 +25,7 @@ urlpatterns = patterns(
     url(r'jobs/' + uuid_regex, views.get_job, name='get_job'),
     url(r'tr55/$', views.start_tr55, name='start_tr55'),
     url(r'gwlfe/$', views.start_gwlfe, name='start_gwlfe'),
+    url(r'subbasins/$', views.subbasins_detail, name='subbasins_detail'),
     url(r'boundary-layers/(?P<table_code>\w+)/(?P<obj_id>[0-9]+)/$',
         views.boundary_layer_detail, name='boundary_layer_detail'),
     url(r'boundary-layers-search/$',

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -42,6 +42,7 @@ from apps.modeling.serializers import (ProjectSerializer,
                                        ScenarioSerializer,
                                        AoiSerializer)
 from apps.modeling.calcs import (get_layer_shape,
+                                 get_huc12s,
                                  apply_gwlfe_modifications,
                                  boundary_search_context,
                                  split_into_huc12s)
@@ -443,6 +444,19 @@ def _construct_tr55_job_chain(model_input, job_id):
     job_chain.append(save_job_result.s(job_id, model_input))
 
     return job_chain
+
+
+@decorators.api_view(['GET'])
+@decorators.permission_classes((AllowAny, ))
+def subbasins_detail(request):
+    mapshed_job_uuid = request.query_params.get('mapshed_job_uuid')
+    mapshed_job = Job.objects.get(uuid=mapshed_job_uuid)
+    gmss = json.loads(mapshed_job.result)
+    if gmss:
+        huc12s = get_huc12s(gmss.keys())
+        return Response(huc12s)
+    else:
+        return Response(status=status.HTTP_404_NOT_FOUND)
 
 
 @decorators.api_view(['GET'])

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
@@ -1,1 +1,51 @@
-<h3>HUC-12 totals here</h3>
+<table class="table custom-hover" data-toggle="table">
+    <thead>
+        <tr>
+            <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">HUC-12 Name</th>
+            <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">HUC-12 Number</th>
+            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (km<sup>2</sup>)</th>
+            <th colspan="3">Total Loads (not normalized)</th>
+            <th colspan="3">Loading Rates (area normalized)</th>
+        </tr>
+        <tr>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/ha/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/ha/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/ha/y)</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for key, row in rows %}
+            <tr>
+                <td class="text-left">{{ subbasins.get(key).get('name') }}</td>
+                <td class="text-right">{{ key }}</td>
+                <td class="strong text-right">{{ row.SummaryLoads.Area|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.SummaryLoads.Sediment|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.SummaryLoads.TotalN|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.SummaryLoads.TotalP|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ (row.SummaryLoads.Sediment/row.SummaryLoads.Area)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ (row.SummaryLoads.TotalN/row.SummaryLoads.Area)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ (row.SummaryLoads.TotalP/row.SummaryLoads.Area)|round(2)|toLocaleString(2) }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+    <tfoot>
+        <tr>
+            <th colspan="2" class="text-left">{{ summaryRow.Source }}</th>
+            <th class="text-right">{{ summaryRow.Area|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.Sediment|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalN|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalP|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ (summaryRow.Sediment/summaryRow.Area)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ (summaryRow.TotalN/summaryRow.Area)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ (summaryRow.TotalP/summaryRow.Area)|round(2)|toLocaleString(2) }}</th>
+        </tr>
+    </tfoot>
+
+</table>
+
+<div class="downloadcsv-link" data-action="download-csv-granular">
+    <i class="fa fa-download"></i> Download this data
+</div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -133,6 +133,20 @@ var AoiSourcesTableView = Marionette.ItemView.extend({
 
 var Huc12TotalsTableView = Marionette.ItemView.extend({
     template: huc12TotalsTableTmpl,
+
+    onAttach: function() {
+        $('[data-toggle="table"]').bootstrapTable();
+    },
+
+    templateHelpers: function() {
+        var result = this.model.get('result');
+        return {
+            rows: result.HUC12s,
+            subbasins: App.currentProject.get('subbasins'),
+            summaryRow: result.SummaryLoads,
+        };
+    },
+
 });
 
 var tableViews = {


### PR DESCRIPTION
## Overview

Add the HUC-12 totals table to the subbasin view. Because this table includes the HUC-12's common name, it was necessary to add a new endpoint to fetch that information (it's not part of the result until that point). I added the HUC-12 shape to the new endpoint as well because we will need it for #2651. 

Connects #2726 

### Demo

![screen shot 2018-04-17 at 10 19 40 am](https://user-images.githubusercontent.com/7633670/38878968-3c288ad2-4230-11e8-81ec-d417aa37ff72.png)
![screen shot 2018-04-17 at 10 19 52 am](https://user-images.githubusercontent.com/7633670/38878969-3c33a1ec-4230-11e8-8cb6-c5d998430cb2.png)
<img width="694" alt="screen shot 2018-04-17 at 2 18 07 pm" src="https://user-images.githubusercontent.com/7633670/38888612-2eeeef40-424a-11e8-907b-68362101acda.png">

## Notes
I originally implemented this by making the `get_huc12s` db query in the original gwlfe task to avoid the additional complexity of more requests. I realized, however, that anything we add to the result, like the shape, will then be stored on the job table as the output and on the scenario in the results. Having all the huc-12 geometries duplicated in these places seemed bad considering some huc8s can have upwards of 100 of them.

## Testing Instructions

 * Pull, restart celery, and bundle
 * Select a huc-10 in the app and proceed to subbasin modeling with it (Analyze -> Multi year -> Water Quality -> Attenuated Results)
 * View the HUC-12 tab and confirm the new table has all its values
