### PR TITLE
Manual Entry: Round Land Cover values to 1 decimal place

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -14,6 +14,7 @@ var EntryFieldModel = Backbone.Model.extend({
         label: '',
         name: '',
         type: ENTRY_FIELD_TYPES.NUMERIC,
+        decimalPlaces: 3,
         minValue: null,
         maxValue: null,
         autoValue: null,

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/field.html
@@ -3,10 +3,10 @@
             type="number"
             class="form-control"
             name="{{ name }}"
-            step="0.000001"
+            step="{{ step }}"
             {% if minValue != null %} min="{{ minValue }}" {% endif %}
             {% if maxValue != null %} max="{{ maxValue }}" {% endif %}
-            placeholder="{{ autoValue | round(3) }}"
+            placeholder="{{ autoValue }}"
             value="{{ userValue }}"
             {% if readOnly %} disabled {% endif %}
     >
@@ -17,7 +17,7 @@
             data-placement="bottom"
             data-trigger="hover"
             data-html="true"
-            data-content="<strong>Reset to auto-estimated:</strong><br />{{ autoValue | round(3) }}"
+            data-content="<strong>Reset to auto-estimated:</strong><br />{{ autoValue }}"
     >
         <i class="fa fa-undo"></i>
     </button>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/landCoverTotal.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/landCoverTotal.html
@@ -1,13 +1,13 @@
 {% if is_modified %}
-    Total: <strong>{{ userTotal | toLocaleString(3) }} ha</strong>
+    Total: <strong>{{ userTotal | toLocaleString(1) }} ha</strong>
     {% if (userTotal) != (autoTotal) %}
     <small>
-        (<span class="error">{{ (userTotal - autoTotal) | abs | toLocaleString(3) }}
+        (<span class="error">{{ (userTotal - autoTotal) | abs | toLocaleString(1) }}
             {{ 'less' if userTotal < autoTotal else 'more' }} than
         </span>
-        required {{ autoTotal | toLocaleString(3) }})
+        required {{ autoTotal | toLocaleString(1) }})
     </small>
     {% endif %}
 {% else %}
-    Total: {{ autoTotal | toLocaleString(3) }} ha
+    Total: {{ autoTotal | toLocaleString(1) }} ha
 {% endif %}

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -76,8 +76,8 @@ var LandCoverModal = modalViews.ModalBaseView.extend({
     },
 
     validateModal: function() {
-        var autoTotal = round(this.model.get('autoTotal'), 3),
-            userTotal = round(this.model.get('userTotal'), 3);
+        var autoTotal = round(this.model.get('autoTotal'), 1),
+            userTotal = round(this.model.get('userTotal'), 1);
 
         this.ui.saveButton.prop('disabled', autoTotal !== userTotal);
     },
@@ -96,8 +96,8 @@ var LandCoverTotalView = Marionette.ItemView.extend({
             hasUserValue = function(field) {
                 return field.get('userValue') !== null;
             },
-            autoTotal = round(this.model.get('autoTotal'), 3),
-            userTotal = round(this.model.get('userTotal'), 3);
+            autoTotal = round(this.model.get('autoTotal'), 1),
+            userTotal = round(this.model.get('userTotal'), 1);
 
         return {
             is_modified: fields.some(hasUserValue),
@@ -309,6 +309,28 @@ var FieldView = Marionette.ItemView.extend({
 var FieldWithLabelView = FieldView.extend({
     className: 'row mapshed-manual-entry',
     template: fieldWithLabelTmpl,
+
+    templateHelpers: function() {
+        var type = this.model.get('type');
+
+        if (type !== models.ENTRY_FIELD_TYPES.NUMERIC) {
+            return {};
+        }
+
+        var autoValue = this.model.get('autoValue'),
+            decimalPlaces = this.model.get('decimalPlaces'),
+            // How many decimal places are allowed for the field in the UI
+            //   decimalPlaces = 0 => step = 1
+            //   decimalPlaces = 1 => step = 0.1
+            //   decimalPlaces = 3 => step = 0.001
+            // and so on.
+            step = Math.pow(10, -decimalPlaces);
+
+        return {
+            step: step,
+            autoValue: round(autoValue, decimalPlaces),
+        };
+    },
 });
 
 var FieldsView = Marionette.CollectionView.extend({
@@ -695,6 +717,7 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                                 name: 'NumAnimals__0',
                                 label: 'Cows, Dairy',
                                 calculator: calcs.ArrayIndex,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
@@ -707,6 +730,7 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                                 name: 'NumAnimals__1',
                                 label: 'Cows, Beef',
                                 calculator: calcs.ArrayIndex,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
@@ -719,18 +743,21 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                                 name: 'NumAnimals__2',
                                 label: 'Chickens, Broilers',
                                 calculator: calcs.ArrayIndex,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
                                 name: 'NumAnimals__3',
                                 label: 'Chickens, Layers',
                                 calculator: calcs.ArrayIndex,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
                                 name: 'NumAnimals__4',
                                 label: 'Pigs / Hogs / Swine',
                                 calculator: calcs.ArrayIndex,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
@@ -743,6 +770,7 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                                 name: 'NumAnimals__5',
                                 label: 'Sheep',
                                 calculator: calcs.ArrayIndex,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
@@ -755,6 +783,7 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                                 name: 'NumAnimals__6',
                                 label: 'Horses',
                                 calculator: calcs.ArrayIndex,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
@@ -767,6 +796,7 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                                 name: 'NumAnimals__7',
                                 label: 'Turkeys',
                                 calculator: calcs.ArrayIndex,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                         ]),
@@ -901,60 +931,70 @@ function showLandCoverModal(dataModel, modifications, addModification) {
                 name: 'Area__0',
                 label: 'Hay / Pasture (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
             {
                 name: 'Area__1',
                 label: 'Cropland (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
             {
                 name: 'Area__2',
                 label: 'Wooded Areas (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
             {
                 name: 'Area__3',
                 label: 'Wetlands (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
             {
                 name: 'Area__6',
                 label: 'Open Land (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
             {
                 name: 'Area__7',
                 label: 'Barren Areas (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
             {
                 name: 'Area__10',
                 label: 'Low-Density Mixed (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
             {
                 name: 'Area__11',
                 label: 'Medium-Density Mixed (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
             {
                 name: 'Area__12',
                 label: 'High-Density Mixed (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
             {
                 name: 'Area__13',
                 label: 'Low-Density Open Space (ha)',
                 calculator: calcs.ArrayIndex,
+                decimalPlaces: 1,
                 minValue: 0
             },
         ]),


### PR DESCRIPTION
## Overview

This PR makes it so that the Land Cover modal shows only 1 decimal place for values. MapShed is not designed to be run for any higher precision, and the extra decimal places gave the incorrect impression that it was.

Makes `FieldsView` parametrizable since it is used by multiple modals, most of which want 3 decimal places, with the Land Cover modal the only exception which prefers 1.

Connects #2989 

### Demo

![image](https://user-images.githubusercontent.com/1430060/46692569-a1edf800-cbd5-11e8-921c-e0af4f73ed29.png)

## Testing Instructions

* Check out this branch and `bundle`
* Create / Open a MapShed project
* Add a scenario. Open the Land Cover modal. Ensure that all the auto-populated values are limited to 1 decimal place.
* Ensure as you type, the total and diff values are always limited to 1 decimal place.
* Ensure you can type in a higher decimal place value, but the total calculation is limited to 1 decimal place.
* Ensure that other settings modals still show higher decimal places when the auto value has it