### PR TITLE
Subbasin: Layer Legend and Opacity

### DIFF
--- a/src/mmw/apps/home/templates/home/home.html
+++ b/src/mmw/apps/home/templates/home/home.html
@@ -12,6 +12,7 @@
 <div id="map"></div>
 <div class="layerpicker" id="layer-picker-region"></div>
 <div id="layer-picker-slider-region"></div>
+<div id="subbasin-slider-region"></div>
 <div id="boundary-label"></div>
 {% endblock map %}
 

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -26,6 +26,7 @@ var MapModel = Backbone.Model.extend({
         dataCatalogActiveResult: null,  // Model
         dataCatalogDetailResult: null,  // Model
         selectedGeocoderArea: null,     // GeoJSON
+        subbasinOpacity: 0.85,
     },
 
     revertMaskLayer: function() {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -1191,20 +1191,23 @@ var MapView = Marionette.ItemView.extend({
             geom = catchment.get('shape');
 
         return new L.GeoJSON(geom, {
-            style: catchment.getStyle(),
+            style: catchment.getStyle(this.model.get('subbasinOpacity')),
             id: catchment.get('id'),
             onEachFeature: function(feature, layer) {
                 var highlightLayer = function() {
+                    var opacity = self.model.get('subbasinOpacity');
+
                     if (catchment.get('highlighted')) {
-                        layer.setStyle(catchment.getHighlightStyle());
+                        layer.setStyle(catchment.getHighlightStyle(opacity));
                         layer.bringToFront();
                     } else {
-                        layer.setStyle(catchment.getStyle());
+                        layer.setStyle(catchment.getStyle(opacity));
                         self.bringActiveSubbasinToFront();
                     }
                 };
 
                 self.listenTo(catchment, 'change:highlighted', highlightLayer);
+                self.listenTo(self.model, 'change:subbasinOpacity', highlightLayer);
 
                 layer.on('mouseover', function() {
                     catchment.set('highlighted', true);

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -106,6 +106,7 @@ var RootView = Marionette.LayoutView.extend({
         geocodeSearchRegion: '#geocode-search-region',
         layerPickerRegion: '#layer-picker-region',
         layerPickerSliderRegion: '#layer-picker-slider-region',
+        subbasinSliderRegion: '#subbasin-slider-region',
         subHeaderRegion: '#sub-header',
         sidebarRegion: {
             regionClass: TransitionRegion,

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -1200,7 +1200,9 @@ var MapView = Marionette.ItemView.extend({
 
                     if (catchment.get('highlighted')) {
                         layer.setStyle(catchment.getHighlightStyle(opacity));
-                        layer.bringToFront();
+                        if (layer._map) {
+                            layer.bringToFront();
+                        }
                     } else {
                         layer.setStyle(catchment.getStyle(opacity));
                         self.bringActiveSubbasinToFront();

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -59,27 +59,28 @@ var dataCatalogDetailStyle = {
 
 var subbasinHuc12Style = {
     stroke: true,
-    color: '#40c4c4',
-    weight: 2,
-    opacity: 1,
+    color: '#E77471',
+    weight: 1.2,
+    opacity: 0.75,
     fill: true,
     fillOpacity: 0,
 };
 
 var subbasinHuc12HighlightedStyle = {
     stroke: true,
-    color: '#1d3331',
-    weight: 2,
-    opacity: 1,
+    color: '#E77471',
+    weight: 1.2,
+    opacity: 0.75,
     fill: true,
-    fillOpacity: 0,
+    fillColor: '#E77471',
+    fillOpacity: 0.2,
 };
 
 var subbasinHuc12ActiveStyle = {
     stroke: true,
-    color: '#dbba29',
+    color: '#E77471',
     weight: 5,
-    opacity: 1,
+    opacity: 0.75,
     fill: false,
 };
 

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
@@ -24,7 +24,7 @@ var ColorSchemes = {
         '#000000',
     ],
     stream: [
-        '#00602D',
+        '#007A39',
         '#00E72A',
         '#EBFF5B',
         '#FF6508',

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/models.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var Backbone = require('../../../../shim/backbone'),
+    _ = require('lodash'),
     d3 = require('d3');
 
 var SubbasinTabModel = Backbone.Model.extend({
@@ -13,6 +14,19 @@ var SubbasinTabModel = Backbone.Model.extend({
 var SubbasinTabCollection = Backbone.Collection.extend({
     model: SubbasinTabModel,
 });
+
+var Breaks = {
+    catchment: {
+        TotalN: [0, 2, 5, 10, 20],
+        TotalP: [0, 0.2, 0.5, 1.0, 2.0],
+        Sediment: [0, 200, 500, 1000, 2000],
+    },
+    stream: {
+        TotalN: [0, 1, 3, 6, 12],
+        TotalP: [0, 0.08, 0.2, 0.5, 1.0],
+        Sediment: [0, 8, 20, 50, 150],
+    }
+};
 
 var ColorSchemes = {
     catchment: [
@@ -44,9 +58,16 @@ function makeColorRamp(values, colorScheme) {
     return d3.scale.linear().domain(domain).range(colorScheme);
 }
 
+var ColorRamps = _.mapValues(Breaks, function(breakSets, scheme) {
+    return _.mapValues(breakSets, function(breaks) {
+        return makeColorRamp(breaks, ColorSchemes[scheme]);
+    });
+});
+
 module.exports = {
     SubbasinTabModel: SubbasinTabModel,
     SubbasinTabCollection: SubbasinTabCollection,
-    makeColorRamp: makeColorRamp,
+    Breaks: Breaks,
     ColorSchemes: ColorSchemes,
+    ColorRamps: ColorRamps,
 };

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerLegend.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerLegend.html
@@ -8,7 +8,7 @@
        value="{{ sliderValue }}"
 >
 <div class="stream-units-label">
-    Mean Annual Concentration<br />(mg/L)
+    Mean Annual Concentration (mg/L)
 </div>
 <div class="climate-legend-unit-breaks-labels">
     <div class="climate-legend-label-values">
@@ -53,5 +53,5 @@
     </div>
 </div>
 <div class="catchment-units-label">
-    Loading Rate<br />(kg/ha/y)
+    Loading Rate (kg/ha/y)
 </div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerLegend.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerLegend.html
@@ -1,0 +1,1 @@
+<div>Here is where the legend will go.</div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerLegend.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerLegend.html
@@ -1,1 +1,57 @@
-<div>Here is where the legend will go.</div>
+<div class="main-label">{{ label }}</div>
+<input title="Drag to change opacity of overlay"
+       type="range"
+       min="0"
+       max="99"
+       step="3"
+       class="subbasin-slider custom-slider"
+       value="{{ sliderValue }}"
+>
+<div class="stream-units-label">
+    Mean Annual Concentration<br />(mg/L)
+</div>
+<div class="climate-legend-unit-breaks-labels">
+    <div class="climate-legend-label-values">
+        {% for break in streamBreaks %}
+            {% if loop.last %}
+                <div class="climate-legend-label-value max">
+                    {{break}}
+                </div>
+            {% else %}
+                <div class="climate-legend-label-value">
+                    {{break}}
+                </div>
+            {% endif %}
+        {% endfor %}
+    </div>
+    <div class="climate-legend-label-ticks">
+        {% for break in streamBreaks %}
+            <div class="climate-legend-label-tick"></div>
+        {% endfor %}
+    </div>
+</div>
+<div class="legend-stream"></div>
+<div class="legend-catchment"></div>
+<div class="climate-legend-unit-breaks-labels">
+    <div class="climate-legend-label-ticks">
+        {% for break in catchmentBreaks %}
+            <div class="climate-legend-label-tick"></div>
+        {% endfor %}
+    </div>
+    <div class="climate-legend-label-values">
+        {% for break in catchmentBreaks %}
+            {% if loop.last %}
+                <div class="climate-legend-label-value max">
+                    {{break}}
+                </div>
+            {% else %}
+                <div class="climate-legend-label-value">
+                    {{break}}
+                </div>
+            {% endif %}
+        {% endfor %}
+    </div>
+</div>
+<div class="catchment-units-label">
+    Loading Rate<br />(kg/ha/y)
+</div>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerSelector.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/layerSelector.html
@@ -5,15 +5,15 @@
             <i class="fa fa-check" aria-hidden="true"></i>
         </a>
     {% else %}
-        {{ layers.length }} related layers
+        3 related layers
     {% endif %}
     <span class="caret"></span>
 </button>
 <ul class="dropdown-menu dropdown-menu-left catchment-layer-dropdown">
-    {% for layer in layers %}
-        <li><a href="#" class="layer-option" data-layer-id="{{ layer.id }}">
-            {{ layer.name }}
-            {%  if selectedLoad == layer.id %}
+    {% for id, name in layers %}
+        <li><a href="#" class="layer-option" data-layer-id="{{ id }}">
+            {{ name }}
+            {%  if selectedLoad == id %}
                 <i class="fa fa-check" aria-hidden="true"></i>
             {% endif %}
         </a></li>

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -7,6 +7,7 @@ var Marionette = require('../../../../shim/backbone.marionette'),
     models = require('./models'),
     resultTmpl = require('./templates/result.html'),
     layerSelectorTmpl = require('./templates/layerSelector.html'),
+    layerLegendTmpl = require('./templates/layerLegend.html'),
     tableTabContentTmpl = require('./templates/tableTabContent.html'),
     tableTabPanelTmpl = require('./templates/tableTabPanel.html'),
     huc12TotalsTableTmpl = require('./templates/huc12TotalsTable.html'),
@@ -104,7 +105,22 @@ var LayerSelectorView = Marionette.ItemView.extend({
         } else {
             this.model.set('selectedLoad', newLoad);
         }
+    },
+
+    onRender: function() {
+        if (this.model.get('selectedLoad')) {
+            App.rootView.subbasinSliderRegion.show(new LayerLegendView({
+                model: App.map,
+            }));
+        } else {
+            App.rootView.subbasinSliderRegion.empty();
+        }
     }
+});
+
+var LayerLegendView = Marionette.ItemView.extend({
+    // model: MapModel,
+    template: layerLegendTmpl,
 });
 
 var TableTabPanelView = Marionette.ItemView.extend({

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -66,6 +66,12 @@ var ResultView = Marionette.LayoutView.extend({
     }
 });
 
+var LABELS = {
+    TotalN: 'Total Nitrogen',
+    TotalP: 'Total Phosphorous',
+    Sediment: 'Total Sediments',
+};
+
 var LayerSelectorView = Marionette.ItemView.extend({
     // model: SubbasinDetailModel
     template: layerSelectorTmpl,
@@ -80,17 +86,11 @@ var LayerSelectorView = Marionette.ItemView.extend({
     },
 
     templateHelpers: function() {
-        var layers = [
-                { id: 'TotalN', name: 'Total Nitrogen' },
-                { id: 'TotalP', name: 'Total Phosphorous' },
-                { id: 'Sediment', name: 'Total Sediments' }
-            ],
-            selectedLoad = this.model.get('selectedLoad'),
-            selectedLoadName = selectedLoad &&
-                               _.findWhere(layers, { id: selectedLoad }).name;
+        var selectedLoad = this.model.get('selectedLoad'),
+            selectedLoadName = selectedLoad && LABELS[selectedLoad];
 
         return {
-            layers: layers,
+            layers: LABELS,
             selectedLoad: selectedLoad,
             selectedLoadName: selectedLoadName,
         };

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -111,6 +111,8 @@ var LayerSelectorView = Marionette.ItemView.extend({
         if (this.model.get('selectedLoad')) {
             App.rootView.subbasinSliderRegion.show(new LayerLegendView({
                 model: App.map,
+                selectedLoad: this.model.get('selectedLoad'),
+                leafletMap: App.getLeafletMap(),
             }));
         } else {
             App.rootView.subbasinSliderRegion.empty();
@@ -121,6 +123,36 @@ var LayerSelectorView = Marionette.ItemView.extend({
 var LayerLegendView = Marionette.ItemView.extend({
     // model: MapModel,
     template: layerLegendTmpl,
+
+    events: {
+        'mousedown input': 'onMouseDown',
+        'mouseup input': 'onMouseUp',
+    },
+
+    templateHelpers: function() {
+        var load = this.selectedLoad;
+
+        return {
+            streamBreaks: models.Breaks.stream[load],
+            catchmentBreaks: models.Breaks.catchment[load],
+            label: LABELS[load],
+            sliderValue: this.model.get('subbasinOpacity') * 100,
+        };
+    },
+
+    initialize: function(options) {
+        this.leafletMap = options.leafletMap;
+        this.selectedLoad = options.selectedLoad;
+    },
+
+    onMouseDown: function() {
+        this.leafletMap.dragging.disable();
+    },
+
+    onMouseUp: function(e) {
+        this.model.set('subbasinOpacity', Number(e.target.value) / 100);
+        this.leafletMap.dragging.enable();
+    }
 });
 
 var TableTabPanelView = Marionette.ItemView.extend({

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -869,10 +869,9 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
         selectedLoad: null,   // one of: null, TotalN, TotalP, Sediment
     },
 
-    getStyle: function() {
+    getStyle: function(fillOpacity) {
         var self = this,
             load = this.get('selectedLoad'),
-            fillOpacity = 1,
             defaultStyle = {
                 stroke: true,
                 color: 'grey',
@@ -902,11 +901,11 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
         }
     },
 
-    getHighlightStyle: function() {
+    getHighlightStyle: function(fillOpacity) {
         return _.defaults({
             weight: 2,
             color: '#1d3331'
-        }, this.getStyle());
+        }, this.getStyle(fillOpacity));
     },
 
     getStreamStyle: function() {

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -13,8 +13,7 @@ var $ = require('jquery'),
     turfIntersect = require('turf-intersect'),
     AoiVolumeModel = require('./tr55/models').AoiVolumeModel,
     subbasinModels = require('./gwlfe/subbasin/models'),
-    makeColorRamp = subbasinModels.makeColorRamp,
-    ColorSchemes = subbasinModels.ColorSchemes,
+    ColorRamps = subbasinModels.ColorRamps,
     round = utils.toRoundedLocaleString;
 
 var ModelPackageControlModel = Backbone.Model.extend({
@@ -881,11 +880,7 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
                 fillColor: '#FFFFFF',
                 fillOpacity: 0.3,
             },
-            ramps = {
-                TotalN: makeColorRamp([0, 2, 5, 10, 20], ColorSchemes.catchment),
-                TotalP: makeColorRamp([0, 0.2, 0.5, 1.0, 2.0], ColorSchemes.catchment),
-                Sediment: makeColorRamp([0, 200, 500, 1000, 2000], ColorSchemes.catchment),
-            },
+            ramps = ColorRamps.catchment,
             loadingRates = self.get('TotalLoadingRates'),
             loadValue = loadingRates && loadingRates.hasOwnProperty(load) &&
                         loadingRates[load] / self.get('area');
@@ -918,11 +913,7 @@ var SubbasinCatchmentDetailModel = Backbone.Model.extend({
                 opacity: 1,
                 fill: false
             },
-            ramps = {
-                TotalN: makeColorRamp([0, 1, 3, 6, 12], ColorSchemes.stream),
-                TotalP: makeColorRamp([0, 0.08, 0.2, 0.5, 1.0], ColorSchemes.stream),
-                Sediment: makeColorRamp([0, 8, 20, 50, 150], ColorSchemes.stream),
-            },
+            ramps = ColorRamps.stream,
             concentrationRates = self.get('LoadingRateConcentrations'),
             loadValue = concentrationRates &&
                         concentrationRates.hasOwnProperty(load) &&

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -192,3 +192,18 @@
     padding: 10px 0;
   }
 }
+
+#subbasin-slider-region {
+  position: absolute;
+  z-index: 400;
+  left: 265px;
+  bottom: 102px;
+  padding: 8px;
+  width: 150px;
+  background-color: $paper;
+  box-shadow: 0 0 6px $black-74;
+
+  &:empty {
+    display: none;
+  }
+}

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -197,9 +197,9 @@
   position: absolute;
   z-index: 400;
   left: 265px;
-  bottom: 23px;
+  bottom: 22px;
   padding: 8px;
-  width: 200px;
+  width: 250px;
   background-color: $paper;
   box-shadow: 0 0 6px $black-74;
 

--- a/src/mmw/sass/pages/_model.scss
+++ b/src/mmw/sass/pages/_model.scss
@@ -197,13 +197,55 @@
   position: absolute;
   z-index: 400;
   left: 265px;
-  bottom: 102px;
+  bottom: 23px;
   padding: 8px;
-  width: 150px;
+  width: 200px;
   background-color: $paper;
   box-shadow: 0 0 6px $black-74;
 
   &:empty {
     display: none;
+  }
+
+  .subbasin-slider {
+    padding: 12px 10px 13px 10px;
+  }
+
+  .legend-stream {
+    height: 10px;
+    margin: 30px 10px 0 9px;
+    background: linear-gradient(90deg,
+                                #007A39   0%,
+                                #00E72A  25%,
+                                #EBFF5B  50%,
+                                #FF6508  75%,
+                                #CB1A00 100%);
+  }
+
+  .legend-catchment {
+    height: 10px;
+    margin: 0 10px -2px 9px;
+    background: linear-gradient(90deg,
+                                #00A151   0%,
+                                #8BDE65  25%,
+                                #FCFFBC  50%,
+                                #FF9555  75%,
+                                #FF6B55 100%);
+  }
+
+  .main-label {
+    text-align: center;
+    font-weight: bold;
+  }
+
+  .stream-units-label {
+    font-size: 0.8em;
+    text-align: center;
+  }
+
+  .catchment-units-label {
+    font-size: 0.8em;
+    text-align: center;
+    margin-top: 30px;
   }
 }


### PR DESCRIPTION
## Overview

Adds a opacity slider and legend box next to the layer picker for a related subbasin layer when selected.

Connects #2821 

### Demo

![2018-06-04 18 59 52](https://user-images.githubusercontent.com/1430060/40946106-d96214e8-6829-11e8-96ab-239cef40cb0c.gif)

There is some lag above because of GIF recording using up the CPU, that is not visible otherwise. Note that the opacity slider adjusts opacity of the catchment fill, not the stream stroke. None of our stroke layers support opacity, so I didn't add them here either. It would be easy to add if we want it though.

Tagging @ajrobbins, @jfrankl for visual review.

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/) and select a HUC-10 and go into subbasin mode
* Ensure the HUC-12 boundaries now use Red instead of the previous Blue for their outline
* Select a HUC-12. Ensure it uses Red instead of the previous Yellow for its outline
* Select a related layer. Ensure its legend and opacity control are shown next to the layer picker.
* Unselect a related layer. Ensure the legend / opacity control go away.
* Select a different related layer. Ensure the legend is properly updated, and that the opacity value persists.
* Turn on a Climate layer, such as Mean Precipitation or Temperature. Ensure the time slider (with the months) is not visible (or rather, hidden behind) the legend / opacity control of a subbasin layer.