### PR TITLE
Add Marker for Coordinate, Address Search

### DIFF
--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -27,6 +27,7 @@ var MapModel = Backbone.Model.extend({
         dataCatalogDetailResult: null,  // Model
         selectedGeocoderArea: null,     // GeoJSON
         subbasinOpacity: 0.85,
+        searchResult: null,             // [lat, lng]
     },
 
     revertMaskLayer: function() {

--- a/src/mmw/js/src/core/views.js
+++ b/src/mmw/js/src/core/views.js
@@ -301,6 +301,7 @@ var MapView = Marionette.ItemView.extend({
         'change:selectedGeocoderArea': 'renderSelectedGeocoderArea',
         'change:subbasinHuc12s': 'renderSubbasinHuc12s',
         'change:subbasinCatchments': 'renderSubbasinCatchments',
+        'change:searchResult': 'renderSearchResult',
     },
 
     // L.Map instance.
@@ -309,6 +310,10 @@ var MapView = Marionette.ItemView.extend({
     // Active "area of interest" shape on the map.
     // L.FeatureGroup instance.
     _areaOfInterestLayer: null,
+
+    // For showing points, etc. that users searched for
+    // L.FeatureGroup instance
+    _searchResultLayer: null,
 
     // Scenario modification shapes drawn on top of area of interest.
     // L.FeatureGroup instance.
@@ -356,6 +361,7 @@ var MapView = Marionette.ItemView.extend({
 
         this._leafletMap = map;
         this._areaOfInterestLayer = new L.FeatureGroup();
+        this._searchResultLayer = new L.FeatureGroup();
         this._modificationsLayer = new L.FeatureGroup();
         this._dataCatalogResultsLayer = new L.FeatureGroup();
         this._dataCatalogActiveLayer = new L.FeatureGroup();
@@ -399,6 +405,7 @@ var MapView = Marionette.ItemView.extend({
         }
 
         map.addLayer(this._areaOfInterestLayer);
+        map.addLayer(this._searchResultLayer);
         map.addLayer(this._modificationsLayer);
         map.addLayer(this._dataCatalogResultsLayer);
         map.addLayer(this._dataCatalogActiveLayer);
@@ -1254,6 +1261,16 @@ var MapView = Marionette.ItemView.extend({
             var layer = new L.GeoJSON(geom, { style: selectedGeocoderAreaStyle });
             this._leafletMap.fitBounds(layer.getBounds(), { reset: true });
             this._selectedGeocoderAreaLayer.addLayer(layer);
+        }
+    },
+
+    renderSearchResult: function() {
+        var point = this.model.get('searchResult');
+
+        this._searchResultLayer.clearLayers();
+
+        if (point && _.isArray(point) && point.length === 2) {
+            this._searchResultLayer.addLayer(L.marker(point));
         }
     }
 });

--- a/src/mmw/js/src/draw/controllers.js
+++ b/src/mmw/js/src/draw/controllers.js
@@ -41,6 +41,7 @@ var DrawController = {
     },
 
     drawCleanUp: function() {
+        App.map.set('searchResult', null);
         App.rootView.geocodeSearchRegion.empty();
         App.rootView.footerRegion.empty();
     },

--- a/src/mmw/js/src/geocode/models.js
+++ b/src/mmw/js/src/geocode/models.js
@@ -31,6 +31,7 @@ var LocationModel = Backbone.Model.extend({
             App.map.set({
                 lat: lat,
                 lng: lng,
+                searchResult: [lat, lng],
                 zoom: zoom || this.get('zoom')
             });
 
@@ -50,11 +51,13 @@ var SuggestionModel = Backbone.Model.extend({
 
     setMapViewToLocation: function(zoom) {
         var lat = this.get('y'),
-            lng = this.get('x');
+            lng = this.get('x'),
+            addMarker = !this.get('isBoundaryLayer');
         if (lat && lng) {
             App.map.set({
                 lat: lat,
                 lng: lng,
+                searchResult: addMarker ? [lat, lng] : null,
                 zoom: zoom || this.get('zoom')
             });
         }


### PR DESCRIPTION
## Overview

Adds a maker to the map when search for coordinates or an address. Does not do it when selecting a HUC. Removes it when moving to Analyze.

🚀 🐦 

Connects #2891 

### Demo

![2018-07-30 16 21 45](https://user-images.githubusercontent.com/1430060/43421478-de299d86-9414-11e8-9fc3-ee883a7638bb.gif)

### Notes

I tried overloading `selectedGeocoderArea` for this, since theoretically it is only used for highlighting the HUC in the exactly exclusive case (of HUC search, _not_ coordinate or address), but the resulting logic was too complicated and hard to follow, so I ended up adding `searchResult` as a field on the `map` object.

## Testing Instructions

* Check out this branch, `bundle`, go to [:8000/](http://localhost:8000/)
* Search for coordinates. Ensure you see a marker.
* Search for an address. Ensure you see a marker.
* Ensure there is at most one marker on the map at any time.
* Search for a HUC. Ensure you don't see a marker.
* Search for something so that you see a marker. Then move to Analyze. Ensure you don't see the marker anymore.