### PR TITLE
Unit Conversion: Subbasin

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/catchmentTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/catchmentTable.html
@@ -2,21 +2,21 @@
     <thead>
         <tr>
             <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">NHD+ ComID</th>
-            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (ha)</th>
+            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area ({{ areaUnit }})</th>
             <th colspan="3">Total Loads (not normalized)</th>
             <th colspan="3">Loading Rates (area normalized)</th>
             <th colspan="3">Mean Annual Concentration(discharge normalized)</th>
         </tr>
         <tr>
-            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/ha/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/ha/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/ha/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Sediment (mg/L)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (mg/L)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (mg/L)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment ({{ massPerTimeUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen ({{ massPerTimeUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus ({{ massPerTimeUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment ({{ massPerAreaUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen ({{ massPerAreaUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus ({{ massPerAreaUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment ({{ concentrationUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen ({{ concentrationUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus ({{ concentrationUnit }})</th>
         </tr>
     </thead>
     <tbody>
@@ -24,16 +24,16 @@
             <tr class="subbasin-catchment-row" data-comid="{{ key }}">
                 {% set area = catchmentDetails.get(key).get('area') if  not catchmentDetails.isEmpty() else 0 %}
                 <td class="text-left">{{ key }}</td>
-                <td class="strong text-right">{{ area|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.TotalLoadingRates.Sediment|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.TotalLoadingRates.TotalN|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.TotalLoadingRates.TotalP|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ ((row.TotalLoadingRates.Sediment/area) or 0)|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ ((row.TotalLoadingRates.TotalN/area) or 0)|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ ((row.TotalLoadingRates.TotalP/area) or 0)|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.LoadingRateConcentrations.Sediment|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.LoadingRateConcentrations.TotalN|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.LoadingRateConcentrations.TotalP|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ area|toUnit(areaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.TotalLoadingRates.Sediment|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.TotalLoadingRates.TotalN|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.TotalLoadingRates.TotalP|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalLoadingRates.Sediment/area) or 0)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalLoadingRates.TotalN/area) or 0)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalLoadingRates.TotalP/area) or 0)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.LoadingRateConcentrations.Sediment|toUnit(concentrationDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.LoadingRateConcentrations.TotalN|toUnit(concentrationDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.LoadingRateConcentrations.TotalP|toUnit(concentrationDisplayUnit)|round(2)|toLocaleString(2) }}</td>
             </tr>
         {% endfor %}
     </tbody>
@@ -41,16 +41,16 @@
         <tr>
             {% set area = summaryRow.Area  %}
             <th class="text-left">{{ summaryRow.Source }}</th>
-            <th class="text-right">{{ summaryRow.Area|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.TotalLoadingRates.Sediment|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.TotalLoadingRates.TotalN|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.TotalLoadingRates.TotalP|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ ((summaryRow.TotalLoadingRates.Sediment/area) or 0)|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ ((summaryRow.TotalLoadingRates.TotalN/area) or 0)|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ ((summaryRow.TotalLoadingRates.TotalP/area) or 0)|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.LoadingRateConcentrations.Sediment|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.LoadingRateConcentrations.TotalN|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.LoadingRateConcentrations.TotalP|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.Area|toUnit(areaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalLoadingRates.Sediment|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalLoadingRates.TotalN|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalLoadingRates.TotalP|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ ((summaryRow.TotalLoadingRates.Sediment/area) or 0)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ ((summaryRow.TotalLoadingRates.TotalN/area) or 0)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ ((summaryRow.TotalLoadingRates.TotalP/area) or 0)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.LoadingRateConcentrations.Sediment|toUnit(concentrationDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.LoadingRateConcentrations.TotalN|toUnit(concentrationDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.LoadingRateConcentrations.TotalP|toUnit(concentrationDisplayUnit)|round(2)|toLocaleString(2) }}</th>
         </tr>
     </tfoot>
 

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/huc12TotalsTable.html
@@ -3,17 +3,17 @@
         <tr>
             <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">HUC-12 Name</th>
             <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">HUC-12 Number</th>
-            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (ha)</th>
+            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area ({{ areaUnit }})</th>
             <th colspan="3">Total Loads (not normalized)</th>
             <th colspan="3">Loading Rates (area normalized)</th>
         </tr>
         <tr>
-            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/ha/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/ha/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/ha/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment ({{ massPerTimeUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen ({{ massPerTimeUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus ({{ massPerTimeUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment ({{ massPerAreaUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen ({{ massPerAreaUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus ({{ massPerAreaUnit }})</th>
         </tr>
     </thead>
     <tbody>
@@ -21,26 +21,26 @@
             <tr class="huc12-total" data-huc12-id="{{ key }}">
                 <td class="text-left">{{ subbasins.get(key).get('name') if subbasins.get(key) else '--' }}</td>
                 <td class="text-right">{{ key }}</td>
-                <td class="strong text-right">{{ row.SummaryLoads.Area|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.SummaryLoads.Sediment|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.SummaryLoads.TotalN|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.SummaryLoads.TotalP|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ (row.SummaryLoads.Sediment/row.SummaryLoads.Area)|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ (row.SummaryLoads.TotalN/row.SummaryLoads.Area)|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ (row.SummaryLoads.TotalP/row.SummaryLoads.Area)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.SummaryLoads.Area|toUnit(areaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.SummaryLoads.Sediment|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.SummaryLoads.TotalN|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.SummaryLoads.TotalP|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ (row.SummaryLoads.Sediment/row.SummaryLoads.Area)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ (row.SummaryLoads.TotalN/row.SummaryLoads.Area)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ (row.SummaryLoads.TotalP/row.SummaryLoads.Area)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
             </tr>
         {% endfor %}
     </tbody>
     <tfoot>
         <tr>
             <th colspan="2" class="text-left">{{ summaryRow.Source }}</th>
-            <th class="text-right">{{ summaryRow.Area|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.Sediment|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.TotalN|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.TotalP|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ (summaryRow.Sediment/summaryRow.Area)|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ (summaryRow.TotalN/summaryRow.Area)|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ (summaryRow.TotalP/summaryRow.Area)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.Area|toUnit(areaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.Sediment|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalN|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalP|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ (summaryRow.Sediment/summaryRow.Area)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ (summaryRow.TotalN/summaryRow.Area)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ (summaryRow.TotalP/summaryRow.Area)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
         </tr>
     </tfoot>
 

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/templates/sourcesTable.html
@@ -2,43 +2,43 @@
     <thead>
         <tr>
             <th rowspan="2" class="subbasin-source-col" data-sortable="true" data-sorter="window.numericSort">Sources</th>
-            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area (ha)</th>
+            <th rowspan="2" data-sortable="true" data-sorter="window.numericSort">Area ({{ areaUnit }})</th>
             <th colspan="3">Total Loads (not normalized)</th>
             <th colspan="3">Loading Rates (area normalized)</th>
         </tr>
         <tr>
-            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Sediment (kg/ha/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen (kg/ha/y)</th>
-            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus (kg/ha/y)</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment ({{ massPerTimeUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen ({{ massPerTimeUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus ({{ massPerTimeUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Sediment ({{ massPerAreaUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Nitrogen ({{ massPerAreaUnit }})</th>
+            <th data-sortable="true" data-sorter="window.numericSort">Total Phosphorus ({{ massPerAreaUnit }})</th>
         </tr>
     </thead>
     <tbody>
         {% for row in rows %}
             <tr>
                 <td class="text-left">{{ row.Source }}</td>
-                <td class="strong text-right">{{ row.Area|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.Sediment|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.TotalN|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ row.TotalP|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ ((row.Sediment/row.Area) or 0)|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ ((row.TotalN/row.Area) or 0)|round(2)|toLocaleString(2) }}</td>
-                <td class="strong text-right">{{ ((row.TotalP/row.Area) or 0)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.Area|toUnit(areaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.Sediment|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.TotalN|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ row.TotalP|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.Sediment/row.Area) or 0)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalN/row.Area) or 0)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
+                <td class="strong text-right">{{ ((row.TotalP/row.Area) or 0)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</td>
             </tr>
         {% endfor %}
     </tbody>
     <tfoot>
         <tr>
             <th class="text-left">{{ summaryRow.Source }}</th>
-            <th class="text-right">{{ summaryRow.Area|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.Sediment|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.TotalN|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ summaryRow.TotalP|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ (summaryRow.Sediment/summaryRow.Area)|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ (summaryRow.TotalN/summaryRow.Area)|round(2)|toLocaleString(2) }}</th>
-            <th class="text-right">{{ (summaryRow.TotalP/summaryRow.Area)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.Area|toUnit(areaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.Sediment|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalN|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ summaryRow.TotalP|toUnit(massPerTimeDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ (summaryRow.Sediment/summaryRow.Area)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ (summaryRow.TotalN/summaryRow.Area)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
+            <th class="text-right">{{ (summaryRow.TotalP/summaryRow.Area)|toUnit(massPerAreaDisplayUnit)|round(2)|toLocaleString(2) }}</th>
         </tr>
     </tfoot>
 

--- a/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/subbasin/views.js
@@ -5,6 +5,8 @@ var Marionette = require('../../../../shim/backbone.marionette'),
     _ = require('lodash'),
     App = require('../../../app'),
     models = require('./models'),
+    settings = require('../../../core/settings'),
+    coreUnits = require('../../../core/units'),
     resultTmpl = require('./templates/result.html'),
     layerSelectorTmpl = require('./templates/layerSelector.html'),
     layerLegendTmpl = require('./templates/layerLegend.html'),
@@ -243,11 +245,20 @@ var SourcesTableView = Marionette.ItemView.extend({
     },
 
     templateHelpers: function() {
-        var result = this.getResult();
+        var result = this.getResult(),
+            scheme = settings.get('unit_scheme');
+
         if (!result) { return; }
+
         return {
             rows: result.Loads,
             summaryRow: result.SummaryLoads,
+            areaUnit: coreUnits[scheme].AREA_L_FROM_HA.name,
+            areaDisplayUnit: 'AREA_L_FROM_HA',
+            massPerAreaUnit: coreUnits[scheme].MASSPERAREA_M.name,
+            massPerAreaDisplayUnit: 'MASSPERAREA_M',
+            massPerTimeUnit: coreUnits[scheme].MASSPERTIME.name,
+            massPerTimeDisplayUnit: 'MASSPERTIME'
         };
     },
 
@@ -326,11 +337,19 @@ var Huc12TotalsTableView = Marionette.ItemView.extend({
     },
 
     templateHelpers: function() {
-        var result = this.model.get('result');
+        var result = this.model.get('result'),
+            scheme = settings.get('unit_scheme');
+
         return {
             rows: result.HUC12s,
             subbasins: App.currentProject.get('subbasins'),
             summaryRow: result.SummaryLoads,
+            areaUnit: coreUnits[scheme].AREA_L_FROM_HA.name,
+            areaDisplayUnit: 'AREA_L_FROM_HA',
+            massPerAreaUnit: coreUnits[scheme].MASSPERAREA_M.name,
+            massPerAreaDisplayUnit: 'MASSPERAREA_M',
+            massPerTimeUnit: coreUnits[scheme].MASSPERTIME.name,
+            massPerTimeDisplayUnit: 'MASSPERTIME'
         };
     },
 
@@ -414,6 +433,7 @@ var CatchmentsTableView = Marionette.ItemView.extend({
         var catchmentDetails = this.catchmentDetails,
             activeSubbasinId = App.currentProject.get('subbasins').getActive().get('id'),
             huc12Result = this.model.get('result').HUC12s[activeSubbasinId],
+            scheme = settings.get('unit_scheme'),
             catchments = huc12Result.Catchments,
             summaryRow = _.reduce(catchments, function(acc, catchment, comid) {
                 var summaryConcentrations = acc.LoadingRateConcentrations,
@@ -443,6 +463,14 @@ var CatchmentsTableView = Marionette.ItemView.extend({
             rows: catchments,
             catchmentDetails: catchmentDetails,
             summaryRow: summaryRow,
+            areaUnit: coreUnits[scheme].AREA_L_FROM_HA.name,
+            areaDisplayUnit: 'AREA_L_FROM_HA',
+            massPerAreaUnit: coreUnits[scheme].MASSPERAREA_M.name,
+            massPerAreaDisplayUnit: 'MASSPERAREA_M',
+            massPerTimeUnit: coreUnits[scheme].MASSPERTIME.name,
+            massPerTimeDisplayUnit: 'MASSPERTIME',
+            concentrationUnit: coreUnits[scheme].CONCENTRATION.name,
+            concentrationDisplayUnit: 'CONCENTRATION'
         };
     },
 


### PR DESCRIPTION
## Overview

Implements Unit Conversion for Mapshed Subbasin.

~~WIP because the area numbers are incorrect.~~ This has been fixed.

Connects #3025

### Demo

**Metric**
![image](https://user-images.githubusercontent.com/1042475/49182259-cccc1100-f327-11e8-973d-9451b657393e.png)

**US Customary**
![image](https://user-images.githubusercontent.com/1042475/49182271-d48bb580-f327-11e8-95a0-a0f91e740df3.png)

## Testing Instructions

*Modified from https://github.com/WikiWatershed/model-my-watershed/pull/3033*

* Checkout this branch and `bundle --debug`
* Login and set your units as "US Customary"
* Make a MapShed project for a well known area. On Staging, also make a MapShed project using the same well known area.
* Kick off the subbasin analysis. Once the analysis is finished, ensure that US Customary units are used in all of the tables, including the HUC-12 tables.
* Compare with the project on staging and ensure the conversions make sense
* Go to settings and change your units to Metric. Re-open the project. Ensure the tables are converted correctly.