### PR TITLE
Unit Conversion: Draw and Analyze

### DIFF
--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTable.html
@@ -2,15 +2,15 @@
     <thead>
         <tr>
             <th data-sortable="true" data-field="nord">Id</th>
-            <th data-sortable="true" data-field="areaha" data-sorter="window.noDataSort"> Area (ha)</th>
+            <th data-sortable="true" data-field="areaha" data-sorter="window.noDataSort"> Area ({{ areaUnit }})</th>
             <th class="text-right" data-field="tn_tot_kgy" data-sortable="true" data-sorter="window.noDataSort">
-                Total N (kg/ha)
+                Total N ({{ massPerAreaMUnit }})
             </th>
             <th class="text-right" data-field="tp_tot_kgy" data-sortable="true" data-sorter="window.noDataSort">
-                Total P (kg/ha)
+                Total P ({{ massPerAreaMUnit }})
             </th>
             <th class="text-right" data-field="tss_tot_kg" data-sortable="true" data-sorter="window.noDataSort">
-                Total SS (kg/ha)
+                Total SS ({{ massPerAreaLUnit }})
             </th>
             <th class="text-right" data-field="tn_yr_avg_" data-sortable="true" data-sorter="window.noDataSort">
                 Avg TN (mg/l)

--- a/src/mmw/js/src/analyze/templates/catchmentWaterQualityTableRow.html
+++ b/src/mmw/js/src/analyze/templates/catchmentWaterQualityTableRow.html
@@ -36,16 +36,16 @@
   </a>
 </td>
 <td class="strong text-right">
