### PR TITLE
Reorder MultiYear Hydrology Fields

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/runoff/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/runoff/views.js
@@ -10,12 +10,12 @@ var $ = require('jquery'),
     tableTmpl = require('./templates/table.html');
 
 var runoffVars = [
-        { name: 'AvPrecipitation', display: 'Precip' },
-        { name: 'AvEvapoTrans', display: 'ET' },
+        { name: 'AvStreamFlow', display: 'Stream Flow' },
         { name: 'AvRunoff', display: 'Surface Runoff' },
         { name: 'AvGroundWater', display: 'Subsurface Flow' },
         { name: 'AvPtSrcFlow', display: 'Point Src Flow' },
-        { name: 'AvStreamFlow', display: 'Stream Flow' },
+        { name: 'AvEvapoTrans', display: 'ET' },
+        { name: 'AvPrecipitation', display: 'Precip' },
     ],
     monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -159,14 +159,14 @@ var ResultModel = Backbone.Model.extend({
     },
 
     toMapShedHydrologyCSV: function() {
-        var rows = ['"Month","Precip (cm)","ET (cm)","Surface Runoff (cm)","Subsurface Flow (cm)","Point Src Flow (cm)","Stream Flow (cm)"'],
+        var rows = ['"Month","Stream Flow (cm)","Surface Runoff (cm)","Subsurface Flow (cm)","Point Src Flow (cm)","ET (cm)","Precip (cm)"'],
             runoffVars = [
-                    'AvPrecipitation',
-                    'AvEvapoTrans',
+                    'AvStreamFlow',
                     'AvRunoff',
                     'AvGroundWater',
                     'AvPtSrcFlow',
-                    'AvStreamFlow',
+                    'AvEvapoTrans',
+                    'AvPrecipitation',
                 ],
             monthNames = [
                     'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',


### PR DESCRIPTION
## Overview

Update the order of the fields in the dropdown, table, and CSV exports as specified.

Connects #2903 

### Demo

![screen shot 2018-08-10 at 1 47 38 pm](https://user-images.githubusercontent.com/1430060/44036873-da89fae6-9ee0-11e8-9c79-dcd8810236c1.png)

Also tagging @aufdenkampe for visual review.

### Notes

I feel like there should be some tests for the CSV export thing, but given the 🚀 🐦 nature I'm skipping adding those for now.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and draw and analyze a shape. Create a MapShed project.
* Once the analysis finishes, ensure that you see the items in the new order in the dropdown and the table
* Export the table to a CSV. Ensure that the CSV has the columns and values in the same order as the table.
* Export the project to HydroShare. Inspect the CSV there. Ensure that the columns and values are in the same order.