### PR TITLE
PA DEP Celery Workflow

### DIFF
--- a/src/mmw/apps/export/tasks.py
+++ b/src/mmw/apps/export/tasks.py
@@ -28,6 +28,7 @@ SHAPEFILE_EXTENSIONS = ['cpg', 'dbf', 'prj', 'shp', 'shx']
 DEFAULT_KEYWORDS = {'mmw', 'model-my-watershed'}
 MMW_APP_KEY_FLAG = '{"appkey": "model-my-watershed"}'
 BMP_SPREADSHEET_TOOL_URL = 'https://github.com/WikiWatershed/MMW-BMP-spreadsheet-tool/raw/master/MMW_BMP_Spreadsheet_Tool.xlsx'  # NOQA
+SQKM_PER_SQM = 1.0E-06
 
 
 @shared_task(time_limit=300)
@@ -161,3 +162,176 @@ def create_resource(user_id, project_id, params):
     # Return newly created HydroShareResource
     serializer = HydroShareResourceSerializer(hsresource)
     return serializer.data
+
+
+@shared_task
+def padep_worksheet(results):
+    """
+    Given a dictionary of results for areas of interest and HUC-12s, indexed
+    by the filename, transforms the results into a payload for generating
+    an Excel worksheet.
+    """
+    payload = []
+
+    for k, v in results.iteritems():
+        huc12_stream_length_km = sum(
+            [c['lengthkm'] for c in v['huc12']['streams']['categories']])
+        huc12_stream_ag_pct = \
+            v['huc12']['streams']['categories'][0]['ag_stream_pct']
+        huc12_stream_ag_length_km = \
+            huc12_stream_length_km * huc12_stream_ag_pct
+        huc12_stream_urb_length_km = \
+            huc12_stream_length_km - huc12_stream_ag_length_km
+
+        huc12_nlcd = {c['nlcd']: (c['area'] / 1.00000E+06)
+                      for c in v['huc12']['nlcd']['categories']}
+
+        aoi_stream_length_km = sum(
+            [c['lengthkm'] for c in v['aoi']['streams']['categories']])
+        aoi_stream_ag_pct = \
+            v['aoi']['streams']['categories'][0]['ag_stream_pct']
+        aoi_stream_ag_length_km = \
+            aoi_stream_length_km * aoi_stream_ag_pct
+        aoi_stream_urb_length_km = \
+            aoi_stream_length_km - aoi_stream_ag_length_km
+
+        date = now()
+
+        spec = {
+            'C11': date.strftime('%Y-%m-%d'),  # Date Data Entered
+            'C13': v['name'],  # Watershed
+            'C14': date.strftime('%Y'),  # Year
+            'L18': round(huc12_stream_length_km, 2),  # Total Length # NOQA
+            'L19': round(huc12_stream_ag_length_km, 2),  # Ag Streams # NOQA
+            'L20': round(huc12_stream_urb_length_km, 2),  # Non-Ag Streams # NOQA
+            'L27': round(v['huc12']['mapshed']['NumAnimals'][2], 2),  # Chickens, Broilers # NOQA
+            'L28': round(v['huc12']['mapshed']['NumAnimals'][3], 2),  # Chickens, Layers # NOQA
+            'L29': round(v['huc12']['mapshed']['NumAnimals'][1], 2),  # Cows, Beef # NOQA
+            'L30': round(v['huc12']['mapshed']['NumAnimals'][0], 2),  # Cows, Dairy # NOQA
+            'L31': round(v['huc12']['mapshed']['NumAnimals'][6], 2),  # Horses # NOQA
+            'L32': round(v['huc12']['mapshed']['NumAnimals'][4], 2),  # Pigs/Hogs/Swine # NOQA
+            'L33': round(v['huc12']['mapshed']['NumAnimals'][5], 2),  # Sheep # NOQA
+            'L34': round(v['huc12']['mapshed']['NumAnimals'][7], 2),  # Turkeys # NOQA
+            'D48': round(huc12_nlcd.get(11, 0), 2),  # Open Water # NOQA
+            'D49': round(huc12_nlcd.get(12, 0), 2),  # Perennial Ice/Snow # NOQA
+            'D50': round(huc12_nlcd.get(21, 0), 2),  # Developed, Open Space # NOQA
+            'D51': round(huc12_nlcd.get(22, 0), 2),  # Developed, Low Intensity # NOQA
+            'D52': round(huc12_nlcd.get(23, 0), 2),  # Developed, Medium Intensity # NOQA
+            'D53': round(huc12_nlcd.get(24, 0), 2),  # Developed, High Intensity # NOQA
+            'D54': round(huc12_nlcd.get(31, 0), 2),  # Barren Land (Rock/Sand/Clay) # NOQA
+            'D55': round(huc12_nlcd.get(41, 0), 2),  # Deciduous Forest # NOQA
+            'D56': round(huc12_nlcd.get(42, 0), 2),  # Evergreen Forest # NOQA
+            'D57': round(huc12_nlcd.get(43, 0), 2),  # Mixed Forest # NOQA
+            'D58': round(huc12_nlcd.get(52, 0), 2),  # Shrub/Scrub # NOQA
+            'D59': round(huc12_nlcd.get(71, 0), 2),  # Grassland/Herbaceous # NOQA
+            'D60': round(huc12_nlcd.get(81, 0), 2),  # Pasture/Hay # NOQA
+            'D61': round(huc12_nlcd.get(82, 0), 2),  # Cultivated Crops # NOQA
+            'D62': round(huc12_nlcd.get(90, 0), 2),  # Woody Wetlands # NOQA
+            'D63': round(huc12_nlcd.get(95, 0), 2),  # Emergent Herbaceous Wetlands # NOQA
+            'K48': round(v['huc12']['gwlfe']['Loads'][0]['Sediment'], 2),  # Hay/Pasture # NOQA
+            'K49': round(v['huc12']['gwlfe']['Loads'][1]['Sediment'], 2),  # Cropland # NOQA
+            'K50': round(v['huc12']['gwlfe']['Loads'][2]['Sediment'], 2),  # Wooded Areas # NOQA
+            'K51': round(v['huc12']['gwlfe']['Loads'][3]['Sediment'], 2),  # Wetlands # NOQA
+            'K52': round(v['huc12']['gwlfe']['Loads'][4]['Sediment'], 2),  # Open Land # NOQA
+            'K53': round(v['huc12']['gwlfe']['Loads'][5]['Sediment'], 2),  # Barren Areas # NOQA
+            'K54': round(v['huc12']['gwlfe']['Loads'][6]['Sediment'], 2),  # Low-Density Mixed # NOQA
+            'K55': round(v['huc12']['gwlfe']['Loads'][7]['Sediment'], 2),  # Medium-Density Mixed # NOQA
+            'K56': round(v['huc12']['gwlfe']['Loads'][8]['Sediment'], 2),  # High-Density Mixed # NOQA
+            'K57': round(v['huc12']['gwlfe']['Loads'][9]['Sediment'], 2),  # Other Upland Areas # NOQA
+            'K58': round(v['huc12']['gwlfe']['Loads'][10]['Sediment'], 2),  # Farm Animals # NOQA
+            'K59': round(v['huc12']['gwlfe']['Loads'][11]['Sediment'], 2),  # Stream Bank Erosion # NOQA
+            'K60': round(v['huc12']['gwlfe']['Loads'][12]['Sediment'], 2),  # Subsurface Flow # NOQA
+            'K61': round(v['huc12']['gwlfe']['Loads'][13]['Sediment'], 2),  # Point Sources # NOQA
+            'K62': round(v['huc12']['gwlfe']['Loads'][14]['Sediment'], 2),  # Septic Systems # NOQA
+            'L48': round(v['huc12']['gwlfe']['Loads'][0]['TotalN'], 2),  # Hay/Pasture # NOQA
+            'L49': round(v['huc12']['gwlfe']['Loads'][1]['TotalN'], 2),  # Cropland # NOQA
+            'L50': round(v['huc12']['gwlfe']['Loads'][2]['TotalN'], 2),  # Wooded Areas # NOQA
+            'L51': round(v['huc12']['gwlfe']['Loads'][3]['TotalN'], 2),  # Wetlands # NOQA
+            'L52': round(v['huc12']['gwlfe']['Loads'][4]['TotalN'], 2),  # Open Land # NOQA
+            'L53': round(v['huc12']['gwlfe']['Loads'][5]['TotalN'], 2),  # Barren Areas # NOQA
+            'L54': round(v['huc12']['gwlfe']['Loads'][6]['TotalN'], 2),  # Low-Density Mixed # NOQA
+            'L55': round(v['huc12']['gwlfe']['Loads'][7]['TotalN'], 2),  # Medium-Density Mixed # NOQA
+            'L56': round(v['huc12']['gwlfe']['Loads'][8]['TotalN'], 2),  # High-Density Mixed # NOQA
+            'L57': round(v['huc12']['gwlfe']['Loads'][9]['TotalN'], 2),  # Other Upland Areas # NOQA
+            'L58': round(v['huc12']['gwlfe']['Loads'][10]['TotalN'], 2),  # Farm Animals # NOQA
+            'L59': round(v['huc12']['gwlfe']['Loads'][11]['TotalN'], 2),  # Stream Bank Erosion # NOQA
+            'L60': round(v['huc12']['gwlfe']['Loads'][12]['TotalN'], 2),  # Subsurface Flow # NOQA
+            'L61': round(v['huc12']['gwlfe']['Loads'][13]['TotalN'], 2),  # Point Sources # NOQA
+            'L62': round(v['huc12']['gwlfe']['Loads'][14]['TotalN'], 2),  # Septic Systems # NOQA
+            'M48': round(v['huc12']['gwlfe']['Loads'][0]['TotalP'], 2),  # Hay/Pasture # NOQA
+            'M49': round(v['huc12']['gwlfe']['Loads'][1]['TotalP'], 2),  # Cropland # NOQA
+            'M50': round(v['huc12']['gwlfe']['Loads'][2]['TotalP'], 2),  # Wooded Areas # NOQA
+            'M51': round(v['huc12']['gwlfe']['Loads'][3]['TotalP'], 2),  # Wetlands # NOQA
+            'M52': round(v['huc12']['gwlfe']['Loads'][4]['TotalP'], 2),  # Open Land # NOQA
+            'M53': round(v['huc12']['gwlfe']['Loads'][5]['TotalP'], 2),  # Barren Areas # NOQA
+            'M54': round(v['huc12']['gwlfe']['Loads'][6]['TotalP'], 2),  # Low-Density Mixed # NOQA
+            'M55': round(v['huc12']['gwlfe']['Loads'][7]['TotalP'], 2),  # Medium-Density Mixed # NOQA
+            'M56': round(v['huc12']['gwlfe']['Loads'][8]['TotalP'], 2),  # High-Density Mixed # NOQA
+            'M57': round(v['huc12']['gwlfe']['Loads'][9]['TotalP'], 2),  # Other Upland Areas # NOQA
+            'M58': round(v['huc12']['gwlfe']['Loads'][10]['TotalP'], 2),  # Farm Animals # NOQA
+            'M59': round(v['huc12']['gwlfe']['Loads'][11]['TotalP'], 2),  # Stream Bank Erosion # NOQA
+            'M60': round(v['huc12']['gwlfe']['Loads'][12]['TotalP'], 2),  # Subsurface Flow # NOQA
+            'M61': round(v['huc12']['gwlfe']['Loads'][13]['TotalP'], 2),  # Point Sources # NOQA
+            'M62': round(v['huc12']['gwlfe']['Loads'][14]['TotalP'], 2),  # Septic Systems # NOQA
+            'N79': round(aoi_stream_length_km, 2),
+            'N80': round(aoi_stream_ag_length_km, 2),
+            'N81': round(aoi_stream_urb_length_km, 2),
+        }
+
+        aoi_total_area = sum(
+            [c['area'] for c in v['aoi']['nlcd']['categories']])
+
+        if aoi_total_area > 2 / SQKM_PER_SQM:
+            # Use SQKM block for Area of Interest
+            aoi_nlcd = {c['nlcd']: (c['area'] * SQKM_PER_SQM)
+                        for c in v['aoi']['nlcd']['categories']}
+            spec.update({
+                'D73': round(aoi_nlcd.get(11, 0), 2),  # Open Water # NOQA
+                'D74': round(aoi_nlcd.get(12, 0), 2),  # Perennial Ice/Snow # NOQA
+                'D75': round(aoi_nlcd.get(21, 0), 2),  # Developed, Open Space # NOQA
+                'D76': round(aoi_nlcd.get(22, 0), 2),  # Developed, Low Intensity # NOQA
+                'D77': round(aoi_nlcd.get(23, 0), 2),  # Developed, Medium Intensity # NOQA
+                'D78': round(aoi_nlcd.get(24, 0), 2),  # Developed, High Intensity # NOQA
+                'D79': round(aoi_nlcd.get(31, 0), 2),  # Barren Land (Rock/Sand/Clay) # NOQA
+                'D80': round(aoi_nlcd.get(41, 0), 2),  # Deciduous Forest # NOQA
+                'D81': round(aoi_nlcd.get(42, 0), 2),  # Evergreen Forest # NOQA
+                'D82': round(aoi_nlcd.get(43, 0), 2),  # Mixed Forest # NOQA
+                'D83': round(aoi_nlcd.get(52, 0), 2),  # Shrub/Scrub # NOQA
+                'D84': round(aoi_nlcd.get(71, 0), 2),  # Grassland/Herbaceous # NOQA
+                'D85': round(aoi_nlcd.get(81, 0), 2),  # Pasture/Hay # NOQA
+                'D86': round(aoi_nlcd.get(82, 0), 2),  # Cultivated Crops # NOQA
+                'D87': round(aoi_nlcd.get(90, 0), 2),  # Woody Wetlands # NOQA
+                'D88': round(aoi_nlcd.get(95, 0), 2),  # Emergent Herbaceous Wetlands # NOQA
+            })
+        else:
+            # Use SQM block for Area of Interest
+            aoi_nlcd = {c['nlcd']: (c['area'])
+                        for c in v['aoi']['nlcd']['categories']}
+            spec.update({
+                'D94': round(aoi_nlcd.get(11, 0), 2),  # Open Water # NOQA
+                'D95': round(aoi_nlcd.get(12, 0), 2),  # Perennial Ice/Snow # NOQA
+                'D96': round(aoi_nlcd.get(21, 0), 2),  # Developed, Open Space # NOQA
+                'D97': round(aoi_nlcd.get(22, 0), 2),  # Developed, Low Intensity # NOQA
+                'D98': round(aoi_nlcd.get(23, 0), 2),  # Developed, Medium Intensity # NOQA
+                'D99': round(aoi_nlcd.get(24, 0), 2),  # Developed, High Intensity # NOQA
+                'D100': round(aoi_nlcd.get(31, 0), 2),  # Barren Land (Rock/Sand/Clay) # NOQA
+                'D101': round(aoi_nlcd.get(41, 0), 2),  # Deciduous Forest # NOQA
+                'D102': round(aoi_nlcd.get(42, 0), 2),  # Evergreen Forest # NOQA
+                'D103': round(aoi_nlcd.get(43, 0), 2),  # Mixed Forest # NOQA
+                'D104': round(aoi_nlcd.get(52, 0), 2),  # Shrub/Scrub # NOQA
+                'D105': round(aoi_nlcd.get(71, 0), 2),  # Grassland/Herbaceous # NOQA
+                'D106': round(aoi_nlcd.get(81, 0), 2),  # Pasture/Hay # NOQA
+                'D107': round(aoi_nlcd.get(82, 0), 2),  # Cultivated Crops # NOQA
+                'D108': round(aoi_nlcd.get(90, 0), 2),  # Woody Wetlands # NOQA
+                'D109': round(aoi_nlcd.get(95, 0), 2),  # Emergent Herbaceous Wetlands # NOQA
+            })
+
+        payload.append({
+            'name': k,
+            'geojson': json.loads(v['geojson']),
+            'worksheet': {
+                'MMW Output': spec
+            }
+        })
+
+    return payload

