### PR TITLE
Celerify HydroShare Export

### DIFF
--- a/src/mmw/apps/export/hydroshare.py
+++ b/src/mmw/apps/export/hydroshare.py
@@ -47,9 +47,9 @@ class HydroShareService(OAuth2Service):
 
         return token
 
-    def renew_access_token(self, user):
+    def renew_access_token(self, user_id):
         # TODO Add checks for when user not found, refresh_token is null
-        token = HydroShareToken.objects.get(user=user)
+        token = HydroShareToken.objects.get(user_id=user_id)
         data = {'refresh_token': token.refresh_token,
                 'grant_type': 'refresh_token'}
 
@@ -63,11 +63,11 @@ class HydroShareService(OAuth2Service):
 
         return token
 
-    def get_client(self, user):
+    def get_client(self, user_id):
         # TODO Add check for when user not found
-        token = HydroShareToken.objects.get(user=user)
+        token = HydroShareToken.objects.get(user_id=user_id)
         if token.is_expired:
-            token = self.renew_access_token(user)
+            token = self.renew_access_token(user_id)
 
         auth = HydroShareAuthOAuth2(CLIENT_ID, CLIENT_SECRET,
                                     token=token.get_oauth_dict())

--- a/src/mmw/apps/export/migrations/0002_hydroshare_disable_autosync.py
+++ b/src/mmw/apps/export/migrations/0002_hydroshare_disable_autosync.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def disable_hydroshare_autosync(apps, schema_editor):
+    HydroShareResource = apps.get_model('export', 'HydroShareResource')
+    HydroShareResource.objects.all().update(autosync=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('export', '0001_hydroshareresource'),
+    ]
+
+    operations = [
+        migrations.RunPython(disable_hydroshare_autosync)
+    ]

--- a/src/mmw/apps/export/tasks.py
+++ b/src/mmw/apps/export/tasks.py
@@ -146,7 +146,7 @@ def create_resource(user_id, project_id, params):
         project=project,
         resource=resource,
         title=params.get('title', project.name),
-        autosync=params.get('autosync', True),
+        autosync=params.get('autosync', False),
         exported_at=now()
     )
     hsresource.save()

--- a/src/mmw/apps/export/tasks.py
+++ b/src/mmw/apps/export/tasks.py
@@ -29,7 +29,7 @@ MMW_APP_KEY_FLAG = '{"appkey": "model-my-watershed"}'
 BMP_SPREADSHEET_TOOL_URL = 'https://github.com/WikiWatershed/MMW-BMP-spreadsheet-tool/raw/master/MMW_BMP_Spreadsheet_Tool.xlsx'  # NOQA
 
 
-@shared_task
+@shared_task(time_limit=300)
 def update_resource(user_id, project_id, params):
     hs = hss.get_client(user_id)
     hsresource = HydroShareResource.objects.get(project_id=project_id)
@@ -66,7 +66,7 @@ def update_resource(user_id, project_id, params):
     return serializer.data
 
 
-@shared_task
+@shared_task(time_limit=300)
 def create_resource(user_id, project_id, params):
     hs = hss.get_client(user_id)
     project = Project.objects.get(pk=project_id)

--- a/src/mmw/apps/export/tasks.py
+++ b/src/mmw/apps/export/tasks.py
@@ -14,6 +14,7 @@ from celery import shared_task
 from django.utils.timezone import now
 from django.contrib.gis.geos import GEOSGeometry
 
+from apps.core.models import Job
 from apps.modeling.models import Project
 from apps.modeling.tasks import to_gms_file
 
@@ -47,12 +48,19 @@ def update_resource(user_id, project_id, params):
     # Update files
     files = params.get('files', [])
     for md in params.get('mapshed_data', []):
