### PR TITLE
MapShed Compare: Add Dropdown for Attributes

### DIFF
--- a/src/mmw/js/src/compare/models.js
+++ b/src/mmw/js/src/compare/models.js
@@ -12,6 +12,26 @@ var CHART = 'chart',
     COMPARE_COLUMN_WIDTH = 134,
     HYDROLOGY = 'Hydrology';
 
+var SelectionOptionModel = Backbone.Model.extend({
+    defaults: {
+        group: '',
+        value: '',
+        name: '',
+        active: false,
+    },
+
+    initialize: function(attrs) {
+        // Default value to name, unless specified otherwise
+        if (attrs.value === undefined) {
+            this.set('value', attrs.name);
+        }
+    }
+});
+
+var SelectionOptionsCollection = Backbone.Collection.extend({
+    model: SelectionOptionModel,
+});
+
 var BarChartRowModel = Backbone.Model.extend({
     defaults: {
         key: '',
@@ -170,6 +190,7 @@ var TabModel = Backbone.Model.extend({
         active: false,
         table: null,  // TableRowsCollection
         charts: null, // ChartRowCollection
+        selections: null, // SelectionOptionsCollection
     },
 });
 
@@ -215,6 +236,8 @@ var WindowModel = Backbone.Model.extend({
 });
 
 module.exports = {
+    SelectionOptionModel: SelectionOptionModel,
+    SelectionOptionsCollection: SelectionOptionsCollection,
     ControlsCollection: ControlsCollection,
     BarChartRowModel: BarChartRowModel,
     Tr55QualityTable: Tr55QualityTable,

--- a/src/mmw/js/src/compare/templates/compareSelection.html
+++ b/src/mmw/js/src/compare/templates/compareSelection.html
@@ -1,0 +1,11 @@
+{% for group in groups %}
+    <optgroup label="{{ group.name }}">
+    {% for option in group.options %}
+        <option value="{{ option.value or option.name }}"
+                {{ 'selected' if option.active }}
+        >
+            {{ option.name }}
+        </option>
+    {% endfor %}
+    </optgroup>
+{% endfor %}

--- a/src/mmw/js/src/compare/templates/compareWindow2.html
+++ b/src/mmw/js/src/compare/templates/compareWindow2.html
@@ -33,6 +33,7 @@
                 </button>
             </div>
         </div>
+        <div id="compare-selection-region"></div>
         <div class="compare-sections polling"></div>
     </div>
 </div>

--- a/src/mmw/js/src/compare/templates/compareWindow2.html
+++ b/src/mmw/js/src/compare/templates/compareWindow2.html
@@ -19,21 +19,20 @@
         </div>
         <div class="compare-scenario-gradient"></div>
         <div class="compare-scenarios">
-    <div class="compare-scenario-row-description">
-        <h2>Scenarios</h2>
-    </div>
-    <div id="compare-title-row" class="compare-scenario-row-content-container">
-    </div>
-    <div class="compare-scenario-buttons">
-        <button class="visible btn-prev-scenario">
-            <i class="fa fa-arrow-left"></i>
-        </button>
-        <button class="visible btn-next-scenario">
-            <i class="fa fa-arrow-right"></i>
-        </button>
-    </div>
+            <div class="compare-scenario-row-description">
+                <h2>Scenarios</h2>
+            </div>
+            <div id="compare-title-row" class="compare-scenario-row-content-container">
+            </div>
+            <div class="compare-scenario-buttons">
+                <button class="visible btn-prev-scenario">
+                    <i class="fa fa-arrow-left"></i>
+                </button>
+                <button class="visible btn-next-scenario">
+                    <i class="fa fa-arrow-right"></i>
+                </button>
+            </div>
         </div>
-        <div class="compare-sections polling">
-        </div>
+        <div class="compare-sections polling"></div>
     </div>
 </div>

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -181,10 +181,30 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
                 this.model.get('mode') === models.constants.CHART &&
                 activeTab.get('name') === models.constants.HYDROLOGY;
 
+        var demoFunction = function() {
+            var selected =
+                activeTab.get('selections').findWhere({ active: true });
+
+            console.log(
+                selected.get('group') + ' ' + selected.get('name'));
+        };
+
+        // TODO Remove demo listener
+        this.model.get('tabs').forEach(function(tab) {
+            var selections = tab.get('selections');
+
+            if (selections) {
+                selections.off();
+            }
+        });
+
         if (activeTab.get('selections') && !isHydrologyChart) {
             this.selectionRegion.show(new SelectionView({
                 model: activeTab,
             }));
+
+            // TODO Demo Listening for Changes
+            activeTab.get('selections').on('change', demoFunction);
         } else {
             this.selectionRegion.empty();
         }

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -20,6 +20,7 @@ var _ = require('lodash'),
     compareWindow2Tmpl = require('./templates/compareWindow2.html'),
     compareTabPanelTmpl = require('./templates/compareTabPanel.html'),
     compareInputsTmpl = require('./templates/compareInputs.html'),
+    compareSelectionTmpl = require('./templates/compareSelection.html'),
     tr55CompareScenarioItemTmpl = require('./templates/tr55CompareScenarioItem.html'),
     gwlfeCompareScenarioItemTmpl = require('./templates/gwlfeCompareScenarioItem.html'),
     compareBarChartRowTmpl = require('./templates/compareBarChartRow.html'),
@@ -376,6 +377,51 @@ var InputsView = Marionette.LayoutView.extend({
                 timeStamp + '.csv';
 
         coreUtils.downloadAsFile(csv, fileName);
+    }
+});
+
+var SelectionView = Marionette.ItemView.extend({
+    // model: TabModel
+    template: compareSelectionTmpl,
+    tagName: 'select',
+    className: 'form-control btn btn-small btn-primary',
+
+    events: {
+        'change': 'select',
+    },
+
+    templateHelpers: function() {
+        var groups = [];
+
+        this.model.get('selections').forEach(function(opt) {
+            var group = _.find(groups, { name: opt.get('group') });
+
+            if (group === undefined) {
+                group = { name: opt.get('group'), options: [] };
+                groups.push(group);
+            }
+
+            group.options.push({
+                name: opt.get('name'),
+                active: opt.get('active'),
+            });
+        });
+
+        return {
+            groups: groups,
+        };
+    },
+
+    select: function() {
+        var selections = this.model.get('selections');
+
+        selections
+            .findWhere({ active: true })
+            .set({ active: false }, { silent: true });
+
+        selections
+            .findWhere({ value: this.$el.val() })
+            .set({ active: true });
     }
 });
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -1013,7 +1013,28 @@ function getGwlfeTabs(scenarios) {
     var hydrologyTable = [],
         hydrologyCharts = [],
         qualityTable = [],
-        qualityCharts = [];
+        qualityCharts = [],
+        qualitySelections = new models.SelectionOptionsCollection([
+            { group: 'Summary', name: 'Total Loads', active: true },
+            { group: 'Summary', name: 'Loading Rates' },
+            { group: 'Summary', name: 'Mean Annual Concentration' },
+            { group: 'Summary', name: 'Mean Low-Flow Concentration' },
+            { group: 'Land Use', name: 'Hay/Pasture' },
+            { group: 'Land Use', name: 'Cropland' },
+            { group: 'Land Use', name: 'Wooded Areas' },
+            { group: 'Land Use', name: 'Wetlands' },
+            { group: 'Land Use', name: 'Open Land' },
+            { group: 'Land Use', name: 'Barren Areas' },
+            { group: 'Land Use', name: 'Low-Density Mixed' },
+            { group: 'Land Use', name: 'Medium-Density Mixed' },
+            { group: 'Land Use', name: 'High-Density Mixed' },
+            { group: 'Land Use', name: 'Other Upland Areas' },
+            { group: 'Land Use', name: 'Farm Animals' },
+            { group: 'Land Use', name: 'Stream Bank Erosion' },
+            { group: 'Land Use', name: 'Subsurface Flow' },
+            { group: 'Land Use', name: 'Point Sources' },
+            { group: 'Land Use', name: 'Septic Systems' },
+        ]);
 
     // TODO Remove once scenarios is actually used.
     // This is to pacify the linter.
@@ -1030,6 +1051,7 @@ function getGwlfeTabs(scenarios) {
             name: 'Water Quality',
             table: qualityTable,
             charts: qualityCharts,
+            selections: qualitySelections,
         },
     ]);
 }

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -66,6 +66,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
         tabRegion: '.compare-tabs',
         inputsRegion: '.compare-inputs',
         scenariosRegion: '#compare-title-row',
