### PR TITLE
MapShed: Default to 10m for stream length if absent

### DIFF
--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -91,7 +91,7 @@ def collect_data(geop_results, geojson, watershed_id=None, weather=None):
     z['ManNitr'], z['ManPhos'] = manure_spread(z['AEU'])
 
     # Data from Streams dataset
-    z['StreamLength'] = stream_length(geom)      # Meters
+    z['StreamLength'] = stream_length(geom) or 10   # Meters
     z['n42b'] = round(z['StreamLength'] / 1000, 1)  # Kilometers
 
     # Data from Point Source Discharge dataset

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/catchmentTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/catchmentTable.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">NHD+ ComID</th>
-            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (km<sup>2</sup>)</th>
+            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (ha)</th>
             <th colspan="3">Total Loads (not normalized)</th>
             <th colspan="3">Loading Rates (area normalized)</th>
             <th colspan="3">Mean Annual Concentration(discharge normalized)</th>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
@@ -3,7 +3,7 @@
         <tr>
             <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">HUC-12 Name</th>
             <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">HUC-12 Number</th>
-            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (km<sup>2</sup>)</th>
+            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (ha)</th>
             <th colspan="3">Total Loads (not normalized)</th>
             <th colspan="3">Loading Rates (area normalized)</th>
         </tr>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">Sources</th>
-            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (km<sup>2</sup>)</th>
+            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (ha)</th>
             <th colspan="3">Total Loads (not normalized)</th>
             <th colspan="3">Loading Rates (area normalized)</th>
         </tr>


### PR DESCRIPTION
## Overview

For shapes with no streams in them, we default to a value of 10, which is small enough to not materially impact the calculations, but also support running desktop MapShed which would crash when given a GMS file with StreamLength set to 0.

Connects #2799

### Demo

Using [Truax-Lake.gms.txt](https://github.com/WikiWatershed/model-my-watershed/files/2036425/Truax-Lake.gms.txt), checking it's Line 2 Comma Position 9:

```shell
$ cat Truax-Lake.gms.txt | sed -n 2p | cut -d',' -f 9

10
```

## Testing Instructions

* Check out this branch and restart Celery 

    ```
    $ vagrant ssh worker -c 'sudo service celeryd restart'
    ```

* Go to [:8000/](http://localhost:8000/), select a shape that has no streams in it (such as a 1 sq km area with no streams, or the Truax Lake HUC-12) and run MapShed. Download the GMS file. Ensure it has a non-zero value in Line 2 Comma Position 9 in the GMS file.