### PR TITLE
Ignore Tests Hanging in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,3 +19,7 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Start after checking out this branch
  * Include any setup required, such as bundling scripts, restarting services, etc.
  * Include test case, and expected output
+
+## Checklist
+
+- [ ] All JavaScript tests pass `./scripts/testem.sh`

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,8 +17,13 @@ vagrant ssh app -c "cd /opt/app && envdir /etc/mmw.d/env ./manage.py test --noin
 # Check for client-side JS lint.
 # vagrant ssh app -c "cd /opt/app && npm run lint"
 
-# Run JS unit tests.
+# Run JS unit tests, unless flag set to skip them.
 # vagrant ssh app -c "cd /var/www/mmw/static &&
 #    xvfb-run /opt/app/node_modules/.bin/testem -f /opt/app/testem.json ci"
-vagrant ssh app -c "cd /var/www/mmw/static &&
-    xvfb-run /opt/app/node_modules/.bin/testem -f /opt/app/testem.json ci Firefox $*"
+
+if [[ -z "${MMW_SKIP_JS_TESTS}" ]]; then
+    vagrant ssh app -c "cd /var/www/mmw/static &&
+        xvfb-run /opt/app/node_modules/.bin/testem -f /opt/app/testem.json ci Firefox $*"
+else
+    echo "SKIPPING JS TESTS"
+fi


### PR DESCRIPTION
## Overview

As fallout from the Ubuntu Upgrade, testem hangs when running in CI mode. We have been unable to pinpoint the source of this error, so to stop CI from hanging every time we add a flag to skip the tests and configure CI with it.

Inspired by OpenTreeMap/otm-cloud#227

Connects #3110 

### Demo

Using the `env` command to set inline environment variables for the `fish` shell:

```fish
> env MMW_SKIP_JS_TESTS=True kj test

+ vagrant ssh app -c 'flake8 /opt/app/apps --exclude migrations || echo flake8 check failed'
Connection to 127.0.0.1 closed.
+ vagrant ssh app -c 'cd /opt/app && envdir /etc/mmw.d/env ./manage.py test --noinput'
Creating test database for alias 'default'...
Got an error creating the test database: database "test_mmw" already exists

Destroying old test database 'default'...
.Not Found: /project/2/clone
.Not Found: /project/3/
.......Not Found: /project/9/clone
.Not Found: /project/10/
..................Not Found: /api/boundary-layers/foo/1234
..........................................................
----------------------------------------------------------------------
Ran 86 tests in 21.413s

OK
Destroying test database for alias 'default'...
Connection to 127.0.0.1 closed.
+ [[ -z True ]]
+ echo 'SKIPPING JS TESTS'
SKIPPING JS TESTS
```

### Notes

Created #3115 for upgrading the tests so that they run on CI again.

## Testing Instructions

* Check out this branch
* Run `MMW_SKIP_JS_TESTS=True ./scripts/test.sh`
  - [x] Ensure JavaScript tests are _not_ run
  - [ ] Ensure you see a message "SKIPPING JS TESTS"
* Ensure the `build` step in CI has been configured with the new variable
  - [x] http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-develop/configure
  - [x] http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-hotfix/configure
  - [x] http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-pull-requests/configure
  - [x] http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-release/configure

## Checklist

- [x] All JavaScript tests pass `./scripts/testem.sh`