+        selectionRegion: '#compare-selection-region',
         sectionsRegion: '.compare-sections',
     },
 
@@ -127,9 +128,12 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
     },
 
     showSectionsView: function() {
+        var activeTab = this.model.get('tabs').findWhere({ active: true });
+
         switch (this.model.get('modelPackage')) {
             case coreUtils.GWLFE:
                 this.showGWLFESectionsView();
+                this.showSelectionView(activeTab);
                 break;
             case coreUtils.TR55_PACKAGE:
                 this.showTR55SectionsView();
@@ -169,6 +173,20 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
             }
         } else {
             window.console.warn('TODO: Implement GWLFE Table');
+        }
+    },
+
+    showSelectionView: function(activeTab) {
+        var isHydrologyChart =
+                this.model.get('mode') === models.constants.CHART &&
+                activeTab.get('name') === models.constants.HYDROLOGY;
+
+        if (activeTab.get('selections') && !isHydrologyChart) {
+            this.selectionRegion.show(new SelectionView({
+                model: activeTab,
+            }));
+        } else {
+            this.selectionRegion.empty();
         }
     },
 

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -318,6 +318,11 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
       flex-direction: column;
       height: calc(100% - 20px);
       -webkit-font-smoothing: antialiased;
+
+    #compare-selection-region > select {
+      width: 250px;
+      margin: 1.5rem;
+    }
   }
 
   .compare-actions {


### PR DESCRIPTION
## Overview

Since the MapShed Compare view involved comparing multiple attributes for every scenario, we cannot show all the information in a single table (or in the case of Water Quality, a single chart). Thus, we need to be able to pick which attribute to compare.

This PR adds a dropdown menu above the comparison sections that is populated with the tab's options, and a demo listener that shows how other items (such as table or chart values) may listen for changes here.

Connects #2910 

### Demo

![2018-08-16 11 07 42](https://user-images.githubusercontent.com/1430060/44217545-b36ed280-a145-11e8-94dc-ae6fb10088e9.gif)

### Notes

We need the dropdown to be visible for all Water Quality tabs, but only for Hydrology table. That will be handled in subsequent PRs.

## Testing Instructions

* Check out this branch, `bundle`
* Open a MapShed project and open Compare view
* Ensure you see the dropdown for Water Quality but not for Hydrology
* Ensure selecting items in the dropdown logs the group and item name to the console