-        mdata = md.get('data')
-        files.append({
-            'name': md.get('name'),
-            'contents': to_gms_file(json.loads(mdata)) if mdata else None,
-            'object': True
-        })
+        muuid = md.get('uuid')
+        if muuid:
+            try:
+                job = Job.objects.get(uuid=muuid)
+                mdata = json.loads(job.result)
+                files.append({
+                    'name': md.get('name'),
+                    'contents': to_gms_file(mdata),
+                    'object': True,
+                })
+            except (Job.DoesNotExist, ValueError):
+                # Either the job wasn't found, or its content isn't JSON
+                pass
 
     # Except the existing analyze files
     files = [f for f in files if f['name'] not in current_analyze_files]
@@ -96,12 +104,19 @@ def create_resource(user_id, project_id, params):
 
     # MapShed Data
     for md in params.get('mapshed_data', []):
-        mdata = md.get('data')
-        files.append({
-            'name': md.get('name'),
-            'contents': to_gms_file(json.loads(mdata)) if mdata else None,
-            'object': True
-        })
+        muuid = md.get('uuid')
+        if muuid:
+            try:
+                job = Job.objects.get(uuid=muuid)
+                mdata = json.loads(job.result)
+                files.append({
+                    'name': md.get('name'),
+                    'contents': to_gms_file(mdata),
+                    'object': True,
+                })
+            except (Job.DoesNotExist, ValueError):
+                # Either the job wasn't found, or its content isn't JSON
+                pass
 
     # Add all files
     hs.add_files(resource, files)

--- a/src/mmw/apps/export/tasks.py
+++ b/src/mmw/apps/export/tasks.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import fiona
+import io
+import json
+import os
+import requests
+
+from celery import shared_task
+
+from django.utils.timezone import now
+from django.contrib.gis.geos import GEOSGeometry
+
+from apps.modeling.models import Project
+from apps.modeling.tasks import to_gms_file
+
+from hydroshare import HydroShareService
+from models import HydroShareResource
+from serializers import HydroShareResourceSerializer
+
+hss = HydroShareService()
+
+SHAPEFILE_EXTENSIONS = ['cpg', 'dbf', 'prj', 'shp', 'shx']
+DEFAULT_KEYWORDS = {'mmw', 'model-my-watershed'}
+MMW_APP_KEY_FLAG = '{"appkey": "model-my-watershed"}'
+BMP_SPREADSHEET_TOOL_URL = 'https://github.com/WikiWatershed/MMW-BMP-spreadsheet-tool/raw/master/MMW_BMP_Spreadsheet_Tool.xlsx'  # NOQA
+
+
+@shared_task
+def update_resource(user_id, project_id, params):
+    hs = hss.get_client(user_id)
+    hsresource = HydroShareResource.objects.get(project_id=project_id)
+
+    existing_files = hs.get_file_list(hsresource.resource)
+    if not existing_files:
+        raise RuntimeError('HydroShare could not find requested resource')
+
+    current_analyze_files = [
+        f['url'][(1 + f['url'].index('/analyze_')):]
+        for f in existing_files
+        if '/analyze_' in f['url']
+    ]
+
+    # Update files
+    files = params.get('files', [])
+    for md in params.get('mapshed_data', []):
+        mdata = md.get('data')
+        files.append({
+            'name': md.get('name'),
+            'contents': to_gms_file(json.loads(mdata)) if mdata else None,
+            'object': True
+        })
+
+    # Except the existing analyze files
+    files = [f for f in files if f['name'] not in current_analyze_files]
+
+    hs.add_files(hsresource.resource, files, overwrite=True)
+
+    hsresource.exported_at = now()
+    hsresource.save()
+
+    serializer = HydroShareResourceSerializer(hsresource)
+    return serializer.data
+
+
+@shared_task
+def create_resource(user_id, project_id, params):
+    hs = hss.get_client(user_id)
+    project = Project.objects.get(pk=project_id)
+
+    # Convert keywords from array to set of values
+    keywords = params.get('keywords')
+    keywords = set(keywords) if keywords else set()
+
+    # POST new resource creates it in HydroShare
+    resource = hs.createResource(
+        'CompositeResource',
+        params.get('title', project.name),
+        abstract=params.get('abstract', ''),
+        keywords=tuple(DEFAULT_KEYWORDS | keywords),
+        extra_metadata=MMW_APP_KEY_FLAG,
+    )
+
+    # Files sent from the client
+    files = params.get('files', [])
+
+    # AoI GeoJSON
+    aoi_geojson = GEOSGeometry(project.area_of_interest).geojson
+    files.append({
+        'name': 'area-of-interest.geojson',
+        'contents': aoi_geojson,
+    })
+
+    # MapShed Data
+    for md in params.get('mapshed_data', []):
+        mdata = md.get('data')
+        files.append({
+            'name': md.get('name'),
+            'contents': to_gms_file(json.loads(mdata)) if mdata else None,
+            'object': True
+        })
+
+    # Add all files
+    hs.add_files(resource, files)
+
+    # AoI Shapefile
+    aoi_json = json.loads(aoi_geojson)
+    crs = {'no_defs': True, 'proj': 'longlat',
+           'ellps': 'WGS84', 'datum': 'WGS84'}
+    schema = {'geometry': aoi_json['type'], 'properties': {}}
+    with fiona.open('/tmp/{}.shp'.format(resource), 'w',
+                    driver='ESRI Shapefile',
+                    crs=crs, schema=schema) as shapefile:
+        shapefile.write({'geometry': aoi_json, 'properties': {}})
+
+    for ext in SHAPEFILE_EXTENSIONS:
+        filename = '/tmp/{}.{}'.format(resource, ext)
+        with open(filename) as shapefile:
+            hs.addResourceFile(resource, shapefile,
+                               'area-of-interest.{}'.format(ext))
+        os.remove(filename)
+
+    # MapShed BMP Spreadsheet Tool
+    if params.get('mapshed_data'):
+        response = requests.get(BMP_SPREADSHEET_TOOL_URL,
+                                allow_redirects=True, stream=True)
+        hs.addResourceFile(resource, io.BytesIO(response.content),
+                           'MMW_BMP_Spreadsheet_Tool.xlsx')
+
+    # Make resource public and shareable
+    endpoint = hs.resource(resource)
+    endpoint.public(True)
+    endpoint.shareable(True)
+
+    # Add geographic coverage
+    endpoint.functions.set_file_type({
+        'file_path': 'area-of-interest.shp',
+        'hs_file_type': 'GeoFeature',
+    })
+
+    # Link HydroShareResrouce to Project and save
+    hsresource = HydroShareResource.objects.create(
+        project=project,
+        resource=resource,
+        title=params.get('title', project.name),
+        autosync=params.get('autosync', True),
+        exported_at=now()
+    )
+    hsresource.save()
+
+    # Make Project public and save
+    project.is_private = False
+    project.save()
+
+    # Return newly created HydroShareResource
+    serializer = HydroShareResourceSerializer(hsresource)
+    return serializer.data

