### PR TITLE
Hide Subbasin Catchment Legend When Not In Subbasin Mode

### DIFF
--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1179,6 +1179,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         this.scenario.set('is_subbasin_active', false);
         App.hideMapInfo({ empty: true });
         App.getMapView().clearSubbasinHuc12s();
+        App.rootView.subbasinSliderRegion.empty();
     },
 
     showSubbasinHuc12View: function() {
@@ -1204,6 +1205,7 @@ var ResultsDetailsView = Marionette.LayoutView.extend({
         App.getMapView().clearSubbasinCatchments();
         this.subbasinRegion.$el.show();
         this.subbasinHuc12Region.empty();
+        App.rootView.subbasinSliderRegion.empty();
     },
 
     showCatchmentsOnMap: function(activeSubbasin, subbasinResult) {


### PR DESCRIPTION
## Overview

Hides the subbasin legend when not in subbasin mode.

Connects #3121 

### Demo

Go to subbasin mode:

![2019-08-28 14 59 18](https://user-images.githubusercontent.com/1430060/63886021-8fc0a800-c9a7-11e9-8515-9f4e6c479d7d.gif)

The legend works correctly, showing the colors for the selected layer, and remembering the selected layer correctly between catchments:

![2019-08-28 14 59 48](https://user-images.githubusercontent.com/1430060/63886084-aa931c80-c9a7-11e9-9303-c548a657eb14.gif)

Once you exit the catchment view, the legend goes away:

![2019-08-28 15 00 33](https://user-images.githubusercontent.com/1430060/63886501-9f8cbc00-c9a8-11e9-81b1-178fdea307dd.gif)

If you switch scenarios, the legend goes away:

![2019-08-28 15 01 05](https://user-images.githubusercontent.com/1430060/63886848-66a11700-c9a9-11e9-976a-daae7c4c767c.gif)

## Testing Instructions

* Go in to subbasin mode, go in to a HUC-12
* Turn on a related layer
  - [x] Ensure the legend appears
* Go back to HUC-12 list
  - [x] Ensure the legend disappears
* Pick a HUC-12 again
  - [x] Ensure the legend appears
* Pick / create a new scenario
  - [x] Ensure the legend disappears