--- a/src/mmw/apps/export/views.py
+++ b/src/mmw/apps/export/views.py
@@ -29,7 +29,7 @@ from apps.geoprocessing_api.views import start_celery_job
 from hydroshare import HydroShareService
 from models import HydroShareResource
 from serializers import HydroShareResourceSerializer
-from tasks import create_resource, update_resource
+from tasks import create_resource, update_resource, padep_worksheet
 
 hss = HydroShareService()
 HYDROSHARE_BASE_URL = settings.HYDROSHARE['base_url']
@@ -170,7 +170,7 @@ def shapefile(request):
 def worksheet(request):
     """Generate a ZIP of BMP Excel Worksheets prefilled with relevant data."""
     # Extract list of items containing worksheet specifications and geojsons
-    items = request.data
+    items = padep_worksheet(request.data)
 
     # Make a temporary directory to save the files in
     tempdir = tempfile.mkdtemp()

--- a/src/mmw/apps/geoprocessing_api/calcs.py
+++ b/src/mmw/apps/geoprocessing_api/calcs.py
@@ -286,26 +286,49 @@ def huc12s_with_aois(geojson):
 
     Finds all HUC-12s the given GeoJSON intersects with, and for each
     matching one, returns a tuple of the HUC-12 shape and the GeoJSON
