### PR TITLE
Upgrade Postgis to 2.2

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -27,8 +27,8 @@ postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
 postgresql_support_libpq_version: "11.1-1.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.7"
-postgis_version: "2.1"
-postgis_package_version: "2.1.*.pgdg14.04+1"
+postgis_version: "2.2"
+postgis_package_version: "2.2.*.pgdg14.04+1"
 
 elasticsearch_cluster_name: "logstash"
 
@@ -60,3 +60,5 @@ observation_api_url: "http://www.wikiwatershed-vs.org/"
 enabled_features: ''
 
 numba_version: "0.38.1"
+
+redis_version: "2:2.8.4-2ubuntu0.2"


### PR DESCRIPTION
## Overview

Bump Postgis to the `2.2.x` line to fix provisioning errors. Additionally, pin Redis to the `2.8.4-2ubuntu0.2` patch in order to work around https://github.com/azavea/ansible-redis/issues/1.

Closes #3031.

### Notes

- Currently RDS [only supports PostGIS 2.1 for databases using Postgres 9.4](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.Extensions.94x), meaning that this change will introduce drift between dev and staging/production. I opened up #3044, #3045, #3046, and #3047 to track the necessary work for remedying this discrepancy.

## Testing Instructions

* (Re)provision the app and confirm that everything installs and starts properly
    * If you haven't provisioned the app yet, provision it following the [Getting Started instructions](https://github.com/WikiWatershed/model-my-watershed#getting-started) with `MW_ITSI_SECRET_KEY="***" vagrant up`
    * If you've already provisioned, reprovision the database and Redis services with `vagrant provision services`
* Copy the `scripts` directory into the `app` VM
* Shell into the `app` VM with `vagrant ssh app`
* In the `app` VM, run `./scripts/aws/setupdb.sh -b` and confirm that boundaries load into the DB properly
* In the `app` VM, run `./scripts/aws/setupdb.sh -s` and confirm that streams load into the DB properly
