### PR TITLE
Upgrade Ulmo to 0.8.5

### DIFF
--- a/src/mmw/apps/bigcz/clients/cuahsi/details.py
+++ b/src/mmw/apps/bigcz/clients/cuahsi/details.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from datetime import date, timedelta
-from timeout_decorator import timeout
+from socket import timeout
 
 from rest_framework.exceptions import ValidationError
 
@@ -31,16 +31,6 @@ def details(wsdl, site):
     return wof.get_site_info(wsdl, site, None)
 
 
-@timeout(settings.BIGCZ_CLIENT_TIMEOUT, timeout_exception=ValuesTimedOutError)
-# NOTE: This @timeout decorator will have to be modified for a multi-threaded
-# environment, with the use_signals=false attribute. Unfortunately, that does
-# not support functions that return values that cannot be pickled, such as this
-# very function, since suds responses are dynamic objects and not pickleable.
-# In this case, we may have to deserialize the values herein. Read more here:
-# https://github.com/pnpnpn/timeout-decorator#multithreading
-# Alternatively, if https://github.com/ulmo-dev/ulmo/issues/155 is addressed,
-# we can use the native timeout capabilities surfaced in Ulmo instead of this
-# wrapper decorator.
 def values(wsdl, site, variable, from_date=None, to_date=None):
     if not wsdl:
         raise ValidationError({
@@ -67,4 +57,8 @@ def values(wsdl, site, variable, from_date=None, to_date=None):
         wsdl += '?WSDL'
 
     from ulmo.cuahsi import wof
-    return wof.get_values(wsdl, site, variable, from_date, to_date, None)
+    try:
+        return wof.get_values(wsdl, site, variable, from_date, to_date, None,
+                              timeout=settings.BIGCZ_CLIENT_TIMEOUT)
+    except timeout:
+        raise ValuesTimedOutError()

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -22,9 +22,8 @@ python-dateutil==2.6.0
 https://bitbucket.org/jurko/suds/get/94664ddd46a6.tar.gz#egg=suds-jurko
 django_celery_results==1.0.1
 pandas==0.22.0
-git+git://github.com/emiliom/ulmo@wml_values_md#egg=ulmo
+ulmo==0.8.5
 hs_restclient==1.3.4
 six==1.11.0
 fiona==1.7.11
-timeout-decorator==0.4.0
 redis==2.10.6


### PR DESCRIPTION
## Overview

This version supports the native suds timeout parameter, which obviates the need for an external timeout library that we'd been using so far.

With this upgrade, the get_values call is updated to supply the timeout to suds, and the now extraneous library is removed.

Connects #3083 

### Demo

![image](https://user-images.githubusercontent.com/1430060/62897399-2b53e680-bd21-11e9-8853-422aa1991595.png)

### Notes

There may still be some other errors you encounter. If so, use the same shape / test on staging, and ensure you see the same failures there. If you do, then the failures are not related to the changes in this PR, but instead come from the third-party services we're querying instead.

## Testing Instructions

* Check out this branch
* Destroy and recreate the `app` VM

      $ vagrant destroy app && vagrant up app

* Go to [:8000/](http://localhost:8000/) and pick a shape
* Go to the Monitor tab search for "water"
* Switch to the CUAHSI tab and click on any of the results in the sidebar
* Wait for the values to come in
    - [x] Ensure they do
      - If they fail, ensure they also fail on staging
* Pick a new result and open it
* Wait for the first `details` call to succeed (this brings in the units)
* Then turn off your local internet to simulate a timeout for the `values` endpoint (which brings in the numbers)
* Ensure that the error you see for the timeouts are different from a plain "Error 500 during fetch", as shown in the screenshot above