### PR TITLE
Unit Conversion: Fix Area Limit

### DIFF
--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -18,7 +18,7 @@ var defaultSettings = {
     vizer_ignore: [],
     vizer_names: {},
     model_packages: [],
-    max_area: 75000,
+    max_area: 75000,  // Default. Populated at runtime by MAX_AREA in base.py
     enabled_features: [],
     branch: null,
     gitDescribe: null,

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -402,7 +402,7 @@ OMGEO_SETTINGS = [[
 ]]
 
 # Keep in sync with src/api/main.py in rapid-watershed-delineation.
-MMW_MAX_AREA = 7.5e+9  # Max area in m², about the size of West Virginia
+MMW_MAX_AREA = 75e+9  # Max area in m², about the size of West Virginia
 
 BIGCZ_HOST = 'portal.bigcz.org'  # BiG-CZ Host, for enabling custom behavior
 BIGCZ_MAX_AREA = 5e+9  # Max area in m², limited by CUAHSI


### PR DESCRIPTION
## Overview

The max area limit had been mistakenly set at 7,500 km², when it should be 75,000 km².

Connects #3058 

### Demo

![image](https://user-images.githubusercontent.com/1430060/50118726-a7437080-021e-11e9-8a29-df06f56a5168.png)

## Testing Instructions

* Check out this branch and go to [:8000/](http://localhost:8000/)
* Select the Schuylkill HUC-8 and ensure you can proceed to Analyze