### PR TITLE
Monitor: Fix CINERGI

### DIFF
--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -197,7 +197,7 @@ def parse_record(item):
     links = parse_links(source)
     begin_date, end_date = parse_time_period(source.get('timeperiod_nst'))
     return CinergiResource(
-        id=item['_id'],
+        id=item['id'],
         title=source['title'],
         description=parse_description(source.get('description')),
         author=None,
@@ -296,11 +296,11 @@ def search(**kwargs):
 
     data = response.json()
 
-    if 'hits' not in data:
+    if 'results' not in data:
         raise ValueError(data)
 
-    results = data['hits']['hits']
-    count = data['hits']['total']
+    results = data['results']
+    count = data['total']
 
     return ResourceList(
         api_url=response.url,

--- a/src/mmw/apps/bigcz/clients/cinergi/search.py
+++ b/src/mmw/apps/bigcz/clients/cinergi/search.py
@@ -11,7 +11,7 @@ from django.contrib.gis.geos import Polygon
 from django.conf import settings
 
 from apps.bigcz.models import ResourceLink, ResourceList
-from apps.bigcz.utils import RequestTimedOutError
+from apps.bigcz.utils import RequestTimedOutError, UnexpectedResponseError
 
 from apps.bigcz.clients.cinergi.models import CinergiResource
 
@@ -297,7 +297,7 @@ def search(**kwargs):
     data = response.json()
 
     if 'results' not in data:
-        raise ValueError(data)
+        raise UnexpectedResponseError()
 
     results = data['results']
     count = data['total']

--- a/src/mmw/apps/bigcz/utils.py
+++ b/src/mmw/apps/bigcz/utils.py
@@ -49,6 +49,11 @@ def get_bounds(aoi):
     return BBox(min(x_coords), min(y_coords), max(x_coords), max(y_coords))
 
 
+class UnexpectedResponseError(APIException):
+    status_code = 500
+    default_detail = 'Unexpected response from data service provider.'
+
+
 class RequestTimedOutError(APIException):
     status_code = 408
     default_detail = 'Requested resource timed out.'

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -405,7 +405,7 @@ MMW_MAX_AREA = 75000  # Max area in km2, about the size of West Virginia
 
 BIGCZ_HOST = 'portal.bigcz.org'  # BiG-CZ Host, for enabling custom behavior
 BIGCZ_MAX_AREA = 5000  # Max area in km2, limited by CUAHSI
-BIGCZ_CLIENT_TIMEOUT = 5  # timeout in seconds
+BIGCZ_CLIENT_TIMEOUT = 8  # timeout in seconds
 BIGCZ_CLIENT_PAGE_SIZE = 100
 
 # ITSI Portal Settings


### PR DESCRIPTION
## Overview

The CINERGI API response was changed recently, although it is unclear when this happened. Thankfully, most of the schema we expect is still preserved in the `_source` key of the response, so we can keep parsing it with minimal modifications.

Connects #2867 

### Demo

![image](https://user-images.githubusercontent.com/1430060/41045924-66901a4c-6977-11e8-901c-f4c50d62f983.png)

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/), select a shape and go to the Monitor tab
* Search for "water". Switch to the CINERGI tab. Ensure you see results.
  - A lot of the results will have "Unknown Time Period" or no contact people, or people listed in the contact organizations field. This is just the data we're given, and same as before.