### PR TITLE
Upgrade GWLF-E to 1.0.1

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -15,7 +15,7 @@ cryptography==2.1.4
 pyOpenSSL==17.4.0
 markdown==2.6.9
 tr55==1.3.0
-git+git://github.com/drexeleds/gwlf-e@develop#egg=gwlf-e
+gwlf-e==1.0.1
 requests[security]==2.9.1
 rollbar==0.13.8
 retry==0.9.1


### PR DESCRIPTION
## Overview

Since the Drexel work has been tested and merged (see https://github.com/WikiWatershed/gwlf-e/pull/81), and released (see https://github.com/WikiWatershed/gwlf-e/releases/tag/1.0.1), we switch to the tagged release from the develop branch.

Connects #2905 

### Note

The code in `gwlf-e==1.0.1` is exactly the same as that in the `drexeleds/develop` branch, which is already deployed to staging. So there won't be any difference in numbers or speed between local and staging. There will, however, be a difference in speed between this and production. This and staging should be 2-4 times faster than the same calculation in production.

## Testing Instructions

* Check out this branch
* Destroy `app` and `worker` VMs
* Create `app` and `worker` VMs
* Populate the `MMW_SRAT_CATCHMENT_API_KEY` from LastPass

      $ vagrant ssh worker -c 'sudo vim /etc/mmw.d/env/MMW_SRAT_CATCHMENT_API_KEY'

* Go to [:8000/](http://localhost:8000/) and create a MapShed project
* Ensure calculations finish successfully
* Go to the water quality tab and go into subbasin mode
* Ensure calculations finish successfully