### PR TITLE
Circumvent GWLF-E SegFaults due to NumPy

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -60,5 +60,6 @@ observation_api_url: "http://www.wikiwatershed-vs.org/"
 enabled_features: ''
 
 numba_version: "0.38.1"
+numpy_version: "1.14.5"
 
 redis_version: "2:2.8.4-2ubuntu0.2"

--- a/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
@@ -2,6 +2,9 @@
 - name: Install numba
   pip: name=numba version={{ numba_version }}
 
+- name: Install numpy
+  pip: name=numpy version={{ numpy_version }}
+
 - name: Install application Python dependencies for development and test
   pip: requirements="{{ app_home }}/requirements/{{ item }}.txt"
   with_items:

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/dependencies.yml
@@ -2,6 +2,9 @@
 - name: Install numba
   pip: name=numba version={{ numba_version }}
 
+- name: Install numpy
+  pip: name=numpy version={{ numpy_version }}
+
 - name: Install application Python dependencies for development and test
   pip: requirements="{{ app_home }}/requirements/{{ item }}.txt"
   with_items:

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -24,10 +24,8 @@ https://bitbucket.org/jurko/suds/get/94664ddd46a6.tar.gz#egg=suds-jurko
 django_celery_results==1.0.1
 pandas==0.22.0
 git+git://github.com/emiliom/ulmo@wml_values_md#egg=ulmo
-numpy==1.14.5
 hs_restclient==1.2.10
 six==1.11.0
 fiona==1.7.11
 timeout-decorator==0.4.0
-numba==0.38.1
 redis==2.10.6


### PR DESCRIPTION
## Overview

A recent release of NumPy introduced a new module `_multiarray_umath`. Unfortunately, there are some tools that depend on NumPy and pull in the latest version as a build dependency. This latest version is then replaced with the version specified in our `requirements.txt`, thus the module is not available at run-time causing the segfaults.

By installing NumPy separately before `requirements.txt` is gathered, we ensure that whatever was using the most recent version of NumPy in its installation now uses the pre-installed one.

We'll have to ensure that the version of NumPy in `requirements.txt` matches the one in Ansible.

For details see:

https://github.com/numpy/numpy/issues/11871
https://stackoverflow.com/q/54153886

Connects #3089 

### Demo

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/1430060/53251371-76ead900-368a-11e9-9bcb-c262a8f20526.png">

## Testing Instructions

* Download and extract this file: [celery-segfault.zip](https://github.com/WikiWatershed/model-my-watershed/files/2894563/celery-segfault.zip)
* Check out this branch and destroy and rebuild the Worker VM
* Transfer the files into the Worker VM, and execute `test.py`

    ```
    $ python test.py
    ```

  - [x] Ensure there are no segfaults
* Compare the generated `output.json` with the included `output.verify.json`:

    ```
    $ diff output.json output.verify.json
    ```
  - [x] Ensure they match
* Go to [:8000](http://localhost:8000) and create a MapShed project.
  - [ ] Ensure the modeling stages complete successfully