### PR TITLE
Switch API Documentation to DRF-YASG

### DIFF
--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from drf_yasg.openapi import (
+    Parameter, Schema,
+    IN_QUERY,
+    FORMAT_DATETIME, FORMAT_UUID,
+    TYPE_ARRAY, TYPE_BOOLEAN, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING
+)
+
+WKAOI = Parameter(
+    'wkaoi',
+    IN_QUERY,
+    description='The table and ID for a well-known area of interest, '
+                'such as a HUC. '
+                'Format "table__id", eg. "huc12__55174" will analyze '
+                'the HUC-12 City of Philadelphia-Schuylkill River.',
+    type=TYPE_STRING,
+)
+
+MULTIPOLYGON = Schema(
+    title='Area of Interest',
+    description='A valid single-ringed Multipolygon GeoJSON '
+                'representation of the shape to analyze. '
+                'See the GeoJSON spec '
+                'https://tools.ietf.org/html/rfc7946#section-3.1.7',
+    type=TYPE_OBJECT,
+    properties={
+        'type': Schema(type=TYPE_STRING,
+                       example='MultiPolygon'),
+        'coordinates': Schema(type=TYPE_ARRAY,
+                              items=Schema(
+                                  type=TYPE_ARRAY,
+                                  items=Schema(
+                                      type=TYPE_ARRAY,
+                                      items=Schema(
+                                          type=TYPE_ARRAY,
+                                          items=Schema(
+                                              type=TYPE_NUMBER
+                                          )))),
+                              example=[[[
+                                  [-75.16468, 39.97054],
+                                  [-75.17086, 39.95001],
+                                  [-75.14888, 39.95975],
+                                  [-75.16468, 39.97054]]]])
+    }
+)
+
+TOKEN_REQUEST = Schema(
+    title='Token Request',
+    type=TYPE_OBJECT,
+    properties={
+        'username': Schema(type=TYPE_STRING, example='username'),
+        'password': Schema(type=TYPE_STRING, example='password'),
+        'regenerate': Schema(type=TYPE_BOOLEAN, default=False),
+    },
+    required=['username', 'password']
+)
+
+TOKEN_RESPONSE = Schema(
+    title='Token Response',
+    type=TYPE_OBJECT,
+    properties={
+        'token': Schema(type=TYPE_STRING,
+                        example='ea467ed7f67c53cfdd313198647a1d187b4d3ab9'),
+        'created_at': Schema(type=TYPE_STRING, format=FORMAT_DATETIME,
+                             example='2019-07-30T20:28:12.880Z'),
+    }
+)
+
+JOB_STARTED_RESPONSE = Schema(
+    title='Job Started Response',
+    type=TYPE_OBJECT,
+    properties={
+        'job': Schema(type=TYPE_STRING, format=FORMAT_UUID,
+                      example='6e514e69-f46b-47e7-9476-c1f5be0bac01'),
+        'status': Schema(type=TYPE_STRING, example='started'),
+    }
+)
+
+JOB_RESPONSE = Schema(
+    title='Job Response',
+    type=TYPE_OBJECT,
+    properties={
+        'job_uuid': Schema(type=TYPE_STRING, format=FORMAT_UUID,
+                           example='6e514e69-f46b-47e7-9476-c1f5be0bac01'),
+        'status': Schema(type=TYPE_STRING, example='started'),
+        'result': Schema(type=TYPE_OBJECT),
+        'error': Schema(type=TYPE_STRING),
+        'started': Schema(type=TYPE_STRING, format=FORMAT_DATETIME,
+                          example='2019-07-30T20:28:12.880Z'),
+        'finished': Schema(type=TYPE_STRING, format=FORMAT_DATETIME,
+                           example='2019-07-30T20:28:12.880Z'),
+    }
+)
+
+RWD_REQUEST = Schema(
+    title='Rapid Watershed Delineation Request',
+    type=TYPE_OBJECT,
+    properties={
+        'location': Schema(type=TYPE_ARRAY, items=Schema(type=TYPE_NUMBER),
+                           example=[39.67185812402583, -75.76742706298828],
+                           description='The point to delineate. '
+                                       'Format is [lat, lng].'),
+        'snappingOn': Schema(type=TYPE_BOOLEAN, default=True,
+                             description='Snap to the nearest stream? '
+                                         'Default is `false`.'),
+        'simplify': Schema(type=TYPE_NUMBER,
+                           example=0.0001,
+                           description='Simplify tolerance for delineated '
+                                       'watershed shape in response. Use `0` '
+                                       'to receive an unsimplified shape. '
+                                       'When this parameter is not supplied, '
+                                       '`simplify` defaults to `0.0001` for '
+                                       '"drb" and is a function of the '
+                                       'shape\'s area for "nhd"'),
+        'dataSource': Schema(type=TYPE_STRING, default='drb',
+                             example='drb',
+                             description='Which resolution to delineate with. '
+                                         'Either "drb" to use Delaware High '
+                                         'Resolution (10m) or "nhd" to use '
+                                         'Continental US High Resolution '
+                                         '(30m). Default is "drb". Points '
+                                         'must be in the Delaware River Basin '
+                                         'to use "drb", and in the '
+                                         'Continental US to use "nhd"'),
+    },
+    required=['location'],
+)

