### PR TITLE
MapShed Compare: Fix Tiny Charts

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -94,6 +94,12 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
                 model: self.model,
                 collection: self.model.get('scenarios'),
             }));
+
+            // Show Sections View and update polling because
+            // some charts need the Compare Window visible
+            // before they can render properly
+            self.showSectionsView();
+            self.setPolling();
         });
     },
 
@@ -135,9 +141,7 @@ var CompareWindow2 = modalViews.ModalBaseView.extend({
             model: this.model,
         }));
 
-        showSectionsView();
         this.highlightButtons();
-        this.setPolling();
     },
 
     showSectionsView: function() {

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -690,29 +690,19 @@ var LineChartRowView = Marionette.ItemView.extend({
     className: 'compare-chart-row -line',
     template: compareLineChartRowTmpl,
 
-    ui: function() {
-        return {
-            chartElement: '#' + this.model.get('chartDiv'),
-        };
+    modelEvents: {
+        'change:values': 'renderChart',
     },
 
     onAttach: function() {
-        this.addChart();
+        this.renderChart();
     },
 
-    onBeforeDestroy: function() {
-        this.destroyChart();
-    },
-
-    onRender: function() {
-        this.addChart();
-    },
-
-    addChart: function() {
-        this.destroyChart();
-
-        var scenarioNames = this.model.get('scenarioNames'),
-            chartData = this.model.get('data')
+    renderChart: function() {
+        var self = this,
+            chartDiv = this.model.get('chartDiv'),
+            chartEl = document.getElementById(chartDiv),
+            data = this.model.get('data')
                 .map(function(scenarioData, index) {
                     return {
                         key: index,
@@ -727,25 +717,23 @@ var LineChartRowView = Marionette.ItemView.extend({
                 })
                 .slice()
                 .reverse(),
-            chartOptions = {
+            options = {
                 yAxisLabel: 'Water Depth (cm)',
                 yAxisUnit: 'cm',
                 xAxisLabel: function(xValue) {
                     return monthNames[xValue];
                 },
                 xTickValues: _.range(12),
+                onRenderComplete: function() {
+                    self.triggerMethod('chart:rendered');
+                },
             },
+            scenarioNames = this.model.get('scenarioNames'),
             tooltipKeyFormatFn = function(d) {
                 return scenarioNames[d];
             };
 
-        if (chartData.length && this.ui.chartElement) {
-            chart.renderLineChart(this.ui.chartElement, chartData, chartOptions, tooltipKeyFormatFn);
-        }
-    },
-
-    destroyChart: function() {
-        this.ui.chartElement.empty();
+        chart.renderLineChart(chartEl, data, options, tooltipKeyFormatFn);
     },
 });
 

--- a/src/mmw/js/src/core/chart.js
+++ b/src/mmw/js/src/core/chart.js
@@ -313,6 +313,7 @@ function renderLineChart(chartEl, data, options, tooltipKeyFormatFn) {
     _.defaults(options, {
         margin: {top: 20, right: 30, bottom: 40, left: 60},
         yTickFormat: '.02f',
+        onRenderComplete: _.noop,
     });
 
     nv.addGraph(function() {
@@ -344,7 +345,7 @@ function renderLineChart(chartEl, data, options, tooltipKeyFormatFn) {
             .call(chart);
 
         return chart;
-    });
+    }, options.onRenderComplete);
 }
 
 function renderCompareMultibarChart(chartEl, name, label, colors, stacked, yMax, data, columnWidth, xAxisWidth, callback) {


### PR DESCRIPTION
## Overview

The line charts require the parent container to be rendered and visible before rendering. By rendering them after the parent, we ensure that they are always sized appropriately.

This change applied to TR-55 Compare View as well, but the result is acceptable. Previously there would be a flash of "No Data" charts, now they are seen (after the Compare Window loads) as always populated.

Also some cleanup on prior code to bring it in to existing style.

Connects #2926 

### Demo

![2018-08-22 13 27 48](https://user-images.githubusercontent.com/1430060/44480294-e23aec00-a610-11e8-98f6-9706d8a3ab63.gif)

## Testing Instructions

* Check out this branch and `bundle`
* Open a GWLF-E project
* Open the Compare View. Ensure that the line charts are all full sized.
* Switch tabs. Close and re-open the Compare View. Ensure that the charts are always full sized.