### PR TITLE
Fix MapShed modification tooltip in Safari

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -795,7 +795,7 @@ var GwlfeToolbarView = ScenarioModelToolbarView.extend({
 
     onThumbClick: function(e) {
         var modKey = $(e.currentTarget).data('value'),
-            thumbOffset = $(e.target).offset();
+            thumbOffset = e.target.getBoundingClientRect();
 
         this.model.set('activeModKey', modKey);
 


### PR DESCRIPTION
## Overview

`$().offset()` doesn't work in Safari, returning `{top: 0, left: 0}` in all cases. We switch to using the Event Target `.getBoundingClientRect()` which works for all browsers. There are no other instances of `$().offset()` in the code.

Connects #2849 

### Demo

Safari:

![image](https://user-images.githubusercontent.com/1430060/41055976-b4724992-6990-11e8-8233-10bbdd2d6df2.png)

Firefox:

![image](https://user-images.githubusercontent.com/1430060/41055990-bbfc97f8-6990-11e8-9efb-1c4e7b2cea68.png)

Chrome:

![image](https://user-images.githubusercontent.com/1430060/41056003-cbdf8d60-6990-11e8-96dd-25cb35a2bf44.png)

IE11:

![image](https://user-images.githubusercontent.com/1430060/41056017-d600a50e-6990-11e8-975d-71be134789f8.png)

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/) in Safari and log in. Either create a new MapShed project or open an existing one
* Add a new scenario and a couple of modifications
* Click a modification. Ensure its tooltip is shown next to it.
* Open various browsers and go to the same scenario and check the tooltips therein.