### PR TITLE
Fix external links for Safari

### DIFF
--- a/src/mmw/apps/water_balance/templates/home_page/index.html
+++ b/src/mmw/apps/water_balance/templates/home_page/index.html
@@ -13,7 +13,10 @@
             <div class="brand"><a href="/">Model My Watershed</a><a href="#">&nbsp;- Micro Site Storm Model</a></div>
             <div class="navigation">
                 <ul class="main">
-                    <li class="header-link"><a target="_blank" href="http://www.wikiwatershed.org">WikiWatershed</a></li>
+                    <li class="header-link">
+                        <a target="_blank" rel="noopener noreferrer"
+                           href="http://www.wikiwatershed.org">WikiWatershed</a>
+                    </li>
                     <li class="header-link">
                         <div class="dropdown" data-toggle="tooltip" data-placement="bottom" title="Information">
                             <a class="main dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true">
@@ -333,7 +336,7 @@
             </div> <!-- End Soils -->
 
             <div class="row pad-sm">
-                <p class="info text-muted">Apply our <a href="http://app.wikiwatershed.org" target="_blank">Site Storm Model</a> to your watershed. Info and help at <a target="_blank" href="http://wikiwatershed.org/model/">http://wikiwatershed.org/model/</a>.</p>
+                <p class="info text-muted">Apply our <a href="http://app.wikiwatershed.org" target="_blank" rel="noopener noreferrer">Site Storm Model</a> to your watershed. Info and help at <a target="_blank" href="http://wikiwatershed.org/model/">http://wikiwatershed.org/model/</a>.</p>
             </div>
 
         </div>

--- a/src/mmw/js/src/account/templates/linkedAccounts.html
+++ b/src/mmw/js/src/account/templates/linkedAccounts.html
@@ -11,7 +11,8 @@
     {% endif %}
 
     <p class="linked-account-description">
-        <a href="https://www.hydroshare.org/" target="_blank">HydroShare</a>
+        <a target="_blank" rel="noopener noreferrer"
+           href="https://www.hydroshare.org/">HydroShare</a>
         is an online collaboration environment for sharing data, models,
         and code.
     </p>

--- a/src/mmw/js/src/core/modals/templates/aboutModal.html
+++ b/src/mmw/js/src/core/modals/templates/aboutModal.html
@@ -11,8 +11,8 @@
         </div>
         <div class="modal-body">
             <p>
-                Model My Watershed is part of <a href="http://www.stroudcenter.org/" target="_blank">
-                Stroud Water Research Center</a>'s <a href="https://wikiwatershed.org/" target="_blank">
+                Model My Watershed is part of <a target="_blank" rel="noopener noreferrer" href="http://www.stroudcenter.org/">
+                Stroud Water Research Center</a>'s <a target="_blank" rel="noopener noreferrer" href="https://wikiwatershed.org/">
                 WikiWatershed</a> initiative. WikiWatershed is a web
                 toolkit designed to support citizens, conservation
                 practitioners, municipal decision-makers, researchers,
@@ -20,14 +20,14 @@
                 knowledge and stewardship of fresh water.
             </p>
             <ul>
-                <li>Read more <a href="https://wikiwatershed.org/model/" target="_blank">about Model My Watershed</a></li>
-                <li>Meet <a href="https://wikiwatershed.org/about/" target="_blank">the development team</a></li>
+                <li>Read more <a target="_blank" rel="noopener noreferrer" href="https://wikiwatershed.org/model/">about Model My Watershed</a></li>
+                <li>Meet <a target="_blank" rel="noopener noreferrer" href="https://wikiwatershed.org/about/">the development team</a></li>
             </ul>
             <hr />
             <h5>With major funding from:</h5>
             <p>
-                <a target="_blank" href="http://www.williampennfoundation.org/"><img class="splash-sponsor-logo" src="/static/images/logo-wpf.png" alt="William Penn Foundation Logo" /></a>
-                <a target="_blank" href="https://www.nsf.gov/"><img class="splash-sponsor-logo" src="/static/images/logo-nsf.png" alt="National Science Foundation Logo" /></a>
+                <a target="_blank" rel="noopener noreferrer" href="http://www.williampennfoundation.org/"><img class="splash-sponsor-logo" src="/static/images/logo-wpf.png" alt="William Penn Foundation Logo" /></a>
+                <a target="_blank" rel="noopener noreferrer" href="https://www.nsf.gov/"><img class="splash-sponsor-logo" src="/static/images/logo-nsf.png" alt="National Science Foundation Logo" /></a>
             </p>
         </div>
     </div>

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -48,7 +48,7 @@
                 <p class="{{ 'hidden' if hydroshare }}">
                     HydroShare is an online collaboration environment for
                     sharing data, models, and code. When you export to HydroShare,
-                    your project will be made public under a <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">
+                    your project will be made public under a <a target="_blank" rel="noopener noreferrer" href="https://creativecommons.org/licenses/by/4.0/">
                     Creative Commons 4.0</a> license.
                 </p>
                 <p id="hydroshare-notification" class="{{ 'hidden' if user_has_authorized_hydroshare }}">

--- a/src/mmw/js/src/core/templates/header.html
+++ b/src/mmw/js/src/core/templates/header.html
@@ -13,10 +13,10 @@
     <div class="navigation">
         <ul class="main">
             {% if data_catalog_enabled %}
