### PR TITLE
Subbasin: Fix Failing HUCs

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -51,7 +51,7 @@ docker_options: "--storage-driver=aufs"
 geop_host: "localhost"
 geop_port: 8090
 
-geop_version: "4.0.0"
+geop_version: "4.0.1"
 geop_cache_enabled: 1
 
 nginx_cache_dir: "/var/cache/nginx"

--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -91,9 +91,21 @@ def apply_subbasin_gwlfe_modifications(gms, modifications,
     ag_stream_length_weighted_keys = ['n43', 'n45', 'n46c']
     urban_stream_length_weighted_keys = ['UrbBankStab']
     weighted_modifications = deepcopy(modifications)
-    ag_pct_total_stream_length = gms['AgLength'] / total_stream_lengths['ag']
-    urban_pct_total_stream_length = \
-        (gms['StreamLength'] - gms['AgLength']) / total_stream_lengths['urban']
+
+    # Weight factors for this subbasin's stream length given
+    # total stream length in the AoI
+    try:
+        ag_pct_total_stream_length = (gms['AgLength'] /
+                                      total_stream_lengths['ag'])
+    except ZeroDivisionError:
+        ag_pct_total_stream_length = 1
+
+    try:
+        urban_pct_total_stream_length = ((gms['StreamLength'] -
+                                          gms['AgLength']) /
+                                         total_stream_lengths['urban'])
+    except ZeroDivisionError:
+        urban_pct_total_stream_length = 1
 
     for mod in weighted_modifications:
         for key, val in mod.iteritems():

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -554,8 +554,12 @@ def collect_subbasin(payload, shapes):
     huc12_ws = nearest_weather_stations(shapes)
     # Find the weather stations unique across all huc12s
     unique_ws = {w.station: w for w in huc12_ws}.values()
+    # Find largest time range for which ALL weather stations have values,
+    # then limit all stations to that range.
     begyear = int(max([w.begyear for w in huc12_ws]))
     endyear = int(min([w.endyear for w in huc12_ws]))
+    huc12_ws = [w._replace(begyear=begyear)._replace(endyear=endyear)
+                for w in huc12_ws]
     # Gather the temp and prcp values for each unique weather stations
     unique_wd = weather_data(unique_ws, begyear, endyear)
 

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -269,6 +269,7 @@ def _initiate_subbasin_gwlfe_job_chain(model_input, mapshed_job_uuid,
                                           stream_lengths,
                                           inputmod_hash,
                                           watershed_id_chunk)
+        .set(link_error=errback)
         for watershed_id_chunk in watershed_id_chunks]))
 
     post_process = \


### PR DESCRIPTION
## Overview

Fixes the failing HUCs by:

* Catching errors quicker (this doesn't actually fix anything but improves the user experience)
* Using uniform date ranges for weather stations (this has other consequences which I'm writing up in a follow up card)
* Not weighing agricultural and urban stream factors by proportion of streams when there are no streams in said category
* Handling HUCs that don't have any streams intersecting them at all (see https://github.com/WikiWatershed/mmw-geoprocessing/pull/89)

See commit messages for more details.

Connects #2826 
Connects #2820 
Connects #2819 

## Testing Instructions

* Check out this branch and reprovision the worker to install the new geoprocessing service:

    ```bash
    $ vagrant reload worker --provision
    ```

* Ensure the `MMW_SRAT_CATCHMENT_API_KEY` is set correctly in the worker. Get it from LastPass if not.
* Run subbasin for all the five HUCs in #2826 and #2820, ensure they all pass