### PR TITLE
Protect Against Celery Failures

### DIFF
--- a/src/mmw/apps/core/tasks.py
+++ b/src/mmw/apps/core/tasks.py
@@ -39,8 +39,7 @@ def save_job_error(request, exc, traceback, job_id):
     except Exception as e:
         logger.error('Failed to save job error status. Job will appear hung. \
                      Job Id: {0}'.format(job.id))
-        logger.error('Error number: {0} - Error: {1}'
-                     .format(e.errno, e.strerror))
+        logger.error('Error: {}'.format(e))
 
 
 @shared_task(bind=True)

--- a/src/mmw/apps/core/tasks.py
+++ b/src/mmw/apps/core/tasks.py
@@ -32,7 +32,7 @@ def save_job_error(request, exc, traceback, job_id):
     try:
         job = Job.objects.get(id=job_id)
         job.error = exc
-        job.traceback = traceback
+        job.traceback = traceback or 'No traceback'
         job.delivered_at = now()
         job.status = 'failed'
         job.save()


### PR DESCRIPTION
## Overview

We are seeing errors like this on staging:

```
[2019-02-20 13:58:35,634: ERROR/MainProcess] Task a8dc7519-21e4-42db-b3aa-33ff69240367 run from job 73134 raised exception: Worker exited prematurely: signal 11 (SIGSEGV).
None
[2019-02-20 13:58:35,710: ERROR/MainProcess] Failed to save job error status. Job will appear hung.                      Job Id: 73134
[2019-02-20 13:58:35,710: ERROR/MainProcess] Pool callback raised exception: AttributeError("'IntegrityError' object has no attribute 'errno'",)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/billiard/pool.py", line 1747, in safe_apply_callback
    fun(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/celery/worker/request.py", line 366, in on_failure
    self.id, exc, request=self, store_result=self.store_errors,
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/base.py", line 168, in mark_as_failure
    self._call_task_errbacks(request, exc, traceback)
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/base.py", line 175, in _call_task_errbacks
    errback(request, exc, traceback)
  File "/usr/local/lib/python2.7/dist-packages/celery/canvas.py", line 178, in __call__
    return self.type(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 630, in __protected_call__
    return orig(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/celery/app/task.py", line 380, in __call__
    return self.run(*args, **kwargs)
  File "apps/core/tasks.py", line 43, in save_job_error
    .format(e.errno, e.strerror))
AttributeError: 'IntegrityError' object has no attribute 'errno'
```

These are called by three problems:

1. Workers failing on something via a segfault, thus not reporting a `traceback`
2. The `core_job` table not allowing `NULL`s in `traceback`, thus being unable to save the error
3. The reported `IntegrityError` not having an `errno` attribute, thus being unable to handle the exception

Of these, 2 and 3 are addressed in this PR.

Connects #2982 