### PR TITLE
Create hydrology tables

### DIFF
--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -46,6 +46,20 @@ var LineChartRowsCollection = Backbone.Collection.extend({
     model: LineChartRowModel,
 });
 
+var MonthlyTableRowModel = Backbone.Model.extend({
+    defaults: {
+        key: '',
+        name: '',
+        values: [],
+        unit: '',
+        selectedAttribute: '',
+    },
+});
+
+var MonthlyTableRowsCollection = Backbone.Collection.extend({
+    model: MonthlyTableRowModel,
+});
+
 var BarChartRowModel = Backbone.Model.extend({
     defaults: {
         key: '',
@@ -82,6 +96,14 @@ var BarChartRowsCollection = Backbone.Collection.extend({
 });
 
 var GwlfeHydrologyCharts = LineChartRowsCollection.extend();
+
+var GwlfeHydrologyTable = MonthlyTableRowsCollection.extend({
+    update: function(selectedAttribute) {
+        this.models.forEach(function(model) {
+            model.set({ selectedAttribute: selectedAttribute });
+        });
+    }
+});
 
 var Tr55RunoffCharts = BarChartRowsCollection.extend({
     update: function() {
@@ -258,6 +280,7 @@ module.exports = {
     BarChartRowModel: BarChartRowModel,
     LineChartRowModel: LineChartRowModel,
     GwlfeHydrologyCharts: GwlfeHydrologyCharts,
+    GwlfeHydrologyTable: GwlfeHydrologyTable,
     Tr55QualityTable: Tr55QualityTable,
     Tr55QualityCharts: Tr55QualityCharts,
     Tr55RunoffTable: Tr55RunoffTable,

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -554,6 +554,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
       display: flex;
       align-items: baseline;
       justify-content: space-around;
+      text-align: right;
     }
 
     .compare-scenario-title {
@@ -698,6 +699,18 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
                 > .compare-line-chart {
                     height: 350px;
                     width: 700px;
+                }
+            }
+        }
+    }
+}
+
+.compare-table-row {
+    &.-hydrology {
+        > .compare-scenario-row-content-container {
+            > .compare-scenario-row-content {
+                > .compare-column {
+                    opacity: 1.0 !important;
                 }
             }
         }


### PR DESCRIPTION
## Overview

This PR implements the hydrology tables as depicted below. Was able to reuse the the table view from TR55, with the data adjusted to reformat it for GWLFE.

The bulk of the change here is a reduce function to transform the GWLFE data into a shape for display in the tables.

Connects #2915 

### Demo

![hydrologytable](https://user-images.githubusercontent.com/4165523/44281444-cd7fe200-a225-11e8-92a8-6e19b17f3e28.gif)

## Testing Instructions

- serve this branch, then visit a MapShed project and open the compare view
- toggle the hydrology table and then verify that you see data and can toggle through the attributes using the selection box