### PR TITLE
Add HydroShare credentials to Worker VM

### DIFF
--- a/deployment/cfn/worker.py
+++ b/deployment/cfn/worker.py
@@ -58,6 +58,8 @@ class Worker(StackNode):
         'PublicHostedZoneName': ['global:PublicHostedZoneName'],
         'VpcId': ['global:VpcId', 'VPC:VpcId'],
         'GlobalNotificationsARN': ['global:GlobalNotificationsARN'],
+        'HydroShareBaseURL': ['global:HydroShareBaseURL'],
+        'HydroShareSecretKey': ['global:HydroShareSecretKey'],
         'SRATCatchmentAPIURL': ['global:SRATCatchmentAPIURL'],
         'SRATCatchmentAPIKey': ['global:SRATCatchmentAPIKey'],
         'RollbarServerSideAccessToken':
@@ -206,6 +208,16 @@ class Worker(StackNode):
             'GlobalNotificationsARN', Type='String',
             Description='ARN for an SNS topic to broadcast notifications'
         ), 'GlobalNotificationsARN')
+
+        self.hydroshare_base_url = self.add_parameter(Parameter(
+            'HydroShareBaseURL', Type='String',
+            Description='Base URL for HydroShare portal'
+        ), 'HydroShareBaseURL')
+
+        self.hydroshare_secret_key = self.add_parameter(Parameter(
+            'HydroShareSecretKey', Type='String', NoEcho=True,
+            Description='Secret key for HydroShare portal integration'
+        ), 'HydroShareSecretKey')
 
         self.srat_catchment_api_url = self.add_parameter(Parameter(
             'SRATCatchmentAPIURL', Type='String',
@@ -422,6 +434,14 @@ class Worker(StackNode):
                 '    permissions: 0440\n',
                 '    owner: root:mmw\n',
                 '    content: ', self.get_input('RollbarServerSideAccessToken'), '\n',  # NOQA
+                '  - path: /etc/mmw.d/env/MMW_HYDROSHARE_BASE_URL\n',
+                '    permissions: 0750\n',
+                '    owner: root:mmw\n',
+                '    content: ', Ref(self.hydroshare_base_url), '\n',
+                '  - path: /etc/mmw.d/env/MMW_HYDROSHARE_SECRET_KEY\n',
+                '    permissions: 0750\n',
+                '    owner: root:mmw\n',
+                '    content: ', Ref(self.hydroshare_secret_key), '\n',
                 '  - path: /etc/mmw.d/env/MMW_SRAT_CATCHMENT_API_URL\n',
                 '    permissions: 0440\n',
                 '    owner: root:mmw\n',


### PR DESCRIPTION
## Overview

These were previously not required because all the HydroShare export processing was done in Django from within App. However, in #2897 it was changed to be done in Celery from within Worker. Without these variables being initialized correctly, the export does not work.

Connects #3067 

## Testing Instructions

* Ensure the scripts are correct, and have all the HydroShare information previously only contained in [`applications.py`](https://github.com/WikiWatershed/model-my-watershed/commit/fa923b1f974f723889f89dcc10663b05029935cb#diff-53cd5caef2254f95d2e0402833625c67)
* Ensure that upon provisioning, the following variables are set in the Worker VM, with the same values as in the App VM:
  - `MMW_HYDROSHARE_BASE_URL`
  - `MMW_HYDROSHARE_SECRET_KEY`
  - `MMW_HYDROSHARE_CLIENT_ID`
    + This one isn't in the scripts in the diff because it is hard-coded
