### PR TITLE
Upgrade Omgeo to correctly resolve suds-jurko

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
@@ -13,13 +13,3 @@
   when: "['packer'] | is_in(group_names)"
   notify:
     - Restart mmw-app
-
-- name: Remove suds
-  pip:
-    name: suds
-    state: absent
-
-- name: Reinstall suds-jurko
-  pip:
-    name: https://bitbucket.org/jurko/suds/get/94664ddd46a6.tar.gz#egg=suds-jurko
-    state: forcereinstall

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -381,7 +381,7 @@ WSGI_APPLICATION = '%s.wsgi.application' % SITE_NAME
 # END WSGI CONFIGURATION
 
 OMGEO_SETTINGS = [[
-    'omgeo.services.EsriWGSSSL',
+    'omgeo.services.esri.EsriWGS',
     {
         'preprocessors': [],
         'postprocessors': [

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -6,7 +6,7 @@ hiredis==0.1.6
 djangorestframework==3.1.1
 django-filter==0.9.2
 django-registration-redux==1.2
-python-omgeo==2.0.0
+python-omgeo==4.0.0
 rauth==0.7.1
 djangorestframework-gis==0.8.2
 django-rest-swagger==0.3.8


### PR DESCRIPTION
## Overview

Previously, python-omgeo would bring in suds as a dependency requiring we remove it and reinstall it. This led to various build issues.

By upgrading python-omgeo, we make it so that suds is never brought in, and doesn't need to be uninstalled for suds-jurko to work correctly. This fixes the build issues.

Connects #2760

## Testing Instructions

* Checkout this branch, destroy and recreate `app`
* Run `vagrant ssh app -c 'sudo -H pip list | grep suds'` and ensure you only see `suds-jurko` and no `suds` dependency
* Open the app and ensure the geocoder works correctly
* Go to the Monitor tab after selecting a shape and search for something CUAHSI. Ensure you see results.