--- a/src/mmw/apps/export/urls.py
+++ b/src/mmw/apps/export/urls.py
@@ -5,10 +5,14 @@ from __future__ import division
 
 from django.conf.urls import patterns, url
 
+from apps.modeling.views import get_job
+from apps.modeling.urls import uuid_regex
+
 from apps.export.views import hydroshare, shapefile
 
 urlpatterns = patterns(
     '',
     url(r'^hydroshare/?$', hydroshare, name='hydroshare'),
     url(r'^shapefile/?$', shapefile, name='shapefile'),
+    url(r'jobs/' + uuid_regex, get_job, name='get_job'),
 )

--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -4,20 +4,16 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import fiona
-import io
 import json
 import os
-import requests
 import StringIO
 import tempfile
 import zipfile
 
 from django.conf import settings
-from django.contrib.gis.geos import GEOSGeometry
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
-from django.utils.timezone import now
 
 from rest_framework import decorators, status
 from rest_framework.response import Response
@@ -25,18 +21,18 @@ from rest_framework.permissions import IsAuthenticated
 
 from apps.modeling.models import Project
 from apps.modeling.serializers import AoiSerializer
-from apps.modeling.tasks import to_gms_file
+from apps.geoprocessing_api.views import start_celery_job
 
 from hydroshare import HydroShareService
 from models import HydroShareResource
 from serializers import HydroShareResourceSerializer
