### PR TITLE
Update libpq glob to reflect main PostgreSQL repository

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -25,7 +25,7 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "10.5-*.pgdg14.04+1"
+postgresql_support_libpq_version: "11.0-1.pgdg14.04+2"
 postgresql_support_psycopg2_version: "2.7"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"


### PR DESCRIPTION
## Overview

Similar to #2904, #2831, #2694, #2653, etc.

This was released this week: https://ubuntuupdates.org/package/postgresql/trusty-pgdg/main/base/libpq5

![image](https://user-images.githubusercontent.com/1430060/47232387-89cc6480-d39d-11e8-8bc9-a3d68e25e8ef.png)
