### PR TITLE
Monitor: Pin Pandas to 0.22

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/tasks/dev-and-test-dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/dev-and-test-dependencies.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Firefox for UI tests
-  apt: pkg="firefox=5*" state=present
+  apt: pkg="firefox=6*" state=present
 
 - name: Install Xvfb for JavaScript tests
   apt: pkg="xvfb=2:1.15.1*" state=present

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -22,6 +22,7 @@ retry==0.9.1
 python-dateutil==2.6.0
 https://bitbucket.org/jurko/suds/get/94664ddd46a6.tar.gz#egg=suds-jurko
 django_celery_results==1.0.1
+pandas==0.22.0
 git+git://github.com/emiliom/ulmo@wml_values_md#egg=ulmo
 numpy==1.13.0
 hs_restclient==1.2.10


### PR DESCRIPTION
## Overview

Fixes [this error](https://rollbar.com/Azavea/MMW/items/320/) happening because of [this line in Ulmo](https://github.com/ulmo-dev/ulmo/blob/ba6ee72d91057c43d356e901a9ce511e1be16684/ulmo/util/misc.py#L52
). `Timestamp().to_datetime` was [deprecated in 0.21](https://pandas.pydata.org/pandas-docs/version/0.21/generated/pandas.Timestamp.to_datetime.html) and [removed in 0.23](https://pandas.pydata.org/pandas-docs/version/0.23/generated/pandas.Timestamp.to_pydatetime.html#pandas.Timestamp.to_pydatetime). Since Ulmo [does not specify dependency versions](https://github.com/emiliom/ulmo/blob/22951dc3f52e30f8596bf27950a0138d3f6f2103/requirements.txt#L8), the latest version of Pandas was used, causing this error.

By pinning Pandas to 0.22 we ensure that the old method is available.

Also upgrade Firefox to 6x series because of 5x is no longer available.

Connects #2807 

### Demo

![image](https://user-images.githubusercontent.com/1430060/40686629-f08e7e04-6365-11e8-85f3-f1ee2bd68b87.png)

## Testing Instructions

* Check out this branch and destroy and recreate the `app` VM to get new Python dependencies in

      $ vagrant destroy app && vagrant up app

* Go to [:8000/](http://localhost:8000/) and pick Lower Schuylkill HUC-10. Go to the Monitor tab, and search for "water".
* Switch to CUAHSI. Test out some of the EnviroDIY results. There should be no 500s, only the occasional 504s.