### PR TITLE
Export BMP Spreadsheet Tool to HydroShare

### DIFF
--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -4,8 +4,10 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import fiona
+import io
 import json
 import os
+import requests
 import StringIO
 import tempfile
 import zipfile
@@ -34,6 +36,7 @@ HYDROSHARE_BASE_URL = settings.HYDROSHARE['base_url']
 SHAPEFILE_EXTENSIONS = ['cpg', 'dbf', 'prj', 'shp', 'shx']
 DEFAULT_KEYWORDS = {'mmw', 'model-my-watershed'}
 MMW_APP_KEY_FLAG = '{"appkey": "model-my-watershed"}'
+BMP_SPREADSHEET_TOOL_URL = 'https://github.com/WikiWatershed/MMW-BMP-spreadsheet-tool/raw/master/MMW_BMP_Spreadsheet_Tool.xlsx'  # NOQA
 
 
 @decorators.api_view(['GET', 'POST', 'PATCH', 'DELETE'])
@@ -191,6 +194,13 @@ def hydroshare(request):
             hs.addResourceFile(resource, shapefile,
                                'area-of-interest.{}'.format(ext))
         os.remove(filename)
+
+    # MapShed BMP Spreadsheet Tool
+    if params.get('mapshed_data'):
+        response = requests.get(BMP_SPREADSHEET_TOOL_URL,
+                                allow_redirects=True, stream=True)
+        hs.addResourceFile(resource, io.BytesIO(response.content),
+                           'MMW_BMP_Spreadsheet_Tool.xlsx')
 
     # Make resource public and shareable
     endpoint = hs.resource(resource)


### PR DESCRIPTION
## Overview

The MMW BMP Spreadsheet Tool has a number of spreadsheets that allow modification and manipulation of BMP data. Stroud hopes to use it in places where MMW doesn't have in-built functionality. By exporting it with the rest of the files to HydroShare, we ensure that users always have immediate access to it, no matter where they download the data from. #2898 added it to the MMW UI. This adds it to they HydroShare export.

The MMW BMP Spreadsheet Tool is fetched from the latest version on GitHub, so it is always the most recent. It will only be added on the first export, not every update afterwards.

Connects #2894 

### Demo

https://beta.hydroshare.org/resource/c7637c31f3bf4496b6851c020764e0d4/

![image](https://user-images.githubusercontent.com/1430060/43605119-758fdff8-9665-11e8-855c-8520db5dd672.png)

## Testing Instructions

* Populate the `MMW_HYDROSHARE_SECRET_KEY` in the `app` and `worker` VMs using the "HydroShare Beta" item in LastPass
* Go to https://beta.hydroshare.org/ and setup an account if you don't already have one
* Check out this branch and go to [:8000/](http://localhost:8000)
* Go to "My Account" → "Linked Accounts" and link to HydroShare (it should automatically connect to the beta site)
* Make a new MapShed project.
* Export to HydroShare. Ensure the export completes successfully.
* Ensure the exported HydroShare Resource has the Spreadsheet Tool on it. Download it from HydroShare and verify.