### PR TITLE
MapShed Manual Entry: Add Waste Water Tab

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -10,8 +10,7 @@ var $ = require('jquery'),
     models = require('./models'),
     modificationConfigUtils = require('./modificationConfigUtils'),
     gwlfeConfig = require('./gwlfeModificationConfig'),
-    entryModels = require('./gwlfe/entry/models'),
-    EntryModal = require('./gwlfe/entry/views').EntryModal,
+    entryViews = require('./gwlfe/entry/views'),
     precipitationTmpl = require('./templates/controls/precipitation.html'),
     manualEntryTmpl = require('./templates/controls/manualEntry.html'),
     userInputTmpl = require('./templates/controls/userInput.html'),
@@ -468,19 +467,15 @@ var GwlfeSettingsView = ControlView.extend({
     },
 
     showSettingsModal: function() {
-        var tabs = new entryModels.EntryTabCollection([
-                { name: 'efficiencies', displayName: 'Efficiencies' },
-                { name: 'waste_water', displayName: 'Waste Water' },
-                { name: 'animals', displayName: 'Animals' },
-                { name: 'other', displayName: 'Other Model Data' },
-            ]),
-            window = new entryModels.WindowModel({
-                dataModel: this.model.get('dataModel'),
-                title: this.model.get('controlDisplayName'),
-                tabs: tabs,
-            });
+        var currentScenario = App.currentProject.get('scenarios')
+                                 .findWhere({ active: true });
 
-        new EntryModal({ model: window }).render();
+        entryViews.showSettingsModal(
+            this.model.get('controlDisplayName'),
+            this.model.get('dataModel'),
+            currentScenario.get('modifications'),
+            this.addModification
+        );
     },
 });
 

