### PR TITLE
Upgrade HydroShare Rest Client to 1.3.4

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -23,7 +23,7 @@ https://bitbucket.org/jurko/suds/get/94664ddd46a6.tar.gz#egg=suds-jurko
 django_celery_results==1.0.1
 pandas==0.22.0
 git+git://github.com/emiliom/ulmo@wml_values_md#egg=ulmo
-hs_restclient==1.2.10
+hs_restclient==1.3.4
 six==1.11.0
 fiona==1.7.11
 timeout-decorator==0.4.0


### PR DESCRIPTION
## Overview

This version fixes problems with deleting HydroShare resources, as discussed in https://github.com/hydroshare/hs_restclient/issues/111.

Connects #3119

## Testing Instructions

* Check out this branch and reprovision `app` and `worker`:

      $ vagrant reload app worker --provision

* Find and edit the `HydroShare OAuth MMW Beta` entry in LastPass, and copy the `client-secret` from the Notes section into `MMW_HYDROSHARE_SECRET_KEY`:

      $ vagrant ssh app -c 'sudo vim /etc/mmw.d/env/MMW_HYDROSHARE_SECRET_KEY'
      $ vagrant ssh worker -c 'sudo vim /etc/mmw.d/env/MMW_HYDROSHARE_SECRET_KEY'

* Restart the app and Celery services:

      $ vagrant ssh app -c 'sudo service mmw-app restart'
      $ vagrant ssh worker -c 'sudo service celeryd restart'

* Go to [:8000/](http://localhost:8000/) and log in to an account
* Make a project and save it
* Click on "Share" and enable HydroShare sharing
* Log in to HydroShare using the credentials for `HydroShare OAuth MMW Beta` in LastPass
  - [x] Ensure that the project is created in HydroShare. It may take a few minutes.
* Make some changes to the project. Open the Share box again. Click "Export Now" to re-share to HydroShare.
  - [x] Ensure this update goes through correctly. Keep it open in its tab.
* Open the Share modal again, and now turn off HydroShare. Accept the consequences in the warning modal.
  - [x] Ensure this completes successfully (i.e. no server side errors in the MMW back-end)
  - [x] Ensure the project is gone from HydroShare by refreshing the tab open from one of the previous exports
