### PR TITLE
Standardize JVM to OpenJDK 8

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -36,8 +36,8 @@ nodejs_npm_version: 2.1.17
 
 apache_version: "2.4.7-*"
 
-java_version: "7u151-*"
-java_major_version: "7"
+java_version: "8u162-*"
+java_major_version: "8"
 java_flavor: "openjdk"
 
 graphite_carbon_version: "0.9.13-pre1"

--- a/deployment/ansible/roles/model-my-watershed.geoprocessing/meta/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.geoprocessing/meta/main.yml
@@ -1,9 +1,5 @@
 ---
 dependencies:
-  - {
-      role: "azavea.java",
-      java_major_version: "8",
-      java_version: "8u162*"
-    }
+  - { role: "azavea.java" }
   - { role: "model-my-watershed.base" }
   - { role: "model-my-watershed.nginx" }


### PR DESCRIPTION
## Overview

Ensure that OpenJDK 8 is used consistently across the `services` and `worker` virtual machine.

Connects #2787

### Notes

Based on my research (destroying and recreating the `worker` virtual machine), only OpenJDK 8 is being installed:

```bash
vagrant@worker:~$ sudo update-alternatives --list java
/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
vagrant@worker:~$ java -version
openjdk version "1.8.0_162"
OpenJDK Runtime Environment (build 1.8.0_162-8u162-b12-1~14.04-b12)
OpenJDK 64-Bit Server VM (build 25.162-b12, mixed mode)
```

The `services` virtual machine is a slightly different story. It turns out that the Logstash APT package lists the `default-jre` virtual package as a dependency. This leads to the installation of OpenJDK 7. After these changes, OpenJDK 8 gets installed further along in the Ansible run (and becomes the default JVM):

```bash
vagrant@services:~$ sudo update-alternatives --list java
/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
vagrant@services:~$ java -version
openjdk version "1.8.0_162"
OpenJDK Runtime Environment (build 1.8.0_162-8u162-b12-1~14.04-b12)
OpenJDK 64-Bit Server VM (build 25.162-b12, mixed mode)
```

## Testing Instructions

Destroy the `services` and `worker` VM, then spin them both back up and confirm the outputs listed above. In addition, hit the [Kibana endpoint](http://localhost:5601/) (exercises Logstash and Elasticsearch, which use the JVM) to ensure that service still works.
