### PR TITLE
MapShed Manual Entry: Add Base Settings Modal

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -10,6 +10,8 @@ var $ = require('jquery'),
     models = require('./models'),
     modificationConfigUtils = require('./modificationConfigUtils'),
     gwlfeConfig = require('./gwlfeModificationConfig'),
+    entryModels = require('./gwlfe/entry/models'),
+    EntryModal = require('./gwlfe/entry/views').EntryModal,
     precipitationTmpl = require('./templates/controls/precipitation.html'),
     manualEntryTmpl = require('./templates/controls/manualEntry.html'),
     userInputTmpl = require('./templates/controls/userInput.html'),
@@ -466,9 +468,12 @@ var GwlfeSettingsView = ControlView.extend({
     },
 
     showSettingsModal: function() {
-        // TODO Implement
-        window.alert('Settings Modal');
-        console.warn('Not implemented');
+        var window = new entryModels.WindowModel({
+                dataModel: this.model.get('dataModel'),
+                title: this.model.get('controlDisplayName'),
+            });
+
+        new EntryModal({ model: window }).render();
     },
 });
 

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -15,6 +15,7 @@ var $ = require('jquery'),
     userInputTmpl = require('./templates/controls/userInput.html'),
     inputInfoTmpl = require('./templates/controls/inputInfo.html'),
     thumbSelectTmpl = require('./templates/controls/thumbSelect.html'),
+    settingsTmpl = require('./templates/controls/settings.html'),
     modDropdownTmpl = require('./templates/controls/modDropdown.html');
 
 var ENTER_KEYCODE = 13;
@@ -441,6 +442,37 @@ var GwlfeConservationPracticeView = ModificationsView.extend({
     }
 });
 
