### PR TITLE
Monitor: Fix SOAP Fetching

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/details.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/details.py
@@ -23,7 +23,7 @@ def details(wsdl, site):
         wsdl += '?WSDL'
 
     from ulmo.cuahsi import wof
-    return wof.get_site_info(wsdl, site)
+    return wof.get_site_info(wsdl, site, None)
 
 
 def values(wsdl, site, variable, from_date=None, to_date=None):
@@ -52,4 +52,4 @@ def values(wsdl, site, variable, from_date=None, to_date=None):
         wsdl += '?WSDL'
 
     from ulmo.cuahsi import wof
-    return wof.get_values(wsdl, site, variable, from_date, to_date)
+    return wof.get_values(wsdl, site, variable, from_date, to_date, None)

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -541,6 +541,9 @@ var Result = Backbone.Model.extend({
                     // Handle error in /details/
                     setError();
                     endFetch();
+
+                    // Throw error to prevent fetching values
+                    throw "Error fetching details, not fetching values.";
                 })
                 .then(function() {
                     return $.when.apply($, runSearches())


### PR DESCRIPTION
## Overview

Previously we were using `ulmo` with `suds-jurko` 0.6, which is the current latest release, but it is 4 years old. Most recent work on `suds-jurko` has been done on the development branch, which has [a number of improvements made in the last 4 years](https://bitbucket.org/jurko/suds/src/94664ddd46a61d06862fa8fb6ba7b9e054214f57/README.rst?at=default&fileviewer=file-view-default#README.rst-85:447).

Unfortunately, the development branch also includes some breaking changes, including [one which "cleans up" the caching module](https://bitbucket.org/jurko/suds/commits/6b24afe3206fc648605cc8d19f7c58c605d9df5f?at=default). This change renames `.setduration()` to `.__set_duration()`, which [is called by `ulmo`](https://github.com/emiliom/ulmo/blob/90dbfe31f38a72ea4cee9a52e572cfa8f8484adc/ulmo/cuahsi/wof/core.py#L284-L292). This was seen in [Rollbar#309](https://rollbar.com/Azavea/MMW/items/309/) and [Rollbar#310](https://rollbar.com/Azavea/MMW/items/310/).

By explicitly setting the caching to `None`, we ensure that line isn't executed and those errors don't crop up.

The performance improvements we get from using the development branch of `suds-jurko` outweigh the benefits of caching for one day, since it is unlikely we will be accessing the exact same content repeatedly.

Connects #2807 

### Demo

![image](https://user-images.githubusercontent.com/1430060/40376136-92bf0438-5dbb-11e8-97f2-13b173d97eee.png)

See below for explanation of failing value.

### Notes

As an alternative to using `None` here, if @emiliom updates [his fork](https://github.com/emiliom/ulmo/) with [the changes needed in `core.py`](https://github.com/emiliom/ulmo/blob/90dbfe31f38a72ea4cee9a52e572cfa8f8484adc/ulmo/cuahsi/wof/core.py#L284-L292), namely renaming `.setduration()` to `.__set_duration()`, we can try using that version instead. But that strays further from the parent repo, increasing the maintenance burden of that fork.

I also noticed that the EnviroDIY service times out on certain variables quite often, especially if the values are not "hot" on the server side. For example, using this simple script that fetches the details and values for the site in the above screenshot:

```python
# envirodiy.py

from ulmo.cuahsi import wof

wsdl = 'http://data.envirodiy.org/wofpy/soap/cuahsi_1_1/.wsdl'
site = 'EnviroDIY:SHPK3S'

wof.get_site_info(wsdl, site, None)

from_date = '05/07/2018'
to_date = '05/21/2018'
variables = [
    'envirodiy:Decagon_CTD-10_Cond',
    'envirodiy:EnviroDIY_Mayfly_Temp',
    'envirodiy:Decagon_CTD-10_Temp',
    'envirodiy:Campbell_OBS-3+_Turb']

values = [wof.get_values(wsdl, site, variable, from_date, to_date)
          for variable in variables]
```

I timed it in 5 runs. It got quicker overall after a couple of "warm up" runs, but did timeout the first time here too:

```
$ for i in 1 2 3 4 5; time -p python -W ignore envirodiy.py; end

Traceback (most recent call last):
  File "envirodiy.py", line 17, in <module>
    for variable in variables]
  File "/Users/ttuhinanshu/scratch/model-my-watershed/ulmo/env/lib/python2.7/site-packages/ulmo/cuahsi/wof/core.py", line 179, in get_values
    endDate=end_dt_isostr)
  File "/Users/ttuhinanshu/scratch/model-my-watershed/ulmo/env/lib/python2.7/site-packages/suds/client.py", line 566, in __call__
    return client.invoke(args, kwargs)
  File "/Users/ttuhinanshu/scratch/model-my-watershed/ulmo/env/lib/python2.7/site-packages/suds/client.py", line 705, in invoke
    result = self.send(soapenv)
  File "/Users/ttuhinanshu/scratch/model-my-watershed/ulmo/env/lib/python2.7/site-packages/suds/client.py", line 752, in send
    return self.process_reply(content, e.httpcode, tostr(e))
  File "/Users/ttuhinanshu/scratch/model-my-watershed/ulmo/env/lib/python2.7/site-packages/suds/client.py", line 819, in process_reply
    raise Exception((status, description))
Exception: (504, u'Gateway Time-out')

real       187.07
user         2.93
sys          0.31

real       167.55
user         4.53
sys          0.35

real       135.26
user         4.73
sys          0.37

real       136.28
user         4.45
sys          0.38

real       140.74
user         4.41
sys          0.38
```

But even when it works it is pretty slow. EnviroDIY performance may need to be tuned on their end to better support this.

## Testing Instructions

* Check out this branch, run `./scripts/debugserver.sh`
* Go to [:8000/](http://localhost:8000/) and select a shape.
* Switch to Monitor tab. Search for "water". Switch to CUAHSI WDC tab.
* Wait for results. Click an EnviroDIY result. Wait for them to populate. Ensure that there are no 500s or 400s in the `/details` and `/values` requests. Some 504s may be observed.