### PR TITLE
Monitor: Increase Area of Interest Limit with suds-jurko

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
@@ -13,3 +13,13 @@
   when: "['packer'] | is_in(group_names)"
   notify:
     - Restart mmw-app
+
+- name: Remove suds
+  pip:
+    name: suds
+    state: absent
+
+- name: Reinstall suds-jurko
+  pip:
+    name: https://bitbucket.org/jurko/suds/get/94664ddd46a6.tar.gz#egg=suds-jurko
+    state: forcereinstall

--- a/src/mmw/apps/bigcz/clients/cuahsi/search.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/search.py
@@ -23,7 +23,6 @@ from apps.bigcz.clients.cuahsi.models import CuahsiResource
 
 
 SQKM_PER_SQM = 0.000001
-CUAHSI_MAX_SIZE_SQKM = 1500
 CATALOG_NAME = 'cuahsi'
 CATALOG_URL = 'http://hiscentral.cuahsi.org/webservices/hiscentral.asmx?WSDL'
 
@@ -294,12 +293,12 @@ def search(**kwargs):
 
     bbox_area = bbox.area() * SQKM_PER_SQM
 
-    if bbox_area > CUAHSI_MAX_SIZE_SQKM:
+    if bbox_area > settings.BIGCZ_MAX_AREA:
         raise ValidationError({
             'error': 'The selected area of interest with a bounding box of {} '
                      'km² is larger than the currently supported maximum size '
                      'of {} km².'.format(round(bbox_area, 2),
-                                          CUAHSI_MAX_SIZE_SQKM)})
+                                          settings.BIGCZ_MAX_AREA)})
 
     world = BBox(-180, -90, 180, 90)
 

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -205,18 +205,21 @@ var Catalog = Backbone.Model.extend({
 
         // Perform local text search for pre-existing CUAHSI results
         if (isCuahsi && isSameGeom && !isSameQuery) {
-            this.set({ loading: true });
+            var searchPromise = this.searchPromise || $.when();
 
-            var results = this.get('serverResults').textFilter(query);
-            this.get('results').reset(results);
+            return searchPromise.then(function() {
+                self.set({ loading: true });
 
-            this.set({
-                loading: false,
-                query: query,
-                resultCount: results.length
+                var results = self.get('serverResults').textFilter(query);
+
+                self.get('results').reset(results);
+
+                self.set({
+                    loading: false,
+                    query: query,
+                    resultCount: results.length
+                });
             });
-
-            return $.when();
         }
 
         // Perform server search

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -403,7 +403,7 @@ OMGEO_SETTINGS = [[
 MMW_MAX_AREA = 75000  # Max area in km2, about the size of West Virginia
 
 BIGCZ_HOST = 'portal.bigcz.org'  # BiG-CZ Host, for enabling custom behavior
-BIGCZ_MAX_AREA = 1500  # Max area in km2, limited by CUAHSI
+BIGCZ_MAX_AREA = 5000  # Max area in km2, limited by CUAHSI
 BIGCZ_CLIENT_TIMEOUT = 5  # timeout in seconds
 BIGCZ_CLIENT_PAGE_SIZE = 100
 

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -20,7 +20,7 @@ requests[security]==2.9.1
 rollbar==0.13.8
 retry==0.9.1
 python-dateutil==2.6.0
-suds==0.4
+https://bitbucket.org/jurko/suds/get/94664ddd46a6.tar.gz#egg=suds-jurko
 django_celery_results==1.0.1
 git+git://github.com/emiliom/ulmo@wml_values_md#egg=ulmo
 numpy==1.13.0


### PR DESCRIPTION
## Overview

Switches to the `suds-jurko` fork which allows slightly more efficient SOAP calls. We are tentatively increasing the CUAHSI search limit from 1500 sq km to 8000 sq km, which allows small HUC-8s and almost all HUC-10s.

Connects #2756 
Connects #2760 

### Demo

![image](https://user-images.githubusercontent.com/1430060/38957223-fd616dca-4327-11e8-9250-95fe550ef195.png)

### Notes

Performance is still hit or miss. It sometimes works for larger shapes, then fails for the same shapes, then works again. The CPU usage of the `app` VM still goes up to 100% when interpreting the results, and can still fail for large payloads.

For future optimization, we can also give [`zeep`](https://github.com/mvantellingen/python-zeep) a try. 

## Testing Instructions

* Check out this branch and reprovision `app`, and `bundle`
* Open [:8000/](http://localhost:8000/) and select a large-ish shape (more than 1500 sq km)
* Go to the Monitor tab and search for something in CUAHSI
* Ensure you get some results