### PR TITLE
Adjust SedAAdjust to 1.5

### DIFF
--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -404,7 +404,7 @@ def soiln(result):
 
     result = parse(result)
 
-    soiln = result.values()[0] * 7.0
+    soiln = result.values()[0] * 8.0
 
     return {
         'soiln': soiln

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -57,7 +57,7 @@ GWLFE_DEFAULTS = {
     'CountyFlag': b.NO,  # Flag: County Layer Detected (0 No; 1 Yes)
     'SoilPFlag': b.YES,  # Flag: Soil P Layer Detected (0 No; 1 Yes)
     'GWNFlag': b.YES,  # Flag: Groundwater N Layer Detected (0 No; 1 Yes)
-    'SedAAdjust': 1.4,  # Default Percent ET
+    'SedAAdjust': 1.5,  # Default Percent ET
     'BankNFrac': 0.25,  # % Bank N Fraction (0 - 1)
     'BankPFrac': 0.25,  # % Bank P Fraction (0 - 1)
     'ManuredAreas': 2,  # Manure Spreading Periods (Default = 2)


### PR DESCRIPTION
## Overview

Per the request in #2824, this PR adjusts the SedAAdjust constant for GWLFE to be 1.5 instead of 1.4.

Connects #2824

### Notes

~We may have already changed the SedNitr value in this PR -- https://github.com/WikiWatershed/model-my-watershed/pull/2563 -- which changed it from 4.0 to 7.0.~

~The document linked from #2824 requests changing it from 4.0 -> 7.0; however the quote in the issue indicated 6.0. Not certain which value to keep.~

@mmcfarland confirmed that the new value should be 6.0, so that change was made in 8f8e847

## Testing Instructions

- get, build, and serve this branch, then run a mapshed job and verify that it still works
