### PR TITLE
MapShed BMPs: Fix Waste Management Deletion

### DIFF
--- a/src/mmw/js/src/core/filters.js
+++ b/src/mmw/js/src/core/filters.js
@@ -97,5 +97,9 @@ nunjucks.env.addFilter('toFriendlyBytes', function(bytes) {
 });
 
 nunjucks.env.addFilter('toUnit', function(value, unit) {
+    if (!unit) {
+        return value;
+    }
+
     return coreUnits.get(unit, value).value;
 });

--- a/src/mmw/js/src/core/units.js
+++ b/src/mmw/js/src/core/units.js
@@ -88,6 +88,11 @@ var units = {
             factor: 2.83168E-02,
             offset: 0
         },
+        PERCENT: {
+            name: '%',
+            factor: 1,
+            offset: 0
+        },
     },
     METRIC: {
         AREA_XL: {
@@ -167,6 +172,11 @@ var units = {
         },
         VOLUME: {
             name: 'm³',
+            factor: 1,
+            offset: 0
+        },
+        PERCENT: {
+            name: '%',
             factor: 1,
             offset: 0
         },

--- a/src/mmw/js/src/modeling/gwlfeModificationConfig.js
+++ b/src/mmw/js/src/modeling/gwlfeModificationConfig.js
@@ -61,6 +61,8 @@ function fromPairs(pairs) {
 }
 
 var displayUnits = fromPairs([
+    [percentAeuToModifyName, 'PERCENT'],
+    [percentAreaToModifyName, 'PERCENT'],
     [areaToModifyName, 'AREA_L_FROM_HA'],
     [lengthToModifyName, 'LENGTH_XL_FROM_KM'],
     [lengthToModifyInAgName, 'LENGTH_XL_FROM_KM'],
@@ -295,6 +297,7 @@ function makeAgBmpConfig(outputName) {
 
 function makeAeuBmpConfig(outputName) {
     return {
+        unit: 'PERCENT',
         dataModelNames: [],
         validateDataModel: makeValidateDataModelFn([]),
         userInputNames: [percentAeuToModifyName],


### PR DESCRIPTION
## Overview

Specifies missing units for Percent-type BMPs for MapShed, whose absence was previously causing a template crash.

Connects #3072 

### Demo

![2019-01-28 09 54 56](https://user-images.githubusercontent.com/1430060/51844350-06e37000-22e3-11e9-8b4d-2709e43514c4.gif)

## Testing Instructions

* On `develop`, make a new MapShed project and add "Poultry Waste Management" as a Conservation Practice to it. Ensure you can't delete it.
* Check out this branch and `bundle`.
* Open the same project. Ensure you can now delete "Poultry Waste Management".
* Ensure you can add and delete "Livestock Waste Management", and other types of Conservation Practices