+from tasks import create_resource, update_resource
 
 hss = HydroShareService()
 HYDROSHARE_BASE_URL = settings.HYDROSHARE['base_url']
 SHAPEFILE_EXTENSIONS = ['cpg', 'dbf', 'prj', 'shp', 'shx']
 DEFAULT_KEYWORDS = {'mmw', 'model-my-watershed'}
 MMW_APP_KEY_FLAG = '{"appkey": "model-my-watershed"}'
-BMP_SPREADSHEET_TOOL_URL = 'https://github.com/WikiWatershed/MMW-BMP-spreadsheet-tool/raw/master/MMW_BMP_Spreadsheet_Tool.xlsx'  # NOQA
 
 
 @decorators.api_view(['GET', 'POST', 'PATCH', 'DELETE'])
@@ -106,130 +102,14 @@ def hydroshare(request):
 
     # POST existing resource updates it
     if hsresource and request.method == 'POST':
-        # Get list of existing files to see if some can be skipped
-        existing_files = hs.get_file_list(hsresource.resource)
-        if not existing_files:
-            return Response(
-                data={
-                    'errors': ['HydroShare could not find requested resource']
-                },
-                status=status.HTTP_404_NOT_FOUND
-            )
-
-        current_analyze_files = [
-            f['url'][(1 + f['url'].index('/analyze_')):]
-            for f in existing_files
-            if '/analyze_' in f['url']
-        ]
-
-        # Update files
-        files = params.get('files', [])
-        for md in params.get('mapshed_data', []):
-            mdata = md.get('data')
-            files.append({
-                'name': md.get('name'),
-                'contents': to_gms_file(json.loads(mdata)) if mdata else None,
-                'object': True
-            })
-
-        # Except the existing analyze files
-        files = [f for f in files if f['name'] not in current_analyze_files]
-
-        hs.add_files(hsresource.resource, files, overwrite=True)
-
-        hsresource.exported_at = now()
-        hsresource.save()
-
-        serializer = HydroShareResourceSerializer(hsresource)
-        return Response(serializer.data)
-
-    # Convert keywords from array to set of values
-    keywords = params.get('keywords')
-    keywords = set(keywords) if keywords else set()
+        return start_celery_job([
+            update_resource.s(request.user.id, project_id, params)
+        ], project_id, request.user)
 
     # POST new resource creates it in HydroShare
-    resource = hs.createResource(
-        'CompositeResource',
-        params.get('title', project.name),
-        abstract=params.get('abstract', ''),
-        keywords=tuple(DEFAULT_KEYWORDS | keywords),
-        extra_metadata=MMW_APP_KEY_FLAG,
-    )
-
-    # Files sent from the client
-    files = params.get('files', [])
-
-    # AoI GeoJSON
-    aoi_geojson = GEOSGeometry(project.area_of_interest).geojson
-    files.append({
-        'name': 'area-of-interest.geojson',
-        'contents': aoi_geojson,
-    })
-
-    # MapShed Data
-    for md in params.get('mapshed_data', []):
-        mdata = md.get('data')
-        files.append({
-            'name': md.get('name'),
-            'contents': to_gms_file(json.loads(mdata)) if mdata else None,
-            'object': True
-        })
-
-    # Add all files
-    hs.add_files(resource, files)
-
-    # AoI Shapefile
-    aoi_json = json.loads(aoi_geojson)
-    crs = {'no_defs': True, 'proj': 'longlat',
-           'ellps': 'WGS84', 'datum': 'WGS84'}
-    schema = {'geometry': aoi_json['type'], 'properties': {}}
-    with fiona.open('/tmp/{}.shp'.format(resource), 'w',
-                    driver='ESRI Shapefile',
-                    crs=crs, schema=schema) as shapefile:
-        shapefile.write({'geometry': aoi_json, 'properties': {}})
-
-    for ext in SHAPEFILE_EXTENSIONS:
-        filename = '/tmp/{}.{}'.format(resource, ext)
-        with open(filename) as shapefile:
-            hs.addResourceFile(resource, shapefile,
-                               'area-of-interest.{}'.format(ext))
-        os.remove(filename)
-
-    # MapShed BMP Spreadsheet Tool
-    if params.get('mapshed_data'):
-        response = requests.get(BMP_SPREADSHEET_TOOL_URL,
-                                allow_redirects=True, stream=True)
-        hs.addResourceFile(resource, io.BytesIO(response.content),
-                           'MMW_BMP_Spreadsheet_Tool.xlsx')
-
-    # Make resource public and shareable
-    endpoint = hs.resource(resource)
-    endpoint.public(True)
-    endpoint.shareable(True)
-
-    # Add geographic coverage
-    endpoint.functions.set_file_type({
-        'file_path': 'area-of-interest.shp',
-        'hs_file_type': 'GeoFeature',
-    })
-
-    # Link HydroShareResrouce to Project and save
-    hsresource = HydroShareResource.objects.create(
-        project=project,
-        resource=resource,
-        title=params.get('title', project.name),
-        autosync=params.get('autosync', True),
-        exported_at=now()
-    )
-    hsresource.save()
-
-    # Make Project public and save
-    project.is_private = False
-    project.save()
-
-    # Return newly created HydroShareResource
-    serializer = HydroShareResourceSerializer(hsresource)
-    return Response(serializer.data, status=status.HTTP_201_CREATED)
+    return start_celery_job([
+        create_resource.s(request.user.id, project_id, params)
+    ], project_id, request.user)
 
 
 @decorators.api_view(['POST'])

