### PR TITLE
Fix loading saved TR-55 projects

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -966,16 +966,21 @@ var ResultsView = Marionette.LayoutView.extend({
         ));
 
         if (scenario) {
+            var results = scenario.get('results'),
+                hasSubbasin = results.some(function(r) {
+                    return r.get('name') === 'subbasin';
+                });
+
             // Close sub-basin of previous detail view if active
             // And make any active subbasin detail inactive
-            if (this.modelingRegion.hasView()) {
+            if (hasSubbasin && this.modelingRegion.hasView()) {
                 this.modelingRegion.currentView.hideSubbasinHuc12View();
                 this.modelingRegion.currentView.hideSubbasinHotSpotView();
             }
 
             this.modelingRegion.show(new ResultsDetailsView({
                 areaOfInterest: this.model.get('area_of_interest'),
-                collection: scenario.get('results'),
+                collection: results,
                 scenario: scenario,
             }));
         }


### PR DESCRIPTION
## Overview

While working on subbasin, we added code to clear the subbasin views from previosly loaded projects. This misfires when there was no previously loaded project, and when loading a TR-55 project that doesn't have subbasin results.

By adding a check for them we ensure that the loading completes correctly.

Connects #2841 

### Demo

![2018-05-29 13 40 50](https://user-images.githubusercontent.com/1430060/40675747-937a8164-6346-11e8-9aec-736c9232c5ad.gif)

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/) and log in to an account
* Create a TR-55 project so it gets saved. Reload the page to open that project directly. Ensure there are no console errors.
* Create a GWLF-E project so it gets saved. _Do not_ go into subbasin mode. Reload the page to open that project directly. Ensure there are no console errors.
* Create a subbasin project so it gets saved. Reload the page to open that project directly. Ensure there are no console errors.
* Ensure opening these projects via the Projects listing works without any console errors as well.