### PR TITLE
Ignore old projects, bad data with no AoI names

### DIFF
--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -667,6 +667,13 @@ var utils = {
     //     parseAoIName('Schuylkill, HUC-8 Watershed (ID 02040203)') =>
     //     { primary: 'Schuylkill, HUC-8 Watershed', suffix: '02040203' }
     parseAoIName: function(name) {
+        if (!name) {
+            return {
+                primary: '',
+                suffix: '',
+            };
+        }
+
         var idIndex = name.indexOf('(ID');
 
         return {


### PR DESCRIPTION
## Overview

When we added code to parse the AoI name in #2842, we didn't account for cases where no name might be present. This is the case with really old projects, at least in my account on staging. To fix this, we handle the empty case.

Connects #2860 

### Demo

![image](https://user-images.githubusercontent.com/1430060/40748619-04b12dea-642f-11e8-8e57-cdb99cf35d5c.png)

## Testing Instructions

* Check out `release/1.23.0` and `bundle --debug`
* Run this query in your database to simulate a project with no area of interest name:
    ```sql
    UPDATE modeling_project SET area_of_interest_name = NULL WHERE id = 1;
    ```
* Go to [:8000/projects/](http://localhost:8000/projects/) and see the empty list and an error in your console
* Check out this branch and `bundle --debug`
* Refresh the page. You should no longer see an error in the console.