### PR TITLE
Monitor: Tolerate CUAHSI Service Being Unavailable

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -25,7 +25,7 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "10.4-*.pgdg14.04+1"
+postgresql_support_libpq_version: "10.5-*.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.7"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"

--- a/src/mmw/apps/bigcz/utils.py
+++ b/src/mmw/apps/bigcz/utils.py
@@ -10,7 +10,7 @@ from apps.bigcz.models import BBox
 from django.conf import settings
 
 from rest_framework import status
-from rest_framework.exceptions import APIException
+from rest_framework.exceptions import APIException, ValidationError
 import dateutil.parser
 
 
@@ -68,6 +68,11 @@ class ValuesTimedOutError(APIException):
     default_detail = \
         'Request for values did not finish in {} seconds'.format(
             settings.BIGCZ_CLIENT_TIMEOUT)
+
+
+class ServiceNotAvailableError(ValidationError):
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = 'Underlying service is not available.'
 
 
 def read_unicode_csv(utf8_data, **kwargs):

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -7,6 +7,7 @@ var $ = require('jquery'),
     settings = require('../core/settings');
 
 var BAD_REQUEST_CODE = 400;
+var SERVICE_UNAVAILABLE_CODE = 503;
 var REQUEST_TIMED_OUT_CODE = 408;
 var DESCRIPTION_MAX_LENGTH = 100;
 var PAGE_SIZE = settings.get('data_catalog_page_size');
@@ -346,7 +347,7 @@ var Catalog = Backbone.Model.extend({
             // was purposefully cancelled
             return;
         }
-        if (response.status === BAD_REQUEST_CODE) {
+        if (response.status === BAD_REQUEST_CODE || SERVICE_UNAVAILABLE_CODE) {
             this.set('error', response.responseJSON &&
                               response.responseJSON.error || "Error");
         } else if (response.status === REQUEST_TIMED_OUT_CODE) {


### PR DESCRIPTION
## Overview

Previously, if the CUAHSI service was unavailable, it would stop MMW from loading at all. This was because the SUDS client that talked to the service was initialized at a top level at app load. Now it is moved to be initialized within a view handler, and is wrapped in a `try` block, and the front-end updated to reflect the error. This insulated MMW from CUAHSI service disruptions.

Connects #2972 

### Demo

![2018-09-17 12 35 40](https://user-images.githubusercontent.com/1430060/45636648-46b56380-ba76-11e8-903e-51cae2d46121.gif)

### Notes

Tagging @tnation14 for deployment notes. I've made a `hotfix/1.23.1` branch at the `1.23.0` tag, and am planning to merge this PR to that branch. Once it has been merged, we should tag that with `1.23.1`, deploy it to production, and merge to `master`.

We shouldn't need to take a database backup as part of this deployment, as it is error handling related change only.

## Testing Instructions

* Check out this branch and `bundle`
    * If you see some `parser` errors when loading the app, that is because `master` and `develop` have different version of `gwlf-e`. Running `vagrant reload app --provision` should fix those.
* Select a shape and click "Monitor". Search for something, like "water". Ensure HydroShare and CINERGI return results. Ensure CUAHSI says "service not available".