### PR TITLE
Make Protected Lands legend more distinguishable

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -202,7 +202,7 @@ LAYER_GROUPS = {
             'code': 'protected-lands-30m',
             'display': 'Protected Lands',
             'short_display': 'Protected Lands',
-            'css_class_prefix': 'protected-lands-30m',
+            'css_class_prefix': 'protected-lands-30m ',
             'help_text': '',
             'url': 'https://{s}.tiles.azavea.com/protected-lands-30m/{z}/{x}/{y}.png',
             'maxNativeZoom': 13,

--- a/src/mmw/sass/components/_layerpicker.scss
+++ b/src/mmw/sass/components/_layerpicker.scss
@@ -170,52 +170,58 @@ span.time-slider-end {
     background-color: rgba(183, 28, 28, 1);
   }
 
-  > .protected-lands-30m-park-federal {
+  > .protected-lands-30m {
+    border: none;
+    width: 14px;
+    height: 14px;
+
+    &.-park-federal {
       background-color: #AFB42B;
-  }
+    }
 
-  > .protected-lands-30m-park-state {
+    &.-park-state {
       background-color: #C0CA33;
-  }
+    }
 
-  > .protected-lands-30m-park-local {
+    &.-park-local {
       background-color: #CDDC39;
-  }
+    }
 
-  > .protected-lands-30m-park-private {
+    &.-park-private {
       background-color: #D4E157;
-  }
+    }
 
-  > .protected-lands-30m-park-unknown {
+    &.-park-unknown {
       background-color: #E6EE9C;
-  }
+    }
 
-  > .protected-lands-30m-natural-resource-federal {
+    &.-natural-resource-federal {
       background-color: #388E3C;
-  }
+    }
 
-  > .protected-lands-30m-natural-resource-state {
+    &.-natural-resource-state {
       background-color: #43A047;
-  }
+    }
 
-  > .protected-lands-30m-natural-resource-local {
+    &.-natural-resource-local {
       background-color: #4CAF50;
-  }
+    }
 
-  > .protected-lands-30m-natural-resource-private {
+    &.-natural-resource-private {
       background-color: #66BB6A;
-  }
+    }
 
-  > .protected-lands-30m-natural-resource-unknown {
+    &.-natural-resource-unknown {
       background-color: #A5D6A7;
-  }
+    }
 
-  > .protected-lands-30m-conservation-easement {
-      background-color: #827717;
-  }
+    &.-conservation-easement {
+      background-color: #9E9446; // Originally #827717, changed for distinguishability
+    }
 
-  > .protected-lands-30m-agricultural-easement {
+    &.-agricultural-easement {
       background-color: #8D6E63;
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

Adjusts legend color of Conservation Easement to make it easier to distinguish from Agricultural Easement, while still matching the tiles.

Connects #2988 

### Demo

![image](https://user-images.githubusercontent.com/1430060/46833748-7c005900-cd77-11e8-8863-a1f8197563fe.png)

In the above, the Conservation Easements are west of West Chester and north of Wallace.

Tagging @aufdenkampe 	for visual review.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/) and turn on the Protected Lands layer. Open the legend. Ensure the Conservation Easement color is distinguishable from Agricultural Easement, and still matches those cases in the map.