### PR TITLE
Unhide compare view scrollbar

### DIFF
--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -333,6 +333,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
   .compare-sections {
     flex: 0 1 auto;
     overflow: auto;
+    z-index: 1000;
 
     &.polling {
       .compare-column, rect {


### PR DESCRIPTION
## Overview

The compare view's scrollbar was obscured a bit behind another div, so
we change the scrollable section's z-index to 1000 to make it apparent.

Connects #2955

### Demo

<img width="1279" alt="screen shot 2018-09-12 at 5 22 31 pm" src="https://user-images.githubusercontent.com/4165523/45454025-7d732e80-b6b0-11e8-9278-17b5adba3bb4.png">

## Testing Instructions

- serve this branch then visit the site in Chrome for Windows 7 or 10
- create or load a MapShed project then open the compare view to verify that the compare view's vertical scrollbar is visible
