### PR TITLE
Show Subbasin Huc-12s On Map

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -66,10 +66,19 @@ var subbasinHuc12Style = {
     fillOpacity: 0,
 };
 
-var subbasinHuc12ActiveStyle = {
+var subbasinHuc12HighlightedStyle = {
     stroke: true,
     color: '#1d3331',
     weight: 2,
+    opacity: 1,
+    fill: true,
+    fillOpacity: 0,
+};
+
+var subbasinHuc12ActiveStyle = {
+    stroke: true,
+    color: '#dbba29',
+    weight: 5,
     opacity: 1,
     fill: true,
     fillOpacity: 0,
@@ -1035,15 +1044,32 @@ var MapView = Marionette.ItemView.extend({
             id: subbasinDetail.get('id'),
             onEachFeature: function(feature, layer) {
                 var highlightLayer = function() {
-                    if (subbasinDetail.get('highlighted')) {
-                        layer.setStyle(subbasinHuc12ActiveStyle);
+                    if (subbasinDetail.get('highlighted') && !subbasinDetail.get('active')) {
+                        layer.setStyle(subbasinHuc12HighlightedStyle);
                         layer.bringToFront();
                     } else {
-                        layer.setStyle(subbasinHuc12Style);
+                        if (subbasinDetail.get('active')) {
+                            layer.setStyle(subbasinHuc12ActiveStyle);
+                        } else {
+                            layer.setStyle(subbasinHuc12Style);
+                            layer.bringToBack();
+                        }
                     }
-                };
+                },
+                    setActiveLayer = function() {
+                        if (subbasinDetail.get('active')) {
+                            layer.setStyle(subbasinHuc12ActiveStyle);
+                            layer.bringToFront();
+                            self._leafletMap.fitBounds(layer.getBounds(), { reset: true });
+                        } else {
+                            layer.setStyle(subbasinHuc12Style);
+                            self.fitToAoi();
+                        }
+                    };
+
 
                 self.listenTo(subbasinDetail, 'change:highlighted', highlightLayer);
+                self.listenTo(subbasinDetail, 'change:active', setActiveLayer);
 
                 layer.on('mouseover', function() {
                     subbasinDetail.set('highlighted', true);

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -1080,7 +1080,9 @@ var MapView = Marionette.ItemView.extend({
                 });
 
                 layer.on('click', function() {
-                    subbasinDetail.setActive();
+                    if (subbasinDetail.get('clickable')) {
+                        subbasinDetail.setActive();
+                    }
                 });
             }
         });

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -1045,7 +1045,7 @@ var MapView = Marionette.ItemView.extend({
                 });
 
                 layer.on('click', function() {
-                    subbasinDetail.set('active', true);
+                    subbasinDetail.setActive();
                 });
             }
         });

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -1037,10 +1037,12 @@ var MapView = Marionette.ItemView.extend({
 
     createSubbasinHuc12Shape: function(subbasinDetail) {
         var self = this,
-            geom = subbasinDetail.get('shape');
+            geom = subbasinDetail.get('shape'),
+            style = subbasinDetail.get('active') ?
+                subbasinHuc12ActiveStyle : subbasinHuc12Style;
 
         return new L.GeoJSON(geom, {
-            style: subbasinHuc12Style,
+            style: style,
             id: subbasinDetail.get('id'),
             onEachFeature: function(feature, layer) {
                 var highlightLayer = function() {
@@ -1088,6 +1090,16 @@ var MapView = Marionette.ItemView.extend({
         });
     },
 
+    clearSubbasinHuc12s: function() {
+        var self = this,
+            subbasins = this.model.get('subbasinHuc12s');
+        if (!subbasins) { return; }
+        subbasins.forEach(function(subbasinDetail) {
+            self.stopListening(subbasinDetail);
+        });
+        this.model.set('subbasinHuc12s', null);
+    },
+
     renderSubbasinHuc12s: function() {
         this._subbasinHuc12sLayer.clearLayers();
 
@@ -1104,6 +1116,16 @@ var MapView = Marionette.ItemView.extend({
             var layer = this.createSubbasinHuc12Shape(subbasinDetail);
             this._subbasinHuc12sLayer.addLayer(layer);
         }, this);
+
+        this._areaOfInterestLayer.bringToFront();
+        if (subbasinDetails.getActive()) {
+            var activeId = subbasinDetails.getActive().get('id');
+            _.forEach(this._subbasinHuc12sLayer.getLayers(), function(layer) {
+                if (layer.options.id === activeId) {
+                    layer.bringToFront();
+                }
+            });
+        }
     },
 
     renderSelectedGeocoderArea: function() {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -1027,20 +1027,29 @@ var MapView = Marionette.ItemView.extend({
     },
 
     createSubbasinHuc12Shape: function(subbasinDetail) {
-        var geom = subbasinDetail.get('shape');
+        var self = this,
+            geom = subbasinDetail.get('shape');
 
         return new L.GeoJSON(geom, {
             style: subbasinHuc12Style,
             id: subbasinDetail.get('id'),
             onEachFeature: function(feature, layer) {
+                var highlightLayer = function() {
+                    if (subbasinDetail.get('highlighted')) {
+                        layer.setStyle(subbasinHuc12ActiveStyle);
+                        layer.bringToFront();
+                    } else {
+                        layer.setStyle(subbasinHuc12Style);
+                    }
+                };
+
+                self.listenTo(subbasinDetail, 'change:highlighted', highlightLayer);
+
                 layer.on('mouseover', function() {
-                    layer.setStyle(subbasinHuc12ActiveStyle);
                     subbasinDetail.set('highlighted', true);
-                    layer.bringToFront();
                 });
 
                 layer.on('mouseout', function() {
-                    layer.setStyle(subbasinHuc12Style);
                     subbasinDetail.set('highlighted', false);
                 });
 

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -57,6 +57,24 @@ var dataCatalogDetailStyle = {
     fillOpacity: 0.5
 };
 
+var subbasinHuc12Style = {
+    stroke: true,
+    color: '#40c4c4',
+    weight: 2,
+    opacity: 1,
+    fill: true,
+    fillOpacity: 0,
+};
+
+var subbasinHuc12ActiveStyle = {
+    stroke: true,
+    color: '#1d3331',
+    weight: 2,
+    opacity: 1,
+    fill: true,
+    fillOpacity: 0,
+};
+
 var selectedGeocoderAreaStyle = {
     stroke: true,
     fill: true,
@@ -270,6 +288,7 @@ var MapView = Marionette.ItemView.extend({
         'change:dataCatalogActiveResult': 'renderDataCatalogActiveResult',
         'change:dataCatalogDetailResult': 'renderDataCatalogDetailResult',
         'change:selectedGeocoderArea': 'renderSelectedGeocoderArea',
+        'change:subbasinHuc12s': 'renderSubbasinHuc12s',
     },
 
     // L.Map instance.
@@ -292,6 +311,9 @@ var MapView = Marionette.ItemView.extend({
     // The shape for a selected geocoder boundary result
     // L.FeatureGroup instance
     _selectedGeocoderAreaLayer: null,
+
+    // The HUC-12s that make up a shape in subbasin modeling mode
+    _subbasinHuc12sLayer: null,
 
     // Flag used to determine if AOI change should trigger a prompt.
     _areaOfInterestSet: false,
@@ -325,6 +347,7 @@ var MapView = Marionette.ItemView.extend({
         this._dataCatalogActiveLayer = new L.FeatureGroup();
         this._dataCatalogDetailLayer = new L.FeatureGroup();
         this._selectedGeocoderAreaLayer = new L.FeatureGroup();
+        this._subbasinHuc12sLayer = new L.FeatureGroup();
 
         this.fitToDefaultBounds();
 
@@ -366,6 +389,7 @@ var MapView = Marionette.ItemView.extend({
         map.addLayer(this._dataCatalogActiveLayer);
         map.addLayer(this._dataCatalogDetailLayer);
         map.addLayer(this._selectedGeocoderAreaLayer);
+        map.addLayer(this._subbasinHuc12sLayer);
     },
 
     fitToDefaultBounds: function() {
@@ -1000,6 +1024,49 @@ var MapView = Marionette.ItemView.extend({
 
         // Listen for clicks on the currently active layer
         this._dataCatalogResultsLayer.on('click', handleClick);
+    },
+
+    createSubbasinHuc12Shape: function(subbasinDetail) {
+        var geom = subbasinDetail.get('shape');
+
+        return new L.GeoJSON(geom, {
+            style: subbasinHuc12Style,
+            id: subbasinDetail.get('id'),
+            onEachFeature: function(feature, layer) {
+                layer.on('mouseover', function() {
+                    layer.setStyle(subbasinHuc12ActiveStyle);
+                    subbasinDetail.set('highlighted', true);
+                    layer.bringToFront();
+                });
+
+                layer.on('mouseout', function() {
+                    layer.setStyle(subbasinHuc12Style);
+                    subbasinDetail.set('highlighted', false);
+                });
+
+                layer.on('click', function() {
+                    subbasinDetail.set('active', true);
+                });
+            }
+        });
+    },
+
+    renderSubbasinHuc12s: function() {
+        this._subbasinHuc12sLayer.clearLayers();
+
+        var subbasinDetails = this.model.get('subbasinHuc12s');
+        if (!subbasinDetails) { return; }
+        // If there are no subbasins loaded yet to display,
+        // listen to the collection for changes, so we can try
+        // to render again when models get added
+        if (subbasinDetails.length <= 0) {
+            return this.listenToOnce(subbasinDetails, 'add', this.renderSubbasinHuc12s, this);
+        }
+
+        subbasinDetails.forEach(function(subbasinDetail) {
+            var layer = this.createSubbasinHuc12Shape(subbasinDetail);
+            this._subbasinHuc12sLayer.addLayer(layer);
+        }, this);
     },
 
     renderSelectedGeocoderArea: function() {

--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -283,6 +283,7 @@ function projectCleanUp() {
     }
 
     App.getMapView().updateModifications(null);
+    App.getMapView().clearSubbasinHuc12s();
     App.rootView.subHeaderRegion.empty();
     App.rootView.sidebarRegion.empty();
     App.rootView.compareRegion.empty();

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
@@ -19,7 +19,7 @@
     <tbody>
         {% for key, row in rows %}
             <tr class="huc12-total" data-huc12-id="{{ key }}">
-                <td class="text-left">{{ subbasins.get(key).get('name') }}</td>
+                <td class="text-left">{{ subbasins.get(key).get('name') if subbasins.get(key) else '--' }}</td>
                 <td class="text-right">{{ key }}</td>
                 <td class="strong text-right">{{ row.SummaryLoads.Area|round(2)|toLocaleString(2) }}</td>
                 <td class="strong text-right">{{ row.SummaryLoads.Sediment|round(2)|toLocaleString(2) }}</td>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -158,6 +158,8 @@ var Huc12TotalsTableView = Marionette.ItemView.extend({
     },
     events: {
         'click @ui.rows': 'handleRowClick',
+        'mouseover @ui.rows': 'handleRowMouseOver',
+        'mouseout @ui.rows': 'handleRowMouseOut',
     },
     onAttach: function() {
         $('[data-toggle="table"]').bootstrapTable();
@@ -183,6 +185,16 @@ var Huc12TotalsTableView = Marionette.ItemView.extend({
         var id = e.currentTarget.getAttribute('data-huc12-id');
         App.currentProject.get('subbasins').get(id).setActive();
         this.options.showHuc12();
+    },
+
+    handleRowMouseOver: function(e) {
+        var id = e.currentTarget.getAttribute('data-huc12-id');
+        App.currentProject.get('subbasins').get(id).set('highlighted', true);
+    },
+
+    handleRowMouseOut: function(e) {
+        var id = e.currentTarget.getAttribute('data-huc12-id');
+        App.currentProject.get('subbasins').get(id).set('highlighted', false);
     },
 
     highlightRow: function(subbasinDetail) {

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -166,10 +166,22 @@ var Huc12TotalsTableView = Marionette.ItemView.extend({
     },
     initialize: function() {
         var self = this;
-        App.currentProject.get('subbasins').forEach(function(subbasin) {
+        self.subbasinDetails = App.currentProject.get('subbasins');
+        if (this.subbasinDetails.isEmpty()) {
+            self.listenToOnce(self.subbasinDetails, 'add', this.setupSubbasinDetails, this);
+        } else {
+            this.setupSubbasinDetails();
+        }
+    },
+
+    setupSubbasinDetails: function() {
+        var self = this;
+        this.render();
+        this.subbasinDetails.forEach(function(subbasin) {
             self.listenTo(subbasin, 'change:highlighted', self.highlightRow, self);
             self.listenTo(subbasin, 'change:active', self.options.showHuc12, self);
         });
+        this.subbasinDetails.setClickable();
     },
 
     templateHelpers: function() {
@@ -182,17 +194,20 @@ var Huc12TotalsTableView = Marionette.ItemView.extend({
     },
 
     handleRowClick: function(e) {
+        if (this.subbasinDetails.isEmpty()) { return; }
         var id = e.currentTarget.getAttribute('data-huc12-id');
         App.currentProject.get('subbasins').get(id).setActive();
         this.options.showHuc12();
     },
 
     handleRowMouseOver: function(e) {
+        if (this.subbasinDetails.isEmpty()) { return; }
         var id = e.currentTarget.getAttribute('data-huc12-id');
         App.currentProject.get('subbasins').get(id).set('highlighted', true);
     },
 
     handleRowMouseOut: function(e) {
+        if (this.subbasinDetails.isEmpty()) { return; }
         var id = e.currentTarget.getAttribute('data-huc12-id');
         App.currentProject.get('subbasins').get(id).set('highlighted', false);
     },

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -806,12 +806,26 @@ var SubbasinDetailModel = Backbone.Model.extend({
         catchments: null,
         highlighted: false,
         active: false,
+    },
+
+    setActive: function() {
+        var currentActive = this.collection.getActive();
+        if (currentActive) {
+            currentActive.set('active', false);
+        }
+        this.set('active', true);
     }
 });
 
 var SubbasinDetailCollection = Backbone.Collection.extend({
     url: '/mmw/modeling/subbasins/',
     model: SubbasinDetailModel,
+
+    getActive: function() {
+        return this.find(function(subbasinDetail) {
+            return subbasinDetail.get('active');
+        });
+    },
 });
 
 /**

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -574,7 +574,9 @@ var ProjectModel = Backbone.Model.extend({
             self.fetchGisDataPromise
                 .done(function(result, job) {
                     if (result) {
-                        self.set('gis_data', result);
+                        if (!isSubbasinMode) {
+                            self.set('gis_data', result);
+                        }
                         self.set(mapshedJobUUIDAttribute, job);
                         saveProjectAndScenarios();
                     }

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -806,6 +806,7 @@ var SubbasinDetailModel = Backbone.Model.extend({
         catchments: null,
         highlighted: false,
         active: false,
+        clickable: false,
     },
 
     setActive: function() {
@@ -826,6 +827,12 @@ var SubbasinDetailCollection = Backbone.Collection.extend({
             return subbasinDetail.get('active');
         });
     },
+
+    setClickable: function() {
+        this.forEach(function(subbasinDetail) {
+            subbasinDetail.set('clickable', true);
+        });
+    }
 });
 
 /**

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -323,6 +323,7 @@ var ProjectModel = Backbone.Model.extend({
 
         this.listenTo(this.get('scenarios'), 'add', this.addIdsToScenarios, this);
 
+        this.set('subbasins', new SubbasinDetailCollection());
         this.listenTo(this, 'change:subbasin_mapshed_job_uuid', this.fetchSubbasins, this);
 
         // Debounce HydroShare export to 5 seconds to allow models to run and
@@ -591,9 +592,7 @@ var ProjectModel = Backbone.Model.extend({
     },
 
     fetchSubbasins: function() {
-        var subbasins = new SubbasinDetailCollection(null);
-        this.set('subbasins', subbasins);
-        subbasins.fetch({ data: { mapshed_job_uuid: this.get('subbasin_mapshed_job_uuid') }});
+        this.get('subbasins').fetch({ data: { mapshed_job_uuid: this.get('subbasin_mapshed_job_uuid') }});
     },
 
     /**
@@ -805,6 +804,8 @@ var SubbasinDetailModel = Backbone.Model.extend({
         name: '',
         shape: null,
         catchments: null,
+        highlighted: false,
+        active: false,
     }
 });
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1107,6 +1107,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
     },
 
     hideSubbasinHuc12View: function() {
+        App.currentProject.get('subbasins').getActive().set('active', false);
         this.subbasinRegion.$el.show();
         this.subbasinHuc12Region.empty();
     }

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1096,14 +1096,13 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         App.map.set('subbasinHuc12s', null);
     },
 
-    showSubbasinHuc12View: function(huc12Id) {
+    showSubbasinHuc12View: function() {
         this.subbasinRegion.$el.hide();
 
         this.subbasinHuc12Region.show(new SubbasinHuc12TabContentView({
             model: this.collection.getResult('subbasin'),
             scenario: this.scenario,
             hideSubbasinHotSpotView: this.hideSubbasinHuc12View,
-            huc12: huc12Id,
         }));
     },
 
@@ -1265,7 +1264,6 @@ var SubbasinHuc12TabContentView = SubbasinResultsTabContentView.extend({
         this.resultContentRegion.show(new gwlfeSubbasinViews.Huc12ResultView({
             model: this.model,
             scenario: this.options.scenario,
-            huc12: this.options.huc12,
         }));
     },
 });

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1070,6 +1070,9 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
     showSubbasinHotSpotView: function() {
         this.panelsRegion.$el.hide();
         this.contentRegion.$el.hide();
+
+        App.map.set('subbasinHuc12s', App.currentProject.get('subbasins'));
+
         if (this.subbasinRegion.hasView()) {
             return this.subbasinRegion.$el.show();
         }
@@ -1089,6 +1092,8 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         this.subbasinRegion.$el.hide();
         this.panelsRegion.$el.show();
         this.contentRegion.$el.show();
+
+        App.map.set('subbasinHuc12s', null);
     },
 
     showSubbasinHuc12View: function(huc12Id) {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -976,6 +976,7 @@ var ResultsView = Marionette.LayoutView.extend({
                 this.monitorRegion.currentView.setVisibility(false);
                 this.modelingRegion.$el.removeClass('active');
                 App.getMapView().updateModifications(null);
+                App.getMapView().clearSubbasinHuc12s();
                 break;
             case utils.MONITOR:
                 if (App.map.get('dataCatalogDetailResult') !== null) {
@@ -988,6 +989,7 @@ var ResultsView = Marionette.LayoutView.extend({
                 this.monitorRegion.currentView.setVisibility(true);
                 this.modelingRegion.$el.removeClass('active');
                 App.getMapView().updateModifications(null);
+                App.getMapView().clearSubbasinHuc12s();
                 break;
             case utils.MODEL:
                 this.aoiRegion.currentView.$el.addClass('hidden');
@@ -998,6 +1000,9 @@ var ResultsView = Marionette.LayoutView.extend({
                 App.getMapView().updateModifications(
                     this.model.get('scenarios').getActiveScenario()
                 );
+                if (this.modelingRegion.currentView.subbasinRegion.hasView()) {
+                    App.map.set('subbasinHuc12s', App.currentProject.get('subbasins'));
+                }
                 break;
         }
     },

--- a/src/mmw/sass/components/_tables.scss
+++ b/src/mmw/sass/components/_tables.scss
@@ -31,6 +31,12 @@
     }
   }
 
+  tr.huc12-total.highlighted,
+  tr.huc12-total:hover,
+  tr.huc12-total:focus {
+    background-color: rgba(56, 155, 155, 0.3);
+  }
+
   tfoot th {
     border-left: 1px solid #ddd;
 


### PR DESCRIPTION
## Overview
Add the huc-12 subbasin shapes to the map. They have two-way interactivity: you can active their hover state by hovering over them on the map or on the huc-12 totals table. You can select one via clicking the map or clicking their row in the huc12 totals table. 

Connects #2651 

### Demo

[ ignore the error on the analyze page in this gif. It isn't related. ]
![3bn3ac1ejw](https://user-images.githubusercontent.com/7633670/39004445-538d3f96-43cb-11e8-948f-bcd60e327e10.gif)


## Testing Instructions

 *  Pull this branch and `./scripts/bundle.sh`
 * Proceed to subbasin modeling and confirm you see shapes appear on the map

Some things to try:
 * hover over the shapes
 * hover over the huc12 total table rows
 * click the shapes
 * click the huc12 total table rows
 * toggle the analyze/monitor/modeling view
 * navigate away from the model view while the shapes are on the map
 * exit subbasin mode and go back into it
