### PR TITLE
Wire Up Subbasin Download CSV Buttons

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/catchmentTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/catchmentTable.html
@@ -56,6 +56,6 @@
 
 </table>
 
-<div class="downloadcsv-link" data-action="download-csv-granular">
+<div class="downloadcsv-link" data-action="download-csv">
     <i class="fa fa-download"></i> Download this data
 </div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
@@ -46,6 +46,6 @@
 
 </table>
 
-<div class="downloadcsv-link" data-action="download-csv-granular">
+<div class="downloadcsv-link" data-action="download-csv">
     <i class="fa fa-download"></i> Download this data
 </div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
@@ -44,6 +44,6 @@
 
 </table>
 
-<div class="downloadcsv-link" data-action="download-csv-granular">
+<div class="downloadcsv-link" data-action="download-csv">
     <i class="fa fa-download"></i> Download this data
 </div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -127,6 +127,15 @@ var TableTabContentCollectionView = Marionette.CollectionView.extend({
 var SourcesTableView = Marionette.ItemView.extend({
     template: sourcesTableTmpl,
 
+    ui: {
+        'table': 'table.table',
+        'downloadCsvButton': '[data-action="download-csv"]',
+    },
+
+    events: {
+        'click @ui.downloadCsvButton': 'downloadCsv',
+    },
+
     onAttach: function() {
         $('[data-toggle="table"]').bootstrapTable();
     },
@@ -142,6 +151,18 @@ var SourcesTableView = Marionette.ItemView.extend({
 
     getResult: function() {
         return this.model.get('result');
+    },
+
+    getCSVFileNamePrefix: function() {
+        return 'subbasin_water_quality_loads_';
+    },
+
+    downloadCsv: function() {
+        var prefix = this.getCSVFileNamePrefix(),
+            timestamp = new Date().toISOString(),
+            filename = prefix + timestamp;
+
+        this.ui.table.tableExport({ type: 'csv', fileName: filename });
     }
 });
 
@@ -150,6 +171,12 @@ var Huc12SourcesTableView = SourcesTableView.extend({
         var huc12 = App.currentProject.get('subbasins').getActive();
         if (!huc12) { return; }
         return this.model.get('result').HUC12s[huc12.get('id')];
+    },
+
+    getCSVFileNamePrefix: function() {
+        var huc12 = App.currentProject.get('subbasins').getActive();
+        if (!huc12) { return; }
+        return 'subbasin_huc12_' + huc12.get('id') + '_water_quality_loads_';
     }
 });
 
@@ -157,11 +184,15 @@ var Huc12TotalsTableView = Marionette.ItemView.extend({
     template: huc12TotalsTableTmpl,
     ui: {
         'rows': '.huc12-total',
+        'table': 'table.table',
+        'downloadCsvButton': '[data-action="download-csv"]',
     },
+
     events: {
         'click @ui.rows': 'handleRowClick',
         'mouseover @ui.rows': 'handleRowMouseOver',
         'mouseout @ui.rows': 'handleRowMouseOut',
+        'click @ui.downloadCsvButton': 'downloadCsv',
     },
     onAttach: function() {
         $('[data-toggle="table"]').bootstrapTable();
@@ -229,6 +260,14 @@ var Huc12TotalsTableView = Marionette.ItemView.extend({
         if (subbasinDetail.get('highlighted')) {
             newHighlighted.addClass('highlighted');
         }
+    },
+
+    downloadCsv: function() {
+        var prefix = 'subbasin_huc12_water_quality_totals_',
+            timestamp = new Date().toISOString(),
+            filename = prefix + timestamp;
+
+        this.ui.table.tableExport({ type: 'csv', fileName: filename });
     }
 });
 
@@ -236,10 +275,13 @@ var CatchmentsTableView = Marionette.ItemView.extend({
     template: catchmentTableTmpl,
     ui: {
         'rows': '.subbasin-catchment-row',
+        'table': 'table.table',
+        'downloadCsvButton': '[data-action="download-csv"]',
     },
     events: {
         'mouseover @ui.rows': 'handleRowMouseOver',
         'mouseout @ui.rows': 'handleRowMouseOut',
+        'click @ui.downloadCsvButton': 'downloadCsv',
     },
     onAttach: function() {
         $('[data-toggle="table"]').bootstrapTable();
@@ -313,6 +355,15 @@ var CatchmentsTableView = Marionette.ItemView.extend({
         if (catchment.get('highlighted')) {
             newHighlighted.addClass('highlighted');
         }
+    },
+
+    downloadCsv: function() {
+        var activeSubbasinId = App.currentProject.get('subbasins').getActive().get('id'),
+            prefix = 'subbasin_huc12_' + activeSubbasinId + '_catchments_water_quality_',
+            timestamp = new Date().toISOString(),
+            filename = prefix + timestamp;
+
+        this.ui.table.tableExport({ type: 'csv', fileName: filename });
     }
 });
 


### PR DESCRIPTION
## Overview

Use the bootstrap table export to wire up each
table's download csv button.

Connects #2656 

### Demo

[subbasin_huc12_020402031004_catchments_water_quality_2018-04-26T17_41_27.016Z.csv.txt](https://github.com/WikiWatershed/model-my-watershed/files/1952374/subbasin_huc12_020402031004_catchments_water_quality_2018-04-26T17_41_27.016Z.csv.txt)
[subbasin_huc12_020402031004_water_quality_loads_2018-04-26T17_40_44.862Z.csv.txt](https://github.com/WikiWatershed/model-my-watershed/files/1952375/subbasin_huc12_020402031004_water_quality_loads_2018-04-26T17_40_44.862Z.csv.txt)
[subbasin_huc12_water_quality_totals_2018-04-26T17_40_28.361Z.csv.txt](https://github.com/WikiWatershed/model-my-watershed/files/1952376/subbasin_huc12_water_quality_totals_2018-04-26T17_40_28.361Z.csv.txt)
[subbasin_water_quality_loads_2018-04-26T17_38_46.431Z.csv.txt](https://github.com/WikiWatershed/model-my-watershed/files/1952377/subbasin_water_quality_loads_2018-04-26T17_38_46.431Z.csv.txt)

<img width="1055" alt="screen shot 2018-04-26 at 1 58 08 pm" src="https://user-images.githubusercontent.com/7633670/39323196-e25e2ec2-4959-11e8-9a09-cc9daf873de6.png">

## Testing Instructions

 * Pull and bundle
 * In subbasin mode, download the csv for all four tables and confirm they represent the correct data and have sensical names that match others we use in the app.