### PR TITLE
Enable client side filtering for WQP catalog

### DIFF
--- a/src/mmw/apps/bigcz/clients/usgswqp/search.py
+++ b/src/mmw/apps/bigcz/clients/usgswqp/search.py
@@ -74,7 +74,7 @@ def parse_record(record):
         service_code=record['MonitoringLocationIdentifier'],
         service_url='https://www.waterqualitydata.us/data/Result/search?siteid={}&mimeType=csv&sorted=no&zip=yes'.format(record['MonitoringLocationIdentifier']),  # NOQA
         service_title=None,
-        service_citation='We thank the water quality portal.',
+        service_citation='National Water Quality Monitoring Council, [YEAR]. Water Quality Portal. Accessed [DATE ACCESSED]. https://www.waterqualitydata.us/',  # NOQA
         begin_date=None,
         end_date=None,
         monitoring_type=record['MonitoringLocationTypeName'],

--- a/src/mmw/js/src/data_catalog/models.js
+++ b/src/mmw/js/src/data_catalog/models.js
@@ -167,7 +167,8 @@ var Catalog = Backbone.Model.extend({
         is_pageable: true,
         page: 1,
         error: '',
-        detail_result: null
+        detail_result: null,
+        client_search: false
     },
 
     initialize: function() {
@@ -199,19 +200,19 @@ var Catalog = Backbone.Model.extend({
         var self = this,
             error = this.get('error'),
             stale = this.get('stale'),
-            isCuahsi = this.id === 'cuahsi',
+            isLocalSearch = this.get('client_search'),
             isSameQuery = query === this.get('query'),
             isSameGeom = geom === this.get('geom'),
             isSameSearch = isSameQuery && isSameGeom;
 
         // Perform local text search for pre-existing CUAHSI results
-        if (isCuahsi && isSameGeom && !isSameQuery) {
+        if (isLocalSearch && isSameGeom && !isSameQuery) {
             var searchPromise = this.searchPromise || $.when();
 
             return searchPromise.then(function() {
                 self.set({ loading: true });
 
-                var results = self.get('serverResults').textFilter(query);
+                var results = self.get('serverResults').textFilter(query, self.id);
 
                 self.get('results').reset(results);
 
@@ -260,7 +261,7 @@ var Catalog = Backbone.Model.extend({
 
     startSearch: function(page) {
         var filters = this.get('filters'),
-            results = this.id === 'cuahsi' ?
+            results = this.get('client_search') ?
                       this.get('serverResults') :
                       this.get('results'),
             dateFilter = filters.findWhere({ id: 'date' }),
@@ -320,13 +321,13 @@ var Catalog = Backbone.Model.extend({
                 resultCount: data.count,
             };
 
-        if (this.id === 'cuahsi') {
+        if (this.get('client_search')) {
             var results = this.get('results'),
                 filtered = this.get('serverResults')
-                               .textFilter(this.get('query'));
+                               .textFilter(this.get('query'), this.id);
 
             if (results === null) {
-                results = new Results(filtered, { catalog: 'cuahsi' });
+                results = new Results(filtered, { catalog: this.id });
             } else {
                 results.reset(filtered);
             }
@@ -556,7 +557,7 @@ var Result = Backbone.Model.extend({
         return this.fetchPromise;
     },
 
-    textFilter: function(query) {
+    cuahsiTextFilter: function(query) {
         var fields = [
             this.get('id').toLowerCase(),
             this.get('title').toLowerCase(),
@@ -564,6 +565,21 @@ var Result = Backbone.Model.extend({
             (this.get('service_org') || '').toLowerCase(),
             this.get('sample_mediums').join(' ').toLowerCase(),
             this.get('variables').pluck('concept_keyword').join(' ').toLowerCase(),
+        ];
+
+        return _.some(fields, function(field) {
+            return field.indexOf(query) >= 0;
+        });
+    },
+
+    wqpTextFilter: function(query) {
+        var fields = [
+            this.get('id').toLowerCase(),
+            (this.get('description') || '').toLowerCase(),
+            (this.get('monitoring_type') || '').toLowerCase(),
+            (this.get('service_org') || '').toLowerCase(),
+            (this.get('service_orgname') || '').toLowerCase(),
+            (this.get('title') || '').toLowerCase(),
         ];
 
         return _.some(fields, function(field) {
@@ -654,15 +670,25 @@ var Results = Backbone.Collection.extend({
         currentDetail.set('show_detail', false);
     },
 
-    textFilter: function(query) {
+    textFilter: function(query, catalog) {
         var lcQueries = query.toLowerCase().split(' ').filter(function(x) {
             // Exclude empty, search logic terms
             return x !== '' && x !== 'and' && x !== 'or';
         });
 
+        // Choose a text filter function based on the catalog type
+        // New functions will need to be implemented if client search
+        // is enabled for a catalog.
+        var textFilterFn = '';
+        if (catalog === 'usgswqp') {
+            textFilterFn = 'wqpTextFilter';
+        } else if (catalog === 'cuahsi') {
+            textFilterFn = 'cuahsiTextFilter';
+        }
+
         return this.filter(function(result) {
             return _.every(lcQueries, function(lcQuery) {
-                return result.textFilter(lcQuery);
+                return result[textFilterFn](lcQuery);
             });
         });
     }
@@ -926,7 +952,8 @@ function createCatalogCollection() {
             filters: new FilterCollection([
                 dateFilter,
                 new GriddedServicesFilter()
-            ])
+            ]),
+            client_search: true
         }),
         new Catalog({
             id: 'cinergi',
@@ -944,7 +971,8 @@ function createCatalogCollection() {
             serverResults: new Results(null, { catalog: 'usgswqp' }),
             filters: new FilterCollection([
                 dateFilter
-            ])
+            ]),
+            client_search: true
         })
     ]);
 }


### PR DESCRIPTION

## Overview

Abstracts the implementation for free text search on the client for the
CUAHSI catalog and allows WQP to also filter locally.

Connects #2918 

### Demo

#### WQP
![screenshot from 2018-11-16 17 20 52](https://user-images.githubusercontent.com/1014341/48650438-16316d80-e9c4-11e8-8f85-34c7d827a8ca.png)
![screenshot from 2018-11-16 17 20 42](https://user-images.githubusercontent.com/1014341/48650439-16316d80-e9c4-11e8-803f-3e7375c343fd.png)
![screenshot from 2018-11-16 17 20 28](https://user-images.githubusercontent.com/1014341/48650440-16316d80-e9c4-11e8-93f0-ec1e19c301b1.png)

#### CUAHSI

![screenshot from 2018-11-16 17 23 55](https://user-images.githubusercontent.com/1014341/48650495-6ad4e880-e9c4-11e8-8db9-f50ba10f570e.png)
![screenshot from 2018-11-16 17 23 45](https://user-images.githubusercontent.com/1014341/48650496-6ad4e880-e9c4-11e8-95d0-88d35694b9c1.png)
![screenshot from 2018-11-16 17 23 34](https://user-images.githubusercontent.com/1014341/48650497-6ad4e880-e9c4-11e8-91db-a6da741992d3.png)


## Testing Instructions
* For an area, use the text filter for both cuahsi and WQP catalogs.  Ensure that the results change based on text known to exist and not exist.


