### PR TITLE
Upgrade Middleware for Production

### DIFF
--- a/src/mmw/mmw/middleware.py
+++ b/src/mmw/mmw/middleware.py
@@ -30,6 +30,6 @@ class BypassMiddleware(MiddlewareMixin):
             handler._response_middleware = []
             handler._exception_middleware = []
 
-            response = handler.get_response(request)
+            response = handler._get_response(request)
 
             return response

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -47,7 +47,7 @@ DEFAULT_FROM_EMAIL = 'noreply@modelmywatershed.org'
 # END EMAIL CONFIGURATION
 
 # MIDDLEWARE CONFIGURATION
-MIDDLEWARE_CLASSES += (
+MIDDLEWARE += (
     'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',
 )
 # END MIDDLEWARE CONFIGURATION


### PR DESCRIPTION
## Overview

This was missed in 3a737432, and has caused Staging and Production deploys to fail. Also fixes the health-check endpoint which was failing.

Connects #3130 

### Demo

http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-packer-app-and-worker/1165/console

and

```http
> http --print HhBb :8000/health-check/
GET /health-check/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Host: localhost:8000
User-Agent: HTTPie/1.0.2



HTTP/1.1 200 OK
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Fri, 26 Jul 2019 18:19:44 GMT
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding

{
    "caches": [
        {
            "default": {
                "ok": true
            }
        }
    ],
    "databases": [
        {
            "default": {
                "ok": true
            }
        }
    ]
}
```

## Testing Instructions

* Check out this branch
* Go to [:8000/health-check/](http://localhost:8000/health-check/)
  - [ ] Ensure it works correctly
* Go to [:8000/health-check](http://localhost:8000/health-check) (no trailing slash)
  - [ ] Ensure you get a ConnectionError, indicating that the middlewares are being skipped correctly (otherwise there is one that appends the trailing slash)