### PR TITLE
Manual Entry: Fix Decimal Place Entry in BMP Efficiencies

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -682,24 +682,28 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
                                 name: 'NumNormalSys',
                                 label: 'Normally Functioning Systems',
                                 calculator: calcs.Array12,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
                                 name: 'NumPondSys',
                                 label: 'Surface Failures',
                                 calculator: calcs.Array12,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
                                 name: 'NumShortSys',
                                 label: 'Subsurface Failures',
                                 calculator: calcs.Array12,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                             {
                                 name: 'NumDischargeSys',
                                 label: 'Direct Discharges',
                                 calculator: calcs.Array12,
+                                decimalPlaces: 0,
                                 minValue: 0
                             },
                         ]),

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -277,6 +277,28 @@ var FieldView = Marionette.ItemView.extend({
         'click @ui.undo': 'resetUserValue',
     },
 
+    templateHelpers: function() {
+        var type = this.model.get('type');
+
+        if (type !== models.ENTRY_FIELD_TYPES.NUMERIC) {
+            return {};
+        }
+
+        var autoValue = this.model.get('autoValue'),
+            decimalPlaces = this.model.get('decimalPlaces'),
+            // How many decimal places are allowed for the field in the UI
+            //   decimalPlaces = 0 => step = 1
+            //   decimalPlaces = 1 => step = 0.1
+            //   decimalPlaces = 3 => step = 0.001
+            // and so on.
+            step = Math.pow(10, -decimalPlaces);
+
+        return {
+            step: step,
+            autoValue: round(autoValue, decimalPlaces),
+        };
+    },
+
     onRender: function() {
         this.$('[data-toggle="popover"]').popover();
         this.toggleUserValueState();
@@ -309,28 +331,6 @@ var FieldView = Marionette.ItemView.extend({
 var FieldWithLabelView = FieldView.extend({
     className: 'row mapshed-manual-entry',
     template: fieldWithLabelTmpl,
-
-    templateHelpers: function() {
-        var type = this.model.get('type');
-
-        if (type !== models.ENTRY_FIELD_TYPES.NUMERIC) {
-            return {};
-        }
-
-        var autoValue = this.model.get('autoValue'),
-            decimalPlaces = this.model.get('decimalPlaces'),
-            // How many decimal places are allowed for the field in the UI
-            //   decimalPlaces = 0 => step = 1
-            //   decimalPlaces = 1 => step = 0.1
-            //   decimalPlaces = 3 => step = 0.001
-            // and so on.
-            step = Math.pow(10, -decimalPlaces);
-
-        return {
-            step: step,
-            autoValue: round(autoValue, decimalPlaces),
-        };
-    },
 });
 
 var FieldsView = Marionette.CollectionView.extend({


### PR DESCRIPTION
## Overview

Previously the decimal place limitation was only applied to field with labels. This excluded the fields in the BMP Efficiencies modal, which because of their tight arrangement do not have labels. This was a mistake, since they need to follow the same decimal place behavior as others.

Connects #2995 

### Demo

![image](https://user-images.githubusercontent.com/1430060/46964255-a9018400-d075-11e8-912c-b3343a25f68b.png)

## Testing Instructions

* Check out this branch and `bundle`
* Ensure each manual entry form follows the appropriate decimal place limitations:
  - Land Cover: 1
  - Animals: 0
  - Everything Else: 3