### PR TITLE
Add DRB Urban Land Cover 2011 tile layer to app

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -212,6 +212,22 @@ LAYER_GROUPS = {
             'big_cz': False,
         },
         {
+            'display': 'DRB Urban Land 2011 Baseline',
+            'code': 'urban-land-cover-2011-30m',
+            'css_class_prefix': 'urban-land-cover-2011-30m',
+            'short_display': '2011 Urban Land Cover',
+            'url': 'https://{s}.tiles.azavea.com/urban-land-cover-2011-30m/{z}/{x}/{y}.png',  # NOQA
+            'maxNativeZoom': 13,
+            'maxZoom': 18,
+            'opacity': 0.618,
+            'has_opacity_slider': True,
+            'legend_mapping': {
+                'nonurban': 'Non-urban area',
+                'urban': 'Urban area',
+            },
+            'big_cz': False,
+        },
+        {
             'display': 'DRB Urban Land 2050 Business as Usual',
             'code': 'shippensburg-2050-baseline-30m',
             'css_class_prefix': 'shippensburg-2050',

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -161,6 +161,14 @@ span.time-slider-end {
 
 .layerpicker-legenditem {
   @include clearfix;
+
+  > .urban-land-cover-2011-30m-nonurban {
+    background-color: rgba(255, 255, 255, 1);
+  }
+
+  > .urban-land-cover-2011-30m-urban {
+    background-color: rgba(183, 28, 28, 1);
+  }
 }
 
 .layerpicker-legendcolor {


### PR DESCRIPTION
## Overview

Add DRB Urban Land Cover 2011 tile layer, using similar settings to the existing Shippensburg layers.

Connects #2864

### Demo

![screen shot 2018-07-25 at 5 32 39 pm](https://user-images.githubusercontent.com/4165523/43228876-d857449a-9030-11e8-9345-da7924c8d936.png)

## Testing Instructions

- get and build this branch (`./scripts/bundle.sh --vendor`), then serve it and visit the app
- turn on the "DRB Urban Land Cover 2011" layer and verify that it works