-    clipped to that HUC-12.
+    clipped to that HUC-12, with the name and wkaoi of the HUC-12.
     """
     sql = '''
-          SELECT ST_AsGeoJSON(geom_detailed) AS huc12,
-                 ST_AsGeoJSON(ST_Intersection(
+          SELECT ST_AsGeoJSON(geom_detailed) AS huc12_geom,
+                 name,
+                 ('huc12__' || id) AS wkaoi,
+                 ST_AsGeoJSON(ST_Multi(ST_Intersection(
                      geom_detailed, ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326)
-                 )) AS aoi
+                 ))) AS aoi_geom,
+                 huc12
           FROM boundary_huc12
           WHERE ST_Intersects(geom_detailed,
                               ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326))
           '''
 
+    matches = []
     with connection.cursor() as cursor:
         cursor.execute(sql, [geojson, geojson])
 
-        pairs = []
         if cursor.rowcount > 0:
-            pairs = [{
-                'huc12': json.loads(row[0]),
-                'aoi': json.loads(row[1]),
+            matches = [{
+                'huc12_geom': row[0],
+                'name': row[1],
+                'wkaoi': row[2],
+                'aoi_geom': row[3],
+                'huc12': row[4],
             } for row in cursor.fetchall()]
 
-    return pairs
+    return matches
+
+
+def streams_for_huc12s(huc12s, drb=False):
+    """
+    Get MultiLineString of all streams in the given HUC-12s
+    """
+    sql = '''
+          SELECT ST_AsGeoJSON(ST_Collect(ST_Force2D(s.geom)))
+          FROM {datasource} s INNER JOIN boundary_huc12 b
+            ON ST_Intersects(s.geom, b.geom_detailed)
+          WHERE b.huc12 IN %s
+          '''.format(datasource='drb_streams_50' if drb else 'nhdflowline')
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql, [tuple(huc12s)])
+
+        return [row[0] for row in cursor.fetchall()]  # List of GeoJSON strings

--- a/src/mmw/apps/geoprocessing_api/tasks.py
+++ b/src/mmw/apps/geoprocessing_api/tasks.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import os
+import json
 import logging
 import urllib
 
@@ -15,9 +16,18 @@ from celery import shared_task
 import requests
 
 from django.conf import settings
+from django.utils.timezone import now
 
 from apps.modeling.geoprocessing import parse
 from apps.modeling.tr55.utils import aoi_resolution
+
+from apps.modeling.tasks import run_gwlfe
+
+from apps.modeling.mapshed.tasks import (NOCACHE,
+                                         collect_data,
+                                         convert_data,
+                                         nlcd_streams,
+                                         )
 
 from apps.geoprocessing_api.calcs import (animal_population,
                                           point_source_pollution,
@@ -35,6 +45,7 @@ RWD_PORT = os.environ.get('RWD_PORT', '5000')
 ACRES_PER_SQM = 0.000247105
 CM_PER_MM = 0.1
 M_PER_CM = 0.01
+SQKM_PER_SQM = 1.0E-06
 
 
 @shared_task
@@ -303,3 +314,280 @@ def analyze_terrain(result):
             'categories': categories
         }
     }
+
+
+def collect_nlcd(histogram, geojson=None):
+    """
+    Convert raw NLCD geoprocessing result to area dictionary
+    """
+    pixel_width = aoi_resolution(geojson) if geojson else 1
+
+    categories = [{
+        'area': histogram.get(nlcd, 0) * pixel_width * pixel_width,
+        'code': code,
+        'nlcd': nlcd,
+        'type': name,
+    } for nlcd, (code, name) in settings.NLCD_MAPPING.iteritems()]
+
+    return {'categories': categories}
+
+
+@shared_task
+def collect_worksheet_aois(result, shapes):
+    """
+    Given a geoprocessing result of NLCD and NLCD+Streams for every
+    area of interest within every HUC-12, processes the raw results
+    and returns a dictionary a area of interest IDs corresponding to
+    their processed results.
+    """
+    if 'error' in result:
+        result['error'] = '[collect_worksheet_aois] {}'.format(
+            result['error'])
+        return result
+
+    NULL_RESULT = {'nlcd_streams': {}, 'nlcd': {}}
+    collection = {}
+
+    for shape in shapes:
+        output = result.get(shape['wkaoi'], NULL_RESULT)
+        nlcd = collect_nlcd(parse(output['nlcd']),
+                            shape['geom'])
+        streams = stream_data(nlcd_streams(output['nlcd_streams']),
+                              shape['geom'])
+        collection[shape['wkaoi']] = {'nlcd': nlcd, 'streams': streams}
+
+    return collection
+
+
+@shared_task
+def collect_worksheet_wkaois(result, shapes):
+    """
+    Given a geoprocessing result of MapShed and a list of HUC-12s, processes
+    the raw results through GWLFE and returns a dictionary of WKAOIs to the
+    modeled results, and also the processed NLCD and NLCD+Streams.
+    """
+    if 'error' in result:
+        result['error'] = '[collect_worksheet_wkaois] {}'.format(
+            result['error'])
+        return result
+
+    collection = {}
+
+    for shape in shapes:
+        wkaoi = shape['wkaoi']
+        geojson = shape['geom']
+
+        converted = convert_data(result, wkaoi)
+
+        histogram = converted[0]['n_count']
+
+        collected = collect_data(converted, geojson)
+        modeled = run_gwlfe(collected, None, None)
+
+        collection[wkaoi] = {
+            'mapshed': collected,
+            'gwlfe': modeled,
+            'nlcd': collect_nlcd(histogram, geojson),
+            'streams': stream_data(nlcd_streams(result[wkaoi]['nlcd_streams']),
+                                   geojson)
+        }
+
+    return collection
+
+
+@shared_task
+def collect_worksheet(results, filenames):
+    """
+    Given a list of results for areas of interest, and another list of results
+    for HUC-12s, rearranges them to be grouped by the filename and returns this
+    new arrangement.
+    """
+    for result in results:
+        if 'error' in result:
+            raise Exception('[collect_worksheet] {}'
+                            .format(result['error']))
+
+    collection = {}
+
+    for f in filenames:
+        collection[f['filename']] = {
+            'name': f['name'],
+            'aoi': results[0].get('{}-{}'.format(NOCACHE, f['wkaoi']), {}),
+            'huc12': results[1].get(f['wkaoi'], {}),
+            'geojson': f['aoi'],
+        }
+
+    return collection
+
+
+@shared_task
+def transform_worksheet(results):
+    """
+    Given a dictionary of results for areas of interest and HUC-12s, indexed
+    by the filename, transforms the results into a payload for generating
+    an Excel worksheet, which can be fed to the /export/worksheet endpoint.
+    """
+    payload = []
+
+    for k, v in results.iteritems():
+        huc12_stream_length_km = sum(
+            [c['lengthkm'] for c in v['huc12']['streams']['categories']])
+        huc12_stream_ag_pct = \
+            v['huc12']['streams']['categories'][0]['ag_stream_pct']
+        huc12_stream_ag_length_km = \
+            huc12_stream_length_km * huc12_stream_ag_pct
+        huc12_stream_urb_length_km = \
+            huc12_stream_length_km - huc12_stream_ag_length_km
+
+        huc12_nlcd = {c['nlcd']: (c['area'] / 1.00000E+06)
+                      for c in v['huc12']['nlcd']['categories']}
+
+        aoi_stream_length_km = sum(
+            [c['lengthkm'] for c in v['aoi']['streams']['categories']])
+        aoi_stream_ag_pct = \
+            v['aoi']['streams']['categories'][0]['ag_stream_pct']
+        aoi_stream_ag_length_km = \
+            aoi_stream_length_km * aoi_stream_ag_pct
+        aoi_stream_urb_length_km = \
+            aoi_stream_length_km - aoi_stream_ag_length_km
+
+        date = now()
+
+        spec = {
+            'C11': date.strftime('%Y-%m-%d'),  # Date Data Entered
+            'C13': v['name'],  # Watershed
+            'C14': date.strftime('%Y'),  # Year
+            'L18': round(huc12_stream_length_km, 2),  # Total Length # NOQA
+            'L19': round(huc12_stream_ag_length_km, 2),  # Ag Streams # NOQA
+            'L20': round(huc12_stream_urb_length_km, 2),  # Non-Ag Streams # NOQA
+            'L27': round(v['huc12']['mapshed']['NumAnimals'][2], 2),  # Chickens, Broilers # NOQA
+            'L28': round(v['huc12']['mapshed']['NumAnimals'][3], 2),  # Chickens, Layers # NOQA
+            'L29': round(v['huc12']['mapshed']['NumAnimals'][1], 2),  # Cows, Beef # NOQA
+            'L30': round(v['huc12']['mapshed']['NumAnimals'][0], 2),  # Cows, Dairy # NOQA
+            'L31': round(v['huc12']['mapshed']['NumAnimals'][6], 2),  # Horses # NOQA
+            'L32': round(v['huc12']['mapshed']['NumAnimals'][4], 2),  # Pigs/Hogs/Swine # NOQA
+            'L33': round(v['huc12']['mapshed']['NumAnimals'][5], 2),  # Sheep # NOQA
+            'L34': round(v['huc12']['mapshed']['NumAnimals'][7], 2),  # Turkeys # NOQA
+            'D48': round(huc12_nlcd.get(11, 0), 2),  # Open Water # NOQA
+            'D49': round(huc12_nlcd.get(12, 0), 2),  # Perennial Ice/Snow # NOQA
+            'D50': round(huc12_nlcd.get(21, 0), 2),  # Developed, Open Space # NOQA
+            'D51': round(huc12_nlcd.get(22, 0), 2),  # Developed, Low Intensity # NOQA
+            'D52': round(huc12_nlcd.get(23, 0), 2),  # Developed, Medium Intensity # NOQA
+            'D53': round(huc12_nlcd.get(24, 0), 2),  # Developed, High Intensity # NOQA
+            'D54': round(huc12_nlcd.get(31, 0), 2),  # Barren Land (Rock/Sand/Clay) # NOQA
+            'D55': round(huc12_nlcd.get(41, 0), 2),  # Deciduous Forest # NOQA
+            'D56': round(huc12_nlcd.get(42, 0), 2),  # Evergreen Forest # NOQA
+            'D57': round(huc12_nlcd.get(43, 0), 2),  # Mixed Forest # NOQA
+            'D58': round(huc12_nlcd.get(52, 0), 2),  # Shrub/Scrub # NOQA
+            'D59': round(huc12_nlcd.get(71, 0), 2),  # Grassland/Herbaceous # NOQA
+            'D60': round(huc12_nlcd.get(81, 0), 2),  # Pasture/Hay # NOQA
+            'D61': round(huc12_nlcd.get(82, 0), 2),  # Cultivated Crops # NOQA
+            'D62': round(huc12_nlcd.get(90, 0), 2),  # Woody Wetlands # NOQA
+            'D63': round(huc12_nlcd.get(95, 0), 2),  # Emergent Herbaceous Wetlands # NOQA
+            'K48': round(v['huc12']['gwlfe']['Loads'][0]['Sediment'], 2),  # Hay/Pasture # NOQA
+            'K49': round(v['huc12']['gwlfe']['Loads'][1]['Sediment'], 2),  # Cropland # NOQA
+            'K50': round(v['huc12']['gwlfe']['Loads'][2]['Sediment'], 2),  # Wooded Areas # NOQA
+            'K51': round(v['huc12']['gwlfe']['Loads'][3]['Sediment'], 2),  # Wetlands # NOQA
+            'K52': round(v['huc12']['gwlfe']['Loads'][4]['Sediment'], 2),  # Open Land # NOQA
+            'K53': round(v['huc12']['gwlfe']['Loads'][5]['Sediment'], 2),  # Barren Areas # NOQA
+            'K54': round(v['huc12']['gwlfe']['Loads'][6]['Sediment'], 2),  # Low-Density Mixed # NOQA
+            'K55': round(v['huc12']['gwlfe']['Loads'][7]['Sediment'], 2),  # Medium-Density Mixed # NOQA
+            'K56': round(v['huc12']['gwlfe']['Loads'][8]['Sediment'], 2),  # High-Density Mixed # NOQA
+            'K57': round(v['huc12']['gwlfe']['Loads'][9]['Sediment'], 2),  # Other Upland Areas # NOQA
+            'K58': round(v['huc12']['gwlfe']['Loads'][10]['Sediment'], 2),  # Farm Animals # NOQA
+            'K59': round(v['huc12']['gwlfe']['Loads'][11]['Sediment'], 2),  # Stream Bank Erosion # NOQA
+            'K60': round(v['huc12']['gwlfe']['Loads'][12]['Sediment'], 2),  # Subsurface Flow # NOQA
+            'K61': round(v['huc12']['gwlfe']['Loads'][13]['Sediment'], 2),  # Point Sources # NOQA
+            'K62': round(v['huc12']['gwlfe']['Loads'][14]['Sediment'], 2),  # Septic Systems # NOQA
+            'L48': round(v['huc12']['gwlfe']['Loads'][0]['TotalN'], 2),  # Hay/Pasture # NOQA
+            'L49': round(v['huc12']['gwlfe']['Loads'][1]['TotalN'], 2),  # Cropland # NOQA
+            'L50': round(v['huc12']['gwlfe']['Loads'][2]['TotalN'], 2),  # Wooded Areas # NOQA
+            'L51': round(v['huc12']['gwlfe']['Loads'][3]['TotalN'], 2),  # Wetlands # NOQA
+            'L52': round(v['huc12']['gwlfe']['Loads'][4]['TotalN'], 2),  # Open Land # NOQA
+            'L53': round(v['huc12']['gwlfe']['Loads'][5]['TotalN'], 2),  # Barren Areas # NOQA
+            'L54': round(v['huc12']['gwlfe']['Loads'][6]['TotalN'], 2),  # Low-Density Mixed # NOQA
+            'L55': round(v['huc12']['gwlfe']['Loads'][7]['TotalN'], 2),  # Medium-Density Mixed # NOQA
+            'L56': round(v['huc12']['gwlfe']['Loads'][8]['TotalN'], 2),  # High-Density Mixed # NOQA
+            'L57': round(v['huc12']['gwlfe']['Loads'][9]['TotalN'], 2),  # Other Upland Areas # NOQA
+            'L58': round(v['huc12']['gwlfe']['Loads'][10]['TotalN'], 2),  # Farm Animals # NOQA
+            'L59': round(v['huc12']['gwlfe']['Loads'][11]['TotalN'], 2),  # Stream Bank Erosion # NOQA
+            'L60': round(v['huc12']['gwlfe']['Loads'][12]['TotalN'], 2),  # Subsurface Flow # NOQA
+            'L61': round(v['huc12']['gwlfe']['Loads'][13]['TotalN'], 2),  # Point Sources # NOQA
+            'L62': round(v['huc12']['gwlfe']['Loads'][14]['TotalN'], 2),  # Septic Systems # NOQA
+            'M48': round(v['huc12']['gwlfe']['Loads'][0]['TotalP'], 2),  # Hay/Pasture # NOQA
+            'M49': round(v['huc12']['gwlfe']['Loads'][1]['TotalP'], 2),  # Cropland # NOQA
+            'M50': round(v['huc12']['gwlfe']['Loads'][2]['TotalP'], 2),  # Wooded Areas # NOQA
+            'M51': round(v['huc12']['gwlfe']['Loads'][3]['TotalP'], 2),  # Wetlands # NOQA
+            'M52': round(v['huc12']['gwlfe']['Loads'][4]['TotalP'], 2),  # Open Land # NOQA
+            'M53': round(v['huc12']['gwlfe']['Loads'][5]['TotalP'], 2),  # Barren Areas # NOQA
+            'M54': round(v['huc12']['gwlfe']['Loads'][6]['TotalP'], 2),  # Low-Density Mixed # NOQA
+            'M55': round(v['huc12']['gwlfe']['Loads'][7]['TotalP'], 2),  # Medium-Density Mixed # NOQA
+            'M56': round(v['huc12']['gwlfe']['Loads'][8]['TotalP'], 2),  # High-Density Mixed # NOQA
+            'M57': round(v['huc12']['gwlfe']['Loads'][9]['TotalP'], 2),  # Other Upland Areas # NOQA
+            'M58': round(v['huc12']['gwlfe']['Loads'][10]['TotalP'], 2),  # Farm Animals # NOQA
+            'M59': round(v['huc12']['gwlfe']['Loads'][11]['TotalP'], 2),  # Stream Bank Erosion # NOQA
+            'M60': round(v['huc12']['gwlfe']['Loads'][12]['TotalP'], 2),  # Subsurface Flow # NOQA
+            'M61': round(v['huc12']['gwlfe']['Loads'][13]['TotalP'], 2),  # Point Sources # NOQA
+            'M62': round(v['huc12']['gwlfe']['Loads'][14]['TotalP'], 2),  # Septic Systems # NOQA
+            'N79': round(aoi_stream_length_km, 2),
+            'N80': round(aoi_stream_ag_length_km, 2),
+            'N81': round(aoi_stream_urb_length_km, 2),
+        }
+
+        aoi_total_area = sum(
+            [c['area'] for c in v['aoi']['nlcd']['categories']])
+
+        if aoi_total_area > 2 / SQKM_PER_SQM:
+            # Use SQKM block for Area of Interest
+            aoi_nlcd = {c['nlcd']: (c['area'] * SQKM_PER_SQM)
+                        for c in v['aoi']['nlcd']['categories']}
+            spec.update({
+                'D73': round(aoi_nlcd.get(11, 0), 2),  # Open Water # NOQA
+                'D74': round(aoi_nlcd.get(12, 0), 2),  # Perennial Ice/Snow # NOQA
+                'D75': round(aoi_nlcd.get(21, 0), 2),  # Developed, Open Space # NOQA
+                'D76': round(aoi_nlcd.get(22, 0), 2),  # Developed, Low Intensity # NOQA
+                'D77': round(aoi_nlcd.get(23, 0), 2),  # Developed, Medium Intensity # NOQA
+                'D78': round(aoi_nlcd.get(24, 0), 2),  # Developed, High Intensity # NOQA
+                'D79': round(aoi_nlcd.get(31, 0), 2),  # Barren Land (Rock/Sand/Clay) # NOQA
+                'D80': round(aoi_nlcd.get(41, 0), 2),  # Deciduous Forest # NOQA
+                'D81': round(aoi_nlcd.get(42, 0), 2),  # Evergreen Forest # NOQA
+                'D82': round(aoi_nlcd.get(43, 0), 2),  # Mixed Forest # NOQA
+                'D83': round(aoi_nlcd.get(52, 0), 2),  # Shrub/Scrub # NOQA
+                'D84': round(aoi_nlcd.get(71, 0), 2),  # Grassland/Herbaceous # NOQA
+                'D85': round(aoi_nlcd.get(81, 0), 2),  # Pasture/Hay # NOQA
+                'D86': round(aoi_nlcd.get(82, 0), 2),  # Cultivated Crops # NOQA
+                'D87': round(aoi_nlcd.get(90, 0), 2),  # Woody Wetlands # NOQA
+                'D88': round(aoi_nlcd.get(95, 0), 2),  # Emergent Herbaceous Wetlands # NOQA
+            })
+        else:
+            # Use SQM block for Area of Interest
+            aoi_nlcd = {c['nlcd']: (c['area'])
+                        for c in v['aoi']['nlcd']['categories']}
+            spec.update({
+                'D94': round(aoi_nlcd.get(11, 0), 2),  # Open Water # NOQA
+                'D95': round(aoi_nlcd.get(12, 0), 2),  # Perennial Ice/Snow # NOQA
+                'D96': round(aoi_nlcd.get(21, 0), 2),  # Developed, Open Space # NOQA
+                'D97': round(aoi_nlcd.get(22, 0), 2),  # Developed, Low Intensity # NOQA
+                'D98': round(aoi_nlcd.get(23, 0), 2),  # Developed, Medium Intensity # NOQA
+                'D99': round(aoi_nlcd.get(24, 0), 2),  # Developed, High Intensity # NOQA
+                'D100': round(aoi_nlcd.get(31, 0), 2),  # Barren Land (Rock/Sand/Clay) # NOQA
+                'D101': round(aoi_nlcd.get(41, 0), 2),  # Deciduous Forest # NOQA
+                'D102': round(aoi_nlcd.get(42, 0), 2),  # Evergreen Forest # NOQA
+                'D103': round(aoi_nlcd.get(43, 0), 2),  # Mixed Forest # NOQA
+                'D104': round(aoi_nlcd.get(52, 0), 2),  # Shrub/Scrub # NOQA
+                'D105': round(aoi_nlcd.get(71, 0), 2),  # Grassland/Herbaceous # NOQA
+                'D106': round(aoi_nlcd.get(81, 0), 2),  # Pasture/Hay # NOQA
+                'D107': round(aoi_nlcd.get(82, 0), 2),  # Cultivated Crops # NOQA
+                'D108': round(aoi_nlcd.get(90, 0), 2),  # Woody Wetlands # NOQA
+                'D109': round(aoi_nlcd.get(95, 0), 2),  # Emergent Herbaceous Wetlands # NOQA
+            })
+
+        payload.append({
+            'name': k,
+            'geojson': json.loads(v['geojson']),
+            'worksheet': {
+                'MMW Output': spec
+            }
+        })
+
+    return payload

--- a/src/mmw/apps/geoprocessing_api/tasks.py
+++ b/src/mmw/apps/geoprocessing_api/tasks.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import os
-import json
 import logging
 import urllib
 
@@ -16,7 +15,6 @@ from celery import shared_task
 import requests
 
 from django.conf import settings
-from django.utils.timezone import now
 
 from apps.modeling.geoprocessing import multi, parse
 from apps.modeling.tr55.utils import aoi_resolution
@@ -47,7 +45,6 @@ RWD_PORT = os.environ.get('RWD_PORT', '5000')
 ACRES_PER_SQM = 0.000247105
 CM_PER_MM = 0.1
 M_PER_CM = 0.01
-SQKM_PER_SQM = 1.0E-06
 
 
 @shared_task
@@ -441,176 +438,3 @@ def collect_worksheet(area_of_interest):
         }
 
     return collection
-
-
-@shared_task
-def transform_worksheet(results):
-    """
-    Given a dictionary of results for areas of interest and HUC-12s, indexed
-    by the filename, transforms the results into a payload for generating
-    an Excel worksheet, which can be fed to the /export/worksheet endpoint.
-    """
-    payload = []
-
-    for k, v in results.iteritems():
-        huc12_stream_length_km = sum(
-            [c['lengthkm'] for c in v['huc12']['streams']['categories']])
-        huc12_stream_ag_pct = \
-            v['huc12']['streams']['categories'][0]['ag_stream_pct']
-        huc12_stream_ag_length_km = \
-            huc12_stream_length_km * huc12_stream_ag_pct
-        huc12_stream_urb_length_km = \
-            huc12_stream_length_km - huc12_stream_ag_length_km
-
-        huc12_nlcd = {c['nlcd']: (c['area'] / 1.00000E+06)
-                      for c in v['huc12']['nlcd']['categories']}
-
-        aoi_stream_length_km = sum(
-            [c['lengthkm'] for c in v['aoi']['streams']['categories']])
-        aoi_stream_ag_pct = \
-            v['aoi']['streams']['categories'][0]['ag_stream_pct']
-        aoi_stream_ag_length_km = \
-            aoi_stream_length_km * aoi_stream_ag_pct
-        aoi_stream_urb_length_km = \
-            aoi_stream_length_km - aoi_stream_ag_length_km
-
-        date = now()
-
-        spec = {
-            'C11': date.strftime('%Y-%m-%d'),  # Date Data Entered
-            'C13': v['name'],  # Watershed
-            'C14': date.strftime('%Y'),  # Year
-            'L18': round(huc12_stream_length_km, 2),  # Total Length # NOQA
-            'L19': round(huc12_stream_ag_length_km, 2),  # Ag Streams # NOQA
-            'L20': round(huc12_stream_urb_length_km, 2),  # Non-Ag Streams # NOQA
-            'L27': round(v['huc12']['mapshed']['NumAnimals'][2], 2),  # Chickens, Broilers # NOQA
-            'L28': round(v['huc12']['mapshed']['NumAnimals'][3], 2),  # Chickens, Layers # NOQA
-            'L29': round(v['huc12']['mapshed']['NumAnimals'][1], 2),  # Cows, Beef # NOQA
-            'L30': round(v['huc12']['mapshed']['NumAnimals'][0], 2),  # Cows, Dairy # NOQA
-            'L31': round(v['huc12']['mapshed']['NumAnimals'][6], 2),  # Horses # NOQA
-            'L32': round(v['huc12']['mapshed']['NumAnimals'][4], 2),  # Pigs/Hogs/Swine # NOQA
-            'L33': round(v['huc12']['mapshed']['NumAnimals'][5], 2),  # Sheep # NOQA
-            'L34': round(v['huc12']['mapshed']['NumAnimals'][7], 2),  # Turkeys # NOQA
-            'D48': round(huc12_nlcd.get(11, 0), 2),  # Open Water # NOQA
-            'D49': round(huc12_nlcd.get(12, 0), 2),  # Perennial Ice/Snow # NOQA
-            'D50': round(huc12_nlcd.get(21, 0), 2),  # Developed, Open Space # NOQA
-            'D51': round(huc12_nlcd.get(22, 0), 2),  # Developed, Low Intensity # NOQA
-            'D52': round(huc12_nlcd.get(23, 0), 2),  # Developed, Medium Intensity # NOQA
-            'D53': round(huc12_nlcd.get(24, 0), 2),  # Developed, High Intensity # NOQA
-            'D54': round(huc12_nlcd.get(31, 0), 2),  # Barren Land (Rock/Sand/Clay) # NOQA
-            'D55': round(huc12_nlcd.get(41, 0), 2),  # Deciduous Forest # NOQA
-            'D56': round(huc12_nlcd.get(42, 0), 2),  # Evergreen Forest # NOQA
-            'D57': round(huc12_nlcd.get(43, 0), 2),  # Mixed Forest # NOQA
-            'D58': round(huc12_nlcd.get(52, 0), 2),  # Shrub/Scrub # NOQA
-            'D59': round(huc12_nlcd.get(71, 0), 2),  # Grassland/Herbaceous # NOQA
-            'D60': round(huc12_nlcd.get(81, 0), 2),  # Pasture/Hay # NOQA
-            'D61': round(huc12_nlcd.get(82, 0), 2),  # Cultivated Crops # NOQA
-            'D62': round(huc12_nlcd.get(90, 0), 2),  # Woody Wetlands # NOQA
-            'D63': round(huc12_nlcd.get(95, 0), 2),  # Emergent Herbaceous Wetlands # NOQA
-            'K48': round(v['huc12']['gwlfe']['Loads'][0]['Sediment'], 2),  # Hay/Pasture # NOQA
-            'K49': round(v['huc12']['gwlfe']['Loads'][1]['Sediment'], 2),  # Cropland # NOQA
-            'K50': round(v['huc12']['gwlfe']['Loads'][2]['Sediment'], 2),  # Wooded Areas # NOQA
-            'K51': round(v['huc12']['gwlfe']['Loads'][3]['Sediment'], 2),  # Wetlands # NOQA
-            'K52': round(v['huc12']['gwlfe']['Loads'][4]['Sediment'], 2),  # Open Land # NOQA
-            'K53': round(v['huc12']['gwlfe']['Loads'][5]['Sediment'], 2),  # Barren Areas # NOQA
-            'K54': round(v['huc12']['gwlfe']['Loads'][6]['Sediment'], 2),  # Low-Density Mixed # NOQA
-            'K55': round(v['huc12']['gwlfe']['Loads'][7]['Sediment'], 2),  # Medium-Density Mixed # NOQA
-            'K56': round(v['huc12']['gwlfe']['Loads'][8]['Sediment'], 2),  # High-Density Mixed # NOQA
-            'K57': round(v['huc12']['gwlfe']['Loads'][9]['Sediment'], 2),  # Other Upland Areas # NOQA
-            'K58': round(v['huc12']['gwlfe']['Loads'][10]['Sediment'], 2),  # Farm Animals # NOQA
-            'K59': round(v['huc12']['gwlfe']['Loads'][11]['Sediment'], 2),  # Stream Bank Erosion # NOQA
-            'K60': round(v['huc12']['gwlfe']['Loads'][12]['Sediment'], 2),  # Subsurface Flow # NOQA
-            'K61': round(v['huc12']['gwlfe']['Loads'][13]['Sediment'], 2),  # Point Sources # NOQA
-            'K62': round(v['huc12']['gwlfe']['Loads'][14]['Sediment'], 2),  # Septic Systems # NOQA
-            'L48': round(v['huc12']['gwlfe']['Loads'][0]['TotalN'], 2),  # Hay/Pasture # NOQA
-            'L49': round(v['huc12']['gwlfe']['Loads'][1]['TotalN'], 2),  # Cropland # NOQA
-            'L50': round(v['huc12']['gwlfe']['Loads'][2]['TotalN'], 2),  # Wooded Areas # NOQA
-            'L51': round(v['huc12']['gwlfe']['Loads'][3]['TotalN'], 2),  # Wetlands # NOQA
-            'L52': round(v['huc12']['gwlfe']['Loads'][4]['TotalN'], 2),  # Open Land # NOQA
-            'L53': round(v['huc12']['gwlfe']['Loads'][5]['TotalN'], 2),  # Barren Areas # NOQA
-            'L54': round(v['huc12']['gwlfe']['Loads'][6]['TotalN'], 2),  # Low-Density Mixed # NOQA
-            'L55': round(v['huc12']['gwlfe']['Loads'][7]['TotalN'], 2),  # Medium-Density Mixed # NOQA
-            'L56': round(v['huc12']['gwlfe']['Loads'][8]['TotalN'], 2),  # High-Density Mixed # NOQA
-            'L57': round(v['huc12']['gwlfe']['Loads'][9]['TotalN'], 2),  # Other Upland Areas # NOQA
-            'L58': round(v['huc12']['gwlfe']['Loads'][10]['TotalN'], 2),  # Farm Animals # NOQA
-            'L59': round(v['huc12']['gwlfe']['Loads'][11]['TotalN'], 2),  # Stream Bank Erosion # NOQA
-            'L60': round(v['huc12']['gwlfe']['Loads'][12]['TotalN'], 2),  # Subsurface Flow # NOQA
-            'L61': round(v['huc12']['gwlfe']['Loads'][13]['TotalN'], 2),  # Point Sources # NOQA
-            'L62': round(v['huc12']['gwlfe']['Loads'][14]['TotalN'], 2),  # Septic Systems # NOQA
-            'M48': round(v['huc12']['gwlfe']['Loads'][0]['TotalP'], 2),  # Hay/Pasture # NOQA
-            'M49': round(v['huc12']['gwlfe']['Loads'][1]['TotalP'], 2),  # Cropland # NOQA
-            'M50': round(v['huc12']['gwlfe']['Loads'][2]['TotalP'], 2),  # Wooded Areas # NOQA
-            'M51': round(v['huc12']['gwlfe']['Loads'][3]['TotalP'], 2),  # Wetlands # NOQA
-            'M52': round(v['huc12']['gwlfe']['Loads'][4]['TotalP'], 2),  # Open Land # NOQA
-            'M53': round(v['huc12']['gwlfe']['Loads'][5]['TotalP'], 2),  # Barren Areas # NOQA
-            'M54': round(v['huc12']['gwlfe']['Loads'][6]['TotalP'], 2),  # Low-Density Mixed # NOQA
-            'M55': round(v['huc12']['gwlfe']['Loads'][7]['TotalP'], 2),  # Medium-Density Mixed # NOQA
-            'M56': round(v['huc12']['gwlfe']['Loads'][8]['TotalP'], 2),  # High-Density Mixed # NOQA
-            'M57': round(v['huc12']['gwlfe']['Loads'][9]['TotalP'], 2),  # Other Upland Areas # NOQA
-            'M58': round(v['huc12']['gwlfe']['Loads'][10]['TotalP'], 2),  # Farm Animals # NOQA
-            'M59': round(v['huc12']['gwlfe']['Loads'][11]['TotalP'], 2),  # Stream Bank Erosion # NOQA
-            'M60': round(v['huc12']['gwlfe']['Loads'][12]['TotalP'], 2),  # Subsurface Flow # NOQA
-            'M61': round(v['huc12']['gwlfe']['Loads'][13]['TotalP'], 2),  # Point Sources # NOQA
-            'M62': round(v['huc12']['gwlfe']['Loads'][14]['TotalP'], 2),  # Septic Systems # NOQA
-            'N79': round(aoi_stream_length_km, 2),
-            'N80': round(aoi_stream_ag_length_km, 2),
-            'N81': round(aoi_stream_urb_length_km, 2),
-        }
-
-        aoi_total_area = sum(
-            [c['area'] for c in v['aoi']['nlcd']['categories']])
-
-        if aoi_total_area > 2 / SQKM_PER_SQM:
-            # Use SQKM block for Area of Interest
-            aoi_nlcd = {c['nlcd']: (c['area'] * SQKM_PER_SQM)
-                        for c in v['aoi']['nlcd']['categories']}
-            spec.update({
-                'D73': round(aoi_nlcd.get(11, 0), 2),  # Open Water # NOQA
-                'D74': round(aoi_nlcd.get(12, 0), 2),  # Perennial Ice/Snow # NOQA
-                'D75': round(aoi_nlcd.get(21, 0), 2),  # Developed, Open Space # NOQA
-                'D76': round(aoi_nlcd.get(22, 0), 2),  # Developed, Low Intensity # NOQA
-                'D77': round(aoi_nlcd.get(23, 0), 2),  # Developed, Medium Intensity # NOQA
-                'D78': round(aoi_nlcd.get(24, 0), 2),  # Developed, High Intensity # NOQA
-                'D79': round(aoi_nlcd.get(31, 0), 2),  # Barren Land (Rock/Sand/Clay) # NOQA
-                'D80': round(aoi_nlcd.get(41, 0), 2),  # Deciduous Forest # NOQA
-                'D81': round(aoi_nlcd.get(42, 0), 2),  # Evergreen Forest # NOQA
-                'D82': round(aoi_nlcd.get(43, 0), 2),  # Mixed Forest # NOQA
-                'D83': round(aoi_nlcd.get(52, 0), 2),  # Shrub/Scrub # NOQA
-                'D84': round(aoi_nlcd.get(71, 0), 2),  # Grassland/Herbaceous # NOQA
-                'D85': round(aoi_nlcd.get(81, 0), 2),  # Pasture/Hay # NOQA
-                'D86': round(aoi_nlcd.get(82, 0), 2),  # Cultivated Crops # NOQA
-                'D87': round(aoi_nlcd.get(90, 0), 2),  # Woody Wetlands # NOQA
-                'D88': round(aoi_nlcd.get(95, 0), 2),  # Emergent Herbaceous Wetlands # NOQA
-            })
-        else:
-            # Use SQM block for Area of Interest
-            aoi_nlcd = {c['nlcd']: (c['area'])
-                        for c in v['aoi']['nlcd']['categories']}
-            spec.update({
-                'D94': round(aoi_nlcd.get(11, 0), 2),  # Open Water # NOQA
-                'D95': round(aoi_nlcd.get(12, 0), 2),  # Perennial Ice/Snow # NOQA
-                'D96': round(aoi_nlcd.get(21, 0), 2),  # Developed, Open Space # NOQA
-                'D97': round(aoi_nlcd.get(22, 0), 2),  # Developed, Low Intensity # NOQA
-                'D98': round(aoi_nlcd.get(23, 0), 2),  # Developed, Medium Intensity # NOQA
-                'D99': round(aoi_nlcd.get(24, 0), 2),  # Developed, High Intensity # NOQA
-                'D100': round(aoi_nlcd.get(31, 0), 2),  # Barren Land (Rock/Sand/Clay) # NOQA
-                'D101': round(aoi_nlcd.get(41, 0), 2),  # Deciduous Forest # NOQA
-                'D102': round(aoi_nlcd.get(42, 0), 2),  # Evergreen Forest # NOQA
-                'D103': round(aoi_nlcd.get(43, 0), 2),  # Mixed Forest # NOQA
-                'D104': round(aoi_nlcd.get(52, 0), 2),  # Shrub/Scrub # NOQA
-                'D105': round(aoi_nlcd.get(71, 0), 2),  # Grassland/Herbaceous # NOQA
-                'D106': round(aoi_nlcd.get(81, 0), 2),  # Pasture/Hay # NOQA
-                'D107': round(aoi_nlcd.get(82, 0), 2),  # Cultivated Crops # NOQA
-                'D108': round(aoi_nlcd.get(90, 0), 2),  # Woody Wetlands # NOQA
-                'D109': round(aoi_nlcd.get(95, 0), 2),  # Emergent Herbaceous Wetlands # NOQA
-            })
-
-        payload.append({
-            'name': k,
-            'geojson': json.loads(v['geojson']),
-            'worksheet': {
-                'MMW Output': spec
-            }
-        })
-
-    return payload

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -1053,7 +1053,6 @@ def start_modeling_worksheet(request, format=None):
 
     return start_celery_job([
         tasks.collect_worksheet.s(area_of_interest),
-        tasks.transform_worksheet.s(),
     ], area_of_interest, user)
 
 

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -2,8 +2,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import json
-
 from celery import chain, group
 
 from rest_framework.response import Response
@@ -24,11 +22,11 @@ from apps.core.tasks import (save_job_error,
 from apps.core.decorators import log_request
 from apps.modeling import geoprocessing
 from apps.modeling.mapshed.calcs import streams
-from apps.modeling.mapshed.tasks import nlcd_streams
+from apps.modeling.mapshed.tasks import NOCACHE, nlcd_streams
 from apps.modeling.serializers import AoiSerializer
 
 from apps.geoprocessing_api import schemas, tasks
-from apps.geoprocessing_api.calcs import huc12s_with_aois
+from apps.geoprocessing_api.calcs import huc12s_with_aois, streams_for_huc12s
 from apps.geoprocessing_api.permissions import AuthTokenSerializerAuthentication  # noqa
 from apps.geoprocessing_api.throttling import (BurstRateThrottle,
                                                SustainedRateThrottle)
@@ -1051,17 +1049,67 @@ def start_modeling_worksheet(request, format=None):
     of dictionaries, which should be posted to the /export/worksheet/ endpoint
     to get the actual Excel files.
     """
