### PR TITLE
MapShed BMPs: Conservation Tillage Split, Curve Number

### DIFF
--- a/src/mmw/js/src/core/modificationConfig.json
+++ b/src/mmw/js/src/core/modificationConfig.json
@@ -140,10 +140,20 @@
         "summary": "Use of annual or perennial plant cover to protect the soil from erosion during the time period between the harvesting and planting of the primary crop. In addition to reducing soil erosion, cover crops can also limit nitrogen loss from cropped areas. Use of annual or perennial plant cover to protect the soil from erosion during the time period between the harvesting and planting of the primary crop. In addition to reducing soil erosion, cover crops can also limit nitrogen loss from cropped areas.",
         "copyStyle": "deciduous_forest"
     },
+    "crop_tillage_no": {
+        "name": "No Till Ag",
+        "summary": "Growing crops or pasture from year to year without tilling or otherwise disturbing the soil, thereby increasing water infiltration, organic matter retention, and nutrient cycling in the soil.",
+        "copyStyle": "green_roof"
+    },
     "conservation_tillage": {
         "name": "Conservation Tillage",
         "summary": "The purpose of this BMP is to leave enough residue from harvested crops on the soil surface (at least 30%) to significantly reduce soil erosion. Variations include seasonal residue management, mulch tillage and no-till planting.",
         "copyStyle": "barren_land"
+    },
+    "crop_tillage_reduced": {
+        "name": "Reduced Tillage",
+        "summary": "The purpose of this BMP is to leave enough residue from harvested crops on the soil surface (at least 30%) to significantly reduce soil erosion. Variations include seasonal residue management, mulch tillage and no-till planting.",
+        "copyStyle": "cluster_housing"
     },
     "nutrient_management": {
         "name": "Nutrient Management",

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -421,8 +421,8 @@ var GwlfeConservationPracticeView = ModificationsView.extend({
                 {
                     name: 'Rural',
                     rows: [
-                        ['cover_crops', 'conservation_tillage', 'nutrient_management', 'waste_management_livestock'],
-                        ['waste_management_poultry', 'buffer_strips', 'streambank_fencing', 'streambank_stabilization']
+                        ['cover_crops', 'crop_tillage_no', 'conservation_tillage', 'crop_tillage_reduced', 'nutrient_management'],
+                        ['waste_management_livestock', 'waste_management_poultry', 'buffer_strips', 'streambank_fencing', 'streambank_stabilization']
                     ]
                 },
                 {

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -224,6 +224,31 @@ function makeCurveAdjustingAgBmpConfig(outputName, tillFactor) {
     };
 }
 
+function makeCropTillageBmpConfig(outputName, tillFactor,
+                                  nEfficiency, pEfficiency, sEfficiency) {
+    function getOutput(inputVal, fractionVal, dataModel) {
+        var currentCN = dataModel[CurveNumberName][CroplandIndex],
+            newCN = adjustCurveNumber(currentCN, fractionVal, tillFactor || 1),
+            curveNumberOutputName = CurveNumberName + '__' + CroplandIndex;
+
+        return fromPairs([
+            ['n65', nEfficiency],
+            ['n73', pEfficiency],
+            ['n81', sEfficiency],
+            [curveNumberOutputName, newCN],
+            [outputName, fractionVal * 100]
+        ]);
+    }
+
+    return {
+        dataModelNames: [n23Name],
+        validateDataModel: makeValidateDataModelFn([n23Name]),
+        userInputNames: [areaToModifyName],
+        validate: makeThresholdValidateFn(n23Name, AREA, areaToModifyName),
+        computeOutput: makeComputeOutputFn(n23Name, areaToModifyName, getOutput)
+    };
+}
+
 function makeAgBmpConfig(outputName) {
     function getOutput(inputVal, fractionVal) {
         return fromPairs([
@@ -315,9 +340,9 @@ function makeUrbanAreaBmpConfig(getOutput) {
 */
 var configs = {
     'cover_crops': makeCurveAdjustingAgBmpConfig(n25Name, 1),
-    'crop_tillage_no': makeCurveAdjustingAgBmpConfig(n26Name, 1),
-    'conservation_tillage': makeCurveAdjustingAgBmpConfig(n26Name, 1.019),
-    'crop_tillage_reduced': makeCurveAdjustingAgBmpConfig(n26Name, 1.036),
+    'crop_tillage_no': makeCropTillageBmpConfig(n26Name, 1, 0.11, 0.29, 0.40),
+    'conservation_tillage': makeCropTillageBmpConfig(n26Name, 1.019, 0.08, 0.22, 0.30),
+    'crop_tillage_reduced': makeCropTillageBmpConfig(n26Name, 1.036, 0.06, 0.17, 0.23),
     'nutrient_management':  makeAgBmpConfig(n28bName),
     'waste_management_livestock': makeAeuBmpConfig(n41bName),
     'waste_management_poultry': makeAeuBmpConfig(n41dName),

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -315,7 +315,9 @@ function makeUrbanAreaBmpConfig(getOutput) {
 */
 var configs = {
     'cover_crops': makeCurveAdjustingAgBmpConfig(n25Name, 1),
+    'crop_tillage_no': makeCurveAdjustingAgBmpConfig(n26Name, 1),
     'conservation_tillage': makeCurveAdjustingAgBmpConfig(n26Name, 1.019),
+    'crop_tillage_reduced': makeCurveAdjustingAgBmpConfig(n26Name, 1.036),
     'nutrient_management':  makeAgBmpConfig(n28bName),
     'waste_management_livestock': makeAeuBmpConfig(n41bName),
     'waste_management_poultry': makeAeuBmpConfig(n41dName),

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -205,6 +205,10 @@ function makeValidateDataModelFn(dataModelNames) {
 // Given the current curve number, the percentage of treated cropland, and
 // tillFactor, computes the new curve number for cropland.
 function adjustCurveNumber(cn, fractionalVal, tillFactor) {
+    if (tillFactor === null || tillFactor === undefined) {
+        tillFactor = 1;
+    }
+
     return (((1.7969 * cn) - 71.966) * fractionalVal * tillFactor) +
            (cn * (1 - fractionalVal));
 }
@@ -212,7 +216,7 @@ function adjustCurveNumber(cn, fractionalVal, tillFactor) {
 function makeCurveAdjustingAgBmpConfig(outputName, tillFactor) {
     function getOutput(inputVal, fractionVal, dataModel) {
         var currentCN = dataModel[CurveNumberName][CroplandIndex],
-            newCN = adjustCurveNumber(currentCN, fractionVal, tillFactor || 1),
+            newCN = adjustCurveNumber(currentCN, fractionVal, tillFactor),
             curveNumberOutputName = CurveNumberName + '__' + CroplandIndex;
 
         return fromPairs([
@@ -233,7 +237,7 @@ function makeCurveAdjustingAgBmpConfig(outputName, tillFactor) {
 function makeCropTillageBmpConfig(outputName, tillFactor, efficiencies) {
     function getOutput(inputVal, fractionVal, dataModel) {
         var currentCN = dataModel[CurveNumberName][CroplandIndex],
-            newCN = adjustCurveNumber(currentCN, fractionVal, tillFactor || 1),
+            newCN = adjustCurveNumber(currentCN, fractionVal, tillFactor),
             curveNumberOutputName = CurveNumberName + '__' + CroplandIndex;
 
         return fromPairs([

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -31,6 +31,12 @@ var n23Name = 'n23',
     percentAreaToModifyName = 'percentAreaToModify',
     CurveNumberName = 'CN',
     CroplandIndex = 1,
+    CropTillageEfficiencyName = { n: 'n65', p: 'n73', s: 'n81' },
+    CropTillageEfficiencyValues = {
+        crop_tillage_no:      { n: 0.11, p: 0.29, s: 0.40 },
+        conservation_tillage: { n: 0.08, p: 0.22, s: 0.30 },
+        crop_tillage_reduced: { n: 0.06, p: 0.17, s: 0.23 },
+    },
     AREA = 'area',
     LENGTH = 'length',
     FilterWidthDefault = 30,
@@ -224,17 +230,16 @@ function makeCurveAdjustingAgBmpConfig(outputName, tillFactor) {
     };
 }
 
-function makeCropTillageBmpConfig(outputName, tillFactor,
-                                  nEfficiency, pEfficiency, sEfficiency) {
+function makeCropTillageBmpConfig(outputName, tillFactor, efficiencies) {
     function getOutput(inputVal, fractionVal, dataModel) {
         var currentCN = dataModel[CurveNumberName][CroplandIndex],
             newCN = adjustCurveNumber(currentCN, fractionVal, tillFactor || 1),
             curveNumberOutputName = CurveNumberName + '__' + CroplandIndex;
 
         return fromPairs([
-            ['n65', nEfficiency],
-            ['n73', pEfficiency],
-            ['n81', sEfficiency],
+            [CropTillageEfficiencyName.n, efficiencies.n],
+            [CropTillageEfficiencyName.p, efficiencies.p],
+            [CropTillageEfficiencyName.s, efficiencies.s],
             [curveNumberOutputName, newCN],
             [outputName, fractionVal * 100]
         ]);
@@ -340,9 +345,9 @@ function makeUrbanAreaBmpConfig(getOutput) {
 */
 var configs = {
     'cover_crops': makeCurveAdjustingAgBmpConfig(n25Name, 1),
-    'crop_tillage_no': makeCropTillageBmpConfig(n26Name, 1, 0.11, 0.29, 0.40),
-    'conservation_tillage': makeCropTillageBmpConfig(n26Name, 1.019, 0.08, 0.22, 0.30),
-    'crop_tillage_reduced': makeCropTillageBmpConfig(n26Name, 1.036, 0.06, 0.17, 0.23),
+    'crop_tillage_no': makeCropTillageBmpConfig(n26Name, 1, CropTillageEfficiencyValues['crop_tillage_no']),
+    'conservation_tillage': makeCropTillageBmpConfig(n26Name, 1.019, CropTillageEfficiencyValues['conservation_tillage']),
+    'crop_tillage_reduced': makeCropTillageBmpConfig(n26Name, 1.036, CropTillageEfficiencyValues['crop_tillage_reduced']),
     'nutrient_management':  makeAgBmpConfig(n28bName),
     'waste_management_livestock': makeAeuBmpConfig(n41bName),
     'waste_management_poultry': makeAeuBmpConfig(n41dName),


### PR DESCRIPTION
## Overview

Adds two new Crop Tillage Practice BMPs, effectively splitting Conservation Tillage into three BMPs. The three options have different affects on the Curve Number, as specified in #2941, as well as a different reduction coefficient (or BMP efficiency), as specified in #2939. These effects implemented herein. Notably, the Conservation Tillage BMP has the same reduction coefficients as the default values, so we don't see a difference when applying that.

Since we do not modify the internal key of Conservation Tillage, existing projects do not need to be updated. All future applications of this BMP will have the effects introduced here. Prior applications will remain as they were.

Connects #2939 
Connects #2941 

### Demo

![image](https://user-images.githubusercontent.com/1430060/44815883-bdb1b780-abae-11e8-8c52-828246dbf25e.png)

The following are diffs between Current Conditions and No Till, Conservation Practice, and Reduced Till. In each of the latter scenarios exactly one modification was added, and they were all set to cover 1000 of 1829.10 available acres of row crops.

Notice how the Curve Number change (the first diff) is different in all three cases. Also notice how the reduction coefficient differences (the third diff) only exists for No Till and Reduced Till, not for Conservation Tillage, which has the same values as default.

![image](https://user-images.githubusercontent.com/1430060/44815799-7dead000-abae-11e8-90ac-49ed493d6ef5.png)

![image](https://user-images.githubusercontent.com/1430060/44815810-87743800-abae-11e8-8ffa-493c61da447b.png)

![image](https://user-images.githubusercontent.com/1430060/44815819-8fcc7300-abae-11e8-8537-50a2205fd51d.png)

### Notes

I've named the new BMPs as follows:

- **No Till Ag**: Growing crops or pasture from year to year without tilling or otherwise disturbing the soil, thereby increasing water infiltration, organic matter retention, and nutrient cycling in the soil.
- **Conservation Tillage**: The purpose of this BMP is to leave enough residue from harvested crops on the soil surface (at least 30%) to significantly reduce soil erosion. Variations include seasonal residue management, mulch tillage and no-till planting.
- **Reduced Tillage**: The purpose of this BMP is to leave enough residue from harvested crops on the soil surface (at least 30%) to significantly reduce soil erosion. Variations include seasonal residue management, mulch tillage and no-till planting.

The name and description of **No Till Ag** was copied from TR-55. **Conservation Tillage** uses its prior description, which is now likely outdated. **Reduced Tillage** uses an identical description as **Conservation Tillage**.

I'll make a follow up card to fix this copy.

## Testing Instructions

* Check out this branch and `bundle`
* Make a MapShed project and add scenarios
* Try adding No Till Ag, Conservation Tillage, and Reduced Tillage BMPs. Observe the GMS files. Ensure you see the differences as described in **Demo** above.