### PR TITLE
Upgrade Docker to resolve key issues

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -47,4 +47,4 @@
 - src: azavea.java
   version: 0.6.1
 - src: azavea.docker
-  version: 1.0.2
+  version: 2.0.0


### PR DESCRIPTION
## Overview

Aims to counter the deployment issues seen in the `model-my-watershed-packer-app-and-worker` Jenkins job.

### Notes

I'm not sure why only that job is affected by the key, and not `model-my-watershed-pull-requests`.

## Testing Instructions

* Ensure `worker` provisions correctly