### PR TITLE
MapShed Manual Entry: Add Animals Tab

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/entry/calcs.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/calcs.js
@@ -70,5 +70,20 @@ module.exports = {
             return _.sum(dataModel[fieldName]) /
                 (DAYS_PER_YEAR * M3_PER_MGAL * CM_PER_M / AREA_SQM);
         },
+    },
+
+    // Corresponds to a certain index of a given array. The fieldName must be
+    // in the format {ArrayName}__{index}
+    ArrayIndex: {
+        toOutput: function(userValue) {
+            return userValue;
+        },
+        getAutoValue: function(fieldName, dataModel) {
+            var arrayIndex = fieldName.split('__'),
+                arrayName = arrayIndex[0],
+                index = parseInt(arrayIndex[1]);
+
+            return dataModel[arrayName][index];
+        },
     }
 };

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -3,10 +3,16 @@
 var Backbone = require('../../../../shim/backbone'),
     GwlfeModificationModel = require('../../models').GwlfeModificationModel;
 
+var ENTRY_FIELD_TYPES = {
+    NUMERIC: 'NUMERIC',
+    YESNO: 'YESNO',
+};
+
 var EntryFieldModel = Backbone.Model.extend({
     defaults: {
         label: '',
         name: '',
+        type: ENTRY_FIELD_TYPES.NUMERIC,
         minValue: null,
         maxValue: null,
         autoValue: null,
@@ -110,6 +116,7 @@ function makeFieldCollection(tabName, dataModel, modifications, fields) {
 }
 
 module.exports = {
+    ENTRY_FIELD_TYPES: ENTRY_FIELD_TYPES,
     EntryFieldModel: EntryFieldModel,
     EntryFieldCollection: EntryFieldCollection,
     EntrySectionModel: EntrySectionModel,

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
@@ -3,6 +3,7 @@
         {{ label }}
     </div>
 </div>
+{% if type == 'NUMERIC' %}
 <div class="col-sm-4">
     <input
             type="number"
@@ -28,3 +29,45 @@
     </button>
     {% endif %}
 </div>
+{% elif type == 'YESNO' %}
+<div class="col-sm-4">
+    <select
+            class="form-control {{ '-unmodified' if not userValue }}"
+            name="{{ name }}"
+    >
+        <option
+            value="<Yes>"
+            {% if (userValue and userValue == '<Yes>') or (not userValue and autoValue == '<Yes>') %}
+            selected
+            {% endif %}
+        >
+            Yes
+        </option>
+        <option
+            value="<No>"
+            {% if (userValue and userValue == '<No>') or (not userValue and autoValue == '<No>') %}
+            selected
+            {% endif %}
+        >
+            No
+        </option>
+    </select>
+    {% if userValue %}
+    <button
+            type="button"
+            class="btn btn-icon"
+            data-toggle="popover"
+            data-placement="bottom"
+            data-trigger="hover"
+            data-html="true"
+            data-content="<strong>Reset to auto-estimated:</strong><br />{{ autoValue | replace('<', '') | replace('>', '') }}"
+    >
+        <i class="fa fa-undo"></i>
+    </button>
+    {% endif %}
+</div>
+{% else %}
+<div class="col-sm-4">
+    Missing Field Type
+</div>
+{% endif %}

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -118,7 +118,7 @@ var FieldView = Marionette.ItemView.extend({
     template: fieldTmpl,
 
     ui: {
-        input: 'input',
+        input: '.form-control',
     },
 
     events: {
@@ -246,10 +246,22 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                                 minValue: 0
                             },
                             {
+                                name: 'GrazingAnimal__0',
+                                label: 'Are Dairy Cows allowed to graze?',
+                                calculator: calcs.ArrayIndex,
+                                type: models.ENTRY_FIELD_TYPES.YESNO
+                            },
+                            {
                                 name: 'NumAnimals__1',
                                 label: 'Cows, Beef',
                                 calculator: calcs.ArrayIndex,
                                 minValue: 0
+                            },
+                            {
+                                name: 'GrazingAnimal__1',
+                                label: 'Are Beef Cows allowed to graze?',
+                                calculator: calcs.ArrayIndex,
+                                type: models.ENTRY_FIELD_TYPES.YESNO
                             },
                             {
                                 name: 'NumAnimals__2',
@@ -270,16 +282,34 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                                 minValue: 0
                             },
                             {
+                                name: 'GrazingAnimal__4',
+                                label: 'Are Pigs / Hogs / Swine allowed to graze?',
+                                calculator: calcs.ArrayIndex,
+                                type: models.ENTRY_FIELD_TYPES.YESNO
+                            },
+                            {
                                 name: 'NumAnimals__5',
                                 label: 'Sheep',
                                 calculator: calcs.ArrayIndex,
                                 minValue: 0
                             },
                             {
+                                name: 'GrazingAnimal__5',
+                                label: 'Are Sheep allowed to graze?',
+                                calculator: calcs.ArrayIndex,
+                                type: models.ENTRY_FIELD_TYPES.YESNO
+                            },
+                            {
                                 name: 'NumAnimals__6',
                                 label: 'Horses',
                                 calculator: calcs.ArrayIndex,
                                 minValue: 0
+                            },
+                            {
+                                name: 'GrazingAnimal__6',
+                                label: 'Are Horses allowed to graze?',
+                                calculator: calcs.ArrayIndex,
+                                type: models.ENTRY_FIELD_TYPES.YESNO
                             },
                             {
                                 name: 'NumAnimals__7',

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -232,7 +232,84 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                     },
                 ]),
             },
-            // { name: 'animals', displayName: 'Animals' },
+            {
+                name: 'animals',
+                displayName: 'Animals',
+                sections: new models.EntrySectionCollection([
+                    {
+                        title: 'Animal Populations',
+                        fields: models.makeFieldCollection('animals', dataModel, modifications, [
+                            {
+                                name: 'NumAnimals__0',
+                                label: 'Cows, Dairy',
+                                calculator: calcs.ArrayIndex,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumAnimals__1',
+                                label: 'Cows, Beef',
+                                calculator: calcs.ArrayIndex,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumAnimals__2',
+                                label: 'Chickens, Broilers',
+                                calculator: calcs.ArrayIndex,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumAnimals__3',
+                                label: 'Chickens, Layers',
+                                calculator: calcs.ArrayIndex,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumAnimals__4',
+                                label: 'Pigs / Hogs / Swine',
+                                calculator: calcs.ArrayIndex,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumAnimals__5',
+                                label: 'Sheep',
+                                calculator: calcs.ArrayIndex,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumAnimals__6',
+                                label: 'Horses',
+                                calculator: calcs.ArrayIndex,
+                                minValue: 0
+                            },
+                            {
+                                name: 'NumAnimals__7',
+                                label: 'Turkeys',
+                                calculator: calcs.ArrayIndex,
+                                minValue: 0
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Populations Served by Animal Waste Management Systems',
+                        fields: models.makeFieldCollection('animals', dataModel, modifications, [
+                            {
+                                name: 'AWMSGrPct',
+                                label: 'Fraction of Livestock served by AWMS (0-1)',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1
+                            },
+                            {
+                                name: 'AWMSNgPct',
+                                label: 'Fraction of Poultry served by AWMS (0-1)',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1
+                            },
+                        ]),
+                    }
+                ]),
+            },
             // { name: 'other', displayName: 'Other Model Data' },
         ]),
         windowModel = new models.WindowModel({

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var Marionette = require('../../../../shim/backbone.marionette'),
+var _ = require('lodash'),
+    Marionette = require('../../../../shim/backbone.marionette'),
     modalViews = require('../../../core/modals/views'),
     models = require('./models'),
     calcs = require('./calcs'),
@@ -20,9 +21,9 @@ var EntryModal = modalViews.ModalBaseView.extend({
         saveButton: '.btn-active',
     },
 
-    events: {
+    events: _.defaults({
         'click @ui.saveButton': 'saveAndClose',
-    },
+    }, modalViews.ModalBaseView.prototype.events),
 
     regions: {
         panelsRegion: '.tab-panels-region',
@@ -234,14 +235,14 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
             // { name: 'animals', displayName: 'Animals' },
             // { name: 'other', displayName: 'Other Model Data' },
         ]),
-        window = new models.WindowModel({
+        windowModel = new models.WindowModel({
             dataModel: dataModel,
             title: title,
             tabs: tabs,
         });
 
     new EntryModal({
-        model: window,
+        model: windowModel,
         addModification: addModification,
     }).render();
 }

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -459,12 +459,16 @@
               box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
             }
           }
+
+          &.-unmodified {
+            color: #999;
+          }
         }
 
         .btn-icon {
           position: absolute;
           top: 0;
-          right: 13px;
+          right: 20px;
 
           i {
             color: #449ff0;


### PR DESCRIPTION
## Overview

Adds Animals tab to Manual Entry modal. Also adds the ability to have dropdown fields. Their values are grayed until the user edits them, when the undo button is visible, which behaves exactly as for the text boxes.

Also fixes the modal itself so it doesn't spawn multiple copies.

Connects #2960 

### Demo

![image](https://user-images.githubusercontent.com/1430060/45511265-89bbc200-b76a-11e8-92dc-72b328a65c1c.png)

### Notes

The dropdowns look different than the text boxes in terms of fill, border, and shadow, but that is browser dependent. I kept them the same width, and made sure the undo button didn't overlap any of the native UI in different browsers.

## Testing Instructions

* Check out this branch and `bundle`
* Go to a MapShed project's scenario and open the settings modal
* Switch to the Animals tab. Ensure the fields match the original issue.
* Try editing values. Ensure they behave as expected in the GMS output.
* Ensure they load correctly for saved scenarios
* Ensure you can close and open the entry modal multiple times and switch tabs correctly