### PR TITLE
Allow MapShed to run for AoIs without streams

### DIFF
--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -169,7 +169,14 @@ def multi(self, opname, shapes, stream_lines):
     """
     data = settings.GEOP['json'][opname].copy()
     data['shapes'] = []
-    data['streamLines'] = stream_lines
+
+    # Don't include the RasterLinesJoin operation if the AoI does
+    # not contain streams
+    if stream_lines is not None:
+        data['streamLines'] = stream_lines
+    else:
+        data['operations'] = [o for o in data['operations']
+                              if not (o.get('name') == 'RasterLinesJoin')]
 
     operation_count = len(data['operations'])
     output = {}


### PR DESCRIPTION
## Overview

If a MapShed run is started for an AoI that does not contain streams, the stream related geoprocessing operation is removed from the list of jobs. Variables and functions that use the output of that job are modified in to account for the output not existing. This mostly involves setting certain values to zero.

Connects to #2767

### Demo

AoI w/o streams
![image](https://user-images.githubusercontent.com/1042475/39018382-dc7d4f58-43f3-11e8-9667-ff2c8cf96af1.png)

AoI w/ streams
![image](https://user-images.githubusercontent.com/1042475/39018457-0ef9876c-43f4-11e8-9153-114745cddd0c.png)

## Testing Instructions

- Select an AoI that does not contain any streams. A 1 km2 AoI somewhere in Center City works well.
- Proceed to the modeling stage and select mapshed.
- Verify the model succeeds and that the results are valid.
- Select another AoI that does contain streams. Select mapshed again and verify that the model succeeds and that the results are valid.
- Make sure to double-check that the results are valid in both scenarios.