### PR TITLE
HydroShare Bulk Upload

### DIFF
--- a/src/mmw/apps/export/hydroshare.py
+++ b/src/mmw/apps/export/hydroshare.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import json
-import StringIO
 
+from cStringIO import StringIO
 from zipfile import ZipFile
 from rauth import OAuth2Service
 from urlparse import urljoin, urlparse
@@ -91,7 +91,7 @@ class HydroShareClient(HydroShare):
                       {'name': 'String', 'contents': 'String'}
         """
         zippath = resource_id + '.zip'
-        stream = StringIO.StringIO()
+        stream = StringIO()
 
         # Zip all given files into the stream
         with ZipFile(stream, 'w') as zf:
@@ -128,7 +128,7 @@ class HydroShareClient(HydroShare):
         snapshot_path = 'mmw_project_snapshot.json'
         try:
             stream = self.getResourceFile(resource_id, snapshot_path)
-            fio = StringIO.StringIO()
+            fio = StringIO()
             for chunk in stream:
                 fio.write(chunk)
 

--- a/src/mmw/apps/export/tasks.py
+++ b/src/mmw/apps/export/tasks.py
@@ -55,8 +55,7 @@ def update_resource(user_id, project_id, params):
                 mdata = json.loads(job.result)
                 files.append({
                     'name': md.get('name'),
-                    'contents': to_gms_file(mdata),
-                    'object': True,
+                    'contents': to_gms_file(mdata).read(),
                 })
             except (Job.DoesNotExist, ValueError):
                 # Either the job wasn't found, or its content isn't JSON
@@ -65,7 +64,7 @@ def update_resource(user_id, project_id, params):
     # Except the existing analyze files
     files = [f for f in files if f['name'] not in current_analyze_files]
 
-    hs.add_files(hsresource.resource, files, overwrite=True)
+    hs.add_files(hsresource.resource, files)
 
     hsresource.exported_at = now()
     hsresource.save()
@@ -111,8 +110,7 @@ def create_resource(user_id, project_id, params):
                 mdata = json.loads(job.result)
                 files.append({
                     'name': md.get('name'),
-                    'contents': to_gms_file(mdata),
-                    'object': True,
+                    'contents': to_gms_file(mdata).read(),
                 })
             except (Job.DoesNotExist, ValueError):
                 # Either the job wasn't found, or its content isn't JSON


### PR DESCRIPTION
## Overview

Previously we uploaded files one by one to HydroShare. When overwriting, we would have to check if the file existed and delete it before uploading the same file again. This took a long time, slowed by the need to make three calls per file.

With the new "unzip overwrite" functionality introduced in hydroshare/hydroshare#2943, we can do "bulk uploads" by zipping all the files into one archive, sending that once, and unzipping on HydroShare, overwriting any existing files.

This reduces the time taken to do a HydroShare Export.

Connects #3016 

### Notes

For some reason, `mmw_project_snapshot.json` is deleted, not overwritten, on subsequent uploads. This is being discussed here: https://github.com/hydroshare/hydroshare/issues/2860#issuecomment-440793151.

## Testing Instructions

* Ensure you are setup for working with HydroShare (talk to me if you're not)
* Check out this branch and restart Celery
    ```
    vagrant ssh worker -c 'sudo service celeryd restart'
    ```
* Create a new project and export it to HydroShare
  - [x] Ensure that the project is created in HydroShare
  - [x] Ensure the modal links to the new project in HydroShare
  - [x] Ensure it has a CSV for every table, a GeoJSON and Shapefile for the area of interest, a GMS file for every MapShed scenario, the MMW Spreadsheet, and a mmw_project_snapshot.json file
* Export the project again
  - [x] Ensure it succeeds
  - [x] Ensure all files are still in HydroShare
* Add a new scenario and export again
  - [x] Ensure the new scenario files are exported to HydroShare
* Change a scenario and export again
  - [x] Ensure the scenario files in HydroShare are updated to reflect changes