+    user = request.user if request.user.is_authenticated else None
     area_of_interest, _ = _parse_input(request)
 
-    pairs = huc12s_with_aois(area_of_interest)
+    matches = huc12s_with_aois(area_of_interest)
+    filenames = [{
+        'filename': '{}__{}'.format(m['huc12'], m['name'].replace(' ', '_')),
+        'name': m['name'],
+        'wkaoi': m['wkaoi'],
+        'aoi_geom': m['aoi_geom'],
+    } for m in matches]
+    huc12_ids = [m['huc12'] for m in matches]
+    streams = streams_for_huc12s(huc12_ids)[0]
 
-    # TODO Run Celery chain to calculate numbers needed for the worksheet
-    print('==> pairs\n{}'.format(json.dumps(pairs)))
+    aoi_shapes = [
+        {
+            'wkaoi': '{}-{}'.format(NOCACHE, m['wkaoi']),
+            'geom': m['aoi_geom'],
+        }
+        for m in matches]
 
-    return Response({
-        'job': '00000000-0000-0000-0000-000000000000',
-        'status': 'started',
-    })
+    wkaoi_shapes = [
+        {
+            'wkaoi': m['wkaoi'],
+            'geom': m['huc12_geom']
+        }
+        for m in matches]
+
+    # Since this is a more complex Celery workflow, start_celery_job cannot
+    # be used here, because its error handling only works on simple chains.
+    # We replicate most of that code here, and add error handlers to the
+    # tasks individually.
+
+    created = now()
+    job = Job.objects.create(created_at=created, result='', error='',
+                             traceback='', user=user, status='started',
+                             model_input=area_of_interest)
+
+    success = save_job_result.s(job.id, area_of_interest)
+    error = save_job_error.s(job.id)
+
+    task_chain = chain([
+        group([
+            geoprocessing.multi.s('worksheet_aoi', aoi_shapes, streams) |
+            tasks.collect_worksheet_aois.s(aoi_shapes),
+
+            geoprocessing.multi.s('mapshed', wkaoi_shapes, streams) |
+            tasks.collect_worksheet_wkaois.s(wkaoi_shapes),
+        ]),
+        tasks.collect_worksheet.s(filenames).set(link_error=error),
+        tasks.transform_worksheet.s().set(link_error=error),
+        success
+    ]).apply_async()
+
+    job.uuid = task_chain.id
+    job.save()
+
+    return Response(
+        {'job': task_chain.id, 'status': 'started'},
+        headers={'Location': reverse('geoprocessing_api:get_job',
+                                     args=[task_chain.id])}
+    )
 
 
 def _initiate_rwd_job_chain(location, snapping, simplify, data_source,

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -16,7 +16,7 @@ from requests.exceptions import ConnectionError, Timeout
 from django.core.cache import cache
 from django.conf import settings
 
-NOWKAOI = 'nowkaoi'
+NOCACHE = 'nocache'
 
 
 @shared_task(bind=True, default_retry_delay=1, max_retries=6)
@@ -181,7 +181,7 @@ def multi(self, opname, shapes, stream_lines):
     # Get cached results
     for shape in shapes:
         cached_operations = 0
-        if shape['id'] != NOWKAOI:
+        if not shape['id'].startswith(NOCACHE):
             output[shape['id']] = {}
             for op in data['operations']:
                 key = 'geop_{}__{}'.format(shape['id'], op['label'])
@@ -202,7 +202,7 @@ def multi(self, opname, shapes, stream_lines):
 
         # Set cached results
         for shape_id, operation_results in result.iteritems():
-            if shape_id != NOWKAOI:
+            if not shape_id.startswith(NOCACHE):
                 for op_label, value in operation_results.iteritems():
                     key = 'geop_{}__{}'.format(shape_id, op_label)
                     cache.set(key, value, None)

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -298,6 +298,7 @@ def nlcd_soil(result):
     return {
         'cn': curve_number(n_count, ng2_count),
         'landuse_pcts': landuse_pcts(n_count),
+        'n_count': n_count,
     }
 
 

--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -8,7 +8,7 @@ from django.conf import settings
 
 from django.contrib.gis.geos import GEOSGeometry
 
-from apps.modeling.geoprocessing import NOWKAOI, multi, run, parse
+from apps.modeling.geoprocessing import NOCACHE, multi, run, parse
 from apps.modeling.mapshed.calcs import (day_lengths,
                                          nearest_weather_stations,
                                          growing_season,
@@ -491,7 +491,7 @@ def nlcd_kfactor(result):
 
 
 def multi_mapshed(aoi, wkaoi):
-    shape = [{'id': wkaoi or NOWKAOI, 'shape': aoi}]
+    shape = [{'id': wkaoi or NOCACHE, 'shape': aoi}]
     stream_lines = streams(aoi)[0]
 
     return multi.s('mapshed', shape, stream_lines)
@@ -510,9 +510,9 @@ def convert_data(payload, wkaoi):
     if 'error' in payload:
         raise Exception(
             '[convert_data] {} {}'.format(
-                wkaoi or NOWKAOI, payload['error']))
+                wkaoi or NOCACHE, payload['error']))
 
