### PR TITLE
Remove 4XX and 5XX CloudWatch alarms

### DIFF
--- a/deployment/cfn/application.py
+++ b/deployment/cfn/application.py
@@ -7,7 +7,6 @@ from troposphere import (
     Base64,
     Join,
     Equals,
-    cloudwatch as cw,
     ec2,
     elasticloadbalancing as elb,
     autoscaling as asg
@@ -279,8 +278,6 @@ class Application(StackNode):
         self.create_auto_scaling_resources(app_server_security_group,
                                            app_server_lb,
                                            backward_compat_app_server_lb)
-
-        self.create_cloud_watch_resources(app_server_lb)
 
         self.add_output(Output('AppServerLoadBalancerEndpoint',
                                Value=GetAtt(app_server_lb, 'DNSName')))
@@ -633,47 +630,6 @@ class Application(StackNode):
                 '    permissions: 0750\n',
                 '    owner: root:mmw\n',
                 '    content: ', Ref(self.client_app_user_password)]
-
-    def create_cloud_watch_resources(self, app_server_lb):
-        self.add_resource(cw.Alarm(
-            'alarmAppServerBackend4XX',
-            AlarmDescription='Application server backend 4XXs',
-            AlarmActions=[Ref(self.notification_topic_arn)],
-            Statistic='Sum',
-            Period=300,
-            Threshold='20',
-            EvaluationPeriods=1,
-            ComparisonOperator='GreaterThanThreshold',
-            MetricName='HTTPCode_Backend_4XX',
-            Namespace='AWS/ELB',
-            Dimensions=[
-                cw.MetricDimension(
-                    'metricLoadBalancerName',
-                    Name='LoadBalancerName',
-                    Value=Ref(app_server_lb)
-                )
-            ],
-        ))
-
-        self.add_resource(cw.Alarm(
-            'alarmAppServerBackend5XX',
-            AlarmDescription='Application server backend 5XXs',
-            AlarmActions=[Ref(self.notification_topic_arn)],
-            Statistic='Sum',
-            Period=60,
-            Threshold='0',
-            EvaluationPeriods=1,
-            ComparisonOperator='GreaterThanThreshold',
-            MetricName='HTTPCode_Backend_5XX',
-            Namespace='AWS/ELB',
-            Dimensions=[
-                cw.MetricDimension(
-                    'metricLoadBalancerName',
-                    Name='LoadBalancerName',
-                    Value=Ref(app_server_lb)
-                )
-            ],
-        ))
 
     def get_tags(self, **kwargs):
         """Helper method to return Troposphere tags + default tags

--- a/deployment/cfn/tile_delivery_network.py
+++ b/deployment/cfn/tile_delivery_network.py
@@ -6,7 +6,6 @@ from troposphere import (
     GetAtt,
     Join,
     cloudfront as cf,
-    cloudwatch as cw,
     route53 as r53,
     s3
 )
@@ -107,56 +106,6 @@ class TileDeliveryNetwork(StackNode):
             )
         ))
 
-        self.add_resource(cw.Alarm(
-            'alarmTileDistributionBlueOrigin4XX',
-            AlarmDescription='Tile distribution origin 4XXs',
-            AlarmActions=[Ref(self.notification_topic_arn)],
-            Statistic='Average',
-            Period=300,
-            Threshold='20',
-            EvaluationPeriods=1,
-            ComparisonOperator='GreaterThanThreshold',
-            MetricName='4xxErrorRate',
-            Namespace='AWS/CloudFront',
-            Dimensions=[
-                cw.MetricDimension(
-                    'metricDistributionId',
-                    Name='DistributionId',
-                    Value=Ref(blue_tile_distribution)
-                ),
-                cw.MetricDimension(
-                    'metricRegion',
-                    Name='Region',
-                    Value='Global'
-                )
-            ]
-        ))
-
-        self.add_resource(cw.Alarm(
-            'alarmTileDistributionBlueOrigin5XX',
-            AlarmDescription='Tile distribution origin 5XXs',
-            AlarmActions=[Ref(self.notification_topic_arn)],
-            Statistic='Average',
-            Period=60,
-            Threshold='0',
-            EvaluationPeriods=1,
-            ComparisonOperator='GreaterThanThreshold',
-            MetricName='5xxErrorRate',
-            Namespace='AWS/CloudFront',
-            Dimensions=[
-                cw.MetricDimension(
-                    'metricDistributionId',
-                    Name='DistributionId',
-                    Value=Ref(blue_tile_distribution)
-                ),
-                cw.MetricDimension(
-                    'metricRegion',
-                    Name='Region',
-                    Value='Global'
-                )
-            ]
-        ))
-
         green_tile_distribution = self.add_resource(cf.Distribution(
             'tileDistributionGreen',
             DistributionConfig=cf.DistributionConfig(
@@ -178,56 +127,6 @@ class TileDeliveryNetwork(StackNode):
                 ),
                 Enabled=True
             )
-        ))
-
-        self.add_resource(cw.Alarm(
-            'alarmTileDistributionGreenOrigin4XX',
-            AlarmDescription='Tile distribution origin 4XXs',
-            AlarmActions=[Ref(self.notification_topic_arn)],
-            Statistic='Average',
-            Period=300,
-            Threshold='20',
-            EvaluationPeriods=1,
-            ComparisonOperator='GreaterThanThreshold',
-            MetricName='4xxErrorRate',
-            Namespace='AWS/CloudFront',
-            Dimensions=[
-                cw.MetricDimension(
-                    'metricDistributionId',
-                    Name='DistributionId',
-                    Value=Ref(green_tile_distribution)
-                ),
-                cw.MetricDimension(
-                    'metricRegion',
-                    Name='Region',
-                    Value='Global'
-                )
-            ]
-        ))
-
-        self.add_resource(cw.Alarm(
-            'alarmTileDistributionGreenOrigin5XX',
-            AlarmDescription='Tile distribution origin 5XXs',
-            AlarmActions=[Ref(self.notification_topic_arn)],
-            Statistic='Average',
-            Period=60,
-            Threshold='0',
-            EvaluationPeriods=1,
-            ComparisonOperator='GreaterThanThreshold',
-            MetricName='5xxErrorRate',
-            Namespace='AWS/CloudFront',
-            Dimensions=[
-                cw.MetricDimension(
-                    'metricDistributionId',
-                    Name='DistributionId',
-                    Value=Ref(green_tile_distribution)
-                ),
-                cw.MetricDimension(
-                    'metricRegion',
-                    Name='Region',
-                    Value='Global'
-                )
-            ]
         ))
 
         return blue_tile_distribution, green_tile_distribution

--- a/deployment/cfn/tiler.py
+++ b/deployment/cfn/tiler.py
@@ -7,7 +7,6 @@ from troposphere import (
     Base64,
     Join,
     Equals,
-    cloudwatch as cw,
     ec2,
     elasticloadbalancing as elb,
     autoscaling as asg,
@@ -212,8 +211,6 @@ class Tiler(StackNode):
 
         self.create_auto_scaling_resources(tile_server_security_group,
                                            tile_server_lb)
-
-        self.create_cloud_watch_resources(tile_server_lb)
 
         self.create_dns_records(tile_server_lb)
 
@@ -424,47 +421,6 @@ class Tiler(StackNode):
                 '    permissions: 0440\n',
                 '    owner: root:mmw\n',
                 '    content: ', self.get_input('RollbarServerSideAccessToken')]  # NOQA
-
-    def create_cloud_watch_resources(self, tile_server_lb):
-        self.add_resource(cw.Alarm(
-            'alarmTileServerBackend4XX',
-            AlarmDescription='Tile server backend 4XXs',
-            AlarmActions=[Ref(self.notification_topic_arn)],
-            Statistic='Sum',
-            Period=300,
-            Threshold='20',
-            EvaluationPeriods=1,
-            ComparisonOperator='GreaterThanThreshold',
-            MetricName='HTTPCode_Backend_4XX',
-            Namespace='AWS/ELB',
-            Dimensions=[
-                cw.MetricDimension(
-                    'metricLoadBalancerName',
-                    Name='LoadBalancerName',
-                    Value=Ref(tile_server_lb)
-                )
-            ],
-        ))
-
-        self.add_resource(cw.Alarm(
-            'alarmTileServerBackend5XX',
-            AlarmDescription='Tile server backend 5XXs',
-            AlarmActions=[Ref(self.notification_topic_arn)],
-            Statistic='Sum',
-            Period=60,
-            Threshold='0',
-            EvaluationPeriods=1,
-            ComparisonOperator='GreaterThanThreshold',
-            MetricName='HTTPCode_Backend_5XX',
-            Namespace='AWS/ELB',
-            Dimensions=[
-                cw.MetricDimension(
-                    'metricLoadBalancerName',
-                    Name='LoadBalancerName',
-                    Value=Ref(tile_server_lb)
-                )
-            ],
-        ))
 
     def create_dns_records(self, tile_server_lb):
         self.add_condition('BlueCondition', Equals('Blue', Ref(self.color)))


### PR DESCRIPTION
## Overview

We currently depend on Panopta and Rollbar to surface issues with the application and tile servers. This change set removes CloudWatch alarms from the following CloudFormation stacks:

- `application`
- `tiler`
- `tile_delivery_network`
- `worker`

Resolves https://github.com/WikiWatershed/model-my-watershed/issues/2830

## Testing Instructions

The following Jenkins build published these changes to staging:

http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-staging-deployment/1092/console

In addition, navigate to the CloudWatch alarms listing and ensure that only `DataPlane` alarms are present:

https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY