### PR TITLE
Subbasin: Color Catchments and Streams by SRAT Values

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -83,43 +83,6 @@ var subbasinHuc12ActiveStyle = {
     fill: false,
 };
 
-var subbasinCatchmentStyle = {
-    stroke: true,
-    color: 'grey',
-    weight: 2,
-    opacity: 1,
-    fill: true,
-    fillOpacity: 0.3,
-};
-
-var subbasinCatchmentHighlightedStyle = {
-    stroke: true,
-    color: '#1d3331',
-    weight: 2,
-    opacity: 1,
-    fill: true,
-    fillColor: 'grey',
-    fillOpacity: 0.3,
-};
-
-var subbasinStreamCatchmentStyle = {
-    stroke: true,
-    color: 'blue',
-    weight: 2,
-    opacity: 1,
-    fill: true,
-    fillOpacity: 0,
-};
-
-var subbasinStreamCatchmentHighlightedStyle = {
-    stroke: true,
-    color: 'red',
-    weight: 2,
-    opacity: 1,
-    fill: true,
-    fillOpacity: 0,
-};
-
 var selectedGeocoderAreaStyle = {
     stroke: true,
     fill: true,
@@ -1186,15 +1149,15 @@ var MapView = Marionette.ItemView.extend({
             geom = catchment.get('stream');
 
         return new L.GeoJSON(geom, {
-            style: subbasinStreamCatchmentStyle,
+            style: catchment.getStreamStyle(),
             id: catchment.get('id'),
             onEachFeature: function(feature, layer) {
                 var highlightLayer = function() {
                     if (catchment.get('highlighted')) {
-                        layer.setStyle(subbasinStreamCatchmentHighlightedStyle);
+                        layer.setStyle(catchment.getStreamHighlightStyle());
                         layer.bringToFront();
                     } else {
-                        layer.setStyle(subbasinStreamCatchmentStyle);
+                        layer.setStyle(catchment.getStreamStyle());
                         layer.bringToBack();
                     }
                 };
@@ -1217,15 +1180,15 @@ var MapView = Marionette.ItemView.extend({
             geom = catchment.get('shape');
 
         return new L.GeoJSON(geom, {
-            style: subbasinCatchmentStyle,
+            style: catchment.getStyle(),
             id: catchment.get('id'),
             onEachFeature: function(feature, layer) {
                 var highlightLayer = function() {
                     if (catchment.get('highlighted')) {
-                        layer.setStyle(subbasinCatchmentHighlightedStyle);
+                        layer.setStyle(catchment.getHighlightStyle());
                         layer.bringToFront();
                     } else {
-                        layer.setStyle(subbasinCatchmentStyle);
+                        layer.setStyle(catchment.getStyle());
                         layer.bringToBack();
                     }
                 };

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerSelector.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerSelector.html
@@ -1,0 +1,21 @@
+<button class="catchment-layertoggle dropdown-toggle" type="button" data-toggle="dropdown">
+    {% if selectedLoadName %}
+        Related Layer: {{ selectedLoadName }}
+        <a class="on-off-toggle">
+            <i class="fa fa-check" aria-hidden="true"></i>
+        </a>
+    {% else %}
+        {{ layers.length }} related layers
+    {% endif %}
+    <span class="caret"></span>
+</button>
+<ul class="dropdown-menu dropdown-menu-left catchment-layer-dropdown">
+    {% for layer in layers %}
+        <li><a href="#" class="layer-option" data-layer-id="{{ layer.id }}">
+            {{ layer.name }}
+            {%  if selectedLoad == layer.id %}
+                <i class="fa fa-check" aria-hidden="true"></i>
+            {% endif %}
+        </a></li>
+    {% endfor %}
+</ul>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/result.html
@@ -5,5 +5,6 @@
     Displaying average annual loads from 30-years of fluxes
 </p>
 
+<div class="subbasin-layer-selector-region"></div>
 <div role="tabpanel" class="subbasin-tab-panel-region"></div>
 <div class="subbasin-tab-content-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -236,7 +236,6 @@ var Huc12TotalsTableView = Marionette.ItemView.extend({
         if (this.subbasinDetails.isEmpty()) { return; }
         var id = e.currentTarget.getAttribute('data-huc12-id');
         App.currentProject.get('subbasins').get(id).setActive();
-        this.options.showHuc12();
     },
 
     handleRowMouseOver: function(e) {

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -6,6 +6,7 @@ var Marionette = require('../../../../shim/backbone.marionette'),
     App = require('../../../app'),
     models = require('./models'),
     resultTmpl = require('./templates/result.html'),
+    layerSelectorTmpl = require('./templates/layerSelector.html'),
     tableTabContentTmpl = require('./templates/tableTabContent.html'),
     tableTabPanelTmpl = require('./templates/tableTabPanel.html'),
     huc12TotalsTableTmpl = require('./templates/huc12TotalsTable.html'),
@@ -17,6 +18,7 @@ var ResultView = Marionette.LayoutView.extend({
     template: resultTmpl,
 
     regions: {
+        layerSelectorRegion: '.subbasin-layer-selector-region',
         tabPanelRegion: '.subbasin-tab-panel-region',
         tabContentRegion: '.subbasin-tab-content-region',
     },
@@ -28,7 +30,9 @@ var ResultView = Marionette.LayoutView.extend({
     },
 
     onShow: function() {
-        var tabCollection = this.getTabCollection();
+        var tabCollection = this.getTabCollection(),
+            layerSelector = this.getLayerSelector();
+
         this.tabPanelRegion.show(new TableTabPanelCollectionView({
             collection: tabCollection,
         }));
@@ -37,6 +41,9 @@ var ResultView = Marionette.LayoutView.extend({
             model: this.model,
             showHuc12: this.options.showHuc12,
         }));
+        if (layerSelector) {
+            this.layerSelectorRegion.show(layerSelector);
+        }
     },
 
     getTabCollection: function() {
@@ -51,6 +58,52 @@ var ResultView = Marionette.LayoutView.extend({
             }),
         ]);
     },
+
+    getLayerSelector: function() {
+        return null;
+    }
+});
+
+var LayerSelectorView = Marionette.ItemView.extend({
+    // model: SubbasinDetailModel
+    template: layerSelectorTmpl,
+    className: 'dropdown',
+
+    events: {
+        'click a.layer-option': 'selectLoad',
+    },
+
+    modelEvents: {
+        'change:selectedLoad': 'render',
+    },
+
+    templateHelpers: function() {
+        var layers = [
+                { id: 'TotalN', name: 'Total Nitrogen' },
+                { id: 'TotalP', name: 'Total Phosphorous' },
+                { id: 'Sediment', name: 'Total Sediments' }
+            ],
+            selectedLoad = this.model.get('selectedLoad'),
+            selectedLoadName = selectedLoad &&
+                               _.findWhere(layers, { id: selectedLoad }).name;
+
+        return {
+            layers: layers,
+            selectedLoad: selectedLoad,
+            selectedLoadName: selectedLoadName,
+        };
+    },
+
+    selectLoad: function(e) {
+        var newLoad = e.currentTarget.getAttribute('data-layer-id'),
+            currentLoad = this.model.get('selectedLoad');
+
+        if (newLoad === currentLoad) {
+            this.model.set('selectedLoad', null);
+        } else {
+            this.model.set('selectedLoad', newLoad);
+        }
+    }
 });
 
 var TableTabPanelView = Marionette.ItemView.extend({
@@ -400,6 +453,12 @@ var Huc12ResultView = ResultView.extend({
                 name: 'catchments',
             }),
         ]);
+    },
+
+    getLayerSelector: function() {
+        return new LayerSelectorView({
+            model: this.model,
+        });
     },
 });
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -863,6 +863,124 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
         stream: null,
         area: null,
         highlighted: false,
+        selectedLoad: null,   // one of: null, TotalN, TotalP, Sediment
+    },
+
+    getStyle: function() {
+        var self = this,
+            load = this.get('selectedLoad'),
+            defaultStyle = {
+                stroke: true,
+                color: 'grey',
+                weight: 2,
+                opacity: 1,
+                fill: true,
+                fillOpacity: 0.3,
+            },
+            // Keep in sync with _variables.scss and tiler/styles.mss
+            breaks = {
+                TotalN: [
+                    [ 5, '#A0A0A0'],
+                    [10, '#888888'],
+                    [15, '#707070'],
+                    [20, '#484848'],
+                    [Number.MAX_VALUE, '#202020']
+                ],
+                TotalP: [
+                    [0.30, '#A0A0A0'],
+                    [0.60, '#888888'],
+                    [0.90, '#707070'],
+                    [1.20, '#484848'],
+                    [Number.MAX_VALUE, '#202020']
+                ],
+                Sediment: [
+                    [ 250, '#A0A0A0'],
+                    [ 500, '#888888'],
+                    [ 750, '#707070'],
+                    [1000, '#484848'],
+                    [Number.MAX_VALUE, '#202020']
+                ]
+            },
+            loadingRates = self.get('TotalLoadingRates'),
+            loadValue = loadingRates && loadingRates.hasOwnProperty(load) &&
+                        loadingRates[load] / self.get('area');
+
+        if (loadValue !== null &&
+            ['TotalN', 'TotalP', 'Sediment'].indexOf(load) >= 0) {
+            var matchingBreak = _.find(breaks[load], function(b) {
+                    return loadValue <= b[0];
+                }),
+                fillColor = matchingBreak[1];
+
+            return _.defaults({ fillColor: fillColor }, defaultStyle);
+        } else {
+            return defaultStyle;
+        }
+    },
+
+    getHighlightStyle: function() {
+        return _.defaults({
+            fillOpacity: 0.4,
+            color: '#1d3331'
+        }, this.getStyle());
+    },
+
+    getStreamStyle: function() {
+        var self = this,
+            load = this.get('selectedLoad'),
+            defaultStyle = {
+                stroke: true,
+                color: '#49B8EA', // $water in _variables.scss
+                weight: 2,
+                opacity: 0.8,
+                fill: false
+            },
+            // Keep in sync with _variables.scss and tiler/styles.mss
+            breaks = {
+                TotalN: [
+                    [1, '#1A9641'],
+                    [2, '#A6D96A'],
+                    [3, '#FFFFBF'],
+                    [4, '#FDAE61'],
+                    [Number.MAX_VALUE, '#D7191C']
+                ],
+                TotalP: [
+                    [0.03, '#1A9641'],
+                    [0.06, '#A6D96A'],
+                    [0.09, '#FFFFBF'],
+                    [0.12, '#FDAE61'],
+                    [Number.MAX_VALUE, '#D7191C']
+                ],
+                Sediment: [
+                    [ 50, '#1A9641'],
+                    [100, '#A6D96A'],
+                    [150, '#FFFFBF'],
+                    [200, '#FDAE61'],
+                    [Number.MAX_VALUE, '#D7191C']
+                ]
+            },
+            concentrationRates = self.get('LoadingRateConcentrations'),
+            loadValue = concentrationRates &&
+                        concentrationRates.hasOwnProperty(load) &&
+                        concentrationRates[load];
+
+        if (loadValue !== null &&
+            ['TotalN', 'TotalP', 'Sediment'].indexOf(load) >= 0) {
+            var matchingBreak = _.find(breaks[load], function(b) {
+                    return loadValue <= b[0];
+                }),
+                color = matchingBreak[1];
+
+            return _.defaults({ color: color }, defaultStyle);
+        } else {
+            return defaultStyle;
+        }
+    },
+
+    getStreamHighlightStyle: function() {
+        return _.defaults({
+            opacity: 1
+        }, this.getStreamStyle());
     }
 });
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -809,6 +809,7 @@ var SubbasinDetailModel = Backbone.Model.extend({
         highlighted: false,
         active: false,
         clickable: false,
+        selectedLoad: null,   // one of: null, TotalN, TotalP, Sediment
     },
 
     setActive: function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1099,11 +1099,19 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
     },
 
     showSubbasinHotSpotView: function() {
+        var self = this;
+
         this.panelsRegion.$el.hide();
         this.contentRegion.$el.hide();
 
         App.map.set('subbasinHuc12s', App.currentProject.get('subbasins'));
         this.scenario.set('is_subbasin_active', true);
+
+        this.collection.getResult('subbasin').on('change:selectedLoad', function() {
+            var activeSubbasin = App.currentProject.get('subbasins').getActive();
+
+            self.showCatchmentsOnMap(activeSubbasin, this);
+        });
 
         if (this.subbasinRegion.hasView()) {
             return this.subbasinRegion.$el.show();
@@ -1121,6 +1129,8 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         this.subbasinRegion.$el.hide();
         this.panelsRegion.$el.show();
         this.contentRegion.$el.show();
+
+        this.collection.getResult('subbasin').off('change:selectedLoad');
 
         this.scenario.set('is_subbasin_active', false);
         App.getMapView().clearSubbasinHuc12s();

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1131,12 +1131,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         var activeSubbasin = App.currentProject.get('subbasins').getActive(),
             subbasinResult = this.collection.getResult('subbasin');
         if (activeSubbasin) {
-            var catchmentComids = Object.keys(
-                subbasinResult.get('result').HUC12s[activeSubbasin.get('id')].Catchments);
-            activeSubbasin.fetchCatchmentsIfNeeded(catchmentComids);
-
-            App.getMapView().clearSubbasinCatchments();
-            App.map.set('subbasinCatchments', activeSubbasin.get('catchments'));
+            this.showCatchmentsOnMap(activeSubbasin, subbasinResult);
 
             this.subbasinHuc12Region.show(new SubbasinHuc12TabContentView({
                 model: subbasinResult,
@@ -1154,6 +1149,28 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         App.getMapView().clearSubbasinCatchments();
         this.subbasinRegion.$el.show();
         this.subbasinHuc12Region.empty();
+    },
+
+    showCatchmentsOnMap: function(activeSubbasin, subbasinResult) {
+        var catchments = subbasinResult.get('result')
+                         .HUC12s[activeSubbasin.get('id')].Catchments,
+            catchmentComids = Object.keys(catchments);
+
+        return activeSubbasin
+            .fetchCatchmentsIfNeeded(catchmentComids)
+            .then(function() {
+                var activeCatchments = activeSubbasin.get('catchments'),
+                    selectedLoad = subbasinResult.get('selectedLoad');
+
+                activeCatchments.forEach(function(c) {
+                    c.set(_.defaults(
+                        { selectedLoad: selectedLoad },
+                        catchments[c.id]));
+                });
+
+                App.getMapView().clearSubbasinCatchments();
+                App.map.set('subbasinCatchments', activeCatchments);
+            });
     }
 });
 

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -130,6 +130,19 @@
             padding: 1rem;
             background: $paper;
 
+            .catchment-layertoggle {
+                padding-left: 0;
+                padding-bottom: 2px;
+                border: none;
+                background: none;
+                display: inline;
+                width: 100%;
+
+                font-size: 13px;
+                font-weight: 400;
+                color: $black-54;
+            }
+
             .result-detail-header {
                 display: flex;
                 flex-direction: row;


### PR DESCRIPTION
## Overview

Adds a "Related Layers" (as seen in the Analyze Terrain tab for example) to the HUC-12 view in Subbasin. Selecting a layer colors the catchments and streams accordingly. Read commit messages for details.

Also fixes hover issue.

Connects #2791 
Connects #2655 

### Demo

![2018-05-11 14 29 24](https://user-images.githubusercontent.com/1430060/39940673-14009940-5528-11e8-9cb4-237c090c6d5f.gif)

### Notes

We may be using another, potentially continuous, color ramp for the catchments and streams. There will be a follow up card to this as soon as the ramp is finalized.

There is also a separate card for the color combinations used #2821 for general design review.

## Testing Instructions

* Check out this branch and run `bundle`
* Go to [:8000/](http://localhost:8000/) and select a HUC-10 shape. Proceed to Analyze, Model with MapShed, and select Subbasin
* In the Subbasin mode, click any child HUC-12. In the left sidebar, ensure you see a "3 related layers ▾" button, similar to Analyze.
* Click that button and select a load type to highlight. Ensure selecting it colors the catchments and streams on the map
* Select another HUC-12. Ensure the highlighted load remains so and the map is colored appropriately.
* Go back to HUC-10 level, then select another HUC-12 from the sidebar. Ensure the load selection carries through.