### PR TITLE
Fix Observations Layer tab data loading

### DIFF
--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -634,7 +634,7 @@ var PlotView = ModalBaseView.extend({
     plotMeasurement: function(varId) {
         var self = this,
             series = self.model.get('seriesMap')[varId],
-            dataUrl = settings.vizerUrls.variable
+            dataUrl = settings.get('vizer_urls').variable
                .replace(/{{var_id}}/, varId)
                .replace(/{{asset_id}}/, this.model.get('siso_id'));
 


### PR DESCRIPTION
## Overview

This bug was introduced in 02b5a7fb. Allows the Observations Layer tab to load historical data again.

Connects #2761

### Notes

The historical data loading still often fails because of server issues.

## Testing Instructions

* Check out this branch and `bundle`
* Open the app and the javascript console
* Go to the observations tab in the layer picker and enable a layer
* Click an observation point and click through to Historical Data
* Ensure there are no javascript errors in the console (disregard any server side errors)