### PR TITLE
Update libpq glob to reflect main PostgreSQL repository

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -25,7 +25,7 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "11.1-1.pgdg14.04+1"
+postgresql_support_libpq_version: "11.1-3.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.7"
 postgis_version: "2.2"
 postgis_package_version: "2.2.*.pgdg14.04+1"


### PR DESCRIPTION
## Overview

Similar to #3005, #2904, #2831, #2694, #2653, etc.

This was released this week: https://ubuntuupdates.org/package/postgresql/trusty-pgdg/main/base/libpq5

![image](https://user-images.githubusercontent.com/1430060/51918899-6065a080-23b0-11e9-8608-f875284ba7bf.png)
