### PR TITLE
Unit Conversion: Manual Entry Total Calculation

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -78,8 +78,11 @@ var LandCoverModal = modalViews.ModalBaseView.extend({
     },
 
     validateModal: function() {
-        var autoTotal = round(this.model.get('autoTotal'), 1),
-            userTotal = round(this.model.get('userTotal'), 1);
+        var get = function(value) {
+                return coreUnits.get('AREA_L_FROM_HA', value).value;
+            },
+            autoTotal = round(get(this.model.get('autoTotal')), 1),
+            userTotal = round(get(this.model.get('userTotal')), 1);
 
         this.ui.saveButton.prop('disabled', autoTotal !== userTotal);
     },


### PR DESCRIPTION
## Overview

Without this, in some cases the "Save" button was not activated even when the shown units matched. Now we always compare the displayed units, ensuring the two are in sync.

Connects #3059 

### Demo

![image](https://user-images.githubusercontent.com/1430060/50117265-7eb97780-021a-11e9-9348-5f22ebcabd4b.png)

## Testing Instructions

* Stay on `release/1.24.0` and `bundle`
* Open Firefox and go to [:8000/](http://localhost:8000/) 
* Log in. Ensure your unit scheme is US Customary
* Search for "Cocalico Creek-Conestoga River" which is a HUC-12 Subwatershed.
* Make a MapShed project, make a new scenario, and edit the Land Cover
* Edit Wetlands to be 70 acres, Open Lands to be 126.6 acres
* Ensure total adds up, but "Save" button is disabled
* Check out this branch and `bundle`
* Hard refresh the page, edit the Land Cover again
* Edit Wetlands to be 70 acres, Open Lands to be 126.6 acres
* Ensure total adds up, and "Save" button is enabled
* Save the edits