### PR TITLE
Subbasin: Use Continuous Color Ramp for Streams, Catchment Load Rates

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var Backbone = require('../../../../shim/backbone');
+var Backbone = require('../../../../shim/backbone'),
+    d3 = require('d3');
 
 var SubbasinTabModel = Backbone.Model.extend({
     defaults: {
@@ -13,7 +14,32 @@ var SubbasinTabCollection = Backbone.Collection.extend({
     model: SubbasinTabModel,
 });
 
+// Matching $streamWaterQualityColors in _variables.scss
+var SubbasinColorScheme = [
+    '#1a9641',
+    '#a6d96a',
+    '#ffffbf',
+    '#fdae61',
+    '#d7191c',
+    '#42090a',
+    '#000000',
+];
+
+function makeColorRamp(values) {
+    if (!(Array.isArray(values) && values.length === 5)) {
+        console.error('Can only make a color ramp with 5 values.');
+        return false;
+    }
+
+    // Add 1 after the end of given range, and MAX_VALUE to the very end,
+    // to allow for fade from dark red to black for overflow values.
+    var domain = values.concat([values[4] + 1, Number.MAX_VALUE]);
+
+    return d3.scale.linear().domain(domain).range(SubbasinColorScheme);
+}
+
 module.exports = {
     SubbasinTabModel: SubbasinTabModel,
     SubbasinTabCollection: SubbasinTabCollection,
+    makeColorRamp: makeColorRamp,
 };

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -909,7 +909,7 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
                 stroke: true,
                 color: '#49B8EA', // $water in _variables.scss
                 weight: 2,
-                opacity: 0.8,
+                opacity: 1,
                 fill: false
             },
             ramps = {
@@ -932,7 +932,7 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
 
     getStreamHighlightStyle: function() {
         return _.defaults({
-            opacity: 1
+            weight: 3,
         }, this.getStreamStyle());
     }
 });

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -12,6 +12,7 @@ var $ = require('jquery'),
     turfErase = require('turf-erase'),
     turfIntersect = require('turf-intersect'),
     AoiVolumeModel = require('./tr55/models').AoiVolumeModel,
+    makeColorRamp = require('./gwlfe/subbasin/models').makeColorRamp,
     round = utils.toRoundedLocaleString;
 
 var ModelPackageControlModel = Backbone.Model.extend({
@@ -877,29 +878,10 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
                 fill: true,
                 fillOpacity: 0.3,
             },
-            // Keep in sync with _variables.scss and tiler/styles.mss
-            breaks = {
-                TotalN: [
-                    [ 5, '#A0A0A0'],
-                    [10, '#888888'],
-                    [15, '#707070'],
-                    [20, '#484848'],
-                    [Number.MAX_VALUE, '#202020']
-                ],
-                TotalP: [
-                    [0.30, '#A0A0A0'],
-                    [0.60, '#888888'],
-                    [0.90, '#707070'],
-                    [1.20, '#484848'],
-                    [Number.MAX_VALUE, '#202020']
-                ],
-                Sediment: [
-                    [ 250, '#A0A0A0'],
-                    [ 500, '#888888'],
-                    [ 750, '#707070'],
-                    [1000, '#484848'],
-                    [Number.MAX_VALUE, '#202020']
-                ]
+            ramps = {
+                TotalN: makeColorRamp([0, 2, 5, 10, 20]),
+                TotalP: makeColorRamp([0, 0.2, 0.5, 1.0, 2.0]),
+                Sediment: makeColorRamp([0, 200, 500, 1000, 2000]),
             },
             loadingRates = self.get('TotalLoadingRates'),
             loadValue = loadingRates && loadingRates.hasOwnProperty(load) &&
@@ -907,12 +889,7 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
 
         if (loadValue !== null &&
             ['TotalN', 'TotalP', 'Sediment'].indexOf(load) >= 0) {
-            var matchingBreak = _.find(breaks[load], function(b) {
-                    return loadValue <= b[0];
-                }),
-                fillColor = matchingBreak[1];
-
-            return _.defaults({ fillColor: fillColor }, defaultStyle);
+            return _.defaults({ fillColor: ramps[load](loadValue) }, defaultStyle);
         } else {
             return defaultStyle;
         }
@@ -935,29 +912,10 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
                 opacity: 0.8,
                 fill: false
             },
-            // Keep in sync with _variables.scss and tiler/styles.mss
-            breaks = {
-                TotalN: [
-                    [1, '#1A9641'],
-                    [2, '#A6D96A'],
-                    [3, '#FFFFBF'],
-                    [4, '#FDAE61'],
-                    [Number.MAX_VALUE, '#D7191C']
-                ],
-                TotalP: [
-                    [0.03, '#1A9641'],
-                    [0.06, '#A6D96A'],
-                    [0.09, '#FFFFBF'],
-                    [0.12, '#FDAE61'],
-                    [Number.MAX_VALUE, '#D7191C']
-                ],
-                Sediment: [
-                    [ 50, '#1A9641'],
-                    [100, '#A6D96A'],
-                    [150, '#FFFFBF'],
-                    [200, '#FDAE61'],
-                    [Number.MAX_VALUE, '#D7191C']
-                ]
+            ramps = {
+                TotalN: makeColorRamp([0, 1, 3, 6, 12]),
+                TotalP: makeColorRamp([0, 0.08, 0.2, 0.5, 1.0]),
+                Sediment: makeColorRamp([0, 8, 20, 50, 150]),
             },
             concentrationRates = self.get('LoadingRateConcentrations'),
             loadValue = concentrationRates &&
@@ -966,12 +924,7 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
 
         if (loadValue !== null &&
             ['TotalN', 'TotalP', 'Sediment'].indexOf(load) >= 0) {
-            var matchingBreak = _.find(breaks[load], function(b) {
-                    return loadValue <= b[0];
-                }),
-                color = matchingBreak[1];
-
-            return _.defaults({ color: color }, defaultStyle);
+            return _.defaults({ color: ramps[load](loadValue) }, defaultStyle);
         } else {
             return defaultStyle;
         }


### PR DESCRIPTION
## Overview

Previously we used discrete color breaks for loading rates and concentration rates for catchments and their streams. Now we switch to a continuous color ramp where each value is interpolated within the gradient.

Each gradient is expected to have 5 stops. Beyond this, we add an addition sixth stop, immediately after the fifth, which goes from a darker red eventually to black.

This color ramp uses the same colors used for stream coloring in _variables.scss.

Connects #2827 

### Demo

![2018-05-14 16 19 42](https://user-images.githubusercontent.com/1430060/40022553-5bc6cedc-5796-11e8-8900-06d3afb7fd65.gif)

## Testing Instructions

* Check out this branch and `bundle`
* Go to subbasin mode and enter a HUC-12
* Turn on a related layer and observe the colors. Ensure they match with the ramp specifications in #2827.