### PR TITLE
Add cron task to restart Celery every day

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ target/
 
 # Ansible
 deployment/ansible/roles/azavea.*
+*.retry
 
 # CloudFormation
 deployment/default.yml

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -25,7 +25,7 @@ postgresql_database: mmw
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "11.1-3.pgdg14.04+1"
+postgresql_support_libpq_version: "11.*.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.7"
 postgis_version: "2.2"
 postgis_package_version: "2.2.*.pgdg14.04+1"

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
@@ -13,3 +13,10 @@
 
 - name: Enable Celery service
   service: name=celeryd enabled=yes state=started
+
+- name: Setup daily Celery service restart
+  cron:
+    name: celery-restart
+    special_time: daily
+    job: service celeryd restart
+    state: present


### PR DESCRIPTION
## Overview

We occasionally encounter service disruptions due to hangups with the Celery service. This brings a brute force solution to the problem by scheduling a restart of the Celery service every day at ~3AM.

Fixes https://github.com/WikiWatershed/model-my-watershed/issues/3085

### Notes

This change set also includes a `libpq` version bump and the addition of `.retry` files to `.gitignore`.

## Testing Instructions

- Provision the changes from this branch on to the `worker` virtual machine

```bash
$ vagrant provision worker
```

- SSH into the `worker` virtual machine and confirm that the `crontab` was modified

```bash
$ vagrant ssh worker
vagrant@worker:~$ sudo crontab -l
#Ansible: celery-restart
@daily service celeryd restart
```

- Optionally, apply the following patch and ensure that the Celery service restarts every 5 minutes

```diff
diff --git a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
index 12df7b44..d349e790 100644
--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
@@ -17,6 +17,10 @@
 - name: Setup daily Celery service restart
   cron:
     name: celery-restart
-    special_time: daily
+    hour: "*"
+    minute: "*/5"
+    day: "*"
+    month: "*"
+    weekday: "*"
     job: service celeryd restart
     state: present
```