### PR TITLE
Monitor: Limit CUAHSI /values/ to 5s

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/templates/gunicorn.py.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/gunicorn.py.j2
@@ -2,6 +2,7 @@ import multiprocessing
 
 bind = "127.0.0.1:8000"
 workers = (2 * multiprocessing.cpu_count()) + 1
+timeout = 60
 
 {% if ['development', 'test'] | some_are_in(group_names) -%}
 accesslog = "-"
@@ -9,12 +10,10 @@ errorlog = "-"
 loglevel = 'debug'
 preload_app = False
 reload = True
-timeout = 1800
 {% else %}
 accesslog = None
 errorlog = "{{ app_gunicorn_log }}"
 loglevel = 'info'
 preload_app = True
 reload = False
-timeout = 60
 {% endif %}

--- a/src/mmw/apps/bigcz/clients/cuahsi/details.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/details.py
@@ -10,6 +10,8 @@ from rest_framework.exceptions import ValidationError
 
 from django.conf import settings
 
+from apps.bigcz.utils import ValuesTimedOutError
+
 DATE_FORMAT = '%m/%d/%Y'
 
 
@@ -29,7 +31,7 @@ def details(wsdl, site):
     return wof.get_site_info(wsdl, site, None)
 
 
-@timeout(settings.BIGCZ_CLIENT_TIMEOUT)
+@timeout(settings.BIGCZ_CLIENT_TIMEOUT, timeout_exception=ValuesTimedOutError)
 # NOTE: This @timeout decorator will have to be modified for a multi-threaded
 # environment, with the use_signals=false attribute. Unfortunately, that does
 # not support functions that return values that cannot be pickled, such as this

--- a/src/mmw/apps/bigcz/clients/cuahsi/details.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/details.py
@@ -4,8 +4,11 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from datetime import date, timedelta
+from timeout_decorator import timeout
 
 from rest_framework.exceptions import ValidationError
+
+from django.conf import settings
 
 DATE_FORMAT = '%m/%d/%Y'
 
@@ -26,6 +29,16 @@ def details(wsdl, site):
     return wof.get_site_info(wsdl, site, None)
 
 
+@timeout(settings.BIGCZ_CLIENT_TIMEOUT)
+# NOTE: This @timeout decorator will have to be modified for a multi-threaded
+# environment, with the use_signals=false attribute. Unfortunately, that does
+# not support functions that return values that cannot be pickled, such as this
+# very function, since suds responses are dynamic objects and not pickleable.
+# In this case, we may have to deserialize the values herein. Read more here:
+# https://github.com/pnpnpn/timeout-decorator#multithreading
+# Alternatively, if https://github.com/ulmo-dev/ulmo/issues/155 is addressed,
+# we can use the native timeout capabilities surfaced in Ulmo instead of this
+# wrapper decorator.
 def values(wsdl, site, variable, from_date=None, to_date=None):
     if not wsdl:
         raise ValidationError({

--- a/src/mmw/apps/bigcz/utils.py
+++ b/src/mmw/apps/bigcz/utils.py
@@ -7,6 +7,9 @@ import csv
 
 from apps.bigcz.models import BBox
 
+from django.conf import settings
+
+from rest_framework import status
 from rest_framework.exceptions import APIException
 import dateutil.parser
 
@@ -53,6 +56,13 @@ class RequestTimedOutError(APIException):
     status_code = 408
     default_detail = 'Requested resource timed out.'
     default_code = 'request_timeout'
+
+
+class ValuesTimedOutError(APIException):
+    status_code = status.HTTP_504_GATEWAY_TIMEOUT
+    default_detail = \
+        'Request for values did not finish in {} seconds'.format(
+            settings.BIGCZ_CLIENT_TIMEOUT)
 
 
 def read_unicode_csv(utf8_data, **kwargs):

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -762,6 +762,13 @@ var CuahsiVariable = Backbone.Model.extend({
         params.from_date = params.from_date.format(DATE_FORMAT);
         params.to_date = params.to_date.format(DATE_FORMAT);
 
+        if (params.from_date === 'Invalid date' ||
+            params.to_date === 'Invalid date') {
+            this.set('error', 'Invalid date');
+
+            return $.Deferred().reject('Invalid date');
+        }
+
         this.set('error', null);
 
         return this.fetch({

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -769,7 +769,10 @@ var CuahsiVariable = Backbone.Model.extend({
                 processData: true,
             })
             .fail(function(error) {
-                self.set('error', 'Error ' + error.status + ' during fetch');
+                var detail =
+                    (error.responseJSON && error.responseJSON.detail) || '';
+                self.set('error',
+                    'Error ' + error.status + ' during fetch. ' + detail);
             });
     },
 

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -28,3 +28,4 @@ numpy==1.13.0
 hs_restclient==1.2.10
 six==1.11.0
 fiona==1.7.11
+timeout-decorator==0.4.0


### PR DESCRIPTION
## Overview

Adds a 5s timeout to CUAHSI /values/ endpoint, which was tying up workers and causing app VM cycles on staging.

Note that if the front-end times out, the user can always go back to the result list and click the same result again, and we'll attempt to re-fetch it. This is useful for cases like NWISUV, which can sometimes have occasional failures, while still protecting from EnviroDIY, which fails consistently.

Also reduce gunicorn timeout on development builds to match production.

Connects #2859 

### Demo

Rare partial failure with NWISUV:

![2018-06-04 10 46 01](https://user-images.githubusercontent.com/1430060/40924491-57767530-67e5-11e8-8885-cc1bc4b1acd2.gif)

Common total failure with EnviroDIY:

![2018-06-04 10 47 50](https://user-images.githubusercontent.com/1430060/40924503-6380a436-67e5-11e8-9db2-9b472339df29.gif)

### Notes

I initially found [this Stack Overflow post](https://stackoverflow.com/a/2282656/6995854) for how to implement it, but ultimately went with [a library](https://github.com/pnpnpn/timeout-decorator) that does the same thing with a clean API.

## Testing Instructions

* Check out this PR and `bundle --debug`
* Go to [:8000/](http://localhost:8000/) and select the Lower Schuylkill HUC-10
* Go to Monitor tab, search for "water" and select the CUAHSI WDC tab
* Click through to any result. Ensure none of the values have requests active for more than 5 seconds.
  - For EnviroDIY, this should be all values
  - For every other data source, the data should come through