### PR TITLE
Upgrade back-end dependencies that have security vulnerabilities

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -10,8 +10,8 @@ rauth==0.7.1
 djangorestframework-gis==0.14.0
 drf_yasg==1.16.0
 django-cors-headers==3.0.2
-cryptography==2.1.4
-pyOpenSSL==17.4.0
+cryptography==2.2.1
+pyOpenSSL==19.0.0
 markdown==2.6.9
 tr55==1.3.0
 gwlf-e==2.0.0

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -1,5 +1,5 @@
 Django>=1.11,<1.11.99
-gunicorn==19.1.1
+gunicorn==19.9.0
 django-redis==4.10.0
 hiredis==0.1.6
 djangorestframework==3.9.4

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -15,7 +15,7 @@ pyOpenSSL==17.4.0
 markdown==2.6.9
 tr55==1.3.0
 gwlf-e==2.0.0
-requests[security]==2.9.1
+requests[security]==2.22.0
 rollbar==0.13.8
 retry==0.9.1
 python-dateutil==2.6.0


### PR DESCRIPTION
## Overview

Upgrades back-end dependencies flagged by Github with security vulnerabilities. 

Connects #3101 

### Notes

Ansible will be upgraded in a separate PR.

## Testing Instructions

- Run `vagrant reload app services worker --reprovision`
- Run the local development services, visit the app, and verify it generally works.

## Checklist

- [ ] All JavaScript tests pass `./scripts/testem.sh`
