### PR TITLE
Fix AMI builds by pinning pip to 18.1

### DIFF
--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -112,7 +112,7 @@
                 "sleep 5",
                 "sudo apt-get update -qq",
                 "sudo apt-get install python-pip python-dev -y",
-                "sudo pip install --upgrade pip",
+                "sudo pip install --upgrade pip==18.1",
                 "sudo pip install ansible==2.4.4.0",
                 "sudo /bin/sh -c 'echo {{user `branch`}} {{user `description`}} > /srv/version.txt'"
             ]


### PR DESCRIPTION
## Overview

As of pip 19.0, it started printing warnings for Python 2.7, which are treated as errors by Jenkins. I looked briefly in to ignoring or silencing those warnings (see https://github.com/pypa/pip/pull/6147#issuecomment-457910432), but couldn't configure Jenkins correctly. Thus, I'm going with the downgrade, as was done for **#bees** in https://github.com/project-icp/bee-pollinator-app/pull/447.

### Demo

http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-packer-app-and-worker/1131
