### PR TITLE
Subbasin Catchments On Map

### DIFF
--- a/src/mmw/js/src/modeling/controllers.js
+++ b/src/mmw/js/src/modeling/controllers.js
@@ -284,6 +284,7 @@ function projectCleanUp() {
 
     App.getMapView().updateModifications(null);
     App.getMapView().clearSubbasinHuc12s();
+    App.getMapView().clearSubbasinCatchments();
     App.rootView.subHeaderRegion.empty();
     App.rootView.sidebarRegion.empty();
     App.rootView.compareRegion.empty();

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -960,7 +960,9 @@ var ResultsView = Marionette.LayoutView.extend({
 
         if (scenario) {
             // Close sub-basin of previous detail view if active
+            // And make any active subbasin detail inactive
             if (this.modelingRegion.hasView()) {
+                this.modelingRegion.currentView.hideSubbasinHuc12View();
                 this.modelingRegion.currentView.hideSubbasinHotSpotView();
             }
 
@@ -1139,7 +1141,10 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
     },
 
     hideSubbasinHuc12View: function() {
-        App.currentProject.get('subbasins').getActive().set('active', false);
+        var activeSubbasin = App.currentProject.get('subbasins').getActive();
+        if (activeSubbasin) {
+            activeSubbasin.set('active', false);
+        }
         App.getMapView().clearSubbasinCatchments();
         this.subbasinRegion.$el.show();
         this.subbasinHuc12Region.empty();

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -982,6 +982,7 @@ var ResultsView = Marionette.LayoutView.extend({
                 this.modelingRegion.$el.removeClass('active');
                 App.getMapView().updateModifications(null);
                 App.getMapView().clearSubbasinHuc12s();
+                App.getMapView().clearSubbasinCatchments();
                 break;
             case utils.MONITOR:
                 if (App.map.get('dataCatalogDetailResult') !== null) {
@@ -995,6 +996,7 @@ var ResultsView = Marionette.LayoutView.extend({
                 this.modelingRegion.$el.removeClass('active');
                 App.getMapView().updateModifications(null);
                 App.getMapView().clearSubbasinHuc12s();
+                App.getMapView().clearSubbasinCatchments();
                 break;
             case utils.MODEL:
                 this.aoiRegion.currentView.$el.addClass('hidden');
@@ -1006,12 +1008,17 @@ var ResultsView = Marionette.LayoutView.extend({
                     this.model.get('scenarios').getActiveScenario()
                 );
                 var modelingView = this.modelingRegion.currentView,
+                    subbasins = App.currentProject.get('subbasins'),
+                    activeSubbasin = subbasins.getActive(),
                     isVisible = function(region) {
                         return region.hasView() && region.$el.is(':visible');
                     };
                 if (isVisible(modelingView.subbasinRegion) ||
                     isVisible(modelingView.subbasinHuc12Region)) {
                     App.map.set('subbasinHuc12s', App.currentProject.get('subbasins'));
+                }
+                if (isVisible(modelingView.subbasinHuc12Region) && activeSubbasin) {
+                    App.map.set('subbasinCatchments', activeSubbasin.get('catchments'));
                 }
                 break;
         }
@@ -1119,6 +1126,10 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
             var catchmentComids = Object.keys(
                 subbasinResult.get('result').HUC12s[activeSubbasin.get('id')].Catchments);
             activeSubbasin.fetchCatchmentsIfNeeded(catchmentComids);
+
+            App.getMapView().clearSubbasinCatchments();
+            App.map.set('subbasinCatchments', activeSubbasin.get('catchments'));
+
             this.subbasinHuc12Region.show(new SubbasinHuc12TabContentView({
                 model: subbasinResult,
                 scenario: this.scenario,
@@ -1129,6 +1140,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
 
     hideSubbasinHuc12View: function() {
         App.currentProject.get('subbasins').getActive().set('active', false);
+        App.getMapView().clearSubbasinCatchments();
         this.subbasinRegion.$el.show();
         this.subbasinHuc12Region.empty();
     }

--- a/src/mmw/sass/components/_tables.scss
+++ b/src/mmw/sass/components/_tables.scss
@@ -33,7 +33,11 @@
 
   tr.huc12-total.highlighted,
   tr.huc12-total:hover,
-  tr.huc12-total:focus {
+  tr.huc12-total:focus,
+  tr.subbasin-catchment-row.highlighted,
+  tr.subbasin-catchment-row:hover,
+  tr.subbasin-catchment-row:focus,
+  {
     background-color: rgba(56, 155, 155, 0.3);
   }
 


### PR DESCRIPTION
## Overview

Similar to #2786, add the catchment geometries and streams to the map. They are two-way interactive with the catchment table's hover state.

Styling is temporary — the streams and catchment fill will be determined by the catchment's loads in #2655.

Connects #2654 

### Demo

![5vjsb7oyvs](https://user-images.githubusercontent.com/7633670/39202212-3e53c2ba-47bf-11e8-9f11-2e9cf522df98.gif)

## Testing Instructions

 * Pull and `bundle`
 * For a subbasin project in subbasin view, test that at the HUC-12 level the catchments render with their streams
   * hover on the map highlights the map and table
   * hover on the catchment table highlights the map and table
* Confirm you can flip between Analyze, Monitor and Model without the shapes carrying over or not reappearing when re-entering the model view.
* Confirm you can add scenarios
* Confirm you can leave subbasin view and enter it again without console errors