### PR TITLE
Fix tab padding, move mean flow text

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
@@ -33,10 +33,10 @@
 </table>
 {% endmacro %}
 
+{{ table(summaryColumns, summaryRows, false, renderPrecision.summaryTable, defaultPrecision.summaryTable, summaryClassName) }}
 <div class="mean-flow">
     Mean Flow: {{ MeanFlow|round(0)|toLocaleString }} (m<sup>3</sup>/year) and {{ MeanFlowPerSecond|round(2)|toLocaleString }} (m<sup>3</sup>/s)
 </div>
-{{ table(summaryColumns, summaryRows, false, renderPrecision.summaryTable, defaultPrecision.summaryTable, summaryClassName) }}
 <div class="downloadcsv-link" data-action="download-csv-summary">
     <i class="fa fa-download"></i> Download this data
 </div>

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -39,16 +39,22 @@
         font-weight: 400;
         color: $black-54;
         margin-bottom: 4px;
+        margin: 2px 0;
     }
 
     #view-subbasin-results-link {
-        font-weight: 800;
+        font-weight: 400;
+        font-size: $font-size-h5;
         color: #389b96;
         cursor: pointer;
+        display: block;
+        margin-top: -2px;
     }
 
     .mean-flow {
-      font-size: $font-size-h4;
+      font-size: $font-size-h5;
+      font-weight: 700;
+      margin-top: 12px;
     }
 
     .runoff-chart-container {
@@ -138,7 +144,7 @@
                 display: inline;
                 width: 100%;
 
-                font-size: 13px;
+                font-size: $font-size-h5;
                 font-weight: 400;
                 color: $black-54;
             }
@@ -164,13 +170,22 @@
                     opacity: 1;
                     color: #389b96;
                     text-shadow: none;
-                    font-size: 15px;
-                    font-weight: 450;
+                    font-size: $font-size-h5;
+                    font-weight: 400;
                     padding: 6px 0 2px;
                 }
             }
         }
     }
+}
+
+
+.subbasin-huc12-region,
+.subbasin-region {
+  .nav-tabs {
+      margin-left: -10px;
+      margin-right: -10px;
+  }
 }
 
 .subbasin-hotspot-info {


### PR DESCRIPTION
## Overview

Addresses "fix padding" issue in #2832. Also, moves the "mean flow" text to below the table. Currently, that text looks like it's a header because of its formatting and location. It is really on the same level as the data in the table.

Connects #2832

### Demo

#### Before: extra padding around tab, should be flush against sidebar

![image](https://user-images.githubusercontent.com/1809908/40144183-b85f9fc0-592b-11e8-99a8-ce382c06eade.png)

#### Before: mean flow information in an arbitrary location

![image](https://user-images.githubusercontent.com/1809908/40144198-ccb6f32e-592b-11e8-803f-532a4e58222a.png)

#### After
![image](https://user-images.githubusercontent.com/1809908/40144122-80a6af6a-592b-11e8-8054-1dba806c5e0b.png)

## Testing Instructions

 * Run subbasin modeling mode, look at general styling
