### PR TITLE
Add Subbasin NHD+ Table

### DIFF
--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -26,6 +26,8 @@ urlpatterns = patterns(
     url(r'tr55/$', views.start_tr55, name='start_tr55'),
     url(r'gwlfe/$', views.start_gwlfe, name='start_gwlfe'),
     url(r'subbasins/$', views.subbasins_detail, name='subbasins_detail'),
+    url(r'subbasins/catchments/$', views.subbasin_catchments_detail,
+        name='subbasin_catchments_detail'),
     url(r'boundary-layers/(?P<table_code>\w+)/(?P<obj_id>[0-9]+)/$',
         views.boundary_layer_detail, name='boundary_layer_detail'),
     url(r'boundary-layers-search/$',

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
+import urllib
 
 from celery import chain, group
 
@@ -43,6 +44,7 @@ from apps.modeling.serializers import (ProjectSerializer,
                                        AoiSerializer)
 from apps.modeling.calcs import (get_layer_shape,
                                  get_huc12s,
+                                 get_catchments,
                                  apply_gwlfe_modifications,
                                  boundary_search_context,
                                  split_into_huc12s)
@@ -455,6 +457,18 @@ def subbasins_detail(request):
     if gmss:
         huc12s = get_huc12s(gmss.keys())
         return Response(huc12s)
+    else:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+
+@decorators.api_view(['GET'])
+@decorators.permission_classes((AllowAny, ))
+def subbasin_catchments_detail(request):
+    encoded_comids = request.query_params.get('catchment_comids')
+    catchment_comids = json.loads(urllib.unquote(encoded_comids))
+    if catchment_comids and len(catchment_comids) > 0:
+        catchments = get_catchments(catchment_comids)
+        return Response(catchments)
     else:
         return Response(status=status.HTTP_404_NOT_FOUND)
 

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/catchmentTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/catchmentTable.html
@@ -1,0 +1,61 @@
+<table class="table custom-hover" data-toggle="table">
+    <thead>
+        <tr>
+            <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">NHD+ ComID</th>
+            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (km<sup>2</sup>)</th>
+            <th colspan="3">Total Loads (not normalized)</th>
+            <th colspan="3">Loading Rates (area normalized)</th>
+            <th colspan="3">Mean Annual Concentration(discharge normalized)</th>
+        </tr>
+        <tr>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/ha/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/ha/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/ha/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment (mg/L)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (mg/L)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (mg/L)</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for key, row in rows %}
+            <tr class="subbasin-catchment-row" data-comid="{{ key }}">
+                {% set area = catchmentDetails.get(key).get('area') if  not catchmentDetails.isEmpty() else 0 %}
+                <td class="text-left">{{ key }}</td>
+                <td class="strong text-right">{{ area|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.TotalLoadingRates.Sediment|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.TotalLoadingRates.TotalN|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.TotalLoadingRates.TotalP|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalLoadingRates.Sediment/area) or 0)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalLoadingRates.TotalN/area) or 0)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalLoadingRates.TotalP/area) or 0)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.LoadingRateConcentrations.Sediment|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.LoadingRateConcentrations.TotalN|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.LoadingRateConcentrations.TotalP|round(2)|toLocaleString(2) }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+    <tfoot>
+        <tr>
+            {% set area = summaryRow.Area  %}
+            <th class="text-left">{{ summaryRow.Source }}</th>
+            <th class="text-right">{{ summaryRow.Area|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalLoadingRates.Sediment|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalLoadingRates.TotalN|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalLoadingRates.TotalP|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ ((summaryRow.TotalLoadingRates.Sediment/area) or 0)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ ((summaryRow.TotalLoadingRates.TotalN/area) or 0)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ ((summaryRow.TotalLoadingRates.TotalP/area) or 0)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.LoadingRateConcentrations.Sediment|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.LoadingRateConcentrations.TotalN|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.LoadingRateConcentrations.TotalP|round(2)|toLocaleString(2) }}</th>
+        </tr>
+    </tfoot>
+
+</table>
+
+<div class="downloadcsv-link" data-action="download-csv-granular">
+    <i class="fa fa-download"></i> Download this data
+</div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -166,23 +166,29 @@ var Huc12TotalsTableView = Marionette.ItemView.extend({
     onAttach: function() {
         $('[data-toggle="table"]').bootstrapTable();
     },
+    onRender: function() {
+        $('[data-toggle="table"]').bootstrapTable();
+    },
     initialize: function() {
         var self = this;
         self.subbasinDetails = App.currentProject.get('subbasins');
         if (this.subbasinDetails.isEmpty()) {
-            self.listenToOnce(self.subbasinDetails, 'add', this.setupSubbasinDetails, this);
+            self.listenToOnce(self.subbasinDetails, 'add', this.renderAndSetup, this);
         } else {
             this.setupSubbasinDetails();
         }
     },
 
-    setupSubbasinDetails: function() {
-        var self = this;
+    renderAndSetup: function() {
         this.render();
+        this.setupSubbasinDetails();
+    },
+
+    setupSubbasinDetails: function() {
         this.subbasinDetails.forEach(function(subbasin) {
-            self.listenTo(subbasin, 'change:highlighted', self.highlightRow, self);
-            self.listenTo(subbasin, 'change:active', self.options.showHuc12, self);
-        });
+            this.listenTo(subbasin, 'change:highlighted', this.highlightRow, this);
+            this.listenTo(subbasin, 'change:active', this.options.showHuc12, this);
+        }, this);
         this.subbasinDetails.setClickable();
     },
 
@@ -235,25 +241,30 @@ var CatchmentsTableView = Marionette.ItemView.extend({
         'mouseover @ui.rows': 'handleRowMouseOver',
         'mouseout @ui.rows': 'handleRowMouseOut',
     },
+    onAttach: function() {
+        $('[data-toggle="table"]').bootstrapTable();
+    },
     onRender: function() {
         $('[data-toggle="table"]').bootstrapTable();
     },
     initialize: function() {
-        var self = this;
-        self.catchmentDetails = App.currentProject.get('subbasins').getActive().get('catchments');
+        this.catchmentDetails = App.currentProject.get('subbasins').getActive().get('catchments');
         if (this.catchmentDetails.isEmpty()) {
-            self.listenToOnce(self.catchmentDetails, 'add', this.setupCatchmentDetails, this);
+            this.listenToOnce(this.catchmentDetails, 'add', this.setupAndRender, this);
         } else {
             this.setupCatchmentDetails();
         }
     },
 
-    setupCatchmentDetails: function() {
-        var self = this;
+    setupAndRender: function() {
         this.render();
+        this.setupCatchmentDetails();
+    },
+
+    setupCatchmentDetails: function() {
         this.catchmentDetails.forEach(function(catchment) {
-            self.listenTo(catchment, 'change:highlighted', self.highlightRow, self);
-        });
+            this.listenTo(catchment, 'change:highlighted', this.highlightRow, this);
+        }, this);
     },
 
     templateHelpers: function() {

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -817,7 +817,26 @@ var SubbasinDetailModel = Backbone.Model.extend({
             currentActive.set('active', false);
         }
         this.set('active', true);
-    }
+    },
+
+    initialize: function() {
+        this.set('catchments', new SubbasinCatchmentDetailCollection());
+    },
+
+    fetchCatchmentsIfNeeded: function(comids) {
+        var catchments = this.get('catchments');
+        if (!catchments.isEmpty() || this.fetchCatchmentsPromise) {
+            return this.fetchCatchmentsPromise || $.when();
+        }
+
+        var encodedComids = encodeURIComponent(JSON.stringify(comids));
+        this.fetchCatchmentsPromise = catchments.fetch({
+            data: { catchment_comids: encodedComids},
+        }).always(function() {
+            delete this.fetchCatchmentsPromise;
+        });
+        return this.fetchCatchmentsPromise;
+    },
 });
 
 var SubbasinDetailCollection = Backbone.Collection.extend({
@@ -835,6 +854,20 @@ var SubbasinDetailCollection = Backbone.Collection.extend({
             subbasinDetail.set('clickable', true);
         });
     }
+});
+
+var SubbasinCatchmentDetailModel = Backbone.Model.extend({
+    defaults: {
+        shape: null,
+        stream: null,
+        area: null,
+        highlighted: false,
+    }
+});
+
+var SubbasinCatchmentDetailCollection = Backbone.Collection.extend({
+    url: '/mmw/modeling/subbasins/catchments/',
+    model: SubbasinCatchmentDetailModel,
 });
 
 /**

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1114,12 +1114,12 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
             var catchmentComids = Object.keys(
                 subbasinResult.get('result').HUC12s[activeSubbasin.get('id')].Catchments);
             activeSubbasin.fetchCatchmentsIfNeeded(catchmentComids);
+            this.subbasinHuc12Region.show(new SubbasinHuc12TabContentView({
+                model: subbasinResult,
+                scenario: this.scenario,
+                hideSubbasinHotSpotView: this.hideSubbasinHuc12View,
+            }));
         }
-        this.subbasinHuc12Region.show(new SubbasinHuc12TabContentView({
-            model: subbasinResult,
-            scenario: this.scenario,
-            hideSubbasinHotSpotView: this.hideSubbasinHuc12View,
-        }));
     },
 
     hideSubbasinHuc12View: function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1103,7 +1103,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         this.panelsRegion.$el.show();
         this.contentRegion.$el.show();
 
-        App.map.set('subbasinHuc12s', null);
+        App.getMapView().clearSubbasinHuc12s();
     },
 
     showSubbasinHuc12View: function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1000,7 +1000,12 @@ var ResultsView = Marionette.LayoutView.extend({
                 App.getMapView().updateModifications(
                     this.model.get('scenarios').getActiveScenario()
                 );
-                if (this.modelingRegion.currentView.subbasinRegion.hasView()) {
+                var modelingView = this.modelingRegion.currentView,
+                    isVisible = function(region) {
+                        return region.hasView() && region.$el.is(':visible');
+                    };
+                if (isVisible(modelingView.subbasinRegion) ||
+                    isVisible(modelingView.subbasinHuc12Region)) {
                     App.map.set('subbasinHuc12s', App.currentProject.get('subbasins'));
                 }
                 break;

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1103,9 +1103,15 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
 
     showSubbasinHuc12View: function() {
         this.subbasinRegion.$el.hide();
-
+        var activeSubbasin = App.currentProject.get('subbasins').getActive(),
+            subbasinResult = this.collection.getResult('subbasin');
+        if (activeSubbasin) {
+            var catchmentComids = Object.keys(
+                subbasinResult.get('result').HUC12s[activeSubbasin.get('id')].Catchments);
+            activeSubbasin.fetchCatchmentsIfNeeded(catchmentComids);
+        }
         this.subbasinHuc12Region.show(new SubbasinHuc12TabContentView({
-            model: this.collection.getResult('subbasin'),
+            model: subbasinResult,
             scenario: this.scenario,
             hideSubbasinHotSpotView: this.hideSubbasinHuc12View,
         }));


### PR DESCRIPTION
## Overview

Similar to #2781 where we got HUC-12 details — get catchment details and geometries and display them in the new catchment table. Also clean up some map-timing bugs.

Connects #2730
Connects #2791

### Demo

<img width="916" alt="screen shot 2018-04-20 at 5 34 31 pm" src="https://user-images.githubusercontent.com/7633670/39074921-5c391fa6-44c1-11e8-8109-90849cea4a3e.png">
<img width="916" alt="screen shot 2018-04-20 at 5 34 21 pm" src="https://user-images.githubusercontent.com/7633670/39074922-5c48279e-44c1-11e8-9b51-90df5bbdf7aa.png">


## Testing Instructions

 * Pull and `bundle`
 * In subbasin view, select a huc-12 and confirm the catchment table is populated
 * Confirm if you select the same huc-12 the catchment details request doesn't execute again
 * Toggle between the various views in various states (eg Analyze toggle while viewing catchments, exit attenuated and then view again). Confirm there are no errors in the console and nothing breaks on the second viewing.
