### PR TITLE
Show More Sophisticated MapShed Polling

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -597,12 +597,19 @@ var TaskModel = Backbone.Model.extend({
 });
 
 var TaskMessageViewModel = Backbone.Model.extend({
+    defaults: {
+        currentStep: 0,
+        numSteps: 1,
+        hasError: false,
+    },
     message: null,
+    waitTimeMessage: null,
     iconClass: null,
 
     setError: function(message) {
         this.set('message', message);
         this.set('iconClasses', 'fa fa-exclamation-triangle');
+        this.set('hasError', true);
     },
 
     setTimeoutError: function() {
@@ -611,11 +618,15 @@ var TaskMessageViewModel = Backbone.Model.extend({
 
         this.set('message', message);
         this.set('iconClasses', 'fa fa-exclamation-triangle');
+        this.set('hasError', true);
     },
 
-    setWorking: function(message) {
+    setWorking: function(message, step, waitTimeMessage) {
         this.set('message', message);
+        this.set('waitTimeMessage', waitTimeMessage);
+        this.set('currentStep', step);
         this.set('iconClasses', 'fa fa-circle-o-notch fa-spin');
+        this.set('hasError', false);
     }
 });
 

--- a/src/mmw/js/src/core/templates/message.html
+++ b/src/mmw/js/src/core/templates/message.html
@@ -4,5 +4,14 @@
     </div>
     <div class="analyze-message-text">
         {{ message }}
+        {% if numSteps > 1 and not hasError %}
+            ({{ currentStep }} / {{ numSteps }})
+        {% endif %}
     </div>
+
+    {% if not hasError %}
+        <div class="analyze-message-sub-text">
+            {{ waitTimeMessage }}
+        </div>
+    {% endif %}
 </div>


### PR DESCRIPTION
Subbasin mapshed can take almost a minute and subbasin
gwlfe can take over 2 minutes. Add more helpful text
to the loading spinners that will temper the user's
expectations for how long they'll be waiting.

Also display which step (1/2) or (2/2) is executing.

Connects #2764 

### Demo
#### Unattenuated
![screen shot 2018-04-26 at 5 06 33 pm](https://user-images.githubusercontent.com/7633670/39332469-7eee7aec-4975-11e8-9db8-31520f9a2d4e.png)
![screen shot 2018-04-26 at 5 06 39 pm](https://user-images.githubusercontent.com/7633670/39332475-850c5ae8-4975-11e8-894e-ed45a74c6a97.png)

#### Subbasin
![screen shot 2018-04-26 at 5 06 59 pm](https://user-images.githubusercontent.com/7633670/39332485-921f0f6e-4975-11e8-8f0d-3b0fdadccf29.png)
![screen shot 2018-04-26 at 5 15 05 pm](https://user-images.githubusercontent.com/7633670/39332493-965781a6-4975-11e8-98c3-b92bc5d9f5d9.png)


## Testing Instructions

 * Pull and bundle
 * Do TR-55 and see that no changes have made it to those spinners
 * Do MultiYear and see the new text. 
 * Do Subbasin and see different new text.