### PR TITLE
Manual Entry: Fix handling of explicit 0s specified by users

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -339,12 +339,15 @@ var FieldView = Marionette.ItemView.extend({
         var value = this.ui.input.val(),
             unit = this.model.get('unit');
 
-        if (unit) {
+        // Treat empty string as null
+        if (value === '') {
+            value = null;
+        } else if (unit) {
             // Convert user preferred unit into underlying representation
             value /= coreUnits.get(unit, 1).value;
         }
 
-        this.model.set('userValue', value || null);
+        this.model.set('userValue', value);
         this.toggleUserValueState();
     },
 
@@ -357,7 +360,7 @@ var FieldView = Marionette.ItemView.extend({
     toggleUserValueState: function() {
         var userValue = this.model.get('userValue');
 
-        if (userValue) {
+        if (userValue !== null) {
             this.$el.addClass('has-user-value');
         } else {
             this.$el.removeClass('has-user-value');


### PR DESCRIPTION
## Overview

Previously, an explicit value of 0 specified by a user would be accidentally coalesced into null, which would default to the auto value. Now we treat empty strings as nulls, but 0s as proper user values.

Connects #3065 

### Demo

In Land Cover:

![2019-01-25 12 31 29](https://user-images.githubusercontent.com/1430060/51762396-9bf52780-209d-11e9-8af1-88f23ef9f0ae.gif)

In Settings:

![2019-01-25 12 32 10](https://user-images.githubusercontent.com/1430060/51762402-a1527200-209d-11e9-827c-6cd3422a0a64.gif)

Saving 0 To Server:

![2019-01-25 12 32 53](https://user-images.githubusercontent.com/1430060/51762417-ab747080-209d-11e9-9b61-1d37947bae94.gif)

## Testing Instructions

* Check out this branch and `./scripts/bundle.sh --debug`
* Open a MapShed project
* Open the Land Cover adjustment dialog and change some values to 0. Ensure they show as black, and have the undo button next to them.
* Adjust other Land Cover values to make up for these deletions. Ensure you can save once the total matches up.
* Ensure saving triggers a recalculation of results. Refresh the page, and ensure they results are saved to the server.
* Check other Settings to ensure they have the same behavior.