### PR TITLE
Add GMS Download button to Scenario Buttons View

### DIFF
--- a/src/mmw/js/src/modeling/templates/scenariosBarButtons.html
+++ b/src/mmw/js/src/modeling/templates/scenariosBarButtons.html
@@ -1,6 +1,10 @@
 {% if editable and not isOnlyCurrentConditions %}
     <button class="btn btn-sm btn-default inverted btn-scenario" id="add-scenario"><i class="fa fa-plus"></i>New scenario</button>
 {% endif %}
+{% if isGwlfe and activeScenario and not isOnlyCurrentConditions %}
+    <button class="btn btn-sm btn-default inverted btn-scenario" id="export-gms"><i class="fa fa-download"></i>Export GMS</button>
+    {% include './gmsDownloadForm.html' %}
+{% endif %}
 {% if showCompare %}
     <button class="btn btn-sm btn-default inverted btn-scenario" id="show-compare"><i class="fa fa-th"></i> Compare</button>
 {% endif %}


### PR DESCRIPTION
## Overview

This view classically does not correspond to a single scenario, but this is where they want the GMS download button to be, so we add it, always querying for the active scenario and then populating its `gis_data` in the download form.

Much of the code has been copied from `ScenarioDropDownMenuOptionsView`, which still has an Export GMS button. A GMS file can be exported from both places.

A third place is in `ScenarioToolbarView`, which is more specific to the scenario, but that comes after the Scenario Buttons of Add New Scenario and Compare, and we want this to be seen before, so it matches to when there's only Current Conditions.

Connects #2882 

### Demo

Current Conditions with no other scenarios (same as before):

![image](https://user-images.githubusercontent.com/1430060/45905796-b05ba780-bdbf-11e8-815e-4339dc8690fb.png)

Current Conditions with other scenarios (now with Export GMS button added):

![image](https://user-images.githubusercontent.com/1430060/45905809-bf425a00-bdbf-11e8-8efb-a029cfadde21.png)

Other scenario (now with Export GMS button added):

![image](https://user-images.githubusercontent.com/1430060/45905828-cec1a300-bdbf-11e8-8d2e-2dd8fba6a1eb.png)

Tagging @jfrankl 	for visual review.

### Notes

Instead of adding the GMS form to a third place, I tried changing `ScenarioToolbarView` which already has it when Current Conditions is the only scenario. I didn't end up sticking to that because:

1. It used flexbox, and as such the button styling was quite different, and would have had to be brought in line. It was simpler to reuse existing styling to match the other buttons.
2. It would place the "Export GMS" button _after_ the "New Scenario" and "Compare" buttons. While that may make sense from one perspective (the buttons get more scenario-specific as you go to the right), the movement of the button from its place when only current conditions exist to when other scenarios are available felt confusing.

Also note that the hover state for the only current conditions case is like a link:

![image](https://user-images.githubusercontent.com/1430060/45905993-7dfe7a00-bdc0-11e8-9a8f-a90ed3778838.png)

Whereas for other cases it is a teal button:

![image](https://user-images.githubusercontent.com/1430060/45906003-8951a580-bdc0-11e8-84c5-ebb11fdda9d9.png)

Should this be made consistent?

## Testing Instructions

* Checkout this branch and `bundle`
* Make a new MapShed project. Ensure you can export GMS of current conditions when there are no more scenarios.
* Add a scenario. Ensure you can export its GMS. Ensure it is identical to Current Conditions (since you have not made any changes to it).
* Make some changes. Export GMS again. Ensure it is no longer identical to Current Conditions.
* Export GMS from the Scenario List dropdown and the header button. Ensure that the generated files are identical.