### PR TITLE
Upgrade Windshaft Followup

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.tiler/tasks/configuration.yml
+++ b/deployment/ansible/roles/model-my-watershed.tiler/tasks/configuration.yml
@@ -1,4 +1,13 @@
 ---
+- name: Configure Node Modules mount
+  template: src=systemd-tiler.mount.j2
+            dest=/etc/systemd/system/opt-tiler-node_modules.mount
+  when: "['development', 'test'] | some_are_in(group_names)"
+
+- name: Enable Node Modules Mount
+  systemd: name=opt-tiler-node_modules.mount enabled=yes state=started daemon_reload=yes
+  when: "['development', 'test'] | some_are_in(group_names)"
+
 - name: Configure Windshaft service definition
   template: src=systemd-tiler.service.j2
             dest=/etc/systemd/system/mmw-tiler.service

--- a/deployment/ansible/roles/model-my-watershed.tiler/templates/systemd-tiler.mount.j2
+++ b/deployment/ansible/roles/model-my-watershed.tiler/templates/systemd-tiler.mount.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mount Node Modules to Prevent Race Conditions
+Before=mmw-tiler.service
+
+[Mount]
+What=/var/cache/node_modules
+Where=/opt/tiler/node_modules
+Type=none
+Options=bind
+
+[Install]
+WantedBy=opt-tiler.mount

--- a/deployment/ansible/tile-servers.yml
+++ b/deployment/ansible/tile-servers.yml
@@ -23,11 +23,5 @@
         mode: "0755"
       when: "['development', 'test'] | some_are_in(group_names)"
 
-    - name: Create bind mount for node_modules cache
-      command: "mount --bind /var/cache/node_modules /opt/tiler/node_modules"
-      args:
-        warn: no
-      when: "['development', 'test'] | some_are_in(group_names)"
-
   roles:
     - { role: "model-my-watershed.tiler" }

--- a/src/tiler/http/rollbar.js
+++ b/src/tiler/http/rollbar.js
@@ -1,9 +1,13 @@
 'use strict';
 
 var Rollbar = require('rollbar'),
-    token = process.env.ROLLBAR_SERVER_SIDE_ACCESS_TOKEN;
+    token = process.env.ROLLBAR_SERVER_SIDE_ACCESS_TOKEN,
+    stackType = process.env.MMW_STACK_TYPE;
 
-module.exports = token ? new Rollbar(token) : {
+module.exports = token ? new Rollbar({
+        accessToken: token,
+        environment: stackType,
+    }) : {
     handleError: ex => { console.error(ex); },
     errorHandler: () => {},
 };


### PR DESCRIPTION
## Overview

### Switch to systemctl for the bind mount

A bind mount was introduced for node_modules in 8c5d49a8 to prevent a race condition. The manner of its implementation made it apply only immediately after provisioning, and not when loading a provisioned VM. By moving that mount to systemctl, we ensure it is always loaded, and ready before the tiler service starts.

### Report correct error in Rollbar

Previously, because Rollbar wasn't initialized with an environment, it would always default to `development`. With proper initialization, it reports the correct one for development, staging, and production.

Connects #3112 

### Demo

Tiler Service working correctly in development after reloading:

```
> vagrant reload tiler && vagrant ssh tiler -c 'sudo service mmw-tiler status' && notify
==> tiler: Attempting graceful shutdown of VM...
==> tiler: Checking if box 'bento/ubuntu-16.04' is up to date...
==> tiler: A newer version of the box 'bento/ubuntu-16.04' for provider 'virtualbox' is
==> tiler: available! You currently have version '201807.12.0'. The latest is version
==> tiler: '201906.18.0'. Run `vagrant box update` to update.
==> tiler: Clearing any previously set forwarded ports...
==> tiler: Clearing any previously set network interfaces...
==> tiler: Preparing network interfaces based on configuration...
    tiler: Adapter 1: nat
    tiler: Adapter 2: hostonly
==> tiler: Forwarding ports...
    tiler: 80 (guest) => 4000 (host) (adapter 1)
    tiler: 22 (guest) => 2222 (host) (adapter 1)
==> tiler: Running 'pre-boot' VM customizations...
==> tiler: Booting VM...
==> tiler: Waiting for machine to boot. This may take a few minutes...
    tiler: SSH address: 127.0.0.1:2222
    tiler: SSH username: vagrant
    tiler: SSH auth method: private key
==> tiler: Machine booted and ready!
==> tiler: Checking for guest additions in VM...
==> tiler: Setting hostname...
==> tiler: Configuring and enabling network interfaces...
==> tiler: Mounting shared folders...
    tiler: /vagrant => /Users/ttuhinanshu/dev/mmw
    tiler: /opt/tiler => /Users/ttuhinanshu/dev/mmw/src/tiler
==> tiler: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> tiler: flag to force provisioning. Provisioners marked to run always will still run.
● mmw-tiler.service - mmw-tiler
   Loaded: loaded (/etc/systemd/system/mmw-tiler.service; enabled; vendor preset: enabled)
   Active: active (running) since Mon 2019-07-22 17:57:08 UTC; 4s ago
 Main PID: 1624 (node)
    Tasks: 7
   Memory: 114.6M
      CPU: 2.713s
   CGroup: /system.slice/mmw-tiler.service
           └─1624 /usr/local/bin/node server.js

Jul 22 17:57:08 tiler systemd[1]: Started mmw-tiler.
Connection to 127.0.0.1 closed.
```

Rollbar reporting environment correctly:

https://rollbar.com/WikiWatershed/ModelMyWatershed/items/37/

<img width="384" alt="image" src="https://user-images.githubusercontent.com/1430060/61654129-be04e680-ac89-11e9-8885-81f213aed5d7.png">