### PR TITLE
Close sub-basin view when changing scenarios

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -959,6 +959,11 @@ var ResultsView = Marionette.LayoutView.extend({
         ));
 
         if (scenario) {
+            // Close sub-basin of previous detail view if active
+            if (this.modelingRegion.hasView()) {
+                this.modelingRegion.currentView.hideSubbasinHotSpotView();
+            }
+
             this.modelingRegion.show(new ResultsDetailsView({
                 areaOfInterest: this.model.get('area_of_interest'),
                 collection: scenario.get('results'),


### PR DESCRIPTION
## Overview

Closes the sub-basin view when switching scenarios to alleviate any map issues resulting from remnant sub-basin artifacts.

Discovered #2791 while working on this, but ended up cutting that into a separate issue.

Connects #2789

### Demo

![2018-04-20 15 18 55](https://user-images.githubusercontent.com/1430060/39069678-81bb0914-44ae-11e8-81e0-168d73f5340b.gif)

### Notes

Switching between scenarios seems to take a pause, not sure if that's coming from `.hasView()` or something else, but I think it's tolerable right now. 🚀 🐦 

## Testing Instructions

* Checkout this branch and `bundle`
* Open subbasin mode on a project
* Change scenarios / add a scenario from within subbasin mode. Ensure that in the next scenario you see MapShed, not subbasin.
* Ensure everything else still works.