--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -44,7 +44,7 @@ BMP_SPREADSHEET_TOOL_URL = 'https://github.com/WikiWatershed/MMW-BMP-spreadsheet
 def hydroshare(request):
     # Get HydroShare client with user's credentials
     try:
-        hs = hss.get_client(request.user)
+        hs = hss.get_client(request.user.id)
     except ObjectDoesNotExist:
         return Response(
             data={'errors': ['User not connected to HydroShare']},

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -67,6 +67,9 @@
                         <span class="hydroshare-timestamp">Last exported: {{ hydroshare.exported_at | toFriendlyDate }}</span>
                         <a href="#" class="hydroshare-export {{ 'hidden' if is_exporting or hydroshare_errors.length > 0 }}">Export Now</a>
                     </p>
+                    {% if has_changed_since_last_export %}
+                        <p>This project has changed since last export.</p>
+                    {% endif %}
                 </div>
                 {% endif %}
             </div>

--- a/src/mmw/js/src/core/modals/templates/multiShareModal.html
+++ b/src/mmw/js/src/core/modals/templates/multiShareModal.html
@@ -63,13 +63,9 @@
                 </p>
                 <div class="hydroshare-autosync-container">
                     <h5>Settings</h5>
-                    <label>
-                        <input type="checkbox" id="hydroshare-autosync" {{ 'checked' if hydroshare.autosync }} />
-                        Automatically push changes to HydroShare
-                    </label>
                     <p>
-                        <span class="hydroshare-timestamp">Last change: {{ hydroshare.exported_at | toFriendlyDate }}</span>
-                        <a href="#" class="hydroshare-export {{ 'hidden' if hydroshare.autosync or is_exporting or hydroshare_errors.length > 0 }}">Export Now</a>
+                        <span class="hydroshare-timestamp">Last exported: {{ hydroshare.exported_at | toFriendlyDate }}</span>
+                        <a href="#" class="hydroshare-export {{ 'hidden' if is_exporting or hydroshare_errors.length > 0 }}">Export Now</a>
                     </p>
                 </div>
                 {% endif %}

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -226,7 +226,6 @@ var MultiShareView = ModalBaseView.extend({
         'hydroShareNotification': '#hydroshare-notification',
         'hydroShareSpinner': '.hydroshare-spinner',
         'hydroShareExport': '.hydroshare-export',
-        'hydroShareAutosync': '#hydroshare-autosync',
         'hydroShareError': '.error-popover',
     },
 
@@ -234,7 +233,6 @@ var MultiShareView = ModalBaseView.extend({
         'click @ui.shareEnabled': 'onLinkToggle',
         'click @ui.hydroShareEnabled': 'connectHydroShare',
         'click @ui.hydroShareExport': 'reExportHydroShare',
-        'click @ui.hydroShareAutosync': 'setHydroShareAutosync',
     }, ModalBaseView.prototype.events),
 
     modelEvents: {
@@ -397,10 +395,6 @@ var MultiShareView = ModalBaseView.extend({
         this.model.exportToHydroShare();
         return false;
     },
-
-    setHydroShareAutosync: function(e) {
-        this.model.setHydroShareAutosync(e.target.checked);
-    }
 });
 
 var HydroShareView = ModalBaseView.extend({

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -240,10 +240,18 @@ var MultiShareView = ModalBaseView.extend({
     },
 
     templateHelpers: function() {
+        var hydroshare = this.model.get('hydroshare'),
+            lastScenarioModifiedAt = _.last(
+                this.model.get('scenarios').pluck('modified_at').sort()),
+            lastHydroShareExportAt = hydroshare && hydroshare.exported_at,
+            hasChangedSinceLastExport = hydroshare &&
+                lastScenarioModifiedAt > lastHydroShareExportAt;
+
         return {
             url: window.location.origin + "/project/" + this.model.id + "/",
             guest: this.options.app.user.get('guest'),
             user_has_authorized_hydroshare: this.options.app.user.get('hydroshare'),
+            has_changed_since_last_export: hasChangedSinceLastExport,
         };
     },
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -708,7 +708,7 @@ var ProjectModel = Backbone.Model.extend({
 
                     return {
                         name: 'model_multiyear_' + scenarioName + '.gms',
-                        data: gisData.model_input
+                        uuid: gisData.mapshed_job_uuid
                     };
                 },
             mapshedData = isTR55 ? [] : scenarios.map(getMapshedData),

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -787,40 +787,6 @@ var ProjectModel = Backbone.Model.extend({
             self.set('is_exporting', false);
         });
     },
-
-    /**
-     * Sets HydroShare Autosync to given value.
-     *
-     * Returns a promise of the AJAX call.
-     */
-    setHydroShareAutosync: function(autosync) {
-        var self = this,
-            hydroshare = self.get('hydroshare');
-
-        self.set({
-            is_exporting: true,
-            hydroshare: _.defaults({
-                autosync: autosync
-            }, hydroshare),
-        });
-
-        return $.ajax({
-            url: '/export/hydroshare?project=' + self.id,
-            type: 'PATCH',
-            contentType: 'application/json',
-            data: JSON.stringify({
-                autosync: autosync
-            })
-        }).done(function () {
-            self.set('hydroshare_errors', []);
-        }) .fail(function(result) {
-            // Restore local state in case update fails
-            self.set('hydroshare', hydroshare);
-            self.set('hydroshare_errors', result.responseJSON.errors);
-        }).always(function() {
-            self.set('is_exporting', false);
-        });
-    },
 });
 
 var ProjectCollection = Backbone.Collection.extend({

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1260,8 +1260,10 @@ var ScenarioModel = Backbone.Model.extend({
         }
 
         if (options.silent) {
-            // Don't reload server values
-            return this.attributes;
+            // Don't reload server values, except for modified_at
+            return _.assign({}, this.attributes, {
+                modified_at: response.modified_at
+            });
         }
 
         this.get('modifications').reset(response.modifications);

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -290,6 +290,7 @@ var HydroShareExportTaskModel = coreModels.TaskModel.extend({
             taskType: 'export',
             taskName: 'hydroshare',
             pollInterval: 6000,
+            timeout: 300000,
         }
     )
 });


### PR DESCRIPTION
## Overview

Since exporting multiple files to HydroShare can take a long time, and projects with multiple scenarios can balloon the number of files really quickly, the exports would time out in some cases.

To mitigate that, we wrap the creation and updating methods for HydroShare resources in Celery Tasks, and return a Job ID instead. This frees the export from the constrains of a request-response cycle, while also not tying up a `gunicorn` worker process.

Celery Tasks have their own timeouts however, and these are set to timeout after 5 minutes. The front-end which polls for these results has the same timeout.

Since these exports take so long, as users add changes in the front-end that can keep being queued for export. But if each export takes ~4 minutes, and each single change triggers an export, we're looking at potentially hours of exports queued up. If the browser is closed, or the user navigates away during this time, the queued exports would be dropped silently. Furthermore, there is no visibility of this queue, or any sort of progress of the exports. Thus, the autosync behavior is too obfuscated with potential data loss for users, which is why the final commit disables it. The autosync options are removed from the UI, all new projects default to it disabled, and a migration turns it off for all currently-syncing HydroShare resources.

~To assist or prompt users to export to HydroShare, we can think about adding a "dirty" or "stale" flag to a HydroShare resource, that can be set when any change to a project is made, and unset when a HydroShare export finishes. This is left to a future task.~

The above has been incorporated here by comparing the last HydroShare export date with the last scenario modification date. If a scenario has been modified more recently than the last export, we add a message to the HydroShare Export modal saying so.

Connects #2885 

### Demo

![image](https://user-images.githubusercontent.com/1430060/43966299-7fa2d74a-9c8f-11e8-929a-5b0108b8acbd.png)

https://beta.hydroshare.org/resource/d1f4f20cd6344b7a809552164cc512a6

![image](https://user-images.githubusercontent.com/1430060/43966360-aea2e5da-9c8f-11e8-8ed1-7fc56ab56cc7.png)

### Notes

I also tried cutting every piece of the export into a Celery Task. That work is vieweable in this diff [hydroshare-celerification-2.patch](https://github.com/WikiWatershed/model-my-watershed/files/2250696/hydroshare-celerification-2.patch.txt). This was suboptimal because since Celery doesn't allow sharing complex objects between tasks, the HydroShare Rest Client could not be shared, and each task would have to create its own which involved making OAuth requests to HydroShare, further slowing down the process. And while splitting up into smaller tasks allowed us to have an unspecified timeout at the Celery level (since each individual task could finish under the default 90s timeout), we would still have a timeout in the front-end, so there is no getting rid of timeouts completely.

### HydroShare Recommendations

There are potential improvements that can be made to the HydroShare API which would help us significantly:

 1. **Support Bulk File Uploads**. Since the most time is spent uploading a file at a time, even though all the files are ready at once, the ability to support bulk file uploads would speed up the process significantly. Probably by an order of magnitude or more. https://github.com/hydroshare/hydroshare/issues/2859 https://github.com/hydroshare/hs_restclient/issues/86

 2. **Allow Overwriting Files**. Currently, if a file already exists in HydroShare, you cannot add it again. We have to first delete that file, then add it. This leads to updates taking twice as long as creation, because for each file we must first delete it then add it. If adding files supported overwriting, this could be done in half the time. https://github.com/hydroshare/hydroshare/issues/2860 https://github.com/hydroshare/hs_restclient/issues/87
 
 3. **Speed Up API Responses**. Currently each API request takes ~1s to turn around. If this was faster the export would be too.

## Testing Instructions

* Populate the `MMW_HYDROSHARE_SECRET_KEY` in the `app` and `worker` VMs using the "HydroShare Beta" item in LastPass
* Go to https://beta.hydroshare.org/ and setup an account if you don't already have one
* Check out this branch, `bundle`, `vagrant ssh app -c 'sudo restart mmw-app'` and `vagrant ssh worker -c 'sudo service celeryd restart'`
* Go to [:8000/](http://localhost:8000/) and log in to an account
* Go to "My Account" → "Linked Accounts" and link to HydroShare (it should automatically connect to the beta site)
* Make a new project. Add a bunch of scenarios to it (I did 11).
* Export to HydroShare. Ensure the export completes successfully.
* Once exported, re-export to HydroShare. Ensure the export completes successfully.
* Make a change to any scenario. Open the HydroShare export dialog. Ensure it has text indicating that there are new changes.
* Test both TR-55 and MapShed projects.