### PR TITLE
Use staging SRAT url for dev, test, staging

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -28,7 +28,7 @@ itsi_secret_key: "{{ lookup('env', 'MMW_ITSI_SECRET_KEY') }}"
 hydroshare_base_url: "https://beta.hydroshare.org/"
 hydroshare_secret_key: "{{ lookup('env', 'MMW_HYDROSHARE_SECRET_KEY') }}"
 
-srat_catchment_api_url: "https://rychrnjrs6.execute-api.us-east-1.amazonaws.com/prod/SratRunModel"
+srat_catchment_api_url: "https://rychrnjrs6.execute-api.us-east-1.amazonaws.com/dev/SratRunModel_DEV"
 srat_catchment_api_key: "{{ lookup('env', 'MMW_SRAT_CATCHMENT_API_KEY') }}"
 
 tilecache_bucket_name: "{{ lookup('env', 'MMW_TILECACHE_BUCKET') | default('', true) }}"

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -25,7 +25,7 @@ itsi_secret_key: "{{ lookup('env', 'MMW_ITSI_SECRET_KEY') }}"
 hydroshare_base_url: "https://beta.hydroshare.org/"
 hydroshare_secret_key: "{{ lookup('env', 'MMW_HYDROSHARE_SECRET_KEY') }}"
 
-srat_catchment_api_url: "https://rychrnjrs6.execute-api.us-east-1.amazonaws.com/prod/SratRunModel"
+srat_catchment_api_url: "https://rychrnjrs6.execute-api.us-east-1.amazonaws.com/dev/SratRunModel_DEV"
 srat_catchment_api_key: "{{ lookup('env', 'MMW_SRAT_CATCHMENT_API_KEY') }}"
 
 tilecache_bucket_name: "tile-cache.staging.app.wikiwatershed.org"


### PR DESCRIPTION
## Overview

Updates the Staging SRAT URL so the service providers can experiment with changes without affecting our production instance.

In addition to these places, I've also updated `civicci01` and the fileshare. The production config still points to the production URL.

Connects #2967 

## Testing Instructions

* Check out this branch and `ssh` in to your `app` and `worker` instances and update the `/etc/mmw.d/env/MMW_SRAT_CATCHMENT_API_URL` file with the new URL. Then restart `mmw-app` and `celeryd`.
* Run subbasin on a HUC-10. Ensure it finishes correctly.