### PR TITLE
Add HUC-12 Level Subbasin View

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
@@ -18,7 +18,7 @@
     </thead>
     <tbody>
         {% for key, row in rows %}
-            <tr>
+            <tr class="huc12-total" data-huc12-id="{{ key }}">
                 <td class="text-left">{{ subbasins.get(key).get('name') }}</td>
                 <td class="text-right">{{ key }}</td>
                 <td class="strong text-right">{{ row.SummaryLoads.Area|round(2)|toLocaleString(2) }}</td>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
@@ -23,9 +23,9 @@
                 <td class="strong text-right">{{ row.Sediment|round(2)|toLocaleString(2) }}</td>
                 <td class="strong text-right">{{ row.TotalN|round(2)|toLocaleString(2) }}</td>
                 <td class="strong text-right">{{ row.TotalP|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ (row.Sediment/row.Area)|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ (row.TotalN/row.Area)|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ (row.TotalP/row.Area)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.Sediment/row.Area) or 0)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalN/row.Area) or 0)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalP/row.Area) or 0)|round(2)|toLocaleString(2) }}</td>
             </tr>
         {% endfor %}
     </tbody>

--- a/src/mmw/js/src/modeling/templates/resultsDetails.html
+++ b/src/mmw/js/src/modeling/templates/resultsDetails.html
@@ -1,5 +1,6 @@
 <div class="output-tabs-wrapper">
   <div class="subbasin-region"></div>
+  <div class="subbasin-huc12-region"></div>
   <div role="tabpanel" class="tab-panels-region"></div>
   <div class="tab-contents-region"></div>
 </div>

--- a/src/mmw/js/src/modeling/templates/subbasinResultsTabContent.html
+++ b/src/mmw/js/src/modeling/templates/subbasinResultsTabContent.html
@@ -3,7 +3,7 @@
         <a type="button" class="close" aria-label="Close"
            data-action="close-subbasin-view"
            id="close-subbasin-view">
-            <i class="fa fa-arrow-left black"></i> Exit subbasin attenuated results
+            <i class="fa fa-arrow-left black"></i> {{ backButtonText or "Exit subbasin attenuated results" }}
         </a>
     </div>
     <div class="result-content-region"></div>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1037,10 +1037,13 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         this.showPrimaryModelingResults = this.showPrimaryModelingResults.bind(this);
         this.showSubbasinHotSpotView = this.showSubbasinHotSpotView.bind(this);
         this.hideSubbasinHotSpotView = this.hideSubbasinHotSpotView.bind(this);
+        this.showSubbasinHuc12View = this.showSubbasinHuc12View.bind(this);
+        this.hideSubbasinHuc12View = this.hideSubbasinHuc12View.bind(this);
     },
 
     regions: {
         subbasinRegion: '.subbasin-region',
+        subbasinHuc12Region: '.subbasin-huc12-region',
         panelsRegion: '.tab-panels-region',
         contentRegion: '.tab-contents-region'
     },
@@ -1078,6 +1081,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
             model: this.collection.getResult('subbasin'),
             scenario: this.scenario,
             hideSubbasinHotSpotView: this.hideSubbasinHotSpotView,
+            showHuc12: this.showSubbasinHuc12View,
         }));
     },
 
@@ -1086,6 +1090,22 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         this.panelsRegion.$el.show();
         this.contentRegion.$el.show();
     },
+
+    showSubbasinHuc12View: function(huc12Id) {
+        this.subbasinRegion.$el.hide();
+
+        this.subbasinHuc12Region.show(new SubbasinHuc12TabContentView({
+            model: this.collection.getResult('subbasin'),
+            scenario: this.scenario,
+            hideSubbasinHotSpotView: this.hideSubbasinHuc12View,
+            huc12: huc12Id,
+        }));
+    },
+
+    hideSubbasinHuc12View: function() {
+        this.subbasinRegion.$el.show();
+        this.subbasinHuc12Region.empty();
+    }
 });
 
 // A model result tab
@@ -1173,6 +1193,7 @@ var ResultsTabContentView = Marionette.LayoutView.extend({
                 areaOfInterest: this.options.areaOfInterest,
                 scenario: this.scenario,
                 showSubbasinHotSpotView: this.options.showSubbasinHotSpotView,
+                showHuc12: this.options.showHuc12,
             }));
         }
 
@@ -1226,6 +1247,20 @@ var SubbasinResultsTabContentView = Marionette.LayoutView.extend({
         this.resultContentRegion.show(new ResultsTabContentView({
             model: this.model,
             scenario: this.options.scenario,
+            showHuc12: this.options.showHuc12,
+        }));
+    },
+});
+
+var SubbasinHuc12TabContentView = SubbasinResultsTabContentView.extend({
+    templateHelpers: {
+        backButtonText: 'Back',
+    },
+    onShow: function() {
+        this.resultContentRegion.show(new gwlfeSubbasinViews.Huc12ResultView({
+            model: this.model,
+            scenario: this.options.scenario,
+            huc12: this.options.huc12,
         }));
     },
 });

--- a/src/mmw/sass/components/_tables.scss
+++ b/src/mmw/sass/components/_tables.scss
@@ -82,7 +82,7 @@
 }
 
 .catchment-water-quality .catchment-water-quality-id,
-    .point-source .point-source-id {
+    .point-source .point-source-id, .huc12-total {
   cursor: pointer;
 }
 

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -123,7 +123,8 @@
   flex-wrap: nowrap !important;
 }
 
-.subbasin-region {
+.subbasin-region,
+.subbasin-huc12-region {
     .tab-pane {
         .result {
             padding: 1rem;


### PR DESCRIPTION
## Overview

* Make the huc-12 table rows clickable.
* Add a Subbasin HUC-12 view over the subbasin AOI-level view.
* Make the SourcesTableView, subbasin ResultView and SubbasinTabContentView extendable and use them to fill out the HUC-12 level subbasin region

Connects #2728 
Connects #2729 

### Demo

![qlabzqvwgc](https://user-images.githubusercontent.com/7633670/38903356-610c2f38-4272-11e8-945b-a9e5c047eae4.gif)


<img width="782" alt="screen shot 2018-04-17 at 7 03 12 pm" src="https://user-images.githubusercontent.com/7633670/38903260-0663cf78-4272-11e8-9d86-8d9ac522d0aa.png">

## Testing Instructions

 * Pull and bundle
 * Select a HUC-10 and progress to Subbasin View. Select the HUC-12 tab in subbasin view
 * Click a row in the HUC-12 table
 * Confirm you can see the huc-12s source results and can navigate back and forth through all the levels of views (Unattenuated model results <-> Subbasin AOI-Level <-> Subbasin HUC-12)