### PR TITLE
MapShed BMPs: Update Crop Tillage Practices text

### DIFF
--- a/src/mmw/js/src/core/modificationConfig.json
+++ b/src/mmw/js/src/core/modificationConfig.json
@@ -141,18 +141,18 @@
         "copyStyle": "deciduous_forest"
     },
     "crop_tillage_no": {
-        "name": "No Till Ag",
-        "summary": "Growing crops or pasture from year to year without tilling or otherwise disturbing the soil, thereby increasing water infiltration, organic matter retention, and nutrient cycling in the soil.",
+        "name": "No Till Agriculture",
+        "summary": "The purpose of this BMP is to leave some residue from harvested crops on the soil surface to reduce soil erosion. This practice is similar to the “Conservation Tillage” and “Reduced Tillage” practices, and only differs with respect to the amount of residue left on the ground. In this case, it is assumed that there is 60% or more residue left.",
         "copyStyle": "green_roof"
     },
     "conservation_tillage": {
         "name": "Conservation Tillage",
-        "summary": "The purpose of this BMP is to leave enough residue from harvested crops on the soil surface (at least 30%) to significantly reduce soil erosion. Variations include seasonal residue management, mulch tillage and no-till planting.",
+        "summary": "The purpose of this BMP is to leave some residue from harvested crops on the soil surface to reduce soil erosion. This practice is similar to the “No Till Agriculture” and “Reduced Tillage” practices, and only differs with respect to the amount of residue left on the ground. In this case, it is assumed that there is between 30-60% residue left.",
         "copyStyle": "barren_land"
     },
     "crop_tillage_reduced": {
         "name": "Reduced Tillage",
-        "summary": "The purpose of this BMP is to leave enough residue from harvested crops on the soil surface (at least 30%) to significantly reduce soil erosion. Variations include seasonal residue management, mulch tillage and no-till planting.",
+        "summary": "The purpose of this BMP is to leave some residue from harvested crops on the soil surface to reduce soil erosion. This practice is similar to the “No Till Agriculture” and “Conservation Tillage” practices, and only differs with respect to the amount of residue left on the ground. In this case, it is assumed that there is between 15-30% residue left.",
         "copyStyle": "cluster_housing"
     },
     "nutrient_management": {

--- a/src/mmw/js/src/core/modificationConfig.json
+++ b/src/mmw/js/src/core/modificationConfig.json
@@ -142,17 +142,17 @@
     },
     "crop_tillage_no": {
         "name": "No Till Agriculture",
-        "summary": "The purpose of this BMP is to leave some residue from harvested crops on the soil surface to reduce soil erosion. This practice is similar to the “Conservation Tillage” and “Reduced Tillage” practices, and only differs with respect to the amount of residue left on the ground. In this case, it is assumed that there is 60% or more residue left.",
+        "summary": "The purpose of this BMP is to leave some residue from harvested crops on the soil surface to reduce soil erosion. This practice is similar to the “Conservation Tillage” and “Reduced Tillage” practices, and only differs with respect to the amount of residue left on the ground. In this case, it is assumed that ground coverage with residual matter is at or greater than 60%.",
         "copyStyle": "green_roof"
     },
     "conservation_tillage": {
         "name": "Conservation Tillage",
-        "summary": "The purpose of this BMP is to leave some residue from harvested crops on the soil surface to reduce soil erosion. This practice is similar to the “No Till Agriculture” and “Reduced Tillage” practices, and only differs with respect to the amount of residue left on the ground. In this case, it is assumed that there is between 30-60% residue left.",
+        "summary": "The purpose of this BMP is to leave some residue from harvested crops on the soil surface to reduce soil erosion. This practice is similar to the “No Till Agriculture” and “Reduced Tillage” practices, and only differs with respect to the amount of residue left on the ground. In this case, it is assumed that ground coverage with residual matter is between 30-60%.",
         "copyStyle": "barren_land"
     },
     "crop_tillage_reduced": {
         "name": "Reduced Tillage",
-        "summary": "The purpose of this BMP is to leave some residue from harvested crops on the soil surface to reduce soil erosion. This practice is similar to the “No Till Agriculture” and “Conservation Tillage” practices, and only differs with respect to the amount of residue left on the ground. In this case, it is assumed that there is between 15-30% residue left.",
+        "summary": "The purpose of this BMP is to leave some residue from harvested crops on the soil surface to reduce soil erosion. This practice is similar to the “No Till Agriculture” and “Conservation Tillage” practices, and only differs with respect to the amount of residue left on the ground. In this case, it is assumed that ground coverage with residual matter is between 15-30%.",
         "copyStyle": "cluster_housing"
     },
     "nutrient_management": {


### PR DESCRIPTION
## Overview

Updates text descriptions for the three Crop Tillage Practice BMPs.

Connects #2956 

### Demo

![screen shot 2018-09-05 at 11 35 19 am](https://user-images.githubusercontent.com/1430060/45104393-0530ca00-b100-11e8-912d-3e5d095e42a9.png)

![screen shot 2018-09-05 at 11 35 22 am](https://user-images.githubusercontent.com/1430060/45104395-0661f700-b100-11e8-964a-1156a844ec76.png)

![screen shot 2018-09-05 at 11 35 26 am](https://user-images.githubusercontent.com/1430060/45104398-082bba80-b100-11e8-9e44-4ae206b7fee3.png)

## Testing Instructions

* Check out this branch and `bundle`
* Go to a MapShed project and open the Conservation Practices dropdown. Hover over "No Till Agriculture", "Conservation Tillage", and "Reduced Tillage" and observe the new descriptions. Ensure there are no typos.
* Check in various browsers.