### PR TITLE
Add link to download BMP Spreadsheet Tool

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
+++ b/src/mmw/js/src/modeling/gwlfe/quality/templates/table.html
@@ -44,3 +44,16 @@
 <div class="downloadcsv-link" data-action="download-csv-granular">
     <i class="fa fa-download"></i> Download this data
 </div>
+<div class="download-bmp row">
+    <hr />
+    <div class="col-sm-2 text-center">
+        <i class="fa fa-lightbulb-o"></i>
+    </div>
+    <div class="col-sm-10">
+        <p>
+            Get our <a href="https://github.com/WikiWatershed/MMW-BMP-spreadsheet-tool/raw/master/MMW_BMP_Spreadsheet_Tool.xlsx" target="_blank" rel="noreferrer noopener">BMP spreadsheet tool</a> for advanced simulation of urban BMPs.
+            Designed to help meet permit renewal obligations in Pennsylvania, this tool is also useful for other regions.
+            <a href="https://github.com/WikiWatershed/MMW-BMP-spreadsheet-tool#readme" target="_blank" rel="noreferrer noopener">More...</a>
+        </p>
+    </div>
+</div>

--- a/src/mmw/sass/components/_sidebar.scss
+++ b/src/mmw/sass/components/_sidebar.scss
@@ -10,3 +10,17 @@
       border-width: 1px;
     }
 }
+
+.download-bmp {
+    padding-bottom: 20px;
+
+    hr {
+        margin-top: 0;
+    }
+
+    i {
+        font-size: 32px;
+        color: $ui-medium-light;
+        margin-top: 5px;
+    }
+}


### PR DESCRIPTION
## Overview

Adds link to download BMP Spreadsheet Tool and styles it accordingly. Also links to the documentation. This will only be visible in the Water Quality tab of MapShed projects.

Connects #2893 

### Demo

Firefox

![image](https://user-images.githubusercontent.com/1430060/43549932-130e31fa-95b0-11e8-8c2f-130eeab7d810.png)

Safari

![image](https://user-images.githubusercontent.com/1430060/43549948-1a045296-95b0-11e8-8438-75dea2872cb6.png)

Chrome

![image](https://user-images.githubusercontent.com/1430060/43549973-2de9b38c-95b0-11e8-9f55-fa3d584c8cff.png)

IE11

![image](https://user-images.githubusercontent.com/1430060/43550000-42cc5a0c-95b0-11e8-971c-2e4ae92c51f7.png)

## Testing Instructions

* Check out this branch and `bundle`
* Go to a MapShed (Multi Year) project, and in the Water Quality tab ensure there is a link at the bottom to the BMP Spreadsheet Tool.
* Ensure the spreadsheet and the documentation both open in a new tab, not disrupting the MMW session
* Ensure the links work in Safari
* Test in all major browsers