### PR TITLE
Compare View Revamp: Fix TR-55 Downloads

### DIFF
--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -440,8 +440,8 @@ var AoiView = Marionette.ItemView.extend({
     },
 
     downloadGeojson: function() {
-        utils.downloadAsFile(this.model.get('shape'),
-                             this.model.get('place') + '.geojson');
+        utils.downloadJson(this.model.get('shape'),
+                           this.model.get('place') + '.geojson');
     }
 });
 

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -433,7 +433,7 @@ var InputsView = Marionette.LayoutView.extend({
             fileName = projectName.replace(/[^a-z0-9+]+/gi, '_') + '_' +
                 timeStamp + '.csv';
 
-        coreUtils.downloadAsFile(csv, fileName);
+        coreUtils.downloadText(csv, fileName);
     }
 });
 

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -695,8 +695,9 @@ var utils = {
     },
 
     // Downloads given data as a text file with given filename
-    downloadAsFile: function(data, filename) {
-        var blob = new Blob([JSON.stringify(data)],
+    _downloadAsFile: function(data, filename, stringify) {
+        var content = stringify ? JSON.stringify(data) : data,
+            blob = new Blob([content],
                             { type: 'data:text/plain;charset=utf-8'}),
             url = URL.createObjectURL(blob),
             a = document.createElement('a');
@@ -716,6 +717,16 @@ var utils = {
         }
 
         URL.revokeObjectURL(url);
+    },
+
+    // Expects data to be a JSON object
+    downloadJson: function(data, filename) {
+        this._downloadAsFile(data, filename, true);
+    },
+
+    // Expects data to be a string
+    downloadText: function(data, filename) {
+        this._downloadAsFile(data, filename, false);
     },
 
     // Checks if current browser is Internet Explorer / Edge. If so,

--- a/src/mmw/js/src/data_catalog/views.js
+++ b/src/mmw/js/src/data_catalog/views.js
@@ -355,7 +355,7 @@ var FormView = Marionette.ItemView.extend({
             filename = 'bigcz-' + catalog.id + '-' +
                        dashedQuery + '-' + dateString + '.json';
 
-        utils.downloadAsFile(data, filename);
+        utils.downloadJson(data, filename);
     },
 
     getFilters: function() {


### PR DESCRIPTION
## Overview

Previously, `downloadAsFile` always stringified the input data, assuming it to be a JSON object. This was not the case for the TR-55 Compare View download, which was a CSV string. Stringifying that led to all the formatting elements, such as quotes and new-lines, being escaped in the final download, thus corrupting it.

We replace `downloadAsFile` by two derived methods, `downloadJson` and `downloadText`, each of which calls the now renamed `_downloadAsFile` with a parameter that tells it to stringify or not.

All existing use cases have been replaced by the appropriate alternative. This allows JSON downloads to continue to work as before, while also allowing CSV downloads to work correctly.

Connects #2907 

### Demo

![image](https://user-images.githubusercontent.com/1430060/44491636-e7f3fa00-a62f-11e8-8858-a7c75c3d3f02.png)

## Testing Instructions

* Check out this branch and `bundle`
* Open a TR-55 project with multiple scenarios
* Open Compare View. Click the download button in the top right. Ensure the downloaded file is legit.
* Ensure you can still download the shape GeoJSON from Analyze, and it is valid JSON.