### PR TITLE
Upgrade numpy and install via pip

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -52,7 +52,6 @@ observation_api_url: "http://www.wikiwatershed-vs.org/"
 enabled_features: ''
 
 numba_version: "0.38.1"
-numpy_version: "1.14.5"
 phantomjs_version: "2.1.*"
 
 redis_version: "2:3.0.6-1ubuntu0.*"

--- a/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
@@ -2,9 +2,6 @@
 - name: Install numba
   pip: name=numba version={{ numba_version }}
 
-- name: Install numpy
-  pip: name=numpy version={{ numpy_version }}
-
 - name: Install application Python dependencies for development and test
   pip: requirements="{{ app_home }}/requirements/{{ item }}.txt"
   with_items:

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/dependencies.yml
@@ -2,9 +2,6 @@
 - name: Install numba
   pip: name=numba version={{ numba_version }}
 
-- name: Install numpy
-  pip: name=numpy version={{ numpy_version }}
-
 - name: Install application Python dependencies for development and test
   pip: requirements="{{ app_home }}/requirements/{{ item }}.txt"
   with_items:

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -27,3 +27,4 @@ hs_restclient==1.3.4
 six==1.11.0
 fiona==1.7.11
 redis==2.10.6
+numpy==1.16.4


### PR DESCRIPTION
## Overview

Undos work done in #3090 to get around an issue with numpy, and installs an updated version of numpy that is compatible with ulmo and other dependencies. 

Connects #3093 

## Testing Instructions

- Analyze and run models for an area, and confirm that things work as expected.
- Follow the instructions in https://github.com/WikiWatershed/model-my-watershed/pull/3090 to test that the segfault issue has been addressed.

## Checklist

- [ ] All JavaScript tests pass `./scripts/testem.sh`
