### PR TITLE
Add --print-json flag for VPC and DataPlane stacks

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -35,6 +35,31 @@ A configuration file is required to launch the stack. An example file (`default.
 
 Stack launching is managed with `mmw_stack.py`. This command provides an interface for automatically generating AMIs and launching Model My Watershed stacks.
 
+### VPC and Data Plane Stacks
+
+The VPC and Data Plane stacks are decoupled from the Model My Watershed stack.
+
+To launch the VPC stack:
+
+```bash
+$ ./mmw_stack.py launch-stacks --aws-profile mmw-stg --mmw-profile staging \
+                               --mmw-config-path default.yml --vpc
+```
+
+To launch the Data Plane stack:
+
+```bash
+$ ./mmw_stack.py launch-stacks --aws-profile mmw-stg --mmw-profile staging \
+                               --mmw-config-path default.yml --data-plane
+```
+
+It is reccomended to use the `--print-json` flag to dump the CloudFormation JSON, and to apply changes to these stacks via a change set in the AWS Console:
+
+```bash
+$ ./mmw_stack.py launch-stacks --aws-profile mmw-stg --mmw-profile staging \
+                               --mmw-config-path default.yml --data-plane --print-json > data-plane.json
+```
+
 ### Generating AMIs
 
 Before launching the Model My Watershed stack, AMIs for each service need to be generated:

--- a/deployment/cfn/stacks.py
+++ b/deployment/cfn/stacks.py
@@ -75,18 +75,33 @@ def build_graph(mmw_config, aws_profile, **kwargs):
                                           Application=application,
                                           aws_profile=aws_profile)
 
-    return s3_vpc_endpoint, data_plane, tiler, application, \
+    return vpc, s3_vpc_endpoint, data_plane, tiler, application, \
         worker, public_hosted_zone
 
 
 def build_stacks(mmw_config, aws_profile, **kwargs):
     """Trigger actual building of graphs"""
-    s3_vpc_endpoint_graph, data_plane_graph, tiler_graph, \
+    vpc_graph, s3_vpc_endpoint_graph, data_plane_graph, tiler_graph, \
         application_graph, worker_graph, \
         public_hosted_zone_graph = build_graph(mmw_config, aws_profile,
                                                **kwargs)
+    if kwargs['vpc']:
+        if kwargs['print_json']:
+            vpc_graph.set_up_stack()
+            print(vpc_graph.to_json())
+        else:
+            vpc_graph.go()
+        return
+
+    if kwargs['data_plane']:
+        if kwargs['print_json']:
+            data_plane_graph.set_up_stack()
+            print(data_plane_graph.to_json())
+        else:
+            data_plane_graph.go()
+        return
+
     s3_vpc_endpoint_graph.go()
-    data_plane_graph.go()
 
     if kwargs['stack_color'] is not None:
         tiler_graph.go()

--- a/deployment/mmw_stack.py
+++ b/deployment/mmw_stack.py
@@ -56,6 +56,15 @@ def main():
     mmw_stacks.add_argument('--activate-dns', action='store_true',
                             default=False,
                             help='Activate DNS for current stack color')
+    mmw_stacks.add_argument('--vpc', action='store_true',
+                            default=False,
+                            help='Activate VPC only')
+    mmw_stacks.add_argument('--data-plane', action='store_true',
+                            default=False,
+                            help='Activate data plane only')
+    mmw_stacks.add_argument('--print-json', action='store_true',
+                            default=False,
+                            help='Print JSON instead of applying for VPC and DataPlane stacks')
     mmw_stacks.set_defaults(func=launch_stacks)
 
     mmw_remove_stacks = subparsers.add_parser('remove-stacks',


### PR DESCRIPTION
## Overview

- Do not update DataPlane stack as a part of a `launch-stacks` run
- Add `--vpc` and `--data-plane` flag which allow us to conditionally update these stacks
- Add `--print-json` flag which prints stack JSON

These changes will allow us to update the VPC and DataPlane stacks by hand using CloudFormation change sets (which provide an increase in visibility). 

Connects #3114 

## Testing Instructions

Setup the `virtualenv` for `majorkirby`:

```bash
python2 -m virtualenv ./env
source ./env/bin/activate
pip install -r requirements.txt
```

Verify that valid JSON is returned for both stacks:

```bash
./mmw_stack.py launch-stacks \
    --aws-profile mmw-stg \
    --mmw-config-path default.yml \
    --mmw-profile staging \
    --vpc \
    --print-json
```

```bash
./mmw_stack.py launch-stacks \
    --aws-profile mmw-stg \
    --mmw-config-path default.yml \
    --mmw-profile staging \
    --data-plane \
    --print-json
```