### PR TITLE
Give VMs More Resources

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,7 +74,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     }.merge(VAGRANT_NETWORK_OPTIONS)
 
     services.vm.provider "virtualbox" do |v|
-      v.memory = 1024
+      v.memory = 2048
     end
 
     services.vm.provision "ansible" do |ansible|
@@ -109,6 +109,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     worker.vm.provider "virtualbox" do |v|
       v.memory = 2048
+      v.cpus = 2
     end
 
     worker.vm.provision "ansible" do |ansible|
@@ -150,7 +151,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     app.ssh.forward_x11 = true
 
     app.vm.provider "virtualbox" do |v|
-      v.memory = 1024
+      v.memory = 2048
     end
 
     app.vm.provision "ansible" do |ansible|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,6 +74,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     }.merge(VAGRANT_NETWORK_OPTIONS)
 
     services.vm.provider "virtualbox" do |v|
+      v.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
       v.memory = 2048
     end
 
@@ -108,6 +109,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     }.merge(VAGRANT_NETWORK_OPTIONS)
 
     worker.vm.provider "virtualbox" do |v|
+      v.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
       v.memory = 2048
       v.cpus = 2
     end
@@ -151,6 +153,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     app.ssh.forward_x11 = true
 
     app.vm.provider "virtualbox" do |v|
+      v.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
       v.memory = 2048
     end
 

--- a/deployment/cfn/application.py
+++ b/deployment/cfn/application.py
@@ -83,7 +83,7 @@ class Application(StackNode):
         'StackType': 'Staging',
         'StackColor': 'Green',
         'KeyName': 'mmw-stg',
-        'AppServerInstanceType': 't2.micro',
+        'AppServerInstanceType': 't2.small',
         'AppServerInstanceProfile': 'AppServerInstanceProfile',
         'AppServerAutoScalingDesired': '1',
         'AppServerAutoScalingMin': '1',
@@ -128,7 +128,7 @@ class Application(StackNode):
         ), 'RDSPassword')
 
         self.app_server_instance_type = self.add_parameter(Parameter(
-            'AppServerInstanceType', Type='String', Default='t2.micro',
+            'AppServerInstanceType', Type='String', Default='t2.small',
             Description='Application server EC2 instance type',
             AllowedValues=EC2_INSTANCE_TYPES,
             ConstraintDescription='must be a valid EC2 instance type.'

--- a/deployment/default.yml.example
+++ b/deployment/default.yml.example
@@ -17,7 +17,7 @@ RDSUsername: 'modelmywatershed'
 RDSPassword: 'modelmywatershed'
 ECInstanceType: 'cache.m1.small'
 GlobalNotificationsARN: 'arn:aws:sns:...'
-AppServerInstanceType: 't2.micro'
+AppServerInstanceType: 't2.small'
 # Leaving this commented dynamically looks up the
 # most recent AMI for this type.
 #AppServerAMI: ''


### PR DESCRIPTION
## Overview

Increase VM capacities to keep up with expanding MMW capabilities.

Expands development VM sizes to match what's on staging so local testing is more accurate. Ups staging app VM size to match production so that large monitor queries are parsed without crashing. Sync VM times so that any timing script running across VMs (app, worker) is consistent.

Tagging @hectcastro to verify that this (in addition to changes in the deployment configuration file) will upgrade staging to t2.small with 2GB RAM, as discussed with @mmcfarland and @ajrobbins yesterday.

Connects #2749 

### Notes

I will edit the deployment configuration files once this is merged.

## Testing Instructions

* Reload `app`, `worker`, and `services` (provisioning should not be necessary)
* Run Monitor on the Brandywine-Christina HUC-08 near Wilmington, DE and ensure it completes
* Run Subbasin on a HUC-10 and ensure it completes