### PR TITLE
Adjust GWLFE Compare View Styling

### DIFF
--- a/src/mmw/js/src/compare/templates/compareInputs.html
+++ b/src/mmw/js/src/compare/templates/compareInputs.html
@@ -3,8 +3,10 @@
     <button id="compare-input-button-chart" class="active"><i class="fa fa-bar-chart"></i></button>
     <button id="compare-input-button-table"><i class="fa fa-table"></i></button>
 </div>
+{% if showDownloadButton %}
 <div class="compare-download compare-input">
     <button id="compare-input-button-download">
         <i class="fa fa-download"></i>
     </button>
 </div>
+{% endif %}

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -313,6 +313,12 @@ var InputsView = Marionette.LayoutView.extend({
         'change:polling': 'toggleDownloadButtonActive'
     },
 
+    templateHelpers: function() {
+        return {
+            showDownloadButton: this.model.get('modelPackage') === coreUtils.TR55_PACKAGE,
+        };
+    },
+
     toggleDownloadButtonActive: function() {
         this.ui.downloadButton.prop('disabled', this.model.get('polling'));
     },

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -765,6 +765,7 @@ var GwlfeBarChartRowView = Marionette.ItemView.extend({
                 onRenderComplete: function() {
                     self.triggerMethod('chart:rendered');
                 },
+                abbreviateTicks: true,
             };
 
         $(chartEl.parentNode).css({ width: parentWidth });

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -756,9 +756,11 @@ var GwlfeBarChartRowView = Marionette.ItemView.extend({
             parentWidth = (_.size(values) *
                 constants.COMPARE_COLUMN_WIDTH +
                 constants.CHART_AXIS_WIDTH) + 'px',
+            yAxisUnit = this.model.get('unit'),
+            yAxisLabel = this.model.get('unitLabel') + ' (' + yAxisUnit + ')',
             options = {
-                yAxisLabel: this.model.get('unitLabel'),
-                yAxisUnit: this.model.get('unit'),
+                yAxisUnit: yAxisUnit,
+                yAxisLabel: yAxisLabel,
                 colors: constants.SCENARIO_COLORS,
                 columnWidth: constants.COMPARE_COLUMN_WIDTH,
                 xAxisWidth: constants.CHART_AXIS_WIDTH,

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -672,6 +672,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
       margin-right: 20px;
       label {
         font-size: 12px;
+        margin-bottom: 0;
       }
     }
   }

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -553,8 +553,12 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
     &.-gwlfe {
       display: flex;
       align-items: baseline;
-      justify-content: space-around;
-      text-align: right;
+      justify-content: left;
+      text-align: left;
+
+      > .compare-scenario-title {
+          padding-left: 5px;
+      }
     }
 
     .compare-scenario-title {


### PR DESCRIPTION
## Overview

This PR addresses some remaining style quirks related to the compare view. Specifically, it:

- removes the download CSV button from the GWLFE compare view
- adjusts the style on the GWLFE compare view scenario header items to left justify the labels but keep the padding
- adds an `abbreviateTicks: true` option to the GWLFE compare view bar charts to round very large numbers & ensure the y axis label stays in view

Connects #2929

### Demo

![screen shot 2018-08-27 at 5 07 42 pm](https://user-images.githubusercontent.com/4165523/44686559-a5119800-aa1c-11e8-9865-b440a7248a39.png)

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- serve this branch then check the GWLFE compare view to ensure it still works as before but has the style adjustments described above
- check the TR55 compare view to verify that it still works & looks as it did before