### PR TITLE
Upgrade cryptography to 2.7

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -10,7 +10,7 @@ rauth==0.7.1
 djangorestframework-gis==0.14.0
 drf_yasg==1.16.0
 django-cors-headers==3.0.2
-cryptography==2.2.1
+cryptography==2.7
 pyOpenSSL==19.0.0
 markdown==2.6.9
 tr55==1.3.0


### PR DESCRIPTION
## Overview

In #3139, cryptography was upgraded from 2.1.4 to 2.2.1 to satisfy a requirement of pyOpenSSL 19.0.0. However, upgrading to that version of cryptography did not fix the security vulnerability, which was patched in 2.3.1. The library is updated again here, to the latest version available, to remedy the vulnerability.

Connects #3101 

## Testing Instructions

- Run vagrant reload app services worker --reprovision
- Run the local development services, visit the app, and verify it generally works.

## Checklist

- [x] All JavaScript tests pass `./scripts/testem.sh`