### PR TITLE
Create GWLFE Compare View Hydrology line charts

### DIFF
--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -37,6 +37,8 @@ var LineChartRowModel = Backbone.Model.extend({
         key: '',
         name: '',
         chartDiv: '',
+        data: [],
+        scenarioNames: [],
     },
 });
 

--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -32,6 +32,18 @@ var SelectionOptionsCollection = Backbone.Collection.extend({
     model: SelectionOptionModel,
 });
 
+var LineChartRowModel = Backbone.Model.extend({
+    defaults: {
+        key: '',
+        name: '',
+        chartDiv: '',
+    },
+});
+
+var LineChartRowsCollection = Backbone.Collection.extend({
+    model: LineChartRowModel,
+});
+
 var BarChartRowModel = Backbone.Model.extend({
     defaults: {
         key: '',
@@ -66,6 +78,8 @@ var BarChartRowsCollection = Backbone.Collection.extend({
         });
     }
 });
+
+var GwlfeHydrologyCharts = LineChartRowsCollection.extend();
 
 var Tr55RunoffCharts = BarChartRowsCollection.extend({
     update: function() {
@@ -240,6 +254,8 @@ module.exports = {
     SelectionOptionsCollection: SelectionOptionsCollection,
     ControlsCollection: ControlsCollection,
     BarChartRowModel: BarChartRowModel,
+    LineChartRowModel: LineChartRowModel,
+    GwlfeHydrologyCharts: GwlfeHydrologyCharts,
     Tr55QualityTable: Tr55QualityTable,
     Tr55QualityCharts: Tr55QualityCharts,
     Tr55RunoffTable: Tr55RunoffTable,

--- a/src/mmw/js/src/compare/templates/compareLineChartRow.html
+++ b/src/mmw/js/src/compare/templates/compareLineChartRow.html
@@ -2,19 +2,9 @@
     <h2>
         {{ name }}
     </h2>
-    {% if legendItems %}
-    <div>
-        {% for item in legendItems %}
-        <div>
-            <span class="scenario-badge" id={{ item.badgeId }}></span>
-            {{ item.name }}
-        </div>
-        {% endfor %}
-    </div>
-    {% endif %}
 </div>
-<div class="compare-scenario-row-content-container">
-    <div class="compare-scenario-row-content">
+<div class="compare-scenario-row-content-container -line">
+    <div class="compare-scenario-row-content -line">
         <div class="compare-line-chart" id={{ chartDiv }}></div>
     </div>
 </div>

--- a/src/mmw/js/src/compare/templates/compareLineChartRow.html
+++ b/src/mmw/js/src/compare/templates/compareLineChartRow.html
@@ -1,0 +1,20 @@
+<div class="compare-scenario-row-description compare-chart-row-description">
+    <h2>
+        {{ name }}
+    </h2>
+    {% if legendItems %}
+    <div>
+        {% for item in legendItems %}
+        <div>
+            <span class="scenario-badge" id={{ item.badgeId }}></span>
+            {{ item.name }}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>
+<div class="compare-scenario-row-content-container">
+    <div class="compare-scenario-row-content">
+        <div class="compare-line-chart" id={{ chartDiv }}></div>
+    </div>
+</div>

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -37,7 +37,17 @@ var SCENARIO_COLORS =  ['#3366cc','#dc3912','#ff9900','#109618','#990099',
         '#0099c6','#dd4477', '#66aa00','#b82e2e','#316395','#3366cc','#994499',
         '#22aa99','#aaaa11', '#6633cc','#e67300','#8b0707','#651067','#329262',
         '#5574a6','#3b3eac', '#b77322','#16d620','#b91383','#f4359e','#9c5935',
-        '#a9c413','#2a778d', '#668d1c','#bea413','#0c5922','#743411'];
+        '#a9c413','#2a778d', '#668d1c','#bea413','#0c5922','#743411'],
+    monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+    hydrologyKeys = Object.freeze({
+        streamFlow: 'AvStreamFlow',
+        surfaceRunoff: 'AvRunoff',
+        subsurfaceFlow: 'AvGroundWater',
+        pointSourceFlow: 'AvPtSrcFlow',
+        evapotranspiration: 'AvEvapoTrans',
+        precipitation: 'AvPrecipitation',
+    });
+
 
 var CompareWindow2 = modalViews.ModalBaseView.extend({
     template: compareWindow2Tmpl,
@@ -1110,39 +1120,83 @@ function getTr55Tabs(scenarios) {
     ]);
 }
 
+function mapScenariosToHydrologyChartData(scenarios, key) {
+    return scenarios
+        .map(function(scenario) {
+            return scenario
+                .get('results')
+                .models
+                .reduce(function(accumulator, next) {
+                    if (next.get('displayName') !== models.constants.HYDROLOGY) {
+                        return accumulator;
+                    }
+
+                    return accumulator.concat(next
+                        .get('result')
+                        .monthly
+                        .map(function(result) {
+                            return result[key];
+                        }));
+                }, []);
+        });
+}
+
+var getMemoizedHydrologyChartData = _.memoize(mapScenariosToHydrologyChartData);
+
+function mapScenariosToNames(scenarios) {
+    return scenarios
+        .map(function(scenario) {
+            return scenario.get('name');
+        });
+}
+
+var getMemoizedScenarioNames = _.memoize(mapScenariosToNames);
+
 function getGwlfeTabs(scenarios) {
     // TODO Implement
     var hydrologyTable = [],
         hydrologyCharts = new models.GwlfeHydrologyCharts([
             {
-                key: 'AvStreamFlow',
+                key: hydrologyKeys.streamFlow,
                 name: 'Stream Flow',
                 chartDiv: 'hydrology-stream-flow-chart',
+                data: getMemoizedHydrologyChartData(scenarios, hydrologyKeys.streamFlow),
+                scenarioNames: getMemoizedScenarioNames(scenarios),
             },
             {
-                key: 'AvRunoff',
+                key: hydrologyKeys.surfaceRunoff,
                 name: 'Surface Runoff',
                 chartDiv: 'hydrology-surface-runoff-chart',
+                data: getMemoizedHydrologyChartData(scenarios, hydrologyKeys.surfaceRunoff),
+                scenarioNames: getMemoizedScenarioNames(scenarios),
             },
             {
-                key: 'AvGroundWater',
+                key: hydrologyKeys.subsurfaceFlow,
                 name: 'Subsurface Flow',
                 chartDiv: 'hydrology-subsurface-flow-chart',
+                data: getMemoizedHydrologyChartData(scenarios, hydrologyKeys.subsurfaceFlow),
+                scenarioNames: getMemoizedScenarioNames(scenarios),
             },
             {
-                key: 'AvPtSrcFlow',
+                key: hydrologyKeys.pointSourceFlow,
                 name: 'Point Source Flow',
                 chartDiv: 'hydrology-point-source-flow-chart',
+                data: getMemoizedHydrologyChartData(scenarios, hydrologyKeys.pointSourceFlow),
+                scenarioNames: getMemoizedScenarioNames(scenarios),
             },
             {
-                key: 'AvEvapoTrans',
+                key: hydrologyKeys.evapotranspiration,
                 name: 'Evapotranspiration',
                 chartDiv: 'hydrology-evapotranspiration-chart',
+                data: getMemoizedHydrologyChartData(scenarios, hydrologyKeys.evapotranspiration),
+                scenarioNames: getMemoizedScenarioNames(scenarios),
             },
             {
-                key: 'AvPrecipitation',
+                key: hydrologyKeys.precipitation,
                 name: 'Precipitation',
                 chartDiv: 'hydrology-precipitation-chart',
+                data: getMemoizedHydrologyChartData(scenarios, hydrologyKeys.precipitation),
+                scenarioNames: getMemoizedScenarioNames(scenarios),
             },
         ], { scenarios: scenarios }),
         qualityTable = [],

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -24,6 +24,7 @@ var _ = require('lodash'),
     tr55CompareScenarioItemTmpl = require('./templates/tr55CompareScenarioItem.html'),
     gwlfeCompareScenarioItemTmpl = require('./templates/gwlfeCompareScenarioItem.html'),
     compareBarChartRowTmpl = require('./templates/compareBarChartRow.html'),
+    compareLineChartRowTmpl = require('./templates/compareLineChartRow.html'),
     compareTableRowTmpl = require('./templates/compareTableRow.html'),
     compareScenariosTmpl = require('./templates/compareScenarios.html'),
     compareScenarioTmpl = require('./templates/compareScenario.html'),
@@ -167,7 +168,10 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
             var activeCollection = this.model.get('tabs').findWhere({ active: true });
 
             if (activeCollection.get('name') === models.constants.HYDROLOGY) {
-                window.console.warn('TODO: Implement GWLFE Hydrology Chart');
+                this.sectionsRegion.show(new GWLFEHydrologyChartView({
+                    model: this.model,
+                    collection: activeCollection.get('charts'),
+                }));
             } else {
                 window.console.warn('TODO: Implement GWLFE Water Quality Chart');
             }
@@ -642,6 +646,20 @@ var BarChartRowView = Marionette.ItemView.extend({
     },
 });
 
+var LineChartRowView = Marionette.ItemView.extend({
+    models: models.LineChartRowModel,
+    className: 'compare-chart-row -line',
+    template: compareLineChartRowTmpl,
+});
+
+var GWLFEHydrologyChartView = Marionette.CollectionView.extend({
+    childView: LineChartRowView,
+
+    onShow: function() {
+        window.console.log('TODO Implement GWLFE Hydrology chart');
+    }
+});
+
 var TR55ChartView = Marionette.CollectionView.extend({
     childView: BarChartRowView,
 
@@ -1095,7 +1113,38 @@ function getTr55Tabs(scenarios) {
 function getGwlfeTabs(scenarios) {
     // TODO Implement
     var hydrologyTable = [],
-        hydrologyCharts = [],
+        hydrologyCharts = new models.GwlfeHydrologyCharts([
+            {
+                key: 'AvStreamFlow',
+                name: 'Stream Flow',
+                chartDiv: 'hydrology-stream-flow-chart',
+            },
+            {
+                key: 'AvRunoff',
+                name: 'Surface Runoff',
+                chartDiv: 'hydrology-surface-runoff-chart',
+            },
+            {
+                key: 'AvGroundWater',
+                name: 'Subsurface Flow',
+                chartDiv: 'hydrology-subsurface-flow-chart',
+            },
+            {
+                key: 'AvPtSrcFlow',
+                name: 'Point Source Flow',
+                chartDiv: 'hydrology-point-source-flow-chart',
+            },
+            {
+                key: 'AvEvapoTrans',
+                name: 'Evapotranspiration',
+                chartDiv: 'hydrology-evapotranspiration-chart',
+            },
+            {
+                key: 'AvPrecipitation',
+                name: 'Precipitation',
+                chartDiv: 'hydrology-precipitation-chart',
+            },
+        ], { scenarios: scenarios }),
         qualityTable = [],
         qualityCharts = [],
         qualitySelections = new models.SelectionOptionsCollection([

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -278,7 +278,7 @@ function renderVerticalBarChart(chartEl, data, options) {
 }
 
 // data is same format as for renderVerticalBarChart
-function renderLineChart(chartEl, data, options) {
+function renderLineChart(chartEl, data, options, tooltipKeyFormatFn) {
     var chart = nv.models.lineChart(),
         svg = makeSvg(chartEl);
 
@@ -301,6 +301,10 @@ function renderLineChart(chartEl, data, options) {
         chart.yAxis
             .axisLabel(options.yAxisLabel)
             .tickFormat(d3.format(options.yTickFormat));
+
+        if (!!tooltipKeyFormatFn) {
+            chart.tooltip.keyFormatter(tooltipKeyFormatFn);
+        }
 
         chart.tooltip.valueFormatter(function(d) {
             return chart.yAxis.tickFormat()(d) + ' ' + options.yAxisUnit;

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -688,3 +688,18 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
   width: 70% !important;
   height: 100% !important;
 }
+
+.compare-scenario-row-content-container {
+    &.-line {
+        padding: 2%;
+
+        > .compare-scenario-row-content {
+            &.-line {
+                > .compare-line-chart {
+                    height: 350px;
+                    width: 700px;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview

This PR implements the Hydrology line charts for the GWLFE compare view. Was able to reuse the existing line chart function with one small modification; otherwise the main work here is transforming the GWLFE  Hydrology Data into a format usable in the line charts.

Connects #2909 

### Demo

![screen shot 2018-08-15 at 11 33 51 am](https://user-images.githubusercontent.com/4165523/44156992-4f81d680-a07f-11e8-9df5-ba6b52325b56.png)

## Notes

Encountered some quirks vis a vis Marionette lifecycle methods viz the charts wouldn't always be sized correctly unless the class had code both in `onAttach` and `onRender` to create the charts. Practically speaking I think the duplicate call should be a no-op after the second call since there's not really input, but I'm open to having this work differently.

## Testing Instructions

- serve this branch then visit a MapShed project and open the compare view
- verify that you see the hydrology line charts, that they match the wireframes, and that they are created and destroyed properly when toggling through the different GWLFE compare views