-            <li class="header-link"><a href="http://bigcz.org/" target="_blank">About</a></li>
+            <li class="header-link"><a target="_blank" rel="noopener noreferrer" href="http://bigcz.org/">About</a></li>
             {% else %}
             <li class="header-link"><a href="javascript:void(0);" id="about-modal-trigger">About</a></li>
-            <li class="header-link"><a href="https://wikiwatershed.org/help/" target="_blank">Help</a></li>
+            <li class="header-link"><a target="_blank" rel="noopener noreferrer" href="https://wikiwatershed.org/help/">Help</a></li>
                 {% if not itsi_embed and not data_catalog_enabled %}
                 <li class="header-link"><a href="javascript:void(0);" id="header-open-project">Projects</a></li>
                 {% endif %}

--- a/src/mmw/js/src/core/templates/observationPopup.html
+++ b/src/mmw/js/src/core/templates/observationPopup.html
@@ -14,7 +14,7 @@
 <div class="row">
     <div class="col-xs-6">
         <div>
-            Data from <br/>{% if url %}<a href="{{ url }}" target="_blank">{% endif %}{{ providerName }}{% if url %}</a>{% endif %}
+            Data from <br/>{% if url %}<a target="_blank" rel="noopener noreferrer" href="{{ url }}">{% endif %}{{ providerName }}{% if url %}</a>{% endif %}
         </div>
     </div>
     <div class="col-xs-6">

--- a/src/mmw/js/src/draw/templates/splash.html
+++ b/src/mmw/js/src/draw/templates/splash.html
@@ -90,12 +90,12 @@
 <hr/>
 
 <div class="center">
-<a target="_blank" href="http://bigcz.org/"><img class="splash-logo" src="/static/images/logo-bigcz.png" alt="BiG CZ Logo" /></a>
+<a target="_blank" rel="noopener noreferrer" href="http://bigcz.org/"><img class="splash-logo" src="/static/images/logo-bigcz.png" alt="BiG CZ Logo" /></a>
 </div>
 
 <p>Supported by:</p>
 
-<a target="_blank" href="https://www.nsf.gov/"><img class="splash-sponsor-logo" src="/static/images/logo-nsf.png" alt="National Science Foundation Logo" /></a>
-<a target="_blank" href="http://www.williampennfoundation.org/"><img class="splash-sponsor-logo" src="/static/images/logo-wpf.png" alt="William Penn Foundation Logo" /></a>
-<a target="_blank" href="http://www.stroudcenter.org/"><img class="splash-sponsor-logo" src="/static/images/logo-stroud.png" alt="Stroud Logo" /></a>
+<a target="_blank" rel="noopener noreferrer" href="https://www.nsf.gov/"><img class="splash-sponsor-logo" src="/static/images/logo-nsf.png" alt="National Science Foundation Logo" /></a>
+<a target="_blank" rel="noopener noreferrer" href="http://www.williampennfoundation.org/"><img class="splash-sponsor-logo" src="/static/images/logo-wpf.png" alt="William Penn Foundation Logo" /></a>
+<a target="_blank" rel="noopener noreferrer" href="http://www.stroudcenter.org/"><img class="splash-sponsor-logo" src="/static/images/logo-stroud.png" alt="Stroud Logo" /></a>
 {% endif %}

--- a/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
+++ b/src/mmw/js/src/modeling/tr55/runoff/templates/table.html
@@ -10,4 +10,4 @@
     </tbody>
 </table>
 
-<p class="info text-muted">Explore how land use and soil determine runoff with our <a target="_blank" href="https://micro.app.wikiwatershed.org/">Micro Site Storm Model</a>. Info and help at <a target="_blank" href="http://wikiwatershed.org/model/">http://wikiwatershed.org/model/</a>.</p>
+<p class="info text-muted">Explore how land use and soil determine runoff with our <a target="_blank" rel="noopener noreferrer" href="https://runoff.app.wikiwatershed.org/">Runoff Simulation</a>. Info and help at <a target="_blank" rel="noopener noreferrer" href="http://wikiwatershed.org/model/">http://wikiwatershed.org/model/</a>.</p>

--- a/src/mmw/templates/registration/registration_base.html
+++ b/src/mmw/templates/registration/registration_base.html
@@ -8,8 +8,8 @@
         </div>
         <div class="navigation">
             <ul class="main">
-                <li class="header-link"><a target="_blank" href="http://www.stroudcenter.org/"><img src="/static/images/stroud-logo.png" alt="Logo" /></a></li>
-                <li class="header-link"><a target="_blank" href="http://www.wikiwatershed.org">WikiWatershed</a></li>
+                <li class="header-link"><a target="_blank" rel="noopener noreferrer" href="http://www.stroudcenter.org/"><img src="/static/images/stroud-logo.png" alt="Logo" /></a></li>
+                <li class="header-link"><a target="_blank" rel="noopener noreferrer" href="http://www.wikiwatershed.org">WikiWatershed</a></li>
             </ul>
         </div>
     </nav>


### PR DESCRIPTION
## Overview

Recent versions of Safari download links as files that have target _blank set, unless also accompanied by the noreferrer noopener rel attributes. By adding them we ensure that all links work correctly in Safari as well as other browsers.

Also fix a lingering reference to the Micro App which is now called Runoff Simulation.

Connects #2715

## Testing Instructions

* Check out this branch and `bundle`
* Ensure there are no `a` tags with `target="_blank"` that _don't_ also have `rel="noreferrer noopener"` set
* Try clicking on new links in Safari. Ensure they open instead of downloading.