### PR TITLE
Clear old MapShed results

### DIFF
--- a/src/mmw/apps/modeling/migrations/0028_clear_old_mapshed_results.py
+++ b/src/mmw/apps/modeling/migrations/0028_clear_old_mapshed_results.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def clear_old_mapshed_results(apps, schema_editor):
+    Project = apps.get_model('modeling', 'Project')
+    Scenario = apps.get_model('modeling', 'Scenario')
+
+    Project.objects.filter(
+        model_package='gwlfe'
+    ).update(
+        gis_data=None,
+        mapshed_job_uuid=None,
+        subbasin_mapshed_job_uuid=None
+    )
+
+    Scenario.objects.filter(
+        project__model_package='gwlfe'
+    ).update(
+        results='[]',
+        modification_hash=''
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0027_project_add_mapshed_job_uuids'),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_old_mapshed_results)
+    ]


### PR DESCRIPTION
## Overview

With the updated ET values in #2737, we need to clear the existing results. This migration clears all stored results for all MapShed projects and scenarios. They will be re-calculated when the scenario is opened again.

Connects #2750 

## Testing Instructions

* Ensure you have existing MapShed projects
* Run the migration
* Ensure when you reload the existing project, it is recalculated
* Ensure TR-55 projects are not affected