### PR TITLE
Monitor: Warn about timeouts for large AoIs

### DIFF
--- a/src/mmw/js/src/data_catalog/templates/window.html
+++ b/src/mmw/js/src/data_catalog/templates/window.html
@@ -10,6 +10,10 @@
         Start typing to find some datasets that would be useful
         for your research. You can add filters if dates are important.
     </p>
+    <p>
+        Certain catalogs may time out for large areas of interest that
+        contain many results.
+    </p>
 </div>
 
 <div class="output-tabs-wrapper hide">

--- a/src/mmw/sass/pages/_data-catalog.scss
+++ b/src/mmw/sass/pages/_data-catalog.scss
@@ -163,6 +163,10 @@
 
     .intro-text {
         padding: 1.5rem 1rem;
+
+        p {
+            margin-bottom: 10px;
+        }
     }
 
     .output-tabs-wrapper {


### PR DESCRIPTION
## Overview

Add a simple message warning users that they may experience timeouts when fetching monitor results for large areas of interest.

Connects #3153 

### Demo

![image](https://user-images.githubusercontent.com/1430060/63724030-e0f45e80-c824-11e9-8b0d-aaf5c9b5a358.png)

## Testing Instructions

* Check out this branch and `./scripts/bundle.sh --debug`
* Go to [:8000/](http://localhost:8000/) and pick a shape
* Switch to the Monitor tab
  - [ ] Ensure you see text that warns about timeouts for large areas of interest