### PR TITLE
Pin version of Python Redis module to 2.x series

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -30,3 +30,4 @@ six==1.11.0
 fiona==1.7.11
 timeout-decorator==0.4.0
 numba==0.38.1
+redis==2.10.6


### PR DESCRIPTION
## Overview

Recently (today), the 3.x series of the Python Redis module was released. A loose version constraint in one of our dependencies was causing the 3.x series to be installed when our project only supports the 2.x series.

Connects #3022 

### Notes

I discovered the Redis version issue by comparing the output of `pip freeze` across application server images from today and 11/13:

```diff
diff --git a/f5db326.txt b/30349f7.txt
index 0a76c3b..0190da9 100644
--- a/f5db326.txt
+++ b/30349f7.txt
@@ -93,7 +93,7 @@ pycurl==7.19.3
 PyNaCl==1.3.0
 pyOpenSSL==17.4.0
 pyserial==2.6
-pytest==3.10.1
+pytest==4.0.0
 python-apt===0.9.3.5ubuntu3
 python-daemon==1.6.1
 python-dateutil==2.6.0
@@ -102,7 +102,7 @@ python-omgeo==4.0.0
 pytz==2018.7
 PyYAML==3.10
 rauth==0.7.1
-redis==2.10.6
+redis==3.0.0.post1
 requests==2.9.1
 requests-oauthlib==1.0.0
 requests-toolbelt==0.8.0
```

## Testing Instructions

- Ensure that application server health checks are currently passing (this branch has been deployed to staging)
- Ensure that Celery jobs are functional

Optionally, this branch should work if you destroy your `app` VM and retrovision it from scratch.