### PR TITLE
Subbasin: Increase front-end timeout to 160s

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -469,13 +469,13 @@ var LayerTabCollection = Backbone.Collection.extend({
 var TaskModel = Backbone.Model.extend({
     defaults: {
         pollInterval: 1000,
-        /* The timeout is set to 45 seconds here, while in the
-           src/mmw/apps/modeling/tasks.py file it is set to 42
-           seconds.  That was done because the countdown starts in the
-           front-end before it does in the back-end and the we would
-           like them to finish at approximately the same time (with the
-           back-end finishing earlier if they are not synced). */
-        timeout: 45000,
+        /* The timeout is set to 160 seconds here. It may be set
+           differently in other parts of the app, in most cases less.
+           The front-end timeout is the highest to allow for patient
+           users time to let large processing finish (subbasin, large
+           areas of interest, etc). In most cases, back-end jobs will
+           finish or fail before this is hit. */
+        timeout: 160000,
     },
 
     url: function(queryParams) {


### PR DESCRIPTION
## Overview

Previously the timeout was set to 45s. This was problematic because the front-end timeout didn't help anyone. It doesn't help the user, because it is giving up for them. If the user wants to give up, they can do that. If they want to wait, they should be able to do that too.

Furthermore, it doesn't help the server, since the timeout doesn't actually stop the Celery job from running and using up server resources. Even when the front end has given up, we keep the job running.

Increasing the front end timeout from 45s to 160s for all use cases is a simple, harmless adjustment. It will not increase our server loads at all, and allow patient users to see results (subbasin and otherwise) that they didn't before.

Connects #2774 

### Demo

<img width="1440" alt="screen shot 2018-04-21 at 5 21 46 pm" src="https://user-images.githubusercontent.com/1430060/39144097-c65fe656-46fd-11e8-991c-a7659efd8ce7.png">

### Notes

160s is really an unreasonable time to expect users to wait on the internet, especially if they don't appreciate the processing happening on the servers. We need to improve the UI for waiting as a result of this.

#2764 is planned to add a progress bar to the wait message, which should help the wait a bit.

## Testing Instructions

* Check out this branch and `bundle`
* Run Analyze, Mapshed, and Subbasin on a large area of interest. Ensure it doesn't timeout.