### PR TITLE
Add hint for entering coordinates

### DIFF
--- a/src/mmw/js/src/geocode/templates/search.html
+++ b/src/mmw/js/src/geocode/templates/search.html
@@ -1,6 +1,11 @@
-<input class="search-input" id="geocoder-search" type="text"
-       placeholder="Jump to location, HUC, or coordinates"
->
+<a data-toggle="popover" tabindex="0"
+   data-html="true" data-container="body" role="button"
+   data-placement="left" data-trigger="focus" data-delay="500"
+   data-content="Enter coordinates as <strong>Lat,Lng</strong><br />(e.g. <strong>32.9526,-75.1652</strong>)">
+    <input class="search-input" id="geocoder-search" type="text"
+           placeholder="Jump to location, HUC, or coordinates"
+    >
+</a>
 <i class="search-icon fa fa-search"></i>
 <button class="search-select-btn hidden">Select</button>
 <div id="geocode-search-results-region"></div>

--- a/src/mmw/js/src/geocode/views.js
+++ b/src/mmw/js/src/geocode/views.js
@@ -80,6 +80,7 @@ var SearchBoxView = Marionette.LayoutView.extend({
     template: searchTmpl,
 
     ui: {
+        'popover': '[data-toggle="popover"]',
         'searchBox': '#geocoder-search',
         'searchIcon': '.search-icon',
         'message': '.message',
@@ -121,6 +122,8 @@ var SearchBoxView = Marionette.LayoutView.extend({
         } else {
             this.ui.searchBox.val(query);
         }
+
+        this.ui.popover.popover();
     },
 
     onDestroy: function() {


### PR DESCRIPTION
## Overview

Since we only accept coordinates in a specific format, add a hint that reveals that format to users. The hint is positioned to the left because there are suggestions below the text box, and no room to the right.

This review should be billed to **NSF**.

Connects #2895 

### Demo

![2018-08-02 16 30 56](https://user-images.githubusercontent.com/1430060/43609285-92a25fba-9671-11e8-9f72-227d6656660a.gif)

Also tagging @ajrobbins and @jfrankl for visual review.

Note: The GIF is a little sped up. The current delay is set to 500ms, but I can make it longer if needed.

### Notes

It feels like if they are searching for an address we shouldn't show this tool tip, but we need to show it when they are _not_ searching for coordinates since we can't parse it as a coordinate. Thus, it always shows after the delay when the search is focused.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/)
* Try searching for something. Ensure you see the hint pop up.
* Ensure the pop up goes away once the search box is not focused.