### PR TITLE
Jump to Coordinates

### DIFF
--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -779,6 +779,31 @@ describe('Core', function() {
             assert.equal(output.version, 'Local');
             assert.equal(output.releaseNotesUrl, latestUrl);
         });
+
+        it('parses coordinates correctly', function() {
+            var lngLat = '-75.1542379,39.9614307',
+                latLng = '39.9614307,-75.1542379',
+                address = '990 Spring Garden, St',
+                hucName = 'Lower Schuylkill',
+                zipCode = '19123',
+                mexico = '23.294249,-111.6364102',
+                spain = '40.1217811,-8.200797',
+                africa = '2.1500228,5.2076582',
+                empty = '',
+                correct = { lat: 39.9614307, lng: -75.1542379 };
+
+            assert.deepEqual(utils.parseLocation(latLng), correct);
+            assert.deepEqual(utils.parseLocation(lngLat), correct);
+            assert.equal(utils.parseLocation(address), false);
+            assert.equal(utils.parseLocation(hucName), false);
+            assert.equal(utils.parseLocation(zipCode), false);
+            assert.equal(utils.parseLocation(mexico), false);
+            assert.equal(utils.parseLocation(spain), false);
+            assert.equal(utils.parseLocation(africa), false);
+            assert.equal(utils.parseLocation(empty), false);
+            assert.equal(utils.parseLocation(null), false);
+            assert.equal(utils.parseLocation(), false);
+        });
     });
 });
 

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -37,6 +37,11 @@ var utils = {
 
     MODEL: 'MODEL',
 
+    CONUS: {
+        NW: [-127.17,24.76],
+        SE: [-66.53,50.4575]
+    },
+
     splashPageTitle: settings.get('title'),
 
     selectAreaPageTitle: 'Choose Area of Interest',
@@ -735,6 +740,50 @@ var utils = {
         });
 
         return gms;
+    },
+
+    // Takes a string query, which is either "Lon,Lat" or "Lat,Lon",
+    // and returns an object {lng: 99.9, lat: 99.9}. If the string
+    // cannot be parsed in the expected way, returns false
+    parseLocation: function(query) {
+        if (!_.isString(query)) {
+            return false;
+        }
+
+        if (query.indexOf(',') < 0) {
+            return false;
+        }
+
+        var coords = _.compact(query.split(',').map(parseFloat)),
+            result = { lat: NaN, lng: NaN };
+
+        if (coords.length !== 2) {
+            // String did not parse correctly
+            return false;
+        }
+
+        if (coords[0] >= this.CONUS.NW[0] && coords[0] <= this.CONUS.SE[0]) {
+            result.lng = coords[0];
+            if (coords[1] >= this.CONUS.NW[1] && coords[1] <= this.CONUS.SE[1]) {
+                result.lat = coords[1];
+            } else {
+                // Out of bounds
+                return false;
+            }
+        } else if (coords[1] >= this.CONUS.NW[0] && coords[1] <= this.CONUS.SE[0]) {
+            result.lng = coords[1];
+            if (coords[0] >= this.CONUS.NW[1] && coords[0] <= this.CONUS.SE[1]) {
+                result.lat = coords[0];
+            } else {
+                // Out of bounds
+                return false;
+            }
+        } else {
+            // Out of bounds
+            return false;
+        }
+
+        return result;
     }
 };
 

--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -3,7 +3,10 @@
 var _ = require('underscore'),
     $ = require('jquery'),
     Backbone = require('../../shim/backbone'),
-    App = require('../app');
+    App = require('../app'),
+    utils = require('../core/utils');
+
+var CONUS_BBOX = _.flatten(_.values(utils.CONUS)).join(',');
 
 var GeocoderModel = Backbone.Model.extend({
     defaults: {
@@ -69,12 +72,7 @@ var GeocodeSuggestions = Backbone.Collection.extend({
     model: SuggestionModel,
     url: function() {
         return 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?f=json' +
-               '&searchExtent=' + this.getBoundingBox();
-    },
-
-    getBoundingBox: function() {
-        // Continental US
-        return '-127.17,24.76,-66.53,50.4575';
+               '&searchExtent=' + CONUS_BBOX;
     },
 
     parse: function(response) {

--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -11,7 +11,31 @@ var CONUS_BBOX = _.flatten(_.values(utils.CONUS)).join(',');
 var GeocoderModel = Backbone.Model.extend({
     defaults: {
         selectedSuggestion: null, // SuggestionModel
+        location: null,           // LocationModel
         query: ''
+    }
+});
+
+var LocationModel = Backbone.Model.extend({
+    defaults: {
+        lat: NaN,
+        lng: NaN,
+        zoom: 14,
+        selected: false
+    },
+
+    select: function(zoom) {
+        var lat = this.get('lat'),
+            lng = this.get('lng');
+        if (lat && lng) {
+            App.map.set({
+                lat: lat,
+                lng: lng,
+                zoom: zoom || this.get('zoom')
+            });
+
+            this.set('selected', true);
+        }
     }
 });
 
@@ -158,6 +182,7 @@ var SuggestionsCollection = Backbone.Collection.extend({
 
 module.exports = {
     GeocoderModel: GeocoderModel,
+    LocationModel: LocationModel,
     SuggestionModel: SuggestionModel,
     SuggestionsCollection: SuggestionsCollection
 };

--- a/src/mmw/js/src/geocode/templates/location.html
+++ b/src/mmw/js/src/geocode/templates/location.html
@@ -1,0 +1,1 @@
+<i class="fa fa-map-marker"></i> Go to {{ lat }}, {{ lng }}

--- a/src/mmw/js/src/geocode/templates/search.html
+++ b/src/mmw/js/src/geocode/templates/search.html
@@ -1,5 +1,5 @@
 <input class="search-input" id="geocoder-search" type="text"
-       placeholder="Jump to location or HUC"
+       placeholder="Jump to location, HUC, or coordinates"
 >
 <i class="search-icon fa fa-search"></i>
 <button class="search-select-btn hidden">Select</button>

--- a/src/mmw/sass/pages/_search-map.scss
+++ b/src/mmw/sass/pages/_search-map.scss
@@ -112,3 +112,16 @@
 .boundary-suggestions {
   padding-bottom: 0.3rem;
 }
+
+.geocoder-search-location-prompt {
+  padding: 0.7rem;
+  cursor: pointer;
+
+  &:hover {
+    color: $black-74;
+  }
+
+  i {
+    margin: 0 0.5rem;
+  }
+}


### PR DESCRIPTION
## Overview

Adds support for users to paste in a lng,lat or lat,lng coordinate in the search bar. If it is within the continental United States, we show a "Go to {{ coordinates }}" button which they can click to jump the map there. The zoom is hard set to 14, using the same defaults used for other kinds of searches.

Connects #2427 

### Demo

![2018-05-25 17 05 24](https://user-images.githubusercontent.com/1430060/40566295-0f30f448-603e-11e8-978f-6817d8a516ca.gif)

![2018-05-25 17 06 08](https://user-images.githubusercontent.com/1430060/40566296-1240b79a-603e-11e8-8da9-a206b6302096.gif)

Tagging @ajrobbins and @jfrankl for brief visual review.

## Testing Instructions

* Check out this branch and `bundle --debug`
* Try searching by coordinates. Ensure Lat, Lon and Lon, Lat both work.
* Ensure you cannot jump to invalid coordinates, or those outside the US.
* Ensure geocoding and HUC searches still work as expected.