-    results = payload[wkaoi or NOWKAOI]
+    results = payload[wkaoi or NOCACHE]
 
     data = [
         nlcd_soil(results['nlcd_soil']),

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -726,6 +726,26 @@ GEOP = {
                     'pixelIsArea': True
                 }
             ]
+        },
+        'worksheet_aoi': {
+            'shapes': [],
+            'streamLines': '',
+            'operations': [
+                {
+                    'name': 'RasterGroupedCount',
+                    'label': 'nlcd',
+                    'rasters': [
+                        'nlcd-2011-30m-epsg5070-512-int8'
+                    ]
+                },
+                {
+                    'name': 'RasterLinesJoin',
+                    'label': 'nlcd_streams',
+                    'rasters': [
+                        'nlcd-2011-30m-epsg5070-512-int8'
+                    ]
+                }
+            ]
         }
     }
 }

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -298,6 +298,7 @@ THIRD_PARTY_APPS = (
     'corsheaders',
     'registration',
     'django_celery_results',
+    'django_extensions',
 )
 
 # THIRD-PARTY CONFIGURATION

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -5,6 +5,7 @@ hiredis==0.1.6
 djangorestframework==3.9.4
 django-filter==0.9.2
 django-registration-redux==2.6
+django-extensions==2.2.5
 python-omgeo==4.0.0
 rauth==0.7.1
 djangorestframework-gis==0.14.0


