### PR TITLE
Update SRAT Catchment API Endpoint

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -25,7 +25,7 @@ itsi_secret_key: "{{ lookup('env', 'MMW_ITSI_SECRET_KEY') }}"
 hydroshare_base_url: "https://beta.hydroshare.org/"
 hydroshare_secret_key: "{{ lookup('env', 'MMW_HYDROSHARE_SECRET_KEY') }}"
 
-srat_catchment_api_url: "https://rychrnjrs6.execute-api.us-east-1.amazonaws.com/dev/SratRunModel_DEV"
+srat_catchment_api_url: "https://802or9kkk2.execute-api.us-east-2.amazonaws.com/prod/SratRunModel_DEV"
 srat_catchment_api_key: "{{ lookup('env', 'MMW_SRAT_CATCHMENT_API_KEY') }}"
 
 tilecache_bucket_name: "{{ lookup('env', 'MMW_TILECACHE_BUCKET') | default('', true) }}"

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -22,7 +22,7 @@ itsi_secret_key: "{{ lookup('env', 'MMW_ITSI_SECRET_KEY') }}"
 hydroshare_base_url: "https://beta.hydroshare.org/"
 hydroshare_secret_key: "{{ lookup('env', 'MMW_HYDROSHARE_SECRET_KEY') }}"
 
-srat_catchment_api_url: "https://rychrnjrs6.execute-api.us-east-1.amazonaws.com/dev/SratRunModel_DEV"
+srat_catchment_api_url: "https://802or9kkk2.execute-api.us-east-2.amazonaws.com/prod/SratRunModel_DEV"
 srat_catchment_api_key: "{{ lookup('env', 'MMW_SRAT_CATCHMENT_API_KEY') }}"
 
 tilecache_bucket_name: "tile-cache.staging.app.wikiwatershed.org"


### PR DESCRIPTION
## Overview

Updates endpoint URL for the SRAT Catchment API, as instructed by Scott Haag.

Also updates the URL and the KEY in deployment configuration in the fileshare and on civicci.

Connects #3128 

### Demo

![image](https://user-images.githubusercontent.com/1430060/62322533-4433e080-b473-11e9-8dc5-8396d1dd6fc2.png)

### Notes

~~Currently the new API is failing with this message:~~

```
[2019-07-24 13:37:04,793: ERROR/ForkPoolWorker-1] Task f2aa3aa0-d6be-4014-8359-8b143062f843 run from job 29 raised exception: SRAT Catchment API returned malformed result: u'tploadrate_conc'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 374, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 629, in __protected_call__
    return self.run(*args, **kwargs)
  File "/opt/app/apps/modeling/tasks.py", line 407, in run_srat
    raise Exception('SRAT Catchment API returned malformed result: %s' % e)
Exception: SRAT Catchment API returned malformed result: u'tploadrate_conc'
```

~~Because the key that should be `tploadrate_conc` is reported as `tploadate_conc`. We are trying to get this fixed on the SRAT end.~~

This has been fixed in the API and it is now working correctly.

## Testing Instructions

* Check out this branch
* `vagrant ssh` in to `app` and `worker` and update `/etc/mmw.d/env/MMW_SRAT_CATCHMENT_API_URL` and `/etc/mmw.d/env/MMW_SRAT_CATCHMENT_API_KEY` with values from civicci's `/var/lib/jenkins/.aws/staging.yml`
* Restart `mmw-app` and `celeryd` services
* Go to [:8000/](http://localhost:8000/) and select a HUC-10 or HUC-8 boundary
* Create a MapShed Model with the shape
* Go to Water Quality tab and view subbasin results
  - [x] Ensure they come through

## Checklist

- [x] All JavaScript tests pass `./scripts/testem.sh`
