### PR TITLE
Bump azavea.java role to 0.6.2

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -45,6 +45,6 @@
 - src: azavea.beaver
   version: 1.0.1
 - src: azavea.java
-  version: 0.6.1
+  version: 0.6.2
 - src: azavea.docker
   version: 2.0.0

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -112,8 +112,8 @@
                 "sleep 5",
                 "sudo apt-get update -qq",
                 "sudo apt-get install python-pip python-dev -y",
-                "sudo pip install paramiko==1.16.0",
-                "sudo pip install ansible==2.0.1.0",
+                "sudo pip install --upgrade pip",
+                "sudo pip install ansible==2.4.4.0",
                 "sudo /bin/sh -c 'echo {{user `branch`}} {{user `description`}} > /srv/version.txt'"
             ]
         },

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.0.1.0
+ansible==2.4.4.0
 majorkirby>=0.2.0,<0.2.99
 troposphere>=1.1.0
 boto==2.39.0


### PR DESCRIPTION
## Overview

Attempts to be the one true fix for https://github.com/WikiWatershed/model-my-watershed/issues/2787.

Resolves https://github.com/WikiWatershed/model-my-watershed/issues/2823

### Notes

See https://github.com/azavea/ansible-java/pull/35

## Testing Instructions

First, destroy the `worker` virtual machine, then attempt to bring it back up using this branch. In the process ensure that version 0.6.2 of the `azavea.java` role is being used.

```bash
$ vagrant destroy -f worker
$ vagrant status
$ head -n1 deployment/ansible/roles/azavea.java/CHANGELOG.md
## 0.6.2
$ vagrant up worker
```