--- a/src/mmw/apps/geoprocessing_api/tests.py
+++ b/src/mmw/apps/geoprocessing_api/tests.py
@@ -8,6 +8,7 @@ import json
 from django.test import (Client,
                          TestCase,
                          LiveServerTestCase)
+from django.urls import reverse
 from django.contrib.auth.models import User
 
 from rest_framework.authtoken.models import Token
@@ -18,7 +19,7 @@ from apps.geoprocessing_api import (tasks, calcs)
 
 
 class ExerciseManageApiToken(LiveServerTestCase):
-    TOKEN_URL = 'http://localhost:8081/api/token/'
+    TOKEN_URL = reverse('geoprocessing_api:authtoken')
 
     def setUp(self):
         User.objects.create_user(username='bob', email='bob@azavea.com',

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from django.conf.urls import include, url
+from django.conf.urls import url
 
 from apps.modeling.views import get_job
 from apps.modeling.urls import uuid_regex
@@ -12,7 +12,6 @@ from apps.geoprocessing_api import views
 
 app_name = 'geoprocessing_api'
 urlpatterns = [
-    url(r'^docs/', include('rest_framework_swagger.urls')),
     url(r'^token/', views.get_auth_token,
         name="authtoken"),
     url(r'analyze/land/$', views.start_analyze_land,

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -15,6 +15,7 @@ from rest_framework.authentication import (SessionAuthentication,
 from rest_framework.permissions import (AllowAny,
                                         IsAuthenticated,
                                         IsAuthenticatedOrReadOnly)
+from drf_yasg.utils import swagger_auto_schema
 
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
@@ -29,6 +30,7 @@ from wsgiref.util import FileWrapper
 from apps.core.models import Job
 from apps.core.tasks import save_job_error, save_job_result
 from apps.core.decorators import log_request
+from apps.geoprocessing_api.schemas import JOB_RESPONSE
 from apps.modeling import tasks, geoprocessing
 from apps.modeling.mapshed.tasks import (multi_subbasin,
                                          multi_mapshed,
@@ -541,6 +543,8 @@ def drb_point_sources(request):
                     headers={'Cache-Control': 'max-age: 604800'})
 
 
+@swagger_auto_schema(method='get',
+                     responses={200: JOB_RESPONSE})
 @decorators.api_view(['GET'])
 @decorators.authentication_classes((SessionAuthentication,
                                     TokenAuthentication, ))
@@ -549,35 +553,6 @@ def drb_point_sources(request):
 def get_job(request, job_uuid, format=None):
     """
     Get a job's status. If it's complete, get its result.
-
-    ---
-    type:
-      job_uuid:
-        required: true
-        type: string
-      status:
-        required: true
-        type: string
-      started:
-        required: true
-        type: datetime
-      finished:
-        required: true
-        type: datetime
-      result:
-        required: true
-        type: object
-      error:
-        required: true
-        type: string
-
-    omit_serializer: true
-    parameters:
-       - name: Authorization
-         paramType: header
-         description: Format "Token&nbsp;YOUR_API_TOKEN_HERE". When using
-                      Swagger you may wish to set this for all requests via
-                      the field at the top right of the page.
     """
     # TODO consider if we should have some sort of session id check to ensure
     # you can only view your own jobs.

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -293,7 +293,7 @@ DJANGO_APPS = (
 THIRD_PARTY_APPS = (
     'rest_framework',
     'rest_framework_gis',
-    'rest_framework_swagger',
+    'drf_yasg',
     'rest_framework.authtoken',
     'corsheaders',
     'registration',
@@ -316,24 +316,39 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^/api/.*$'
 
 SWAGGER_SETTINGS = {
-    'exclude_namespaces': ['bigcz',
-                           'export',
-                           'mmw',
-                           'user'],
-    'doc_expansion': 'list',
-    'info': {
-        'description': 'The Model My Watershed API allows '
-                       'you to delineate watersheds and analyze '
-                       'geo-data for watersheds and arbitrary areas. '
-                       'You can read more about the work at '
-                       '<a href="http://www.wikiwatershed.org/">'
-                       'WikiWatershed</a> '
-                       'or use the <a href="https://modelmywatershed.org">'
-                       'web app.',
-        'license': 'Apache 2.0',
-        'licenseUrl': 'http://www.apache.org/licenses/LICENSE-2.0.html',
-        'title': 'Model My Watershed API',
-    }
+    'MMW_API_DESCRIPTION':
+        '<p>'
+        'The Model My Watershed API allows you to delineate watersheds and analyze geo-data for watersheds and arbitrary areas. '  # NOQA
+        'You can read more about the work at <a href="http://www.wikiwatershed.org/">WikiWatershed</a> or use the <a href="https://modelmywatershed.org">web app</a>. '  # NOQA
+        '</p>'
+        '<p>'
+        'To use this interactive API documentation, first get your API key from My Account > Account in the web app. '  # NOQA
+        'Then, click on the green Authorize button just below and paste in <code>Token $YOUR_MMW_TOKEN</code> in the "Value" textbox, then click Authorize, then Close. '  # NOQA
+        'All the endpoints in this documentation will then be prepared with your token, and you will now be able to run them interactively. '  # NOQA
+        'Do not use the Django Login / Logout buttons. This API uses Token Authentication only. '  # NOQA
+        '</p>'
+        '<p>'
+        'All <strong>analyze</strong> endpoints take <em>either</em> a MultiPolygon request body <em>or</em> a well-known area of interest query parameter. '  # NOQA
+        'The shape of their result object is documented individually. '
+        '</p>'
+        '<p>'
+        'All <strong>analyze</strong> and <strong>watershed</strong> endpoints return a <strong>Job Started Response</strong> on success. '  # NOQA
+        'This response has a <code>job</code> value, as well as a <code>Location</code> header, either of which can be used with the <strong>jobs</strong> endpoint to get the result. '  # NOQA
+        '</p>'
+        '<p>'
+        'The <strong>jobs</strong> endpoint has a <code>status</code> key, whose value is either <strong>started</strong>, <strong>complete</strong>, or <strong>failed</strong>. '  # NOQA
+        'In cases of completion and failure, the <code>finished</code> key has a timestamp. '  # NOQA
+        'The value of <code>result</code> depends on the kind of job it was. '  # NOQA
+        '</p>',
+    'SECURITY_DEFINITIONS': {
+        'Token': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header',
+            'description': 'Paste in `Token $YOUR_MMW_TOKEN` here',
+            'scheme': 'Token',
+        },
+    },
 }
 
 # registration

--- a/src/mmw/mmw/urls.py
+++ b/src/mmw/mmw/urls.py
@@ -5,9 +5,30 @@ from __future__ import division
 
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.conf import settings
+
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 
 admin.autodiscover()
+
+apipatterns = [
+    url(r'^api/', include('apps.geoprocessing_api.urls')),
+]
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title='Model My Watershed API',
+        default_version='v1',
+        description=settings.SWAGGER_SETTINGS['MMW_API_DESCRIPTION'],
+        license=openapi.License(name='Apache 2.0')
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+    patterns=apipatterns,
+)
 
 urlpatterns = [
     url(r'^', include('apps.home.urls')),
@@ -18,6 +39,8 @@ urlpatterns = [
     url(r'^mmw/geocode/', include('apps.geocode.urls')),
     url(r'^mmw/modeling/', include('apps.modeling.urls')),
     url(r'^export/', include('apps.export.urls')),
+    url(r'^api/docs/$', schema_view.with_ui('swagger', cache_timeout=0),
+        name='schema-swagger-ui'),
     url(r'^api/', include('apps.geoprocessing_api.urls')),
     url(r'^micro/', include('apps.water_balance.urls')),
     url(r'^user/', include('apps.user.urls')),

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -8,7 +8,7 @@ django-registration-redux==2.6
 python-omgeo==4.0.0
 rauth==0.7.1
 djangorestframework-gis==0.14.0
-django-rest-swagger==0.3.8
+drf_yasg==1.16.0
 django-cors-headers==3.0.2
 cryptography==2.1.4
 pyOpenSSL==17.4.0


### PR DESCRIPTION
## Overview

The Django Upgrade in #3123 broken Django Rest Swagger, a project that is no longer maintained. We switch to the recommended (by the author of Django Rest Swagger) alternative drf-yasg for the API generation instead.

This new tool doesn't use the YAML documentation previously there, instead relying on OpenAPI Schema decoration. The documentation is converted to this new format, and some supplemental instruction is added as well.

Connects #3124 

### Demo

![Screen Shot 2019-07-30 at 18 30 51-fullpage](https://user-images.githubusercontent.com/1430060/62329582-5b2efe80-b484-11e9-9001-28fcfb5346da.png)

## Testing Instructions

* Check out this branch and reprovision your `app` VM to install the new dependencies

      $ vagrant reload --provision app

* Go to [:8000/api/docs](http://localhost:8000/api/docs) and ensure you see the Swagger UI, and not an error page
* Compare the values with production https://modelmywatershed.org/api/docs/ and ensure that the information there has been faithfully captured
* Ensure there are no typos or confusing sentences in the opening instructions near the header