### PR TITLE
PublicSubnets -> PublicSubnetCIDRRanges in VPC stack

### DIFF
--- a/deployment/cfn/vpc.py
+++ b/deployment/cfn/vpc.py
@@ -31,8 +31,8 @@ class VPC(StackNode):
         'StackType': ['global:StackType'],
         'KeyName': ['global:KeyName'],
         'AvailabilityZones': ['global:AvailabilityZones'],
-        'PublicSubnets': ['global:PublicSubnets'],
-        'PrivateSubnets': ['global:PrivateSubnets'],
+        'PublicSubnetCIDRRanges': ['global:PublicSubnetCIDRRanges'],
+        'PrivateSubnetCIDRRanges': ['global:PrivateSubnetCIDRRanges'],
         'NATInstanceType': ['global:NATInstanceType'],
         'NATInstanceAMI': ['global:NATInstanceAMI'],
         'PapertrailPort': ['global:PapertrailPort'],
@@ -44,8 +44,8 @@ class VPC(StackNode):
         'StackType': 'Staging',
         'KeyName': 'mmw-stg',
         'AvailabilityZones': 'us-east-1b,us-east-1d',
-        'PublicSubnets': '10.0.2.0/24,10.0.4.0/24',
-        'PrivateSubnets': '10.0.3.0/24,10.0.5.0/24',
+        'PublicSubnetCIDRRanges': '10.0.2.0/24,10.0.4.0/24',
+        'PrivateSubnetCIDRRanges': '10.0.3.0/24,10.0.5.0/24',
         'NATInstanceType': 't2.micro',
     }
 
@@ -60,9 +60,9 @@ class VPC(StackNode):
         self.region = self.get_input('Region')
         self.availability_zones = get_availability_zones(self.aws_profile,
                                                          self.get_input('AvailabilityZones').split(','))
-        self.public_subnets = iter(self.get_input('PublicSubnets').split(','))
-        self.private_subnets = iter(
-            self.get_input('PrivateSubnets').split(','))
+        self.public_subnet_cidr_ranges = iter(self.get_input('PublicSubnetCIDRRanges').split(','))
+        self.private_subnet_cidr_ranges = iter(
+            self.get_input('PrivateSubnetCIDRRanges').split(','))
 
         self.add_description('VPC stack for MMW')
 
@@ -169,7 +169,7 @@ class VPC(StackNode):
             public_subnet = self.create_resource(ec2.Subnet(
                 public_subnet_name,
                 VpcId=Ref(self.vpc),
-                CidrBlock=next(self.public_subnets),
+                CidrBlock=next(self.public_subnet_cidr_ranges),
                 AvailabilityZone=availability_zone.name,
                 Tags=self.get_tags(Name=public_subnet_name)
             ))
@@ -185,7 +185,7 @@ class VPC(StackNode):
             private_subnet = self.create_resource(ec2.Subnet(
                 private_subnet_name,
                 VpcId=Ref(self.vpc),
-                CidrBlock=next(self.private_subnets),
+                CidrBlock=next(self.private_subnet_cidr_ranges),
                 AvailabilityZone=availability_zone.name,
                 Tags=self.get_tags(Name=private_subnet_name)
             ))


### PR DESCRIPTION
## Overview

This PR renames the `PublicSubnets` input to the VPC stack, which was overloaded, to `PublicSubnetCIDRRanges`.

I also updated the `default.yml` file, as well as the `staging.yml` file on CI.

## Testing Instructions

 - Apply this diff:
```diff
diff --git a/deployment/cfn/stacks.py b/deployment/cfn/stacks.py
index da44c9e7..38daed73 100644
--- a/deployment/cfn/stacks.py
+++ b/deployment/cfn/stacks.py
@@ -51,6 +51,10 @@ def build_graph(mmw_config, aws_profile, **kwargs):

     global_config = GlobalConfigNode(**mmw_config)
     vpc = VPC(globalconfig=global_config, aws_profile=aws_profile)
+
+    vpc.set_up_stack()
+    print(vpc.to_json())
+
     s3_vpc_endpoint = S3VPCEndpoint(globalconfig=global_config, VPC=vpc,
                                     aws_profile=aws_profile)
     private_hosted_zone = PrivateHostedZone(globalconfig=global_config,
@@ -85,16 +89,16 @@ def build_stacks(mmw_config, aws_profile, **kwargs):
         application_graph, worker_graph, \
         public_hosted_zone_graph = build_graph(mmw_config, aws_profile,
                                                **kwargs)
-    s3_vpc_endpoint_graph.go()
-    data_plane_graph.go()
+    # s3_vpc_endpoint_graph.go()
+    # data_plane_graph.go()

-    if kwargs['stack_color'] is not None:
-        tiler_graph.go()
-        application_graph.go()
-        worker_graph.go()
+    # if kwargs['stack_color'] is not None:
+    #     tiler_graph.go()
+    #     application_graph.go()
+    #     worker_graph.go()

-    if kwargs['activate_dns']:
-        public_hosted_zone_graph.go()
+    # if kwargs['activate_dns']:
+    #     public_hosted_zone_graph.go()
```
- Generate a new VPC stack `template.json`:
```bash
./mmw_stack.py launch-stacks --aws-profile mmw-stg --mmw-config-path ~/mmw-staging.yml --mmw-profile staging > ~/template-vpc.json
```
- See that there are no changes when you try to apply the update the VPC stack in the AWS Console.