### PR TITLE
Subbasin Weighted BMPs + Misc. Fixes

### DIFF
--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -707,6 +707,18 @@ var utils = {
 
         // other browser
         return false;
+    },
+
+    applyGwlfeModifications: function(gisData, modifications) {
+        // Merge the values that came back from Mapshed with the values
+        // in the modifications from the user.
+        var gms = lodash.cloneDeep(gisData);
+
+        modifications.forEach(function(mod) {
+            _.assign(gms, mod.get('output'));
+        });
+
+        return gms;
     }
 };
 

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -272,18 +272,29 @@ var CatchmentsTableView = Marionette.ItemView.extend({
             activeSubbasinId = App.currentProject.get('subbasins').getActive().get('id'),
             huc12Result = this.model.get('result').HUC12s[activeSubbasinId],
             catchments = huc12Result.Catchments,
-            summaryConcentrations = _.reduce(catchments, function(acc, catchment) {
-                acc.Sediment += catchment.LoadingRateConcentrations.Sediment;
-                acc.TotalN += catchment.LoadingRateConcentrations.TotalN;
-                acc.TotalP += catchment.LoadingRateConcentrations.TotalP;
+            summaryRow = _.reduce(catchments, function(acc, catchment, comid) {
+                var summaryConcentrations = acc.LoadingRateConcentrations,
+                    summaryLoadingRates = acc.TotalLoadingRates;
+
+                summaryConcentrations.Sediment += catchment.LoadingRateConcentrations.Sediment;
+                summaryConcentrations.TotalN += catchment.LoadingRateConcentrations.TotalN;
+                summaryConcentrations.TotalP += catchment.LoadingRateConcentrations.TotalP;
+                acc.LoadingRateConcentrations = summaryConcentrations;
+
+                summaryLoadingRates.Sediment += catchment.TotalLoadingRates.Sediment;
+                summaryLoadingRates.TotalN += catchment.TotalLoadingRates.TotalN;
+                summaryLoadingRates.TotalP += catchment.TotalLoadingRates.TotalP;
+                acc.TotalLoadingRates = summaryLoadingRates;
+                if (!catchmentDetails.isEmpty()) {
+                    acc.Area += catchmentDetails.get(parseInt(comid)).get('area');
+                }
                 return acc;
-            }, { Sediment: 0, TotalN: 0, TotalP: 0 }),
-            summaryRow = {
-                TotalLoadingRates: huc12Result.SummaryLoads,
-                LoadingRateConcentrations: summaryConcentrations,
-                Area: huc12Result.SummaryLoads.Area,
-                Source: 'Entire area',
-            };
+            }, {
+                    TotalLoadingRates: { Sediment: 0, TotalN: 0, TotalP: 0 },
+                    LoadingRateConcentrations: { Sediment: 0, TotalN: 0, TotalP: 0 },
+                    Area: 0,
+                    Source: 'Entire area',
+            });
 
         return {
             rows: catchments,

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -343,15 +343,15 @@ var ProjectModel = Backbone.Model.extend({
         return createTaskResultCollection(this.get('model_package'));
     },
 
-    fetchResultsIfNeeded: function(isSubbasinMode) {
+    fetchResultsIfNeeded: function() {
         var promises = [];
 
         this.get('scenarios').forEach(function(scenario) {
-            promises.push(scenario.fetchResultsIfNeeded(isSubbasinMode || false));
+            promises.push(scenario.fetchResultsIfNeeded());
         });
 
         this.get('scenarios').on('add', function(scenario) {
-            scenario.fetchResultsIfNeeded(isSubbasinMode || false);
+            scenario.fetchResultsIfNeeded();
         });
 
         return $.when.apply($, promises);
@@ -1072,6 +1072,7 @@ var ScenarioModel = Backbone.Model.extend({
         modifications: null, // ModificationsCollection
         modification_hash: null, // MD5 string
         active: false,
+        is_subbasin_active: false,
         job_id: null,
         poll_error: null,
         results: null, // ResultCollection
@@ -1111,6 +1112,7 @@ var ScenarioModel = Backbone.Model.extend({
         this.updateInputModHash();
 
         this.on('change:project change:name', this.attemptSave, this);
+        this.on('change:is_subbasin_active', this.queueFetchResultsIfNeeded, this);
         this.get('modifications').on('add remove change', this.updateModificationHash, this);
         this.debouncedFetchResults = _.debounce(_.bind(this.fetchResults, this), 500);
         this.get('inputs').on('add', _.bind(this.fetchResultsAfterInitial, this));
@@ -1217,8 +1219,9 @@ var ScenarioModel = Backbone.Model.extend({
         return response;
     },
 
-    fetchResultsIfNeeded: function(isSubbasinMode) {
+    fetchResultsIfNeeded: function() {
         var self = this,
+            isSubbasinMode = this.get('is_subbasin_active'),
             inputmod_hash = this.get('inputmod_hash'),
             needsResults = this.get('results').some(function(resultModel) {
                 var results = resultModel.get('result'),
@@ -1235,7 +1238,7 @@ var ScenarioModel = Backbone.Model.extend({
                 fetchGisDataPromise = App.currentProject.fetchGisDataIfNeeded(isSubbasinMode);
 
             self.fetchResultsPromise = fetchGisDataPromise.then(function() {
-                var promises = fetchResults(isSubbasinMode);
+                var promises = fetchResults();
                 return $.when(promises.startPromise, promises.pollingPromise);
             });
 
@@ -1250,8 +1253,9 @@ var ScenarioModel = Backbone.Model.extend({
         return self.fetchResultsPromise || $.when();
     },
 
-    setResults: function(isSubbasinMode) {
-        var serverResults = this.get('taskModel').get('result');
+    setResults: function() {
+        var serverResults = this.get('taskModel').get('result'),
+            isSubbasinMode = this.get('is_subbasin_active');
 
         if (_.isEmpty(serverResults)) {
             this.get('results').setNullResults(isSubbasinMode);
@@ -1281,11 +1285,12 @@ var ScenarioModel = Backbone.Model.extend({
 
     // Poll the taskModel for results and reset the results collection when done.
     // If not successful, the results collection is reset to be empty.
-    fetchResults: function(isSubbasinMode) {
+    fetchResults: function() {
         this.updateInputModHash();
         this.attemptSave();
 
         var self = this,
+            isSubbasinMode = this.get('is_subbasin_active'),
             results = this.get('results'),
             taskModel = this.get('taskModel'),
             gisData = this.getGisData(isSubbasinMode),
@@ -1306,7 +1311,7 @@ var ScenarioModel = Backbone.Model.extend({
                     console.log(isSubbasinMode ?
                         'Polling for SUBBASIN modeling results succeeded' :
                         'Polling for modeling results succeeded');
-                    self.setResults(isSubbasinMode);
+                    self.setResults();
                 },
 
                 pollFailure: function(error) {
@@ -1343,6 +1348,19 @@ var ScenarioModel = Backbone.Model.extend({
             };
 
         return taskModel.start(taskHelper);
+    },
+
+    queueFetchResultsIfNeeded: function() {
+        var fetchResultsIfNeeded = _.bind(this.fetchResultsIfNeeded, this);
+        if (this.fetchResultsPromise) {
+            this.fetchResultsPromise = this.fetchResultsPromise.then(
+                    // on success
+                    fetchResultsIfNeeded,
+                    // also on failure, so we can try subbasin
+                    // again if unattenuate run fails and vice-versa
+                    fetchResultsIfNeeded);
+        }
+        return this.fetchResultsIfNeeded();
     },
 
     fetchResultsAfterInitial: function() {

--- a/src/mmw/js/src/modeling/templates/subbasinResultsTabContent.html
+++ b/src/mmw/js/src/modeling/templates/subbasinResultsTabContent.html
@@ -5,6 +5,7 @@
            id="close-subbasin-view">
             <i class="fa fa-arrow-left black"></i> {{ backButtonText or "Exit subbasin attenuated results" }}
         </a>
+        <i class="subbasin-spinner fa fa-circle-o-notch fa-spin {{ 'hidden' if not polling }}"></i>
     </div>
     <div class="result-content-region"></div>
 </div>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1261,6 +1261,7 @@ var SubbasinResultsTabContentView = Marionette.LayoutView.extend({
 
     ui: {
         'close': '[data-action="close-subbasin-view"]',
+        'spinner': '.subbasin-spinner',
     },
 
     events: {
@@ -1269,6 +1270,14 @@ var SubbasinResultsTabContentView = Marionette.LayoutView.extend({
 
     regions: {
         resultContentRegion: '.result-content-region',
+    },
+
+    modelEvents: {
+        'change:polling': 'showSpinner',
+    },
+
+    showSpinner: function() {
+        this.ui.spinner.toggleClass('hidden', !this.model.get('polling'));
     },
 
     handleSubbasinCloseButtonClick: function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1094,13 +1094,11 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         this.contentRegion.$el.hide();
 
         App.map.set('subbasinHuc12s', App.currentProject.get('subbasins'));
+        this.scenario.set('is_subbasin_active', true);
 
         if (this.subbasinRegion.hasView()) {
             return this.subbasinRegion.$el.show();
         }
-
-        var isSubbasinMode = true;
-        App.currentProject.fetchResultsIfNeeded(isSubbasinMode);
 
         this.subbasinRegion.show(new SubbasinResultsTabContentView({
             model: this.collection.getResult('subbasin'),
@@ -1115,6 +1113,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         this.panelsRegion.$el.show();
         this.contentRegion.$el.show();
 
+        this.scenario.set('is_subbasin_active', false);
         App.getMapView().clearSubbasinHuc12s();
     },
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -463,13 +463,15 @@ var ScenarioDropDownMenuOptionsView = Marionette.ItemView.extend({
     },
 
     templateHelpers: function() {
-        var gis_data = this.model.getGisData().model_input,
+        var gis_data = utils.applyGwlfeModifications(
+                App.currentProject.get('gis_data'),
+                this.model.get('modifications')),
             is_gwlfe = App.currentProject.get('model_package') === utils.GWLFE && !_.isEmpty(gis_data);
 
         return {
             is_gwlfe: is_gwlfe,
             csrftoken: csrf.getToken(),
-            gis_data: gis_data,
+            gis_data: JSON.stringify(gis_data),
             editable: isEditable(this.model),
             is_new: this.model.isNew(),
         };
@@ -548,7 +550,9 @@ var ScenarioDropDownMenuItemView = Marionette.LayoutView.extend({
     },
 
     templateHelpers: function() {
-        var gis_data = App.currentProject.get('gis_data'),
+        var gis_data = utils.applyGwlfeModifications(
+                App.currentProject.get('gis_data'),
+                this.model.get('modifications')),
             is_gwlfe = App.currentProject.get('model_package') === utils.GWLFE &&
                         gis_data !== null &&
                         gis_data !== '{}' &&
@@ -556,7 +560,7 @@ var ScenarioDropDownMenuItemView = Marionette.LayoutView.extend({
 
             return {
                 is_gwlfe: is_gwlfe,
-                gis_data: gis_data,
+                gis_data: JSON.stringify(gis_data),
                 csrftoken: csrf.getToken(),
                 editable: isEditable(this.model),
                 is_new: this.model.isNew(),
@@ -880,7 +884,10 @@ var ScenarioToolbarView = Marionette.CompositeView.extend({
     },
 
     templateHelpers: function() {
-        var gisData = this.currentConditions.getGisData().model_input,
+        // We don't need to apply modifications to gis_data here
+        // because it's only downloadable from this view if
+        // the only scenario is current conditions (ie no modifications)
+        var gisData = this.model.get('gis_data'),
             isGwlfe = this.modelPackage === utils.GWLFE && !_.isEmpty(gisData),
             isOnlyCurrentConditions = this.collection.length === 1 &&
                 this.collection.first().get('is_current_conditions'),
@@ -890,7 +897,7 @@ var ScenarioToolbarView = Marionette.CompositeView.extend({
             isOnlyCurrentConditions: isOnlyCurrentConditions,
             isGwlfe: isGwlfe,
             csrftoken: csrf.getToken(),
-            gis_data: gisData,
+            gis_data: JSON.stringify(gisData),
             editable: editable
         };
     },

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -131,6 +131,16 @@
             background: $paper;
 
             .result-detail-header {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-between;
+
+                .subbasin-spinner {
+                    height: 14px;
+                    width: 14px;
+                    margin: 0.7rem;
+                }
+
                 a.zoom {
                     display: block;
                 }


### PR DESCRIPTION
## Overview

* Make modifications work as expected in subbasin mode
  * Weight absolute stream length modification types
  * Don't rerun model for subbasin or unattenuated until that view is active

* Fix GMS download
    * Mods need to be applied before download and we need to read the base GMS from the active project

* Sum catchment table
   * We can't re-use the HUC-12 sums because catchments seem to have different results, and their areas extend past the HUC-12


Connects #2542 
Connects #2731 

### Demo

![vn7dgnu5bx](https://user-images.githubusercontent.com/7633670/39318137-5160c03c-494b-11e8-80a6-a6858c927d67.gif)

## Testing Instructions

#### Modifications

 * Pull, bundle
* Apply this patch so you can see what mods are being applied [print_modifications.patch.txt](https://github.com/WikiWatershed/model-my-watershed/files/1952101/print_modifications.patch.txt)
* Restart and debug celery
 * Start a subbasin project and confirm you can add modifications while in regular mode and while in subbasin mode. Adding in regular mode should kick off a subbasin re-run when you next enter subbasin mode and vice versa.
* There should be a new spinner indicating when subbasin is polling
* In the celery logs you should see the weighted BMPs printed

#### Downloading GMS
* Confirm you can download the GMS file when the only scenario is Current conditions and when there are multiple scenarios and you download via dropdown.

#### Catchment Summation
* The "entire area" row of the catchment table should still have values. They will likely be larger than what they used to be.