-    {{ areaha|filterNoData()|toLocaleString(3) }}
+    {{ area|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ tn_tot_kgy|filterNoData()|toLocaleString(3) }}
+    {{ tn_tot|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ tp_tot_kgy|filterNoData()|toLocaleString(3) }}
+    {{ tp_tot|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
-    {{ tss_tot_kg|filterNoData()|toLocaleString(3) }}
+    {{ tss_tot|filterNoData()|toLocaleString(3) }}
 </td>
 <td class="strong text-right">
     {{ tn_yr_avg_|filterNoData()|toLocaleString(3) }}

--- a/src/mmw/js/src/analyze/templates/climateTable.html
+++ b/src/mmw/js/src/analyze/templates/climateTable.html
@@ -4,10 +4,10 @@
         <th data-visible="false" data-field="monthidx">Month Index</th>
         <th data-sortable="true" data-field="month" data-sort-name="monthidx">Month</th>
         <th class="text-right" data-field="ppt" data-sortable="true" data-sorter="window.numericSort">
-            Mean Precip. (cm)
+            Mean Precip. ({{ lengthUnit }})
         </th>
         <th class="text-right" data-field="tmean" data-sortable="true" data-sorter="window.numericSort">
-            Mean Temp. (&deg;C)
+            Mean Temp. ({{ tempUnit }})
         </th>
     </tr>
     </thead>

--- a/src/mmw/js/src/analyze/templates/pointSourceTable.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTable.html
@@ -4,13 +4,13 @@
           <th data-field="npdes_id" data-sortable="true">NPDES Code</th>
           <th data-field="city" data-sortable="true">City</th>
           <th data-field="mgd" class="text-right" data-sortable="true">
-              Discharge (MGD)
+              Discharge ({{ volumetricFlowRateUnit }})
           </th>
           <th data-field="kgn_yr" class="text-right" data-sortable="true">
-              TN Load (kg/yr)
+              TN Load ({{ massPerTimeUnit }})
           </th>
           <th data-field="kgp_yr" class="text-right" data-sortable="true">
-              TP Load (kg/yr)
+              TP Load ({{ massPerTimeUnit }})
           </th>
       </tr>
     </thead>

--- a/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
+++ b/src/mmw/js/src/analyze/templates/pointSourceTableRow.html
@@ -15,6 +15,6 @@
   </a>
 </td>
 <td>{{ city|title if city else noData }}</td>
-<td class="strong text-right">{{ mgd|filterNoData()|toLocaleString(3) }}</td>
-<td class="strong text-right">{{ kgn_yr|filterNoData()|toLocaleString(3) }}</td>
-<td class="strong text-right">{{ kgp_yr|filterNoData()|toLocaleString(3) }}</td>
+<td class="strong text-right">{{ discharge|filterNoData()|toLocaleString(3) }}</td>
+<td class="strong text-right">{{ n_load|filterNoData()|toLocaleString(3) }}</td>
+<td class="strong text-right">{{ p_load|filterNoData()|toLocaleString(3) }}</td>

--- a/src/mmw/js/src/analyze/templates/streamLengthPopover.html
+++ b/src/mmw/js/src/analyze/templates/streamLengthPopover.html
@@ -1,6 +1,6 @@
 <a class="help" data-toggle="popover" tabindex="0"
    data-html="true" data-container="body" role="button"
-   data-content="Derived using a uniform one-pixel (30m) riparian width for flowlines. <br> See our <a href='https://wikiwatershed.org/documentation/mmw-tech/#analyze-area-of-interest-aoi' target='_blank'>documentation on streams</a>."
+   data-content="Derived using a uniform one-pixel ({{ '30m' if lengthUnit == 'km' else '98.5ft' }}) riparian width for flowlines. <br> See our <a href='https://wikiwatershed.org/documentation/mmw-tech/#analyze-area-of-interest-aoi' target='_blank'>documentation on streams</a>."
    data-template="<div class='popover'><div class='pull-right'
      id='popover-close-button'><i class='fa fa-times' /></div><div
      class='popover-content'></div><div class='arrow'></div></div>">

--- a/src/mmw/js/src/analyze/templates/streamTable.html
+++ b/src/mmw/js/src/analyze/templates/streamTable.html
@@ -5,7 +5,7 @@
                 Stream Order
             </th>
             <th class="text-right" data-field="lengthkm" data-sortable="true" data-sorter="window.numericSort">
-                Total Length (km)
+                Total Length ({{ lengthUnit }})
             </th>
             <th class="text-right" data-field="avgslope" data-sortable="true" data-sorter="window.noDataSort" data-formatter="window.percentFormatter">
                 Mean Channel Slope (%)
@@ -30,11 +30,11 @@
 </table>
 <div id="streams-tab-ag-section">
     <div class="streams-tab-ag-line-item">
-        Length in agricultural areas = {{ lengthInAg|round(2)|toLocaleString(2) }} km
+        Length in agricultural areas = {{ lengthInAg|round(2)|toLocaleString(2) }} {{ lengthUnit }}
         {% include "./streamLengthPopover.html" %}
     </div>
     <div class="streams-tab-ag-line-item">
-        Length in non-agricultural areas = {{ lengthInNonAg|round(2)|toLocaleString(2) }} km
+        Length in non-agricultural areas = {{ lengthInNonAg|round(2)|toLocaleString(2) }} {{ lengthUnit }}
         {% include "./streamLengthPopover.html" %}
     </div>
 </div>

--- a/src/mmw/js/src/analyze/templates/streamTableRow.html
+++ b/src/mmw/js/src/analyze/templates/streamTableRow.html
@@ -12,7 +12,7 @@
     {% endif %}
 </td>
 <td class="strong text-right">
-    {{ lengthkm|round(2)|toLocaleString(2) }}
+    {{ length|round(2)|toLocaleString(2) }}
 </td>
 <td class="strong text-right">
     {% if avgslope %}
@@ -21,4 +21,3 @@
         {{ noData }}
     {% endif %}
 </td>
-

--- a/src/mmw/js/src/analyze/templates/terrainTable.html
+++ b/src/mmw/js/src/analyze/templates/terrainTable.html
@@ -3,7 +3,7 @@
     <tr>
         <th data-field="type"></th>
         <th data-field="elevation" class="text-right">
-            Elevation (m)
+            Elevation ({{ lengthUnit }})
         </th>
         <th data-field="slope" class="text-right">
             Slope (%)

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -8,6 +8,8 @@ var _ = require('lodash'),
     Marionette = require('../../shim/backbone.marionette'),
     coreModels = require('../core/models'),
     coreUtils = require('../core/utils'),
+    settings = require('../core/settings'),
+    coreUnits = require('../core/units'),
     models = require('./models'),
     views = require('./views'),
     mocks = require('./mocks'),
@@ -34,6 +36,8 @@ describe('Analyze', function() {
         if ($(sandboxSelector).length === 0) {
             $('<div>', {id: sandboxId}).appendTo('body');
         }
+
+        settings.set('unit_scheme', coreUnits.UNIT_SCHEME.METRIC);
     });
 
     beforeEach(function() {
@@ -96,9 +100,7 @@ function landTableFormatter(categories) {
 
     return collection.map(function(category) {
         var name = category.get('type'),
-            areaKm2 = coreUtils.changeOfAreaUnits(category.get('area'),
-                                                  'm<sup>2</sup>',
-                                                  'km<sup>2</sup>'),
+            areaKm2 = category.get('area') / coreUnits.METRIC.AREA_XL.factor,
             coverage = category.get('coverage') * 100;
 
         return [name, areaKm2.toFixed(2), coverage.toFixed(1)];
@@ -110,9 +112,7 @@ function soilTableFormatter(categories) {
 
     return collection.map(function(category) {
         var name = category.get('type'),
-            areaKm2 = coreUtils.changeOfAreaUnits(category.get('area'),
-                'm<sup>2</sup>',
-                'km<sup>2</sup>'),
+            areaKm2 = category.get('area') / coreUnits.METRIC.AREA_XL.factor,
             coverage = category.get('coverage') * 100;
 
         return [name, areaKm2.toFixed(2), coverage.toFixed(1)];
@@ -173,8 +173,8 @@ var dataFormatters = {
 };
 
 var tableHeaders = {
-    land: ['Type', 'Area (km2)', 'Coverage (%)'],
-    soil: ['Type', 'Area (km2)', 'Coverage (%)'],
+    land: ['Type', 'Area (km²)', 'Coverage (%)'],
+    soil: ['Type', 'Area (km²)', 'Coverage (%)'],
     animals: ['Animal', 'Count'],
     pointsource: ['NPDES Code', 'City', 'Discharge (MGD)', 'TN Load (kg/yr)', 'TP Load (kg/yr)'],
     catchment_water_quality: ['Id', 'Area (ha)', 'Total N (kg/ha)', 'Total P (kg/ha)',

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -136,7 +136,9 @@ function pointsourceTableFormatter(categories) {
     return collection.map(function(category) {
         var code = category.get('npdes_id'),
             city = coreUtils.toTitleCase(category.get('city')),
-            discharge = renderPtSrcAndWQTableRowValue(category.get('mgd')),
+            discharge = renderPtSrcAndWQTableRowValue(
+                category.get('mgd') / coreUnits.METRIC.VOLUMETRICFLOWRATE.factor
+            ),
             tn_load = renderPtSrcAndWQTableRowValue(category.get('kgn_yr')),
             tp_load = renderPtSrcAndWQTableRowValue(category.get('kgp_yr'));
 
@@ -176,7 +178,7 @@ var tableHeaders = {
     land: ['Type', 'Area (km²)', 'Coverage (%)'],
     soil: ['Type', 'Area (km²)', 'Coverage (%)'],
     animals: ['Animal', 'Count'],
-    pointsource: ['NPDES Code', 'City', 'Discharge (MGD)', 'TN Load (kg/yr)', 'TP Load (kg/yr)'],
+    pointsource: ['NPDES Code', 'City', 'Discharge (m³/d)', 'TN Load (kg/a)', 'TP Load (kg/a)'],
     catchment_water_quality: ['Id', 'Area (ha)', 'Total N (kg/ha)', 'Total P (kg/ha)',
         'Total SS (kg/ha)', 'Avg TN (mg/l)', 'Avg TP (mg/l)', 'Avg TSS (mg/l)'],
 };

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -783,12 +783,29 @@ var StreamTableView = Marionette.CompositeView.extend({
 var TerrainTableRowView = Marionette.ItemView.extend({
     tagName: 'tr',
     template: terrainTableRowTmpl,
+
+    templateHelpers: function() {
+        var elevation = coreUnits.get('LENGTH_M', this.model.get('elevation')).value;
+
+        return {
+            elevation: elevation,
+        };
+    },
 });
 
 var TerrainTableView = Marionette.CompositeView.extend({
     childView: TerrainTableRowView,
     childViewContainer: 'tbody',
     template: terrainTableTmpl,
+
+    templateHelpers: function() {
+        var scheme = settings.get('unit_scheme'),
+            lengthUnit = coreUnits[scheme].LENGTH_M.name;
+
+        return {
+            lengthUnit: lengthUnit,
+        };
+    },
 
     onAttach: function() {
         $('[data-toggle="table"]').bootstrapTable();

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1046,8 +1046,17 @@ var CatchmentWaterQualityTableRowView = Marionette.ItemView.extend({
     template: catchmentWaterQualityTableRowTmpl,
 
     templateHelpers: function() {
+        // Standardize input hectare to m² before converting units
+        var area = coreUnits.get('AREA_L', 10000 * this.model.get('areaha')),
+            tn_tot = coreUnits.get('MASSPERAREA_M', this.model.get('tn_tot_kgy')),
+            tp_tot = coreUnits.get('MASSPERAREA_M', this.model.get('tp_tot_kgy')),
+            tss_tot = coreUnits.get('MASSPERAREA_L', this.model.get('tss_tot_kg'));
+
         return {
-            val: this.model.get('value'),
+            area: area.value,
+            tn_tot: tn_tot.value,
+            tp_tot: tp_tot.value,
+            tss_tot: tss_tot.value,
             noData: utils.noData
         };
     }
@@ -1061,8 +1070,15 @@ var CatchmentWaterQualityTableView = Marionette.CompositeView.extend({
         };
     },
     templateHelpers: function() {
+        var scheme = settings.get('unit_scheme'),
+            areaUnit = coreUnits[scheme].AREA_L.name,
+            massPerAreaMUnit = coreUnits[scheme].MASSPERAREA_M.name,
+            massPerAreaLUnit = coreUnits[scheme].MASSPERAREA_L.name;
+
         return {
-            headerUnits: this.options.units,
+            areaUnit: areaUnit,
+            massPerAreaMUnit: massPerAreaMUnit,
+            massPerAreaLUnit: massPerAreaLUnit,
         };
     },
     childViewContainer: 'tbody',

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -943,8 +943,14 @@ var PointSourceTableRowView = Marionette.ItemView.extend({
     template: pointSourceTableRowTmpl,
 
     templateHelpers: function() {
+        var mgd = coreUnits.get('VOLUMETRICFLOWRATE', this.model.get('mgd')),
+            kgn = coreUnits.get('MASSPERTIME', this.model.get('kgn_yr')),
+            kgp = coreUnits.get('MASSPERTIME', this.model.get('kgp_yr'));
+
         return {
-            val: this.model.get('value'),
+            discharge: mgd.value,
+            n_load: kgn.value,
+            p_load: kgp.value,
             noData: utils.noData
         };
     }
@@ -958,13 +964,18 @@ var PointSourceTableView = Marionette.CompositeView.extend({
         };
     },
     templateHelpers: function() {
+        var models = this.collection.fullCollection.models,
+            getValue = function(key) { return utils.totalForPointSourceCollection(models, key); },
+            totalMGD = coreUnits.get('VOLUMETRICFLOWRATE', getValue('mgd')),
+            totalKGN = coreUnits.get('MASSPERTIME', getValue('kgn_yr')),
+            totalKGP = coreUnits.get('MASSPERTIME', getValue('kgp_yr'));
+
         return {
-            totalMGD: utils.totalForPointSourceCollection(
-                this.collection.fullCollection.models, 'mgd'),
-            totalKGN: utils.totalForPointSourceCollection(
-                this.collection.fullCollection.models, 'kgn_yr'),
-            totalKGP: utils.totalForPointSourceCollection(
-                this.collection.fullCollection.models, 'kgp_yr'),
+            totalMGD: totalMGD.value,
+            totalKGN: totalKGN.value,
+            totalKGP: totalKGP.value,
+            massPerTimeUnit: totalKGN.unit,
+            volumetricFlowRateUnit: totalMGD.unit,
         };
     },
     childViewContainer: 'tbody',

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -11,6 +11,7 @@ var $ = require('jquery'),
     models = require('./models'),
     csrf = require('../core/csrf'),
     settings = require('../core/settings'),
+    coreUnits = require('../core/units'),
     modalModels = require('../core/modals/models'),
     modalViews = require('../core/modals/views'),
     coreModels = require('../core/models'),
@@ -172,19 +173,18 @@ var ResultsView = Marionette.LayoutView.extend({
 
         if (modelPackageName === utils.GWLFE &&
             settings.get('mapshed_max_area')) {
-            var areaInSqKm = utils.changeOfAreaUnits(aoiModel.get('area'),
-                                                     aoiModel.get('units'),
-                                                     'km<sup>2</sup>'),
+            var area = aoiModel.getAreaInMeters(),
                 mapshedMaxArea = settings.get('mapshed_max_area');
 
-            if (areaInSqKm > mapshedMaxArea) {
+            if (area > mapshedMaxArea) {
+                var mmaValue = coreUnits.get('AREA_XL', mapshedMaxArea);
                 alertView = new modalViews.AlertView({
                     model: new modalModels.AlertModel({
                         alertMessage:
                             "The selected Area of Interest is too big for " +
                             "the Watershed Multi-Year Model. The currently " +
-                            "maximum supported size is " + mapshedMaxArea +
-                            " km².",
+                            "maximum supported size is " + mmaValue.value +
+                            " " + mmaValue.unit + ".",
                         alertType: modalModels.AlertTypes.warn
                     })
                 });
@@ -614,7 +614,7 @@ var TableRowView = Marionette.ItemView.extend({
             // Convert coverage to percentage for display.
             coveragePct: (this.model.get('coverage') * 100),
             // Scale the area to display units.
-            scaledArea: utils.changeOfAreaUnits(area, 'm<sup>2</sup>', units),
+            scaledArea: coreUnits.get(units, area).value,
             code: code,
             isLandTable: isLandTable
         };
@@ -630,8 +630,11 @@ var TableView = Marionette.CompositeView.extend({
         };
     },
     templateHelpers: function() {
+        var scheme = settings.get('unit_scheme'),
+            units = this.options.units;
+
         return {
-            headerUnits: this.options.units,
+            headerUnits: coreUnits[scheme][units].name,
             isLandTable: this.options.modelName === 'land'
         };
     },

--- a/src/mmw/js/src/core/catchmentWaterQualityLayer.js
+++ b/src/mmw/js/src/core/catchmentWaterQualityLayer.js
@@ -4,6 +4,7 @@ var L = require('leaflet'),
     utils = require('./utils'),
     Backbone = require('../../shim/backbone'),
     Marionette = require('../../shim/backbone.marionette'),
+    coreUnits = require('./units'),
     catchmentWaterQualityPopupTmpl = require('./templates/catchmentWaterQualityPopup.html');
 
 var Layer = {
@@ -23,7 +24,38 @@ var CatchmentWaterQualityPopupView = Marionette.ItemView.extend({
     className: 'catchment-water-quality-popup',
 
     templateHelpers: function() {
+        var tn_ag_kgyr = coreUnits.get('MASSPERAREA_M', this.model.get('tn_ag_kgyr')),
+            tp_ag_kgyr = coreUnits.get('MASSPERAREA_M', this.model.get('tp_ag_kgyr')),
+            tn_natural = coreUnits.get('MASSPERAREA_M', this.model.get('tn_natural')),
+            tp_natural = coreUnits.get('MASSPERAREA_M', this.model.get('tp_natural')),
+            tn_pt_kgyr = coreUnits.get('MASSPERAREA_M', this.model.get('tn_pt_kgyr')),
+            tp_pt_kgyr = coreUnits.get('MASSPERAREA_M', this.model.get('tp_pt_kgyr')),
+            tn_riparia = coreUnits.get('MASSPERAREA_M', this.model.get('tn_riparia')),
+            tp_riparia = coreUnits.get('MASSPERAREA_M', this.model.get('tp_riparia')),
+            tn_urban_k = coreUnits.get('MASSPERAREA_M', this.model.get('tn_urban_k')),
+            tp_urban_k = coreUnits.get('MASSPERAREA_M', this.model.get('tp_urban_k')),
+            tss_ag_kgy = coreUnits.get('MASSPERAREA_L', this.model.get('tss_ag_kgy')),
+            tss_natura = coreUnits.get('MASSPERAREA_L', this.model.get('tss_natura')),
+            tss_rip_kg = coreUnits.get('MASSPERAREA_L', this.model.get('tss_rip_kg')),
+            tss_urban_ = coreUnits.get('MASSPERAREA_L', this.model.get('tss_urban_'));
+
         return {
+            massPerAreaMUnit: tn_ag_kgyr.unit,
+            massPerAreaLUnit: tss_ag_kgy.unit,
+            tn_ag_kgyr: tn_ag_kgyr.value,
+            tp_ag_kgyr: tp_ag_kgyr.value,
+            tn_natural: tn_natural.value,
+            tp_natural: tp_natural.value,
+            tn_pt_kgyr: tn_pt_kgyr.value,
+            tp_pt_kgyr: tp_pt_kgyr.value,
+            tn_riparia: tn_riparia.value,
+            tp_riparia: tp_riparia.value,
+            tn_urban_k: tn_urban_k.value,
+            tp_urban_k: tp_urban_k.value,
+            tss_ag_kgy: tss_ag_kgy.value,
+            tss_natura: tss_natura.value,
+            tss_rip_kg: tss_rip_kg.value,
+            tss_urban_: tss_urban_.value,
             noData: utils.noData
         };
     }

--- a/src/mmw/js/src/core/pointSourceLayer.js
+++ b/src/mmw/js/src/core/pointSourceLayer.js
@@ -4,6 +4,7 @@ var L = require('leaflet'),
     utils = require('./utils'),
     Backbone = require('../../shim/backbone'),
     Marionette = require('../../shim/backbone.marionette'),
+    coreUnits = require('./units'),
     pointSourcePopupTmpl = require('./templates/pointSourcePopup.html');
 
 // Increase or decrease the marker size based on the map zoom level
@@ -46,7 +47,16 @@ var PointSourcePopupView = Marionette.ItemView.extend({
     className: 'point-source-popup',
 
     templateHelpers: function() {
+        var mgd = coreUnits.get('VOLUMETRICFLOWRATE', this.model.get('mgd')),
+            kgn = coreUnits.get('MASSPERTIME', this.model.get('kgn_yr')),
+            kgp = coreUnits.get('MASSPERTIME', this.model.get('kgp_yr'));
+
         return {
+            mgd: mgd.value,
+            kgn_yr: kgn.value,
+            kgp_yr: kgp.value,
+            volumetricFlowRateUnit: mgd.unit,
+            massPerTimeUnit: kgn.unit,
             noData: utils.noData
         };
     }

--- a/src/mmw/js/src/core/templates/catchmentWaterQualityPopup.html
+++ b/src/mmw/js/src/core/templates/catchmentWaterQualityPopup.html
@@ -3,9 +3,9 @@
     <thead>
         <tr>
             <th>Source</th>
-            <th class="text-right">TN (kg/ha)</th>
-            <th class="text-right">TP (kg/ha)</th>
-            <th class="text-right">TSS (kg/ha)</th>
+            <th class="text-right">TN ({{ massPerAreaMUnit }})</th>
+            <th class="text-right">TP ({{ massPerAreaMUnit }})</th>
+            <th class="text-right">TSS ({{ massPerAreaLUnit }})</th>
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/core/templates/pointSourcePopup.html
+++ b/src/mmw/js/src/core/templates/pointSourcePopup.html
@@ -14,19 +14,19 @@
     </thead>
     <tbody>
         <tr>
-            <td>Discharge (MGD)</td>
+            <td>Discharge ({{ volumetricFlowRateUnit }})</td>
             <td class="text-right">
                 {{ mgd|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
         <tr>
-            <td>TN Load (kg/yr)</td>
+            <td>TN Load ({{ massPerTimeUnit }})</td>
             <td class="text-right">
                 {{ kgn_yr|filterNoData()|toLocaleString(3) }}
             </td>
         </tr>
         <tr>
-            <td>TP Load (kg/yr)</td>
+            <td>TP Load ({{ massPerTimeUnit }})</td>
             <td class="text-right">
                 {{ kgp_yr|filterNoData()|toLocaleString(3) }}
             </td>

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -216,7 +216,7 @@ describe('Core', function() {
                         value: 'developed_low',
                         shape: {},
                         area: 100,
-                        units: 'm<sup>2</sup>',
+                        units: 'm²',
                     }),
                     view = new views.ModificationPopupView({ model: model, editable: true});
                 var spy = sinon.spy(model, 'destroy');
@@ -233,7 +233,7 @@ describe('Core', function() {
                     value: 'developed_low',
                     shape: {},
                     area: 100,
-                    units: 'm<sup>2</sup>',
+                    units: 'm²',
                 }),
                     view = new views.ModificationPopupView({ model: model, editable: false});
 
@@ -254,7 +254,7 @@ describe('Core', function() {
                     });
 
                     assert.equal(Math.round(model.get('area')), 270);
-                    assert.equal(model.get('units'), 'm<sup>2</sup>');
+                    assert.equal(model.get('units'), 'm²');
                 });
 
                 it('calculates and sets the area attribute to sq. km. if the area is greater than 1,000 sq. m.', function() {
@@ -263,7 +263,7 @@ describe('Core', function() {
                     });
 
                     assert.equal(Math.round(model.get('area')), 7);
-                    assert.equal(model.get('units'), 'km<sup>2</sup>');
+                    assert.equal(model.get('units'), 'km²');
                 });
 
                 it('sets the provided fields instead of the defaults if arguments are passed', function() {
@@ -275,7 +275,7 @@ describe('Core', function() {
 
                     model.setDisplayArea('effectiveShape', 'effectiveArea', 'effectiveUnits');
                     assert.equal(Math.round(model.get('effectiveArea')), 7);
-                    assert.equal(model.get('effectiveUnits'), 'km<sup>2</sup>');
+                    assert.equal(model.get('effectiveUnits'), 'km²');
                 });
             });
         });

--- a/src/mmw/js/src/core/units.js
+++ b/src/mmw/js/src/core/units.js
@@ -43,6 +43,16 @@ var units = {
             factor: 5.55556E-01,
             offset: 32
         },
+        MASSPERAREA_L: {
+            name: 'ton/ac', // US short ton
+            factor: 2.24170E+03, // from kg/ha
+            offset: 0
+        },
+        MASSPERAREA_M: {
+            name: 'lb/ac',
+            factor: 1.12085,
+            offset: 0
+        },
         MASSPERTIME: {
             name: 'lb/a',
             factor: 1/2.204620532,
@@ -50,6 +60,11 @@ var units = {
         },
         VOLUMETRICFLOWRATE: {
             name: 'mgd',
+            factor: 1,
+            offset: 0
+        },
+        CONCENTRATION: {
+            name: 'mg/L',
             factor: 1,
             offset: 0
         },
@@ -90,6 +105,16 @@ var units = {
             factor: 1,
             offset: 0
         },
+        MASSPERAREA_L: { // both MASSPERAREA are kg/ha in METRIC
+            name: 'kg/ha',
+            factor: 1,
+            offset: 0
+        },
+        MASSPERAREA_M: {
+            name: 'kg/ha',
+            factor: 1,
+            offset: 0
+        },
         MASSPERTIME: {
             name: 'kg/a',
             factor: 1,
@@ -98,6 +123,11 @@ var units = {
         VOLUMETRICFLOWRATE: {
             name: 'm³/d',
             factor: 1/3785.411784,
+            offset: 0
+        },
+        CONCENTRATION: {
+            name: 'mg/L',
+            factor: 1,
             offset: 0
         },
     },

--- a/src/mmw/js/src/core/units.js
+++ b/src/mmw/js/src/core/units.js
@@ -38,6 +38,11 @@ var units = {
             factor: 2.54000E-02,
             offset: 0
         },
+        TEMPERATURE: {
+            name: '°F',
+            factor: 5.55556E-01,
+            offset: 32
+        },
     },
     METRIC: {
         AREA_XL: {
@@ -68,6 +73,11 @@ var units = {
         LENGTH_S: {
             name: 'cm',
             factor: 1.00000E-02,
+            offset: 0
+        },
+        TEMPERATURE: {
+            name: '°C',
+            factor: 1,
             offset: 0
         },
     },

--- a/src/mmw/js/src/core/units.js
+++ b/src/mmw/js/src/core/units.js
@@ -43,6 +43,16 @@ var units = {
             factor: 5.55556E-01,
             offset: 32
         },
+        MASSPERTIME: {
+            name: 'lb/a',
+            factor: 1/2.204620532,
+            offset: 0
+        },
+        VOLUMETRICFLOWRATE: {
+            name: 'mgd',
+            factor: 1,
+            offset: 0
+        },
     },
     METRIC: {
         AREA_XL: {
@@ -78,6 +88,16 @@ var units = {
         TEMPERATURE: {
             name: '°C',
             factor: 1,
+            offset: 0
+        },
+        MASSPERTIME: {
+            name: 'kg/a',
+            factor: 1,
+            offset: 0
+        },
+        VOLUMETRICFLOWRATE: {
+            name: 'm³/d',
+            factor: 1/3785.411784,
             offset: 0
         },
     },

--- a/src/mmw/js/src/core/units.js
+++ b/src/mmw/js/src/core/units.js
@@ -23,6 +23,21 @@ var units = {
             factor: 9.29030E-02,
             offset: 0
         },
+        LENGTH_XL: {
+            name: 'mi',
+            factor: 1.60934E+03,
+            offset: 0
+        },
+        LENGTH_M: {
+            name: 'ft',
+            factor: 3.04800E-01,
+            offset: 0
+        },
+        LENGTH_S: {
+            name: 'in',
+            factor: 2.54000E-02,
+            offset: 0
+        },
     },
     METRIC: {
         AREA_XL: {
@@ -38,6 +53,21 @@ var units = {
         AREA_M: {
             name: 'm²',
             factor: 1,
+            offset: 0
+        },
+        LENGTH_XL: {
+            name: 'km',
+            factor: 1.00000E+03,
+            offset: 0
+        },
+        LENGTH_M: {
+            name: 'm',
+            factor: 1,
+            offset: 0
+        },
+        LENGTH_S: {
+            name: 'cm',
+            factor: 1.00000E-02,
             offset: 0
         },
     },

--- a/src/mmw/js/src/core/units.js
+++ b/src/mmw/js/src/core/units.js
@@ -1,0 +1,56 @@
+"use strict";
+
+var settings = require('./settings');
+
+var units = {
+    UNIT_SCHEME: {
+        METRIC: 'METRIC',
+        USCUSTOMARY: 'USCUSTOMARY',
+    },
+    USCUSTOMARY: {
+        AREA_XL: {
+            name: 'mi²',
+            factor: 2.58999E+06,
+            offset: 0
+        },
+        AREA_L: {
+            name: 'acre',
+            factor: 4.04686E+03,
+            offset: 0
+        },
+        AREA_M: {
+            name: 'ft²',
+            factor: 9.29030E-02,
+            offset: 0
+        },
+    },
+    METRIC: {
+        AREA_XL: {
+            name: 'km²',
+            factor: 1.00000E+06,
+            offset: 0
+        },
+        AREA_L: {
+            name: 'ha',
+            factor: 1.00000E+04,
+            offset: 0
+        },
+        AREA_M: {
+            name: 'm²',
+            factor: 1,
+            offset: 0
+        },
+    },
+    get: function(unit, value) {
+        var scheme = settings.get('unit_scheme');
+
+        return {
+            unit: this[scheme][unit].name,
+            value: value /
+                this[scheme][unit].factor +
+                this[scheme][unit].offset,
+        };
+    },
+};
+
+module.exports = units;

--- a/src/mmw/js/src/core/utils.js
+++ b/src/mmw/js/src/core/utils.js
@@ -6,9 +6,9 @@ var L = require('leaflet'),
     md5 = require('blueimp-md5').md5,
     intersect = require('turf-intersect'),
     centroid = require('turf-centroid'),
-    settings = require('./settings');
+    settings = require('./settings'),
+    units = require('./units');
 
-var M2_IN_KM2 = 1000000;
 var noData = 'No Data';
 var RELEASE_NOTES_BASE_URL = 'https://github.com/WikiWatershed/model-my-watershed/releases';
 var MINOR_MAJOR_REGEX = /^[0-9]+\.[0-9]+\./; // Matches strings like 2.22.
@@ -379,27 +379,13 @@ var utils = {
     },
 
     magnitudeOfArea: function(value) {
-        if (value >= M2_IN_KM2) {
-            return 'km<sup>2</sup>';
+        var scheme = settings.get('unit_scheme'),
+            minLargeValue = units[scheme].AREA_XL.factor;
+
+        if (value >= minLargeValue) {
+            return 'AREA_XL';
         } else {
-            return 'm<sup>2</sup>';
-        }
-    },
-
-    changeOfAreaUnits: function(value, fromUnit, toUnit) {
-        var fromTo = (fromUnit + ':' + toUnit).toLowerCase();
-
-        switch (fromTo) {
-            case 'm<sup>2</sup>:km<sup>2</sup>':
-                 return value / M2_IN_KM2;
-            case 'km<sup>2</sup>:m<sup>2</sup>':
-                 return value * M2_IN_KM2;
-            case 'km<sup>2</sup>:km<sup>2</sup>':
-                 return value;
-            case 'm<sup>2</sup>:m<sup>2</sup>':
-                 return value;
-            default:
-                 throw 'Conversion not implemented.';
+            return 'AREA_M';
         }
     },
 

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -7,13 +7,10 @@ var $ = require('jquery'),
     turfArea = require('turf-area'),
     turfBboxPolygon = require('turf-bbox-polygon'),
     turfKinks = require('turf-kinks'),
-    coreUtils = require('../core/utils'),
     intersect = require('turf-intersect'),
     settings = require('../core/settings');
 
 var CANCEL_DRAWING = 'CANCEL_DRAWING';
-
-var MAX_AREA = settings.get('max_area');
 
 var polygonDefaults = {
         fillColor: '#E77471',
@@ -109,17 +106,11 @@ function getGeoJsonLatLngs(shape) {
     return null;
 }
 
-// Return shape area in km2.
-function shapeArea(shape) {
-    return coreUtils.changeOfAreaUnits(turfArea(shape),
-            'm<sup>2</sup>', 'km<sup>2</sup>');
-}
-
 function shapeBoundingBox(shape) {
     return L.latLngBounds(getGeoJsonLatLngs(shape));
 }
 
-// Get the bounding box of the shape and return its area in km2
+// Get the bounding box of the shape and return its area in m²
 function shapeBoundingBoxArea(shape) {
     var latLngBounds = shapeBoundingBox(shape),
         boundingBox = [
@@ -129,7 +120,8 @@ function shapeBoundingBoxArea(shape) {
             latLngBounds.getNorth()
         ],
         boundingBoxPolygon = turfBboxPolygon(boundingBox);
-    return shapeArea(boundingBoxPolygon);
+
+    return turfArea(boundingBoxPolygon);
 }
 
 function getFileFromZipObjects(zipObjects, extension) {
@@ -189,8 +181,10 @@ function isSelfIntersecting(shape) {
 
 function isValidForAnalysis(shape) {
     if (shape) {
-        var area = shapeBoundingBoxArea(shape);
-        return area > 0 && area <= MAX_AREA;
+        var area = shapeBoundingBoxArea(shape),
+            maxArea = settings.get('max_area');
+
+        return area > 0 && area <= maxArea;
     }
     return false;
 }
@@ -244,5 +238,4 @@ module.exports = {
     NHD: 'nhd',
     DRB: 'drb',
     CANCEL_DRAWING: CANCEL_DRAWING,
-    MAX_AREA: MAX_AREA
 };

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -15,6 +15,7 @@ var $ = require('jquery'),
     utils = require('./utils'),
     models = require('./models'),
     settings = require('../core/settings'),
+    coreUnits = require('../core/units'),
     coreUtils = require('../core/utils'),
     drawUtils = require('../draw/utils'),
     drawSettings = require('./settings'),
@@ -111,12 +112,16 @@ function validateShape(polygon) {
                        'over its own border.';
         d.reject(errorMsg);
     } else if (invalidForAnalysis) {
-        var maxArea = utils.MAX_AREA.toLocaleString(),
-            selectedBoundingBoxArea = Math.floor(utils.shapeBoundingBoxArea(polygon)).toLocaleString(),
+        var maxArea = coreUnits.get('AREA_XL', settings.get('max_area')),
+            maxAreaString = Math.floor(maxArea.value).toLocaleString() +
+                            '&nbsp;' + maxArea.unit,
+            selectedBoundingBoxArea = coreUnits.get('AREA_XL', utils.shapeBoundingBoxArea(polygon)),
+            selectedBoundingBoxAreaString = Math.floor(selectedBoundingBoxArea.value).toLocaleString() +
+                                            '&nbsp;' + selectedBoundingBoxArea.unit,
             message = 'Sorry, the bounding box of the selected area is too large ' +
-                      'to analyze or model. ' + selectedBoundingBoxArea + '&nbsp;km² were ' +
+                      'to analyze or model. ' + selectedBoundingBoxAreaString + ' were ' +
                       'selected, but the maximum supported size is ' +
-                      'currently ' + maxArea + '&nbsp;km².';
+                      'currently ' + maxAreaString + '.';
         d.reject(message);
     } else if (outsideConus) {
         var conusMessage = 'The area of interest must be within the Continental US.';

--- a/src/mmw/js/src/modeling/mocks.js
+++ b/src/mmw/js/src/modeling/mocks.js
@@ -17,7 +17,7 @@ var scenarios = {
                 "value": 0.984252,
                 "shape": null,
                 "effectiveShape": null,
-                "units": "m<sup>2</sup>",
+                "units": "m²",
                 "effectiveArea": null,
                 "type": "",
                 "isValidForAnalysis": false
@@ -2165,14 +2165,14 @@ var modifications = {
         "name":"Land Cover",
         "value":"developed_low",
         "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-76.00479125976562,40.19251207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]]}},
-        "area":10977.041602204828,
-        "units":"acres"
+        "area": 44.42257988387458,
+        "units":"km²"
     },
 
     sample1OutOfOrder: {
-        "area":10977.041602204828,
+        "area": 44.42257988387458,
         "name":"Land Cover",
-        "units":"acres",
+        "units":"km²",
         "shape":{"type":"Feature","geometry":{"coordinates":[[[-76.00479125976562,40.19251207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]], "type":"Polygon"},"properties":{}},
         "value":"developed_low"
     },
@@ -2181,8 +2181,8 @@ var modifications = {
         "name":"Conservation Practice",
         "value":"rain_garden",
         "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-75.53237915039062,40.18307014852534],[-75.66009521484375,40.107487419012415],[-75.50491333007812,40.10118506258701],[-75.43350219726561,40.13899044275822],[-75.42800903320312,40.1673306817866],[-75.53237915039062,40.18307014852534]]]}},
-        "area":26292.18855342856,
-        "units":"acres"
+        "area": 106.40087636198604,
+        "units":"km²"
     },
 
     // Identical to sample1 except has a slightly smaller area
@@ -2190,8 +2190,8 @@ var modifications = {
         "name":"Land Cover",
         "value":"developed_low",
         "shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-76.00479125976562,40.19252207621169],[-76.04324340820312,40.13794057716276],[-75.95260620117188,40.136890695345905],[-75.93338012695312,40.182020964319086],[-75.96221923828125,40.199854889057676],[-76.00479125976562,40.19251207621169]]]}},
-        "area":10777.041602204828,
-        "units":"acres"
+        "area": 10777.041602204828,
+        "units":"km²"
     }
 };
 

--- a/src/mmw/js/src/modeling/tests.js
+++ b/src/mmw/js/src/modeling/tests.js
@@ -206,9 +206,9 @@ describe('Modeling', function() {
             it('lists all of the modifications and their effective area', function() {
                 this.model.get('modifications').add([this.modsModel1, this.modsModel2]);
                 assert.equal($('#sandbox #mod-landcover tbody tr td:first-child').text(), 'Developed, Low Intensity');
-                assert.equal($('#sandbox #mod-landcover tbody tr td:nth-child(2)').text(), '44.42 km2');
+                assert.equal($('#sandbox #mod-landcover tbody tr td:nth-child(2)').text(), '44.42 km²');
                 assert.equal($('#sandbox #mod-conservationpractice tbody tr td:first-child').text(), 'Rain Garden');
-                assert.equal($('#sandbox #mod-conservationpractice tbody tr td:nth-child(2)').text(), '106.40 km2');
+                assert.equal($('#sandbox #mod-conservationpractice tbody tr td:nth-child(2)').text(), '106.40 km²');
             });
 
             it('ensures each modification has a pattern', function() {
@@ -547,7 +547,7 @@ describe('Modeling', function() {
             it('inherits defaults from coreModels.GeoModel', function() {
                 var model = new models.ModificationModel({});
 
-                assert.equal(model.get('units'), 'm<sup>2</sup>');
+                assert.equal(model.get('units'), 'm²');
                 assert.equal(model.get('area'), 0);
             });
 
@@ -562,7 +562,7 @@ describe('Modeling', function() {
 
                 assert.equal(JSON.stringify(modification.get('effectiveShape')), JSON.stringify(effectiveShape));
                 assert.equal(Math.round(modification.get('effectiveArea')), 30295);
-                assert.equal(modification.get('effectiveUnits'), 'm<sup>2</sup>');
+                assert.equal(modification.get('effectiveUnits'), 'm²');
             });
 
             it('has an effective area which is equal to the total area if the modification is contained within the AoI', function() {
@@ -666,14 +666,14 @@ describe('Modeling', function() {
                     });
 
                     model.updateModificationHash();
-                    assert.equal(model.get('modification_hash'), '582b6178186440159bd4ea25f0260892');
+                    assert.equal(model.get('modification_hash'), '95abe779fa6e7c59668acc5c3f2881e6');
 
                     var mod = new models.ModificationModel(mocks.modifications.sample2);
                     model.get('modifications').add(mod);
-                    assert.equal(model.get('modification_hash'), 'd95d0c983f0e3d0b171aaa0a84540205');
+                    assert.equal(model.get('modification_hash'), '6d99c132e843a5257bfd0f7f2561c890');
 
                     model.get('modifications').remove(mod);
-                    assert.equal(model.get('modification_hash'), '582b6178186440159bd4ea25f0260892');
+                    assert.equal(model.get('modification_hash'), '95abe779fa6e7c59668acc5c3f2881e6');
                 });
 
                 it('is called when the modifications for a scenario changes', function() {

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Django settings for model_my_watershed project.
 
@@ -401,10 +402,10 @@ OMGEO_SETTINGS = [[
 ]]
 
 # Keep in sync with src/api/main.py in rapid-watershed-delineation.
-MMW_MAX_AREA = 75000  # Max area in km2, about the size of West Virginia
+MMW_MAX_AREA = 7.5e+9  # Max area in m², about the size of West Virginia
 
 BIGCZ_HOST = 'portal.bigcz.org'  # BiG-CZ Host, for enabling custom behavior
-BIGCZ_MAX_AREA = 5000  # Max area in km2, limited by CUAHSI
+BIGCZ_MAX_AREA = 5e+9  # Max area in m², limited by CUAHSI
 BIGCZ_CLIENT_TIMEOUT = 8  # timeout in seconds
 BIGCZ_CLIENT_PAGE_SIZE = 100
 

--- a/src/mmw/mmw/settings/gwlfe_settings.py
+++ b/src/mmw/mmw/settings/gwlfe_settings.py
@@ -481,7 +481,7 @@ GWLFE_CONFIG = {
     'SSLDR': 4.4,
     'SSLDM': 2.2,
     'WeatherNull': -99999,  # This value is used to indicate NULL in ms_weather dataset
-    'MaxAoIArea': 5000,  # Maximum allowed area in square kilometers
+    'MaxAoIArea': 5e+9,  # Maximum allowed area in square meters
     'ETGrowCoeff': [
         1.00,  # Hay/Pasture
         0.80,  # Cropland


### PR DESCRIPTION
## Overview

Adds a core module for converting units. Uses that core module to display favored units for the Draw and Analyze stages. All the work has been done according to [this source document](https://docs.google.com/spreadsheets/d/1Hn_PmhFz1mpDg79ZsF_gP1lZzVNCRvWQ2THsDhG6KBs).

Connects #3013 
Connects #3015 

### Demo

![image](https://user-images.githubusercontent.com/1430060/48449476-98c1ef00-e770-11e8-8582-8544f7e67b81.png)

![image](https://user-images.githubusercontent.com/1430060/48449496-b2633680-e770-11e8-8112-ccb1367f7213.png)

![image](https://user-images.githubusercontent.com/1430060/48449688-6bc20c00-e771-11e8-8c79-dea4ba9a1318.png)

etc.

### Notes

The work for the Model stage is upcoming, so #3015 isn't completely satisfied. Also, we'll have to think about the implications for existing scenarios, which may use `m<sup>2</sup>` terminology instead of the newer `m²`.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000/](http://localhost:8000/)
* Set `US Customary` as your favored unit scheme
* Draw a very large shape, the size of a small state, so you get an error message saying it is too big. Ensure the units in the error message are US Customary.
* Draw a smaller shape. Wait for Analyze to complete.
* Ensure that all the units are shown in US Customary.
* Compare the same shape on staging. Ensure that the values translate reasonably.
* Go to your account and set unit scheme to Metric.
* Draw the same shape. Wait for Analyze to complete.
* Ensure that all the units are shown in Metric.