### PR TITLE
Manual Entry: Add Help links to Land Cover, Settings modals

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/landCoverModal.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/landCoverModal.html
@@ -2,6 +2,14 @@
     <div class="modal-content entry-modal-content">
         <div class="modal-header">
             <div class="title">
+                <a
+                    class="btn close"
+                    target="_blank"
+                    href="https://wikiwatershed.org/documentation/mmw-tech/#description-and-editing-of-key-model-input-data-and-parameters"
+                    title="Description and Editing of Key Model Input Data and Parameters"
+                >
+                    <i class="fa fa-question-circle"></i>
+                </a>
                 <h1>{{ title }}</h1>
             </div>
         </div>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/modal.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/modal.html
@@ -2,6 +2,14 @@
     <div class="modal-content entry-modal-content">
         <div class="modal-header">
             <div class="title">
+                <a
+                        class="btn close"
+                        target="_blank"
+                        href="https://wikiwatershed.org/documentation/mmw-tech/#description-and-editing-of-key-model-input-data-and-parameters"
+                        title="Description and Editing of Key Model Input Data and Parameters"
+                >
+                    <i class="fa fa-question-circle"></i>
+                </a>
                 <h1>{{ title }}</h1>
             </div>
         </div>


### PR DESCRIPTION
## Overview

Adds a link to the documentation at the top of the Land Cover and Settings modals.

Connects #2998 

### Demo

![image](https://user-images.githubusercontent.com/1430060/47679773-6d010f80-db9b-11e8-9ebe-ab77dc624dd7.png)

## Testing Instructions

* Check out this branch and `bundle`
* Make a MapShed project, add a scenario, and make Land Cover and Settings changes
* Ensure you see a help button in the top right and clicking it takes you to the specified documentation