### PR TITLE
Update services VM OpenJDK version

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -36,7 +36,7 @@ nodejs_npm_version: 2.1.17
 
 apache_version: "2.4.7-*"
 
-java_version: "7u151-*"
+java_version: "7u171-*"
 java_major_version: "7"
 java_flavor: "openjdk"
 


### PR DESCRIPTION
## Overview

The previous version was removed from apt.

I found this version by visiting https://launchpad.net/ubuntu/+source/openjdk-7.

## Testing Instructions

- Provision the services VM and verify it builds successfully.
