### PR TITLE
MapShed Manual Entry: BMP Efficiencies

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/entry/calcs.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/calcs.js
@@ -26,6 +26,18 @@ module.exports = {
         },
     },
 
+    // Always returns the same static value
+    Static: function(staticValue) {
+        return {
+            toOutput: function() {
+                return staticValue;
+            },
+            getAutoValue: function() {
+                return staticValue;
+            },
+        };
+    },
+
     // Takes the userValue and makes an array with the value repeated 12 times
     Array12: {
         toOutput: function(userValue) {

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -18,6 +18,7 @@ var EntryFieldModel = Backbone.Model.extend({
         maxValue: null,
         autoValue: null,
         userValue: null,
+        readOnly: false,  // Used to indicate a field that cannot be edited
     },
 
     initialize: function(attrs, dataModel) {

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -52,6 +52,7 @@ var EntryTabModel = Backbone.Model.extend({
         displayName: '',
         name: '',
         sections: null,  // EntrySectionCollection
+        triplet: false,
     },
 
     getOutput: function() {

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
@@ -14,6 +14,7 @@
             {% if maxValue != null %} max="{{ maxValue }}" {% endif %}
             placeholder="{{ autoValue | round(3) }}"
             value="{{ userValue }}"
+            {% if readOnly %} disabled {% endif %}
     >
     <button
             type="button"

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
@@ -1,5 +1,5 @@
 <div class="col-sm-8">
-    <div class="manual-entry-label">
+    <div class="mapshed-manual-entry-label">
         {{ label }}
     </div>
 </div>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
@@ -1,10 +1,4 @@
-<div class="col-sm-8">
-    <div class="mapshed-manual-entry-label">
-        {{ label }}
-    </div>
-</div>
 {% if type == 'NUMERIC' %}
-<div class="col-sm-4">
     <input
             type="number"
             class="form-control"
@@ -27,9 +21,7 @@
     >
         <i class="fa fa-undo"></i>
     </button>
-</div>
 {% elif type == 'YESNO' %}
-<div class="col-sm-4">
     <select
             class="form-control {{ '-unmodified' if not userValue }}"
             name="{{ name }}"
@@ -62,9 +54,6 @@
     >
         <i class="fa fa-undo"></i>
     </button>
-</div>
 {% else %}
-<div class="col-sm-4">
     Missing Field Type
-</div>
 {% endif %}

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/fieldWithLabel.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/fieldWithLabel.html
@@ -1,0 +1,8 @@
+<div class="col-sm-8">
+    <div class="mapshed-manual-entry-label">
+        {{ label }}
+    </div>
+</div>
+<div class="col-sm-4">
+    {% include './field.html' %}
+</div>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/tripletSection.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/tripletSection.html
@@ -1,0 +1,4 @@
+<td>{{ title }}</td>
+<td class="n-region"></td>
+<td class="p-region"></td>
+<td class="s-region"></td>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/tripletTabContent.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/tripletTabContent.html
@@ -1,0 +1,12 @@
+<table>
+    <thead>
+        <tr>
+            <th width="99%"><h3>Conservation Practice</h3></th>
+            <th>Nitrogen</th>
+            <th>Phosphorus</th>
+            <th>Sediment</th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -7,6 +7,7 @@ var _ = require('lodash'),
     models = require('./models'),
     calcs = require('./calcs'),
     fieldTmpl = require('./templates/field.html'),
+    fieldWithLabelTmpl = require('./templates/fieldWithLabel.html'),
     modalTmpl = require('./templates/modal.html'),
     landCoverModalTmpl = require('./templates/landCoverModal.html'),
     landCoverTotalTmpl = require('./templates/landCoverTotal.html'),
@@ -211,7 +212,7 @@ var TabContentsView = Marionette.CollectionView.extend({
 });
 
 var FieldView = Marionette.ItemView.extend({
-    className: 'row mapshed-manual-entry',
+    className: 'mapshed-manual-entry',
     template: fieldTmpl,
 
     ui: {
@@ -254,8 +255,13 @@ var FieldView = Marionette.ItemView.extend({
     }
 });
 
+var FieldWithLabelView = FieldView.extend({
+    className: 'row mapshed-manual-entry',
+    template: fieldWithLabelTmpl,
+});
+
 var FieldsView = Marionette.CollectionView.extend({
-    childView: FieldView,
+    childView: FieldWithLabelView,
 });
 
 var SectionView = Marionette.LayoutView.extend({

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -211,7 +211,7 @@ var TabContentsView = Marionette.CollectionView.extend({
 });
 
 var FieldView = Marionette.ItemView.extend({
-    className: 'row manual-entry',
+    className: 'row mapshed-manual-entry',
     template: fieldTmpl,
 
     ui: {

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -280,7 +280,294 @@ var SectionsView = Marionette.CollectionView.extend({
 
 function showSettingsModal(title, dataModel, modifications, addModification) {
     var tabs = new models.EntryTabCollection([
-            // { name: 'efficiencies', displayName: 'Efficiencies' },
+            {
+                name: 'efficiencies',
+                displayName: 'Efficiencies',
+                sections: new models.EntrySectionCollection([
+                    {
+                        title: 'Cover Crops',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n63',
+                                label: 'Nitrogen',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n71',
+                                label: 'Phosphorus',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n79',
+                                label: 'Sediment',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'No Till Agriculture',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n65',
+                                label: 'Nitrogen',
+                                calculator: calcs.Static(0.11),
+                                readOnly: true,
+                            },
+                            {
+                                name: 'n73',
+                                label: 'Phosphorus',
+                                calculator: calcs.Static(0.29),
+                                readOnly: true,
+                            },
+                            {
+                                name: 'n81',
+                                label: 'Sediment',
+                                calculator: calcs.Static(0.40),
+                                readOnly: true,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Conservation Tillage',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n65',
+                                label: 'Nitrogen',
+                                calculator: calcs.Static(0.08),
+                                readOnly: true,
+                            },
+                            {
+                                name: 'n73',
+                                label: 'Phosphorus',
+                                calculator: calcs.Static(0.22),
+                                readOnly: true,
+                            },
+                            {
+                                name: 'n81',
+                                label: 'Sediment',
+                                calculator: calcs.Static(0.30),
+                                readOnly: true,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Reduced Tillage',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n65',
+                                label: 'Nitrogen',
+                                calculator: calcs.Static(0.06),
+                                readOnly: true,
+                            },
+                            {
+                                name: 'n73',
+                                label: 'Phosphorus',
+                                calculator: calcs.Static(0.17),
+                                readOnly: true,
+                            },
+                            {
+                                name: 'n81',
+                                label: 'Sediment',
+                                calculator: calcs.Static(0.23),
+                                readOnly: true,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Nutrient Management',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n70',
+                                label: 'Nitrogen',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n78',
+                                label: 'Phosphorus',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Livestock Waste Management',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n85h',
+                                label: 'Nitrogen',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n85i',
+                                label: 'Phosphorus',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Poultry Waste Management',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n85j',
+                                label: 'Nitrogen',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n85k',
+                                label: 'Phosphorus',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Vegetated Buffer Strips',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n64',
+                                label: 'Nitrogen',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n72',
+                                label: 'Phosphorus',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n80',
+                                label: 'Sediment',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Streambank Fencing',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n69',
+                                label: 'Nitrogen',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n77',
+                                label: 'Phosphorus',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n85',
+                                label: 'Sediment',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Streambank Stabilization',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n69c',
+                                label: 'Nitrogen',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n77c',
+                                label: 'Phosphorus',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n85d',
+                                label: 'Sediment',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Surface Water Retention',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n70b',
+                                label: 'Nitrogen',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n78b',
+                                label: 'Phosphorus',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n85c',
+                                label: 'Sediment',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                        ]),
+                    },
+                    {
+                        title: 'Infiltration / Bioretention',
+                        fields: models.makeFieldCollection('efficiencies', dataModel, modifications, [
+                            {
+                                name: 'n71b',
+                                label: 'Nitrogen',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n79b',
+                                label: 'Phosphorus',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                            {
+                                name: 'n79c',
+                                label: 'Sediment',
+                                calculator: calcs.Direct,
+                                minValue: 0,
+                                maxValue: 1,
+                            },
+                        ]),
+                    },
+                ]),
+            },
             {
                 name: 'waste_water',
                 displayName: 'Waste Water',

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -522,3 +522,27 @@
     }
   }
 }
+
+.triplet-tab-pane {
+  table {
+    width: 100%;
+
+    th {
+      padding-bottom: 5px;
+    }
+
+    td {
+      padding-right: 5px;
+      padding-bottom: 5px;
+
+      .mapshed-manual-entry {
+        width: 100px;
+        position: relative;
+
+        .btn-undo {
+          right: 0;
+        }
+      }
+    }
+  }
+}

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -470,8 +470,8 @@
   }
 }
 
-.manual-entry {
-  .manual-entry-label {
+.mapshed-manual-entry {
+  .mapshed-manual-entry-label {
     padding-top: 7px;
   }
 


### PR DESCRIPTION
## Overview

Adds a tab for editing BMP efficiencies. Most of them are simple Direct replacements. A few are hard-coded Static values that are [out of scope](https://github.com/WikiWatershed/model-my-watershed/issues/2962#issuecomment-424730883) to manage.

Includes a new UI for handling triplet fields.

Connects #2962 

### Demo

![image](https://user-images.githubusercontent.com/1430060/46168939-cce85b80-c267-11e8-8abc-5a2ccbbc8755.png)

![image](https://user-images.githubusercontent.com/1430060/46168520-ba215700-c266-11e8-95a5-8f2076bfe9b7.png)

## Testing Instructions

* Checkout this branch and `bundle`
* Open a MapShed project and add a scenario
* Edit the BMP efficiencies. Ensure saving and undo work as they do for other tabs.
* Change a few fields and export GMS and compare with Current Conditions. Ensure the right fields diff.