### PR TITLE
Reduce UTFGrid Tile Caching

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -690,13 +690,23 @@ var SelectBoundaryView = DrawToolBaseView.extend({
 
     changeOutlineLayer: function(tileUrl, layerCode, shortDisplay, minZoom) {
         var self = this,
-            ofg = self.model.get('outlineFeatureGroup');
+            ofg = self.model.get('outlineFeatureGroup'),
+            // Generate 50 random strings to append to UtfGrid requests so we
+            // don't use the cached verions, which may be incorrect.
+            // The tiler may sometimes generate incorrect tiles because of
+            // https://github.com/CartoDB/Windshaft/issues/310
+            cacheBusters = _.range(50).map(function() {
+                // Generate and return a random string
+                // https://stackoverflow.com/a/8084248
+                return Math.random().toString(36).substring(7);
+            });
 
         // Go about the business of adding the outline and UTFgrid layers.
         if (tileUrl && layerCode !== undefined) {
             var ol = new L.TileLayer(tileUrl + '.png', {minZoom: minZoom || 0}),
-                grid = new L.UtfGrid(tileUrl + '.grid.json',
+                grid = new L.UtfGrid(tileUrl + '.grid.json?{s}',
                                      {
+                                         subdomains: cacheBusters,
                                          minZoom: minZoom,
                                          useJsonP: false,
                                          resolution: 4,

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -231,6 +231,8 @@ var DrawWindow = Marionette.LayoutView.extend({
             model: this.model,
             resetDrawingState: resetDrawingState
         }));
+
+        this.listenTo(App.map, 'change:lat, change:lng', resetDrawingState);
     },
 
     resetDrawingState: function(options) {


### PR DESCRIPTION
## Overview

Attempts to help with incorrect UtfGrid results by appending a random string to tile requests to get fresh tiles every time. Unfortunately, because of https://github.com/CartoDB/Windshaft/issues/310, the true underlying issue can only be fixed by upgrading Windshaft, which can be a pretty involved process (see https://github.com/OpenTreeMap/otm-tiler/pull/116).

We also disable the drawing tool upon search, hoping to create a further delay that could help invalidate the internal cache.

Connects #3082 

### Notes

This is not a new bug, and has probably been there from the very beginning. A short term solution would be to invalidate all `.grid.json` caches in production when this is deployed.

## Testing Instructions

* Check out this branch and `bundle`
* Go to [:8000](http://localhost:8000/) and select a boundary to draw.
* Before picking a boundary, search for a new location that takes you to a different part of the country
  - [ ] Ensure that the draw tool is closed
* Enable the same boundary draw tool again. Hover over the new location area.
  - [ ] Ensure you get hover values for the new location, and not the old one