### PR TITLE
MapShed Compare: Modifications Popover

### DIFF
--- a/src/mmw/js/src/compare/templates/compareDescriptionPopover.html
+++ b/src/mmw/js/src/compare/templates/compareDescriptionPopover.html
@@ -6,11 +6,19 @@
 {% elif is_current_conditions %}
     <h3 class="compare-no-mod-title">{{name}}</h3>
     <p>
+    {% if isTr55 %}
         Model results based on 2011 NLCD land and 2016 gSSURGO soil datasets.
+    {% else %}
+        Model results based on 2011 NLCD Land, National Streams, Weather, Slope, Animal Types, Growing Season, Soil Erodibility Factor, Point-Source Discharge, and Groundwater Nitrogen datasets.
+    {% endif %}
     </p>
 {% else %}
     <h3 class="compare-no-mod-title">No modifications</h3>
     <p>
+    {% if isTr55 %}
         To add modifications, close this modal and select "Land cover" or "Conservation practices".
+    {% else %}
+        To add modifications, close this modal and select "Conservation Practice".
+    {% endif %}
     </p>
 {% endif %}

--- a/src/mmw/js/src/compare/templates/compareModificationsPopover.html
+++ b/src/mmw/js/src/compare/templates/compareModificationsPopover.html
@@ -18,6 +18,30 @@
 </table>
 {% endmacro %}
 
+{% macro gwlfeModificationsTable(caption, mods) %}
+<table class="compare-modifications-table -gwlfe">
+{% if modifications.length > 0 %}
+    <h5>{{ caption }}</h5>
+{% endif %}
+    <tbody>
+    {% for mod in mods %}
+        <tr>
+            <td class="modification-value -gwlfe">
+                {{ mod.name | replace("_", " ") | title }}
+            </td>
+            <td class="modification-area -gwlfe">
+                +{{ mod.value }} {{ mod.input }}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endmacro %}
+
 <h3>Modifications</h3>
+{% if isTr55 %}
 {{ modificationsTable('Land Cover', landCovers) }}
 {{ modificationsTable('Conservation Practices', conservationPractices) }}
+{% else %}
+{{ gwlfeModificationsTable('Conservation Practices', gwlfeModifications) }}
+{% endif %}

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -16,6 +16,7 @@ var _ = require('lodash'),
     tr55Models = require('../modeling/tr55/models'),
     PrecipitationView = require('../modeling/controls').PrecipitationView,
     modConfigUtils = require('../modeling/modificationConfigUtils'),
+    gwlfeConfig = require('../modeling/gwlfeModificationConfig'),
     compareWindowTmpl = require('./templates/compareWindow.html'),
     compareWindow2Tmpl = require('./templates/compareWindow2.html'),
     compareTabPanelTmpl = require('./templates/compareTabPanel.html'),
@@ -487,7 +488,23 @@ var CompareModificationsPopoverView = Marionette.ItemView.extend({
     template: compareModificationsPopoverTmpl,
 
     templateHelpers: function() {
+        var isTr55 = App.currentProject.get('model_package') ===
+                     coreUtils.TR55_PACKAGE,
+            gwlfeModifications = isTr55 ? [] : _.flatten(
+                this.model.map(function(m) {
+                    return _.map(m.get('userInput'), function(value, key) {
+                        return {
+                            name: m.get('modKey'),
+                            value: value,
+                            input: gwlfeConfig.displayNames[key],
+                        };
+                    });
+                })
+            );
+
         return {
+            isTr55: isTr55,
+            gwlfeModifications: gwlfeModifications,
             conservationPractices: this.model.filter(function(modification) {
                 return modification.get('name') === 'conservation_practice';
             }),

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -502,7 +502,14 @@ var CompareModificationsPopoverView = Marionette.ItemView.extend({
 var CompareDescriptionPopoverView = Marionette.ItemView.extend({
     // model: ScenarioModel
     template: compareDescriptionPopoverTmpl,
-    className: 'compare-no-mods-popover'
+    className: 'compare-no-mods-popover',
+
+    templateHelpers: function() {
+        return {
+            isTr55: App.currentProject.get('model_package') ===
+                    coreUtils.TR55_PACKAGE,
+        };
+    },
 });
 
 var GWLFEScenarioItemView = Marionette.ItemView.extend({

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -622,6 +622,10 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
       width: 100%;
       .modification-value {
           padding-right: 12px;
+
+        &.-gwlfe {
+          padding-top: 12px;
+        }
       }
       .modification-area {
           color: $brand-primary;


### PR DESCRIPTION
## Overview

Given that GWLF-E modifications are organized differently than TR-55, this adapts the relevant views to show them as well.

Connects #2920 

### Demo

![image](https://user-images.githubusercontent.com/1430060/44411449-86029a00-a534-11e8-8d73-7a88d81a2b6a.png)

![image](https://user-images.githubusercontent.com/1430060/44411453-8ac74e00-a534-11e8-9ec8-48ffc59a9dab.png)

![image](https://user-images.githubusercontent.com/1430060/44411460-8e5ad500-a534-11e8-9dd4-d4df4faffaf7.png)

### Notes

The Current Conditions wording should probably be changed to something more meaningful. This can be done afterwords in a polish pass.

~~This is targeting #2931 to simplify the diff, but will ultimately be merged on to `develop`.~~

## Testing Instructions

* Check out this branch and `bundle`
* Make a MapShed project. Add two scenarios to it. To one, add modifications. Open the Compare View.
* Hover over each scenario in the header once. Ensure you see an appropriate message in the popover.
* Ensure that TR-55 Compare View popovers still work as before.