### PR TITLE
Create pg_trgm index on boundary_huc* tables to speed up search

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ $ ./scripts/bundle.sh
 To load or reload boundary data, from an `app` server, run (`scripts` is not mounted by default to the VM, you may need to copy the file over):
 
 ```bash
-$ ./scripts/setupdb.sh -b
+$ vagrant upload ./scripts/ app
+$ vagrant ssh app
+$ ./scripts/aws/setupdb.sh -b
 ```
 
 The same script can be used to load the stream network data:
 
 ```bash
-$ ./scripts/setupdb.sh -s
+$ ./scripts/aws/setupdb.sh -s
 ```
 
 Note that if you receive out of memory errors while loading the data, you may want to increase the RAM on your `services` VM (1512 MB may be all that is necessary).


### PR DESCRIPTION
## Overview

This PR adds the pg_trgm extension and creates indexes on the `name` column of the `boundary_huc*` tables on database setup.

[See this blog post](https://niallburkley.com/blog/index-columns-for-like-in-postgres/) about speeding up the LIKE operator with the `pg_trgm` extension.

Connects #2833

### Demo

![mmw-search](https://user-images.githubusercontent.com/2320142/70570597-36514300-1b6a-11ea-8510-5dc1f6ac8573.gif)
### Notes

With the index, I still have seen some slow-ish database query times - but this seems to be on startup, and after a bit of warm up time the queries come back quite fast.

## Testing Instructions

* Re-run the `setupdb.sh` script as explained in the README changes as part of this PR.
* Perform the duplication steps of the related issue
* Notice it's not as slow as it once was.

## Checklist

- [ ] ~~All JavaScript tests pass `./scripts/testem.sh`~~ (no javascript changes)