+var GwlfeSettingsView = ControlView.extend({
+    template: settingsTmpl,
+
+    events: {
+        'click button': 'showSettingsModal',
+    },
+
+    getControlName: function() {
+        return 'gwlfe_settings';
+    },
+
+    initialize: function(options) {
+        ControlView.prototype.initialize.apply(this, [options]);
+
+        this.model.set({
+            controlName: this.getControlName(),
+            controlDisplayName: 'Settings',
+            dataModel: gwlfeConfig.cleanDataModel(App.currentProject.get('gis_data')),
+            errorMessages: null,
+            infoMessages: null,
+        });
+    },
+
+    showSettingsModal: function() {
+        // TODO Implement
+        window.alert('Settings Modal');
+        console.warn('Not implemented');
+    },
+});
+
+
 var PrecipitationView = ControlView.extend({
     template: precipitationTmpl,
 
@@ -509,6 +541,8 @@ function getControlView(controlName) {
             return ConservationPracticeView;
         case 'gwlfe_conservation_practice':
             return GwlfeConservationPracticeView;
+        case 'gwlfe_settings':
+            return GwlfeSettingsView;
         case 'precipitation':
             return PrecipitationView;
     }

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -468,9 +468,16 @@ var GwlfeSettingsView = ControlView.extend({
     },
 
     showSettingsModal: function() {
-        var window = new entryModels.WindowModel({
+        var tabs = new entryModels.EntryTabCollection([
+                { name: 'efficiencies', displayName: 'Efficiencies' },
+                { name: 'waste_water', displayName: 'Waste Water' },
+                { name: 'animals', displayName: 'Animals' },
+                { name: 'other', displayName: 'Other Model Data' },
+            ]),
+            window = new entryModels.WindowModel({
                 dataModel: this.model.get('dataModel'),
                 title: this.model.get('controlDisplayName'),
+                tabs: tabs,
             });
 
         new EntryModal({ model: window }).render();

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -1,0 +1,15 @@
+"use strict";
+
+var Backbone = require('../../../../shim/backbone');
+
+var WindowModel = Backbone.Model.extend({
+    defaults: {
+        feedbackRequired: true,
+        dataModel: null, // Cleaned MapShed GIS Data
+        title: '',
+    },
+});
+
+module.exports = {
+    WindowModel: WindowModel,
+};

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -2,14 +2,28 @@
 
 var Backbone = require('../../../../shim/backbone');
 
+var EntryTabModel = Backbone.Model.extend({
+    defaults: {
+        displayName: '',
+        name: '',
+    },
+});
+
+var EntryTabCollection = Backbone.Collection.extend({
+    model: EntryTabModel,
+});
+
 var WindowModel = Backbone.Model.extend({
     defaults: {
         feedbackRequired: true,
         dataModel: null, // Cleaned MapShed GIS Data
         title: '',
+        tabs: null,      // EntryTabCollection
     },
 });
 
 module.exports = {
+    EntryTabCollection: EntryTabCollection,
+    EntryTabModel: EntryTabModel,
     WindowModel: WindowModel,
 };

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/modal.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/modal.html
@@ -1,0 +1,21 @@
+<div class="modal-dialog">
+    <div class="modal-content entry-modal-content">
+        <div class="modal-header">
+            <div class="title">
+                <h1>{{ title }}</h1>
+            </div>
+        </div>
+        <div class="modal-body">
+            <div role="tablist" class="tab-panels-region"></div>
+            <div class="tab-contents-region"></div>
+        </div>
+        <div class="modal-footer" style="text-align: right">
+            <div class="footer-content">
+                <button class="btn btn-md btn-default" data-dismiss="modal">
+                    Cancel
+                </button>
+                <button class="btn btn-md btn-active">Save</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/tabContent.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/tabContent.html
@@ -1,0 +1,2 @@
+<!-- TODO Add Real Content -->
+<h1>{{ displayName }}</h1>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/tabPanel.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/tabPanel.html
@@ -1,0 +1,3 @@
+<a href="#{{ name }}" aria-controls="home" role="tab" data-toggle="tab">
+    <div class="tab-label">{{ displayName }}</div>
+</a>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/tabPanel.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/tabPanel.html
@@ -1,3 +1,3 @@
-<a href="#{{ name }}" aria-controls="home" role="tab" data-toggle="tab">
+<a href="#entry_{{ name }}" aria-controls="home" role="tab" data-toggle="tab">
     <div class="tab-label">{{ displayName }}</div>
 </a>

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -1,7 +1,9 @@
 "use strict";
 
-var modalViews = require('../../../core/modals/views'),
-    modalTmpl = require('./templates/modal.html');
+var Marionette = require('../../../../shim/backbone.marionette'),
+    modalViews = require('../../../core/modals/views'),
+    modalTmpl = require('./templates/modal.html'),
+    tabPanelTmpl = require('./templates/tabPanel.html');
 
 var EntryModal = modalViews.ModalBaseView.extend({
     template: modalTmpl,
@@ -11,6 +13,37 @@ var EntryModal = modalViews.ModalBaseView.extend({
 
     regions: {
         panelsRegion: '.tab-panels-region',
+    },
+
+    // Override to populate tabs
+    onRender: function() {
+        this.panelsRegion.show(new TabPanelsView({
+            collection: this.model.get('tabs'),
+        }));
+
+        this.$el.modal('show');
+    }
+});
+
+var TabPanelView = Marionette.ItemView.extend({
+    tagName: 'li',
+    template: tabPanelTmpl,
+    attributes: {
+        role: 'presentation'
+    },
+});
+
+var TabPanelsView = Marionette.CollectionView.extend({
+    tagName: 'ul',
+    className: 'nav nav-tabs',
+    attributes: {
+        role: 'tablist'
+    },
+
+    childView: TabPanelView,
+
+    onRender: function() {
+        this.$('li:first').addClass('active');
     },
 });
 

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -3,6 +3,7 @@
 var Marionette = require('../../../../shim/backbone.marionette'),
     modalViews = require('../../../core/modals/views'),
     modalTmpl = require('./templates/modal.html'),
+    tabContentTmpl = require('./templates/tabContent.html'),
     tabPanelTmpl = require('./templates/tabPanel.html');
 
 var EntryModal = modalViews.ModalBaseView.extend({
@@ -13,12 +14,18 @@ var EntryModal = modalViews.ModalBaseView.extend({
 
     regions: {
         panelsRegion: '.tab-panels-region',
+        contentsRegion: '.tab-contents-region',
     },
 
     // Override to populate tabs
     onRender: function() {
+        var tabs = this.model.get('tabs');
+
         this.panelsRegion.show(new TabPanelsView({
-            collection: this.model.get('tabs'),
+            collection: tabs,
+        }));
+        this.contentsRegion.show(new TabContentsView({
+            collection: tabs,
         }));
 
         this.$el.modal('show');
@@ -44,6 +51,28 @@ var TabPanelsView = Marionette.CollectionView.extend({
 
     onRender: function() {
         this.$('li:first').addClass('active');
+    },
+});
+
+var TabContentView = Marionette.LayoutView.extend({
+    className: 'tab-pane',
+    template: tabContentTmpl,
+    attributes: {
+        role: 'tabpanel'
+    },
+
+    id: function() {
+        return 'entry_' + this.model.get('name');
+    },
+});
+
+var TabContentsView = Marionette.CollectionView.extend({
+    className: 'tab-content',
+
+    childView: TabContentView,
+
+    onRender: function() {
+        this.$('.tab-pane:first').addClass('active');
     },
 });
 

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var modalViews = require('../../../core/modals/views'),
+    modalTmpl = require('./templates/modal.html');
+
+var EntryModal = modalViews.ModalBaseView.extend({
+    template: modalTmpl,
+
+    id: 'entry-modal',
+    className: 'modal modal-large fade',
+
+    regions: {
+        panelsRegion: '.tab-panels-region',
+    },
+});
+
+module.exports = {
+    EntryModal: EntryModal,
+};

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1819,7 +1819,8 @@ function getControlsForModelPackage(modelPackageName, options) {
             return new ModelPackageControlsCollection();
         } else {
             return new ModelPackageControlsCollection([
-                new ModelPackageControlModel({ name: 'gwlfe_conservation_practice' })
+                new ModelPackageControlModel({ name: 'gwlfe_conservation_practice' }),
+                new ModelPackageControlModel({ name: 'gwlfe_settings' }),
             ]);
         }
     }

--- a/src/mmw/js/src/modeling/templates/controls/settings.html
+++ b/src/mmw/js/src/modeling/templates/controls/settings.html
@@ -1,0 +1,3 @@
+<button class="btn btn-sm btn-icon" type="button">
+    <i class="fa fa-cog"></i> {{ controlDisplayName }}
+</button>

--- a/src/mmw/sass/components/_buttons.scss
+++ b/src/mmw/sass/components/_buttons.scss
@@ -157,6 +157,10 @@
       color: $black-74;
     }
   }
+
+  .gwlfe_settings > & {
+    margin-right: 39px;
+  }
 }
 
 .btn-scenario {

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -426,4 +426,8 @@
       }
     }
   }
+
+  .tab-pane {
+    padding: 2rem;
+  }
 }

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -372,3 +372,20 @@
     }
   }
 }
+
+#entry-modal {
+  .modal-header {
+    background: $ui-light;
+    padding: 2rem;
+    border-bottom: 1px solid $black-12;
+  }
+
+  .modal-body {
+    padding: 0;
+  }
+
+  .modal-footer > .footer-content {
+    background: $paper;
+    border-top: 1px solid $black-12;
+  }
+}

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -388,4 +388,42 @@
     background: $paper;
     border-top: 1px solid $black-12;
   }
+
+  .nav-tabs {
+    padding: 0 2rem;
+    font-weight: 400;
+    font-size: 13px;
+    border-bottom: 1px solid $black-12;
+    background: $paper;
+
+    > li {
+      > a {
+        border: none;
+        border-bottom: inherit;
+        padding: 0;
+        margin: 0 1rem 2px;
+        line-height: 47px;
+        height: 47px;
+        color: $ui-secondary;
+
+        &:hover, &:focus {
+          background: inherit;
+        }
+
+        > .tab-label {
+          padding: 0 1px;
+        }
+      }
+
+      &.active > a > .tab-label {
+        color: $brand-primary;
+        font-weight: 800;
+        border-bottom: 2px solid $brand-primary;
+      }
+
+      &:first-child > a {
+        margin-left: 0;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Overview

Adds a base settings modal, to which all manual entry tabs will be added.

Connects #2958 

### Demo

![2018-09-10 11 54 15](https://user-images.githubusercontent.com/1430060/45308892-81f0e900-b4f0-11e8-98b3-3a529483b076.gif)

![screen shot 2018-09-10 at 11 53 49 am](https://user-images.githubusercontent.com/1430060/45308923-91703200-b4f0-11e8-8f70-f369504f0a67.png)

![screen shot 2018-09-10 at 11 54 01 am](https://user-images.githubusercontent.com/1430060/45308913-8d441480-b4f0-11e8-8a02-12dec3745d8d.png)


## Testing Instructions

* Check out this branch and `bundle`
* Open / create a MapShed project. Add a scenario. Ensure you see a "⚙️ Settings" button to the right of "Conservation Practices", clicking which opens the Settings modal.
* Ensure you can close it with the "Cancel". "Save" currently does nothing.
* Ensure you cannot close it by clicking outside the modal.