### PR TITLE
MapShed BMPs: Aggregate GWLF-E Modifications

### DIFF
--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -758,28 +758,6 @@ var utils = {
         return false;
     },
 
-    applyGwlfeModifications: function(gisData, modifications) {
-        // Merge the values that came back from Mapshed with the values
-        // in the modifications from the user.
-        var gms = lodash.cloneDeep(gisData);
-
-        modifications.forEach(function(mod) {
-            lodash.forEach(mod.get('output'), function(value, key) {
-                if (key.indexOf('__') > 0) {
-                    var split = key.split('__'),
-                        gmskey = split[0],
-                        index = parseInt(split[1]);
-
-                    gms[gmskey][index] = value;
-                } else {
-                    gms[key] = value;
-                }
-            });
-        });
-
-        return gms;
-    },
-
     // Takes a string query, which is either "Lon,Lat" or "Lat,Lon",
     // and returns an object {lng: 99.9, lat: 99.9}. If the string
     // cannot be parsed in the expected way, returns false

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1469,6 +1469,39 @@ var ScenarioModel = Backbone.Model.extend({
     },
 
     /**
+     * Given an aggregate of GWLF-E modifications, validates them
+     * and warns about errors.
+     *
+     * In the future we may incorporate these warnings into a UI of
+     * some sort. For now, they are simply logged to the console.
+     */
+    validateGwlfeModifications: function(mods) {
+        var get = function(key) {
+            if (mods.hasOwnProperty(key)) {
+                return mods[key];
+            } else {
+                return 0;
+            }
+        };
+
+        if (get('n26') > 100) {
+            console.warn(
+                'GWLF-E: Crop Tillage Practice treated land use' +
+                'is too high: ' + round(get('n26'), 2) + '%'
+            );
+        }
+
+        if (get('n25') + get('n26') + get('n28b') > 100) {
+            console.warn(
+                'GWLF-E: Total treated percent of Cropland too high: ' +
+                round(get('n25') + get('n26') + get('n28b'), 2) + '%'
+            );
+        }
+
+        return true;
+    },
+
+    /**
      * Converts current modifications into a single object with key / value
      * pairs for overriding the baseline data model. Useful for aggregating
      * the final value when multiple BMPs target the same value in a GMS file.
@@ -1520,6 +1553,8 @@ var ScenarioModel = Backbone.Model.extend({
                 'n81': _.sum(input['n81']) / n26,
             });
         }
+
+        this.validateGwlfeModifications(output);
 
         // Technically `output` is a singleton that contains everything,
         // but we put it in an array to maintain backwards compatibility.

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1526,6 +1526,31 @@ var ScenarioModel = Backbone.Model.extend({
         return [output];
     },
 
+    /**
+     * Returns a `gis_data` object with the overriding modifications
+     * of this scenario applied.
+     */
+    getModifiedGwlfeGisData: function() {
+        var gisData = _.cloneDeep(App.currentProject.get('gis_data')),
+            modifications = this.aggregateGwlfeModifications();
+
+        _.forEach(modifications, function(override) {
+            _.forEach(override, function(value, key) {
+                if (key.indexOf('__') > 0) {
+                    var split = key.split('__'),
+                        gmskey = split[0],
+                        index = parseInt(split[1]);
+
+                    gisData[gmskey][index] = value;
+                } else {
+                    gisData[key] = value;
+                }
+            });
+        });
+
+        return gisData;
+    },
+
     getGisData: function(isSubbasinMode) {
         var self = this,
             project = App.currentProject,

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -461,9 +461,7 @@ var ScenarioDropDownMenuOptionsView = Marionette.ItemView.extend({
     },
 
     templateHelpers: function() {
-        var gis_data = utils.applyGwlfeModifications(
-                App.currentProject.get('gis_data'),
-                this.model.get('modifications')),
+        var gis_data = this.model.getModifiedGwlfeGisData(),
             is_gwlfe = App.currentProject.get('model_package') === utils.GWLFE && !_.isEmpty(gis_data);
 
         return {
@@ -548,9 +546,7 @@ var ScenarioDropDownMenuItemView = Marionette.LayoutView.extend({
     },
 
     templateHelpers: function() {
-        var gis_data = utils.applyGwlfeModifications(
-                App.currentProject.get('gis_data'),
-                this.model.get('modifications')),
+        var gis_data = this.model.getModifiedGwlfeGisData(),
             is_gwlfe = App.currentProject.get('model_package') === utils.GWLFE &&
                         gis_data !== null &&
                         gis_data !== '{}' &&


### PR DESCRIPTION
## Overview

The recent changes in #2938 and #2941 have different modifications targeting the same spots in the baseline GMS. Currently, when this happens, each value overrides the last, so only the last value in a set is counted, and the others are lost.

To alleviate this, we pre-process the dict of modifications sent to the server to override the baseline GMS, aggregating each value differently. The aggregations introduced in this PR are:

| Field Name | Field Description | Aggregation | Mathematically |
|---------------------|-------------------------------------------------------------|-----------------------------------------------------------------------------|-------------------------------------------------|
| `CN__1` | Curve Number of Cropland | Sum of all adjusted curve numbers less the current curve number (n-1) times | `sum(new_cns) - count(new_cns) * old_cn` |
| `n26` | Percentage of Cropland treated with Crop Tillage Practice | Simple sum | `sum(n26s)` |
| `n65`, `n73`, `n81` | Efficiency / Reduction Coefficient of Crop Tillage Practice | Area weighted sum | `(a1*n65_1 + a2*n65_2 + a3*n65_3) / (a1+a2+a3)` |

Also ensures that this aggregation is used when generating GMS files.

Connects #2942 

### Demo

Comparing Baseline to when only Cover Crops are added (to ~35%), we see Curve Number changes:

![image](https://user-images.githubusercontent.com/1430060/44879553-f79ac080-ac77-11e8-8c7b-69130504b793.png)

Similarly, it also changes for Conservation Tillage (applied to same amount of land):

![image](https://user-images.githubusercontent.com/1430060/44879580-15682580-ac78-11e8-925f-7ca5fc1c27c6.png)

But if add them both at 50% of the previous two, we see Curve Number is updated to an in between value:

![image](https://user-images.githubusercontent.com/1430060/44879606-30d33080-ac78-11e8-841f-572ac9ad291b.png)

---

When applying only No Till Ag to ~35%, we see the updated efficiencies:

![image](https://user-images.githubusercontent.com/1430060/44879691-70018180-ac78-11e8-947e-16972ae4648b.png)

But when we have ~18% No Till Ag and ~18% Conservation Tillage, the efficiencies are in between, even though the total area to which Crop Tillage Practices have been applied is ~35%:

![image](https://user-images.githubusercontent.com/1430060/44879727-87406f00-ac78-11e8-8372-2c3ceae6af0f.png)

### Notes

This PR also adds some basic validation of the underlying assumptions (such as the amount of treated cropland can't be more than available cropland), and logs it to the console. In the future we may devise UIs that do this.

## Testing Instructions

* Checkout this branch and `bundle`
* Make a GWLF-E project. Ensure it creates correctly, and you can add and remove modifications without errors.
* Add Cover Crops and Conservation Practice modifications. Ensure the change in Curve Number of Cropland (line 21, comma position 3) is somewhere in between having just Cover Crops and Conservation Practices.
* Add Conservation Practice and Reduced Tillage or No Till Ag. Ensure efficiency values (line 114 position 3, line 115 position 4, and line 116 position 6) are somewhere in between when only one is used, proportional to how much of each was added.