### PR TITLE
Unit Conversion: Show correct slider value on slide end

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -600,8 +600,8 @@ var PrecipitationView = ControlView.extend({
         // Update values for IE which doesn't trigger onSliderDragged. Will
         // effectively noop on other browsers, since the same values were
         // already set by onSliderDragged.
-        this.ui.slider.attr('value', value);
-        this.ui.displayValue.text(this.getDisplayValue(value));
+        this.ui.slider.attr('value', sliderValue);
+        this.ui.displayValue.text(this.getDisplayValue(sliderValue));
 
         this.addOrReplaceInput(modification);
     },


### PR DESCRIPTION
## Overview

When the slider is dragged, we use two events to update the numeric value shown next to it: onSliderDragged and onSliderChanged. The latter is necessary because Internet Explorer does not support onSliderDragged. That is usually a no-op, because the value it sets are the same as those set in onSliderDragged.

Unfortunately, when we updated the code to use Unit Conversions in https://github.com/WikiWatershed/model-my-watershed/commit/6728d758fbb83dce6f9ff7c13092b60c9df5c7a7#diff-974b9f0d8dedea0247b441534588d17dR573, we mistakenly started displaying the "under the hood" value, which is always in inches, rather than the slider's display value. By showing the slider value, we ensure it is correct in all unit schemes.

Connects #3071 

### Demo

Before:

![2019-01-25 13 21 13](https://user-images.githubusercontent.com/1430060/51765221-3442da80-20a5-11e9-8125-902fb059b128.gif)

After:

![2019-01-25 13 21 38](https://user-images.githubusercontent.com/1430060/51765228-386ef800-20a5-11e9-83c6-75bb995f9f9f.gif)

## Testing Instructions

* Check out this branch and `bundle`
* Open a TR-55 project.
* Play around with the slider. Ensure the values shown are correct, and correspond with the total precipitation available in the results
* Change your preferred unit scheme. Go back to the same project. Ensure it initializes with the correct equivalent precipitation in the new unit to be the same value as the old.
* Drag the slider. Ensure the numbers match up.