### PR TITLE
Remove remaining references to monitoring service

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,6 @@ ANSIBLE_GROUPS = {
   "app-servers" => [ "app" ],
   "services" => [ "services" ],
   "workers" => [ "worker" ],
-  "monitoring-servers" => [ "services" ],
   "tile-servers" => [ "tiler" ]
 }
 
@@ -27,7 +26,7 @@ if !ENV["VAGRANT_ENV"].nil? && ENV["VAGRANT_ENV"] == "TEST"
 else
   ANSIBLE_ENV_GROUPS = {
     "development:children" => [
-      "app-servers", "services", "monitoring-servers", "workers", "tile-servers"
+      "app-servers", "services", "workers", "tile-servers"
     ]
   }
   VAGRANT_NETWORK_OPTIONS = { auto_correct: false }

--- a/deployment/MIGRATIONS.md
+++ b/deployment/MIGRATIONS.md
@@ -41,7 +41,7 @@ $ ssh-add -L
 ### SSH into Bastion
 
 ```bash
-$ ssh -A -l ubuntu monitoring.mmw.foo.com
+$ ssh -A -l ubuntu bastion.mmw.foo.com
 ```
 
 The `-A`  enables forwarding of the authentication agent connection so that the `.pem` file doesn't have to by copied to the bastion.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -41,7 +41,7 @@ Before launching the Model My Watershed stack, AMIs for each service need to be 
 
 ```bash
 $ ./mmw_stack.py create-ami --aws-profile mmw-stg --mmw-profile staging \
-                            --machine-type mmw-{app,monitoring,tiler,worker}
+                            --machine-type mmw-{app,tiler,worker}
 ```
 
 ### Pruning AMIs
@@ -50,7 +50,7 @@ After creating several AMIs, older ones become stale and are no longer needed. T
 
 ```bash
 $ ./mmw_stack.py prune-ami --aws-profile mmw-stg --mmw-profile staging \
-                           --keep 5 --machine-type mmw-{app,monitoring,tiler,worker}
+                           --keep 5 --machine-type mmw-{app,tiler,worker}
 ```
 
 ### Launching Stacks

--- a/deployment/ansible/inventory/packer-monitoring-server
+++ b/deployment/ansible/inventory/packer-monitoring-server
@@ -1,8 +1,0 @@
-[mmw-monitoring]
-localhost ansible_user=ubuntu
-
-[monitoring-servers]
-mmw-monitoring
-
-[packer:children]
-monitoring-servers

--- a/deployment/ec2/amis.py
+++ b/deployment/ec2/amis.py
@@ -10,7 +10,6 @@ LOGGER.setLevel(logging.INFO)
 
 MACHINE_TYPE_MAPPING = {
     'mmw-app': 'Application',
-    'mmw-monitoring': 'Monitoring',
     'mmw-tiler': 'Tiler',
     'mmw-worker': 'Worker',
 }


### PR DESCRIPTION
## Overview

This PR removes remaining references to the former monitoring service. 

In service of preparing documentation, e.g. [RELEASES.md](https://github.com/WikiWatershed/model-my-watershed/blob/develop/deployment/RELEASES.md) and [MIGRATIONS.md](https://github.com/WikiWatershed/model-my-watershed/blob/develop/deployment/MIGRATIONS.md), with changes to the deployment process.

Connects #3114 

## Testing Instructions

I made sure I could still execute `vagrant up --provision`.