--- a/src/mmw/js/src/modeling/gwlfe/entry/calcs.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/calcs.js
@@ -1,0 +1,74 @@
+"use strict";
+
+var _ = require('lodash'),
+    turfArea = require('turf-area'),
+    App = require('../../../app');
+
+/**
+ * This module exports a set of objects for calculating outputs of, and auto-
+ * estimatates for, a manual entry field for GWLF-E.
+ *
+ * Each calculator object has two methods: `toOutput` which given a user
+ * value converts it to the expected GMS format, and `getAutoValue` that
+ * gets a user-friendly value from the GMS dataModel given a field name.
+ *
+ * Each manual entry field will be configured with one of these calculators.
+ */
+
+module.exports = {
+    // Takes the userValue and uses it directly in the output
+    Direct: {
+        toOutput: function(userValue) {
+            return userValue;
+        },
+        getAutoValue: function(fieldName, dataModel) {
+            return dataModel[fieldName];
+        },
+    },
+
+    // Takes the userValue and makes an array with the value repeated 12 times
+    Array12: {
+        toOutput: function(userValue) {
+            return _.fill(new Array(12), userValue);
+        },
+        getAutoValue: function(fieldName, dataModel) {
+            return dataModel[fieldName][0];
+        },
+    },
+
+    // Takes the userValue and divides into an array of 12 values evenly
+    EqualMonths: {
+        toOutput: function(userValue) {
+            return _.fill(new Array(12), userValue / 12);
+        },
+        getAutoValue: function(fieldName, dataModel) {
+            return _.sum(dataModel[fieldName]);
+        },
+    },
+
+    // Takes the user value in million gallons per day and converts it to
+    // centimeters per month, and applies it to twelve months. Equivalent to
+    // point_source_discharge method in mapshed/calcs.py
+    PointSourceDischarge: {
+        toOutput: function(userValue) {
+            var MONTHDAYS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+                AREA_SQM = turfArea(App.currentProject.get('area_of_interest')),
+                M3_PER_MGAL = 3785.41178,
+                CM_PER_M = 100.0;
+
+            return MONTHDAYS.map(function(DAYS_PER_MONTH) {
+                return userValue *
+                    (DAYS_PER_MONTH * M3_PER_MGAL * CM_PER_M / AREA_SQM);
+            });
+        },
+        getAutoValue: function(fieldName, dataModel) {
+            var DAYS_PER_YEAR = 365,
+                AREA_SQM = turfArea(App.currentProject.get('area_of_interest')),
+                M3_PER_MGAL = 3785.41178,
+                CM_PER_M = 100.0;
+
+            return _.sum(dataModel[fieldName]) /
+                (DAYS_PER_YEAR * M3_PER_MGAL * CM_PER_M / AREA_SQM);
+        },
+    }
+};

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var Backbone = require('../../../../shim/backbone');
+var Backbone = require('../../../../shim/backbone'),
+    GwlfeModificationModel = require('../../models').GwlfeModificationModel;
 
 var EntryFieldModel = Backbone.Model.extend({
     defaults: {
@@ -44,6 +45,31 @@ var EntryTabModel = Backbone.Model.extend({
         name: '',
         sections: null,  // EntrySectionCollection
     },
+
+    getOutput: function() {
+        var output = {},
+            userInput = {};
+
+        this.get('sections').forEach(function(section) {
+            section.get('fields').forEach(function(field) {
+                var name = field.get('name'),
+                    userValue = field.get('userValue');
+
+                if (userValue !== null &&
+                    userValue !== undefined &&
+                    userValue !== '') {
+                    output[name] = field.toOutput(userValue);
+                    userInput[name] = userValue;
+                }
+            });
+        });
+
+        return new GwlfeModificationModel({
+            modKey: 'entry_' + this.get('name'),
+            output: output,
+            userInput: userInput,
+        });
+    }
 });
 
 var EntryTabCollection = Backbone.Collection.extend({

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -59,6 +59,30 @@ var WindowModel = Backbone.Model.extend({
     },
 });
 
+/**
+ * Returns a FieldCollection for a section
+ * @param tabName  Name of the tab
+ * @param dataModel  Project's gis_data, cleaned
+ * @param modifications  Scenario's current modification collection
+ * @param fields  Object with {name, label, calculator} for each field, with
+ *                minValue and maxValue optionally specified
+ * @returns A FieldCollection with specified fields
+ */
+function makeFieldCollection(tabName, dataModel, modifications, fields) {
+    var mods = modifications.findWhere({ modKey: 'entry_' + tabName }),
+        userInput = mods ? mods.get('userInput') : {};
+
+    return new EntryFieldCollection(fields.map(function(fieldInfo) {
+        var field = new EntryFieldModel(fieldInfo, dataModel);
+
+        if (userInput.hasOwnProperty(fieldInfo.name)) {
+            field.set('userValue', userInput[fieldInfo.name]);
+        }
+
+        return field;
+    }));
+}
+
 module.exports = {
     EntryFieldModel: EntryFieldModel,
     EntryFieldCollection: EntryFieldCollection,
@@ -67,4 +91,5 @@ module.exports = {
     EntryTabCollection: EntryTabCollection,
     EntryTabModel: EntryTabModel,
     WindowModel: WindowModel,
+    makeFieldCollection: makeFieldCollection,
 };

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -11,6 +11,16 @@ var EntryFieldModel = Backbone.Model.extend({
         autoValue: null,
         userValue: null,
     },
+
+    initialize: function(attrs, dataModel) {
+        this.toOutput = attrs.calculator.toOutput;
+        this.set('autoValue',
+            attrs.calculator.getAutoValue(attrs.name, dataModel));
+    },
+
+    toOutput: function() {
+        throw "Calculator not provided.";
+    }
 });
 
 var EntryFieldCollection = Backbone.Collection.extend({

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -2,10 +2,37 @@
 
 var Backbone = require('../../../../shim/backbone');
 
+var EntryFieldModel = Backbone.Model.extend({
+    defaults: {
+        label: '',
+        name: '',
+        minValue: null,
+        maxValue: null,
+        autoValue: null,
+        userValue: null,
+    },
+});
+
+var EntryFieldCollection = Backbone.Collection.extend({
+    model: EntryFieldModel,
+});
+
+var EntrySectionModel = Backbone.Model.extend({
+    defaults: {
+        title: '',
+        fields: null,  // EntryFieldCollection
+    }
+});
+
+var EntrySectionCollection = Backbone.Collection.extend({
+    model: EntrySectionModel,
+});
+
 var EntryTabModel = Backbone.Model.extend({
     defaults: {
         displayName: '',
         name: '',
+        sections: null,  // EntrySectionCollection
     },
 });
 
@@ -23,6 +50,10 @@ var WindowModel = Backbone.Model.extend({
 });
 
 module.exports = {
+    EntryFieldModel: EntryFieldModel,
+    EntryFieldCollection: EntryFieldCollection,
+    EntrySectionModel: EntrySectionModel,
+    EntrySectionCollection: EntrySectionCollection,
     EntryTabCollection: EntryTabCollection,
     EntryTabModel: EntryTabModel,
     WindowModel: WindowModel,

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
@@ -1,0 +1,30 @@
+<div class="col-sm-8">
+    <div class="manual-entry-label">
+        {{ label }}
+    </div>
+</div>
+<div class="col-sm-4">
+    <input
+            type="number"
+            class="form-control"
+            name="{{ name }}"
+            step="0.000001"
+            {% if minValue != null %} min="{{ minValue }}" {% endif %}
+            {% if maxValue != null %} max="{{ maxValue }}" {% endif %}
+            placeholder="{{ autoValue | round(3) }}"
+            value="{{ userValue }}"
+    >
+    {% if userValue %}
+    <button
+            type="button"
+            class="btn btn-icon"
+            data-toggle="popover"
+            data-placement="bottom"
+            data-trigger="hover"
+            data-html="true"
+            data-content="<strong>Reset to auto-estimated:</strong><br />{{ autoValue | round(3) }}"
+    >
+        <i class="fa fa-undo"></i>
+    </button>
+    {% endif %}
+</div>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/section.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/section.html
@@ -1,0 +1,2 @@
+<h3>{{ title }}</h3>
+<div class="rows"></div>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/tabContent.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/tabContent.html
@@ -1,2 +1,1 @@
-<!-- TODO Add Real Content -->
-<h1>{{ displayName }}</h1>
+<div class="sections-region"></div>

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -146,6 +146,83 @@ var SectionsView = Marionette.CollectionView.extend({
     childView: SectionView,
 });
 
+function showSettingsModal(title, dataModel, modifications, addModification) {
+    var tabs = new models.EntryTabCollection([
+            // { name: 'efficiencies', displayName: 'Efficiencies' },
+            {
+                name: 'waste_water',
+                displayName: 'Waste Water',
+                sections: new models.EntrySectionCollection([
+                    {
+                        title: 'Wastewater Treatment Plants',
+                        fields: models.makeFieldCollection('waste_water', dataModel, modifications, [
+                            {
+                                name: 'PointNitr',
+                                label: 'Annual TN Load (kg/yr)',
+                                calculator: calcs.EqualMonths,
+                                minValue: 0
+                            },
+                            {
+                                name: 'PointPhos',
+                                label: 'Annual TP Load (kg/yr)',
+                                calculator: calcs.EqualMonths,
+                                minValue: 0
+                            },
+                            {
+                                name: 'PointFlow',
+                                label: 'Daily Effluent Discharge (MGD)',
+                                calculator: calcs.PointSourceDischarge,
+                                minValue: 0
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Number of Persons on Different Septic System Types',
+                        fields: models.makeFieldCollection('waste_water', dataModel, modifications, [
+                            {
+                                name: 'NumNormalSys',
+                                label: 'Normally Functioning Systems',
+                                calculator: calcs.Array12,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumPondSys',
+                                label: 'Surface Failures',
+                                calculator: calcs.Array12,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumShortSys',
+                                label: 'Subsurface Failures',
+                                calculator: calcs.Array12,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumDischargeSys',
+                                label: 'Direct Discharges',
+                                calculator: calcs.Array12,
+                                minValue: 0
+                            },
+                        ]),
+                    },
+                ]),
+            },
+            // { name: 'animals', displayName: 'Animals' },
+            // { name: 'other', displayName: 'Other Model Data' },
+        ]),
+        window = new models.WindowModel({
+            dataModel: dataModel,
+            title: title,
+            tabs: tabs,
+        });
+
+    new EntryModal({
+        model: window,
+        addModification: addModification,
+    }).render();
+}
+
 module.exports = {
     EntryModal: EntryModal,
+    showSettingsModal: showSettingsModal,
 };

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -2,7 +2,9 @@
 
 var Marionette = require('../../../../shim/backbone.marionette'),
     modalViews = require('../../../core/modals/views'),
+    fieldTmpl = require('./templates/field.html'),
     modalTmpl = require('./templates/modal.html'),
+    sectionTmpl = require('./templates/section.html'),
     tabContentTmpl = require('./templates/tabContent.html'),
     tabPanelTmpl = require('./templates/tabPanel.html');
 
@@ -64,6 +66,16 @@ var TabContentView = Marionette.LayoutView.extend({
     id: function() {
         return 'entry_' + this.model.get('name');
     },
+
+    regions: {
+        sectionsRegion: '.sections-region',
+    },
+
+    onShow: function() {
+        this.sectionsRegion.show(new SectionsView({
+            collection: this.model.get('sections'),
+        }));
+    },
 });
 
 var TabContentsView = Marionette.CollectionView.extend({
@@ -74,6 +86,64 @@ var TabContentsView = Marionette.CollectionView.extend({
     onRender: function() {
         this.$('.tab-pane:first').addClass('active');
     },
+});
+
+var FieldView = Marionette.ItemView.extend({
+    className: 'row',
+    template: fieldTmpl,
+
+    ui: {
+        input: 'input',
+    },
+
+    events: {
+        'change @ui.input': 'updateUserValue',
+        'click button': 'resetUserValue',
+    },
+
+    modelEvents: {
+        'change:userValue': 'render',
+    },
+
+    onRender: function() {
+        this.$('[data-toggle="popover"]').popover();
+    },
+
+    updateUserValue: function() {
+        var value = this.ui.input.val();
+
+        this.model.set('userValue', value || null);
+    },
+
+    resetUserValue: function() {
+        this.ui.input.val('');
+        this.$('[data-toggle="popover"]').popover('destroy');
+        this.model.set('userValue', null);
+    }
+});
+
+var FieldsView = Marionette.CollectionView.extend({
+    childView: FieldView,
+});
+
+var SectionView = Marionette.LayoutView.extend({
+    template: sectionTmpl,
+
+    regions: {
+        fieldsRegion: '.rows',
+    },
+
+    onShow: function() {
+        this.fieldsRegion.show(new FieldsView({
+            collection: this.model.get('fields'),
+        }));
+    }
+});
+
+var SectionsView = Marionette.CollectionView.extend({
+    className: 'section',
+
+    childView: SectionView,
 });
 
 module.exports = {

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -2,6 +2,8 @@
 
 var Marionette = require('../../../../shim/backbone.marionette'),
     modalViews = require('../../../core/modals/views'),
+    models = require('./models'),
+    calcs = require('./calcs'),
     fieldTmpl = require('./templates/field.html'),
     modalTmpl = require('./templates/modal.html'),
     sectionTmpl = require('./templates/section.html'),
@@ -14,9 +16,21 @@ var EntryModal = modalViews.ModalBaseView.extend({
     id: 'entry-modal',
     className: 'modal modal-large fade',
 
+    ui: {
+        saveButton: '.btn-active',
+    },
+
+    events: {
+        'click @ui.saveButton': 'saveAndClose',
+    },
+
     regions: {
         panelsRegion: '.tab-panels-region',
         contentsRegion: '.tab-contents-region',
+    },
+
+    initialize: function(options) {
+        this.mergeOptions(options, ['addModification']);
     },
 
     // Override to populate tabs
@@ -31,6 +45,16 @@ var EntryModal = modalViews.ModalBaseView.extend({
         }));
 
         this.$el.modal('show');
+    },
+
+    saveAndClose: function() {
+        var addModification = this.addModification;
+
+        this.model.get('tabs').forEach(function(tab) {
+            addModification(tab.getOutput());
+        });
+
+        this.hide();
     }
 });
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -800,12 +800,13 @@ var GwlfeToolbarView = ScenarioModelToolbarView.extend({
 
     templateHelpers: function() {
         var activeMod = this.getActiveMod(),
+            isEntry = function(m) { return m.modKey.startsWith('entry_'); },
             modifications = this.model.get('modifications').toJSON(),
             editable = isEditable(this.model);
 
         activeMod = activeMod ? activeMod.toJSON() : null;
         return {
-            modifications: modifications,
+            modifications: _.reject(modifications, isEntry),
             activeMod: activeMod,
             displayNames: gwlfeConfig.displayNames,
             editable: editable

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -429,5 +429,52 @@
 
   .tab-pane {
     padding: 2rem;
+
+    .rows {
+      padding: 2rem 0;
+
+      .row {
+        padding-bottom: 0.5rem;
+
+        .manual-entry-label {
+          padding-top: 7px;
+        }
+
+        input[type='number'] {
+          -moz-appearance: textfield;
+        }
+
+        input::-webkit-outer-spin-button,
+        input::-webkit-inner-spin-button {
+          -webkit-appearance: none;
+        }
+
+        .form-control {
+          border-radius: 0;
+
+          &:invalid {
+            border-color: $ui-danger;
+
+            &:focus {
+              box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+            }
+          }
+        }
+
+        .btn-icon {
+          position: absolute;
+          top: 0;
+          right: 13px;
+
+          i {
+            color: #449ff0;
+          }
+
+          &:focus {
+            outline: none;
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Overview

This PR is a double-header: it sets up the plumbing for configuring sections and fields for all tabs, and adds the specific sections and fields for Waste Water. Other tabs are temporarily hidden, to be re-added with the their fields in later cards.

Since the user-facing field configuration doesn't always map one-to-one with the underlying GMS representation, each field is configured with a "calculator" helper which provides methods for converting to and from the GMS format. Some calculator helpers have already been added, with more expected to be added when required in the future.

The manual entries are added as special modifications to the scenario. By adding them as modifications, we take advantage of existing code which overrides the GMS variables with these changes, both in the front- and back-ends. This also scopes them to a scenario, so different scenarios can have different manual entries. They are also saved to the scenario, so when a project is reloaded, all the manual entries are retrieved and reused.

The special modifications are prefixed with `entry_` so they can be ignored by certain parts of the UI, such as the tiles in the top-right added for each active BMP.

Connects #2959 

### Demo

![2018-09-12 16 40 59](https://user-images.githubusercontent.com/1430060/45452123-2028ae80-b6ab-11e8-9913-7baa83e17a4c.gif)

![image](https://user-images.githubusercontent.com/1430060/45452091-04250d00-b6ab-11e8-8aa9-4044ac124201.png)

## Testing Instructions

* Check out this branch and `bundle`
* Create or open a MapShed project. Create or open a scenario other than "Current Conditions".
* Open the settings modal. Ensure there are no errors in the console.
* Add a value to one of the fields. Ensure you see a revert / undo button once the field loses focus.
* Hover over the undo button. Ensure it shows the previous / auto-estimated value.
* Click the undo button. Ensure it removes the user value.
* Add a user value and click "Save". Ensure the results are re-run.
* Open the settings modal again. Ensure the user value is still there.
* Go to a different scenario, and open the settings modal. Ensure the user values from the previous scenario did not get carried over, and this has a fresh state.
* Go back to the previous scenario. Ensure its settings still persist.
* Reload the page. Open the settings modal. Ensure the settings were persisted to the database and load correctly.
* Export a GMS file from Current Conditions. Export a GMS file from a scenario with manual entries. Compare the two files, and ensure the diff corresponds to the manual entries. Refer to #2959 to see where the values for each field should reflect.