### PR TITLE
Monitor: Add WQP, Anonymize IP Addresses

### DIFF
--- a/src/mmw/apps/core/templates/head.html
+++ b/src/mmw/apps/core/templates/head.html
@@ -20,6 +20,7 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '{{ GOOGLE_ANALYTICS_ACCOUNT }}', 'auto');
+        ga('set', 'anonymizeIp', true);
         ga('send', 'pageview');
     </script>
 </head>

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -10,7 +10,6 @@ var BAD_REQUEST_CODE = 400;
 var REQUEST_TIMED_OUT_CODE = 408;
 var DESCRIPTION_MAX_LENGTH = 100;
 var PAGE_SIZE = settings.get('data_catalog_page_size');
-var BIGCZ = settings.get('data_catalog_enabled');
 
 var DATE_FORMAT = 'MM/DD/YYYY';
 var WATERML_VARIABLE_TIME_INTERVAL = '{http://www.cuahsi.org/water_ml/1.1/}variable_time_interval';
@@ -904,53 +903,49 @@ var ExpandableListModel = Backbone.Model.extend({
 });
 
 function createCatalogCollection() {
-    var dateFilter = new DateFilter(),
-        catalogs = new Catalogs([
-            new Catalog({
-                id: 'hydroshare',
-                name: 'HydroShare',
-                active: true,
-                results: new Results(null, { catalog: 'hydroshare' }),
-                filters: new FilterCollection([
-                    dateFilter,
-                    new PrivateResourcesFilter(),
-                ]),
-            }),
-            new Catalog({
-                id: 'cuahsi',
-                name: 'CUAHSI WDC',
-                is_pageable: false,
-                results: new Results(null, { catalog: 'cuahsi' }),
-                serverResults: new Results(null, { catalog: 'cuahsi' }),
-                filters: new FilterCollection([
-                    dateFilter,
-                    new GriddedServicesFilter(),
-                ]),
-            }),
-            new Catalog({
-                id: 'cinergi',
-                name: 'CINERGI',
-                results: new Results(null, { catalog: 'cinergi' }),
-                filters: new FilterCollection([
-                    dateFilter,
-                ]),
-            }),
-        ]);
+    var dateFilter = new DateFilter();
 
-    if (BIGCZ) {
-        catalogs.push(new Catalog({
+    return new Catalogs([
+        new Catalog({
+            id: 'hydroshare',
+            name: 'HydroShare',
+            active: true,
+            results: new Results(null, { catalog: 'hydroshare' }),
+            filters: new FilterCollection([
+                dateFilter,
+                new PrivateResourcesFilter(),
+            ]),
+        }),
+        new Catalog({
+            id: 'cuahsi',
+            name: 'CUAHSI WDC',
+            is_pageable: false,
+            results: new Results(null, { catalog: 'cuahsi' }),
+            serverResults: new Results(null, { catalog: 'cuahsi' }),
+            filters: new FilterCollection([
+                dateFilter,
+                new GriddedServicesFilter()
+            ])
+        }),
+        new Catalog({
+            id: 'cinergi',
+            name: 'CINERGI',
+            results: new Results(null, { catalog: 'cinergi' }),
+            filters: new FilterCollection([
+                dateFilter,
+            ]),
+        }),
+        new Catalog({
             id: 'usgswqp',
             name: 'WQP',
             is_pageable: false,
             results: new Results(null, { catalog: 'usgswqp' }),
             serverResults: new Results(null, { catalog: 'usgswqp' }),
             filters: new FilterCollection([
-                dateFilter,
-            ]),
-        }));
-    }
-
-    return catalogs;
+                dateFilter
+            ])
+        })
+    ]);
 }
 
 module.exports = {


### PR DESCRIPTION
## Overview

Adds WQP to Monitor since it has not exhibited any issues in its BiG-CZ deployment (restricted to BiG-CZ in #2856). It is now available as a fourth tab in Monitor.

Also anonymizes IP addresses of users in Google Analytics. The issue #2875 gives instructions for `gtag.js`, but we currently use `analytics.js`, so I found and used instructions for that. There is a [migration guide](https://developers.google.com/analytics/devguides/collection/gtagjs/migration#track_events) for upgrading to `gtag.js`, but we [most likely don't need to](https://reflectivedata.com/gtag-js-migrate/):

> ##### Using `analytics.js`
> This scenario is probably applicable to most websites on the web. As this solution is working fine and will continue to be most popular snippet for years (probably), there is no rush for migrating. You have the widest range of tutorials and third-party support.

Furthermore, changing all the tracking code added in #2480 would have been outside the scope of this card. We can revisit this in the future if we need to.

Connects #2884 
Connects #2875 

### Demo

Monitor:

![image](https://user-images.githubusercontent.com/1430060/42698077-dafc9060-868a-11e8-9e49-8c6b3c59446e.png)

BiG-CZ:

![image](https://user-images.githubusercontent.com/1430060/42698083-dfc32988-868a-11e8-910a-36968236ac3c.png)

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and select a shape. Go to Monitor and search for Water. Click the final tab of WQP and ensure the search works.
* Go to [:8000/?bigcz](http://localhost:8000/?bigcz) and do the same. Ensure the search works.