### PR TITLE
Subbasin: Fine Tune Catchment Coloring

### DIFF
--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -1114,13 +1114,22 @@ var MapView = Marionette.ItemView.extend({
     },
 
     bringActiveSubbasinToFront: function(subbasinDetails) {
-        if (subbasinDetails.getActive()) {
-            var activeId = subbasinDetails.getActive().get('id');
-            _.forEach(this._subbasinHuc12sLayer.getLayers(), function(layer) {
-                if (layer.options.id === activeId) {
-                    layer.bringToFront();
+        if (!subbasinDetails) {
+            subbasinDetails = this.model.get('subbasinHuc12s');
+        }
+
+        var activeSubbasin = subbasinDetails.getActive();
+
+        if (activeSubbasin) {
+            var activeId = activeSubbasin.get('id'),
+                subbasinLayers = this._subbasinHuc12sLayer.getLayers();
+
+            for (var i = 0; i < subbasinLayers.length; i++) {
+                if (subbasinLayers[i].options.id === activeId) {
+                    subbasinLayers[i].bringToFront();
+                    return;
                 }
-            });
+            }
         }
     },
 
@@ -1159,7 +1168,7 @@ var MapView = Marionette.ItemView.extend({
                         layer.bringToFront();
                     } else {
                         layer.setStyle(catchment.getStreamStyle());
-                        layer.bringToBack();
+                        self.bringActiveSubbasinToFront();
                     }
                 };
 
@@ -1190,7 +1199,7 @@ var MapView = Marionette.ItemView.extend({
                         layer.bringToFront();
                     } else {
                         layer.setStyle(catchment.getStyle());
-                        layer.bringToBack();
+                        self.bringActiveSubbasinToFront();
                     }
                 };
 

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
@@ -14,32 +14,39 @@ var SubbasinTabCollection = Backbone.Collection.extend({
     model: SubbasinTabModel,
 });
 
-// Matching $streamWaterQualityColors in _variables.scss
-var SubbasinColorScheme = [
-    '#1a9641',
-    '#a6d96a',
-    '#ffffbf',
-    '#fdae61',
-    '#d7191c',
-    '#42090a',
-    '#000000',
-];
+var ColorSchemes = {
+    catchment: [
+        '#00A151',
+        '#8BDE65',
+        '#FCFFBC',
+        '#FF9555',
+        '#FF6B55',
+        '#000000',
+    ],
+    stream: [
+        '#00602D',
+        '#00E72A',
+        '#EBFF5B',
+        '#FF6508',
+        '#CB1A00',
+        '#000000',
+    ],
+};
 
-function makeColorRamp(values) {
+function makeColorRamp(values, colorScheme) {
     if (!(Array.isArray(values) && values.length === 5)) {
         console.error('Can only make a color ramp with 5 values.');
         return false;
     }
 
-    // Add 1 after the end of given range, and MAX_VALUE to the very end,
-    // to allow for fade from dark red to black for overflow values.
-    var domain = values.concat([values[4] + 1, Number.MAX_VALUE]);
+    var domain = values.concat([Number.MAX_VALUE]);
 
-    return d3.scale.linear().domain(domain).range(SubbasinColorScheme);
+    return d3.scale.linear().domain(domain).range(colorScheme);
 }
 
 module.exports = {
     SubbasinTabModel: SubbasinTabModel,
     SubbasinTabCollection: SubbasinTabCollection,
     makeColorRamp: makeColorRamp,
+    ColorSchemes: ColorSchemes,
 };

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -870,12 +870,14 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
     getStyle: function() {
         var self = this,
             load = this.get('selectedLoad'),
+            fillOpacity = 1,
             defaultStyle = {
                 stroke: true,
                 color: 'grey',
                 weight: 2,
                 opacity: 1,
                 fill: true,
+                fillColor: '#FFFFFF',
                 fillOpacity: 0.3,
             },
             ramps = {
@@ -889,7 +891,10 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
 
         if (loadValue !== null &&
             ['TotalN', 'TotalP', 'Sediment'].indexOf(load) >= 0) {
-            return _.defaults({ fillColor: ramps[load](loadValue) }, defaultStyle);
+            return _.defaults({
+                fillColor: ramps[load](loadValue),
+                fillOpacity: fillOpacity,
+            }, defaultStyle);
         } else {
             return defaultStyle;
         }
@@ -897,7 +902,6 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
 
     getHighlightStyle: function() {
         return _.defaults({
-            fillOpacity: 0.4,
             color: '#1d3331'
         }, this.getStyle());
     },

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -12,7 +12,9 @@ var $ = require('jquery'),
     turfErase = require('turf-erase'),
     turfIntersect = require('turf-intersect'),
     AoiVolumeModel = require('./tr55/models').AoiVolumeModel,
-    makeColorRamp = require('./gwlfe/subbasin/models').makeColorRamp,
+    subbasinModels = require('./gwlfe/subbasin/models'),
+    makeColorRamp = subbasinModels.makeColorRamp,
+    ColorSchemes = subbasinModels.ColorSchemes,
     round = utils.toRoundedLocaleString;
 
 var ModelPackageControlModel = Backbone.Model.extend({
@@ -881,9 +883,9 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
                 fillOpacity: 0.3,
             },
             ramps = {
-                TotalN: makeColorRamp([0, 2, 5, 10, 20]),
-                TotalP: makeColorRamp([0, 0.2, 0.5, 1.0, 2.0]),
-                Sediment: makeColorRamp([0, 200, 500, 1000, 2000]),
+                TotalN: makeColorRamp([0, 2, 5, 10, 20], ColorSchemes.catchment),
+                TotalP: makeColorRamp([0, 0.2, 0.5, 1.0, 2.0], ColorSchemes.catchment),
+                Sediment: makeColorRamp([0, 200, 500, 1000, 2000], ColorSchemes.catchment),
             },
             loadingRates = self.get('TotalLoadingRates'),
             loadValue = loadingRates && loadingRates.hasOwnProperty(load) &&
@@ -917,9 +919,9 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
                 fill: false
             },
             ramps = {
-                TotalN: makeColorRamp([0, 1, 3, 6, 12]),
-                TotalP: makeColorRamp([0, 0.08, 0.2, 0.5, 1.0]),
-                Sediment: makeColorRamp([0, 8, 20, 50, 150]),
+                TotalN: makeColorRamp([0, 1, 3, 6, 12], ColorSchemes.stream),
+                TotalP: makeColorRamp([0, 0.08, 0.2, 0.5, 1.0], ColorSchemes.stream),
+                Sediment: makeColorRamp([0, 8, 20, 50, 150], ColorSchemes.stream),
             },
             concentrationRates = self.get('LoadingRateConcentrations'),
             loadValue = concentrationRates &&

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -876,7 +876,7 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
             defaultStyle = {
                 stroke: true,
                 color: 'grey',
-                weight: 2,
+                weight: 1,
                 opacity: 1,
                 fill: true,
                 fillColor: '#FFFFFF',
@@ -904,6 +904,7 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
 
     getHighlightStyle: function() {
         return _.defaults({
+            weight: 2,
             color: '#1d3331'
         }, this.getStyle());
     },
@@ -914,7 +915,7 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
             defaultStyle = {
                 stroke: true,
                 color: '#49B8EA', // $water in _variables.scss
-                weight: 2,
+                weight: 3,
                 opacity: 1,
                 fill: false
             },
@@ -937,9 +938,8 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
     },
 
     getStreamHighlightStyle: function() {
-        return _.defaults({
-            weight: 3,
-        }, this.getStreamStyle());
+        // No changes for highlighting streams
+        return this.getStreamStyle();
     }
 });
 


### PR DESCRIPTION
## Overview

Minor fixes and tweaks to the way the catchments and streams are colored. Now we switch the colored catchments (when a related layer is selected, e.g. Total N, Total P, or Sediments) to be fully opaque. In the future there will be an opacity slider that adjusts this.

The base color of the catchments has been changed from grey to white, which make the blue streams _slightly_ easier to see. A tweak has also been made to ensure that the stream lines are always in front of the catchment.

Connects #2850 

### Demo

![2018-05-30 14 57 30](https://user-images.githubusercontent.com/1430060/40741720-2743a9d8-641a-11e8-8a0e-4e6270c1e28d.gif)

Tagging @ajrobbins for visual review.

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/) and select a HUC-10 or HUC-8. Choose MapShed, choose subbasin.
* In the subbasin view, select a HUC-12 to inspect. Select a related layer. Ensure the values on the map are colored according to [the ramp](https://docs.google.com/spreadsheets/d/1Hlf_Uv1vl7hQ5hGl-A4t7J_EzQ1Vht1Q2heOg8pwBoE).