### PR DESCRIPTION
## Overview

Adds a Celery workflow that

 - Takes an area of interest (AoI)
 - Matches it to one or more HUC-12s
 - In case of more than one HUC-12, clips the AoI to each HUC-12 and pairs it with the HUC-12
 - For each AoI, runs NLCD and Streams analyses
 - For each HUC-12, runs NLCD and Streams analyses, and also GWLF-E to get land category specific water quality loads
 - Assembles all these values into a JSON object
 - This object can then be POSTed to `/export/worksheet/` to get a ZIP file containing an Excel file per HUC-12, and the shape of the clipped AoI as geojson

Connects #3192 
Connects #3193 

### Demo

![image](https://user-images.githubusercontent.com/1430060/70359940-1f011580-184b-11ea-86f0-e7a10272eda8.png)

### Notes

~There are certain odd cases where I'm seeing the return of the dreaded `chord_unlock` cycle. I will make a separate card to investigate that.~

We avoid this entirely by changing the Celery workflow to be linear rather than chorded in 09731c5.

## Testing Instructions

* Check out this branch and reprovision `app` and `worker`
* Run `debugcelery`
* Login to MMW and find your API Key (under My Account → Account)
* Save it as an environment variable
* Download this shape: [northwales.geojson.txt](https://github.com/WikiWatershed/model-my-watershed/files/3934111/northwales.geojson.txt)
* Use that shape to POST to `/api/modeling/worksheet/` with your API Token:

```http
http :8000/api/modeling/worksheet/ Authorization:"Token $MMW_API_TOKEN" < northwales.geojson

HTTP/1.1 200 OK
Allow: POST, OPTIONS
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Fri, 06 Dec 2019 20:05:02 GMT
Location: /api/jobs/b7986887-c2f4-4cd8-959f-c1167ed00af1/
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie, Origin

{
    "job": "b7986887-c2f4-4cd8-959f-c1167ed00af1",
    "status": "started"
}
```

* Save the results of that job to a file

```console
http :8000/api/jobs/b7986887-c2f4-4cd8-959f-c1167ed00af1/ Authorization:"Token $MMW_API_TOKEN" | jq .result > northwales-payload.json
```

* Send that payload to the export endpoint and save the result:

```http
http --download :8000/export/worksheet/ < northwales-payload.json

HTTP/1.1 200 OK
Allow: POST, OPTIONS
Connection: keep-alive
Content-Disposition: attachment; filename="MMW_BMP_Spreadsheets.zip"
Content-Length: 82889
Content-Type: application/zip
Date: Fri, 06 Dec 2019 21:37:28 GMT
Server: nginx
Vary: Accept, Cookie

Downloading 80.95 kB to "MMW_BMP_Spreadsheets.zip"
Done. 80.95 kB in 0.00205s (38.63 MB/s)
```

* Ensure the file contents are identical to this: [MMW_BMP_Spreadsheets.zip](https://github.com/WikiWatershed/model-my-watershed/files/3934205/MMW_BMP_Spreadsheets.zip)
* Ensure the square meter block is populated, as should be the case for any AoI less than 2 square kilometer in size
* Try another shape, perhaps one that intersects multiple HUC-12s. Ensure the results are expected.