### PR TITLE
Add HUC to AoI Name, Fix Catchment Layer Legend Units

### DIFF
--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -143,12 +143,20 @@ def get_layer_shape(table_code, id):
 
     table = layer['table_name']
     field = layer.get('json_field', 'geom')
+    properties = ''
+
+    if table.startswith('boundary_huc'):
+        properties = "'huc', {}".format(table[-5:])
 
     sql = '''
-          SELECT ST_AsGeoJSON({field})
+          SELECT json_build_object(
+            'type', 'Feature',
+            'id', id,
+            'geometry', ST_AsGeoJSON({field})::json,
+            'properties', json_build_object({properties}))
           FROM {table}
           WHERE id = %s
-          '''.format(field=field, table=table)
+          '''.format(field=field, properties=properties, table=table)
 
     with connection.cursor() as cursor:
         cursor.execute(sql, [int(id)])

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -485,7 +485,7 @@ def boundary_layer_detail(request, table_code, obj_id):
     geojson = get_layer_shape(table_code, obj_id)
 
     if geojson:
-        return Response(json.loads(geojson))
+        return Response(geojson)
     else:
         return Response(status=status.HTTP_404_NOT_FOUND)
 

--- a/src/mmw/js/src/analyze/templates/aoiHeader.html
+++ b/src/mmw/js/src/analyze/templates/aoiHeader.html
@@ -22,4 +22,11 @@
     <!-- Put `shape` in single quotes, to keep any unescaped chars from breaking the template -->
     <input type="hidden" name="shape" value='{{ shape }}' />
 </form>
-<h2>{{ place }}<span class="aoi-area">{{ area|round|toLocaleString }}&nbsp;{{ units }}</span></h2>
+<h2>
+    <span class="aoi-primary">{{ name.primary }}</span>
+    {% if name.suffix %}
+        <span class="aoi-suffix">ID&nbsp;{{ name.suffix }}</span>&nbsp;<span class="aoi-area">{{ area|round|toLocaleString }}&nbsp;{{ units }}</span>
+    {% else %}
+        <span class="aoi-area">{{ area|round|toLocaleString }}&nbsp;{{ units }}</span>
+    {% endif %}
+</h2>

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -429,6 +429,7 @@ var AoiView = Marionette.ItemView.extend({
 
     templateHelpers: function() {
         return {
+            name: utils.parseAoIName(this.model.get('place')),
             csrftoken: csrf.getToken(),
             shape: JSON.stringify(this.model.get('shape'))
         };

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -656,6 +656,22 @@ var utils = {
         };
     },
 
+    // Parse Area Of Interest Name to return an object like to be formatted by
+    // the view. It looks for (ID XXXX) at the end of the name and separates it
+    // into a suffix. E.g.
+    //     parseAoIName('Schuylkill, HUC-8 Watershed (ID 02040203)') =>
+    //     { primary: 'Schuylkill, HUC-8 Watershed', suffix: '02040203' }
+    parseAoIName: function(name) {
+        var idIndex = name.indexOf('(ID');
+
+        return {
+            primary: idIndex < 0 ? name :
+                     name.substr(0, idIndex),
+            suffix: idIndex < 0 ? '' :
+                    name.substring(idIndex + 4, name.length - 1)
+        };
+    },
+
     // Downloads given data as a text file with given filename
     downloadAsFile: function(data, filename) {
         var blob = new Blob([JSON.stringify(data)],

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -1102,8 +1102,14 @@ function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {
             })
             .then(validateShape)
             .then(function(shape) {
-                var wkaoi = layerCode + '__' + shapeId;
-                addLayer(shape, shapeName, layerName, wkaoi);
+                var wkaoi = layerCode + '__' + shapeId,
+                    parsedLayerName = layerName;
+
+                if (shape.properties && shape.properties.huc) {
+                    parsedLayerName += ' (ID ' + shape.properties.huc + ')';
+                }
+
+                addLayer(shape, shapeName, parsedLayerName, wkaoi);
                 clearBoundaryLayer(model);
                 navigateToAnalyze();
                 deferred.resolve();

--- a/src/mmw/js/src/modeling/templates/modelDetailsDropdown.html
+++ b/src/mmw/js/src/modeling/templates/modelDetailsDropdown.html
@@ -1,6 +1,9 @@
 <div class="model-details-dropdown">
     <span>Area of Interest</span> (<button class="edit-btn" id="change-aoi">Edit</button>)
-    <h3>{{ aoiModel.get('place') }}</h3>
+    <h3>{{ aoiModel.get('place').primary }}</h3>
+    {% if aoiModel.get('place').suffix %}
+        <span class="aoi-suffix">ID&nbsp;{{ aoiModel.get('place').suffix }}</span>
+    {% endif %}
     <span class="aoi-area">{{ aoiModel.get('area')|round|toLocaleString }} {{ aoiModel.get('units') }}</span>
 
     <hr/>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -157,7 +157,7 @@ var ProjectMenuView = Marionette.ItemView.extend({
                                   {name: modelPackageName}),
             aoiModel = new coreModels.GeoModel({
                 shape: App.map.get('areaOfInterest'),
-                place: App.map.get('areaOfInterestName')
+                place: utils.parseAoIName(App.map.get('areaOfInterestName')),
             });
         return {
             itsi: App.user.get('itsi'),

--- a/src/mmw/js/src/projects/templates/projectRow.html
+++ b/src/mmw/js/src/projects/templates/projectRow.html
@@ -1,6 +1,11 @@
 <div class="col-md-5">
     <h2><i class="fa {{ "fa-lock" if is_private else "fa-globe" }}"></i> {{  name }}</h2>
-    <p>{{ area_of_interest_name }}</p>
+    <p>
+        {{ aoiName.primary }}
+        {% if aoiName.suffix %}
+            (ID&nbsp;{{ aoiName.suffix }})
+        {% endif %}
+    </p>
     <p><small>{{ created_at|toFriendlyDate }}</small></p>
 </div>
 <div class="col-md-offset-1 col-md-4">

--- a/src/mmw/js/src/projects/views.js
+++ b/src/mmw/js/src/projects/views.js
@@ -78,6 +78,12 @@ var ProjectRowView = Marionette.ItemView.extend({
         'change': 'render'
     },
 
+    templateHelpers: function() {
+        return {
+            aoiName: utils.parseAoIName(this.model.get('area_of_interest_name')),
+        };
+    },
+
     renameProject: function() {
         var self = this,
             rename = new modalViews.InputView({

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -222,11 +222,11 @@ LAYER_GROUPS = {
             'css_class_prefix': 'catchment',
             # Defined in tiler/styles.mss
             'legend_mapping': {
-                1: 'Less than 5 kg/y',
-                2: 'Less than 10 kg/y',
-                3: 'Less than 15 kg/y',
-                4: 'Less than 20 kg/y',
-                5: 'Greater than 20 kg/y',
+                1: 'Less than 5 kg/ha',
+                2: 'Less than 10 kg/ha',
+                3: 'Less than 15 kg/ha',
+                4: 'Less than 20 kg/ha',
+                5: 'Greater than 20 kg/ha',
             },
             'big_cz': False,
         },
@@ -243,11 +243,11 @@ LAYER_GROUPS = {
             'css_class_prefix': 'catchment',
             # Defined in tiler/styles.mss
             'legend_mapping': {
-                1: 'Less than 0.30 kg/y',
-                2: 'Less than 0.60 kg/y',
-                3: 'Less than 0.90 kg/y',
-                4: 'Less than 1.20 kg/y',
-                5: 'Greater than 1.20 kg/y',
+                1: 'Less than 0.30 kg/ha',
+                2: 'Less than 0.60 kg/ha',
+                3: 'Less than 0.90 kg/ha',
+                4: 'Less than 1.20 kg/ha',
+                5: 'Greater than 1.20 kg/ha',
             },
             'big_cz': False,
         },
@@ -264,11 +264,11 @@ LAYER_GROUPS = {
             'css_class_prefix': 'catchment',
             # Defined in tiler/styles.mss
             'legend_mapping': {
-                1: 'Less than 250 kg/y',
-                2: 'Less than 500 kg/y',
-                3: 'Less than 750 kg/y',
-                4: 'Less than 1000 kg/y',
-                5: 'Greater than 1000 kg/y',
+                1: 'Less than 250 kg/ha',
+                2: 'Less than 500 kg/ha',
+                3: 'Less than 750 kg/ha',
+                4: 'Less than 1000 kg/ha',
+                5: 'Greater than 1000 kg/ha',
             },
             'big_cz': False,
         }

--- a/src/mmw/sass/pages/_analyze.scss
+++ b/src/mmw/sass/pages/_analyze.scss
@@ -87,8 +87,18 @@
 .aoi-area {
   font-size: $font-size-h4;
   color: $black-39;
-  margin-left: 10px;
   font-weight: 400;
+}
+
+.aoi-suffix {
+  font-size: $font-size-h4;
+  color: $ui-grey;
+  margin-right: 10px;
+  font-weight: 400;
+}
+
+.aoi-primary {
+  margin-right: 10px;
 }
 
 .analyze-message-region {

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -115,10 +115,6 @@
             text-decoration: underline;
         }
     }
-
-    > .aoi-area {
-        margin-left: 0;
-    }
 }
 
 .itsi-model-toolbar {


### PR DESCRIPTION
## Overview

To enable advanced users to coordinate their MMW work with external systems, include the HUC of the respective shape in the area of interest name. This will be available in all places that show the area of interest name, including the Analyze / Monitor sidebar, the Details popup in Modeling, and the Projects listing page. Only projects going forward will have this.

If we wish to add this to existing projects as well, that can be done for those that have a WKAoI value stored with the project. We will have to write a migration to do this. Is this desired? /cc @ajrobbins 

Also updates the units in the legend text for DRB Catchment Water Quality Coverage layers.

Connects #2814 
Connects #2776 

### Demo

![image](https://user-images.githubusercontent.com/1430060/40390818-65aa39f8-5de4-11e8-9d75-93f69ffa717d.png)

![image](https://user-images.githubusercontent.com/1430060/40390876-9537b45c-5de4-11e8-803f-625a42e8350a.png)

![image](https://user-images.githubusercontent.com/1430060/40390887-a12dddf4-5de4-11e8-9891-046e18a9ce2d.png)

### Notes

I also considered updating the UTF-8 grid with the values and using that:

```diff
commit 1f96a375b0c151c9010db5b85369f64abd5494e3
Author: Terence Tuhinanshu <ttuhinanshu@azavea.com>
Date:   Tue May 22 16:03:40 2018 -0400

    Add HUC field to JSON Grid

diff --git a/src/mmw/js/src/draw/views.js b/src/mmw/js/src/draw/views.js
index a8c71f51..8cfe596e 100644
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -1088,11 +1088,19 @@ function getShapeAndAnalyze(e, model, ofg, grid, layerCode, layerName) {
         shapeName = e.data && e.data.name ? e.data.name : null,
         shapeId = e.data ? e.data.id : null;
 
-        if (shapeId) {
-            _getShapeAndAnalyze();
-        } else {
-            pollForShapeId();
-        }
+    if (shapeId) {
+        _getShapeAndAnalyze();
+    } else {
+        pollForShapeId();
+    }
+
+    if (shapeName) {
+        shapeName +=
+            e.data.huc08 ? ' (' + e.data.huc08 + ')':
+            e.data.huc10 ? ' (' + e.data.huc10 + ')':
+            e.data.huc12 ? ' (' + e.data.huc12 + ')':
+            '';
+    }
 
     function _getShapeAndAnalyze() {
         App.restApi
diff --git a/src/tiler/server.js b/src/tiler/server.js
index 78a23a88..42d93972 100644
--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -44,9 +44,9 @@ var interactivity = {
         'boundary_county': 'name,id',
         'boundary_district': 'name,id',
         'boundary_school_district': 'name,id',
-        'boundary_huc08': 'name,id',
-        'boundary_huc10': 'name,id',
-        'boundary_huc12': 'name,id'
+        'boundary_huc08': 'name,id,huc08',
+        'boundary_huc10': 'name,id,huc10',
+        'boundary_huc12': 'name,id,huc12'
     },
     tables = {
         county: 'boundary_county',
```

but after talking to @mmcfarland decided against it since it would involve invalidating an S3 cache that has been slowly building for 2+ years.

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/) and try the various ways of getting a shape.
* Ensure that when you select any HUC shape, it's hydrological unit code is present in the area of interest name. Ensure that is not the case for any other case.
* Ensure you can move through Analyze, Monitor, Modeling, saving and reloading as before. This ensures that switching from `MultiPolygon` to `Feature` as the boundary layer detail response type does not change anything.
* Ensure the legend units have been updated to match expectations.