### PR TITLE
Upgrade Basemap

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -56,8 +56,8 @@ LAYER_GROUPS = {
     'basemap': [
         {
             'display': 'Streets',
-            'url': 'https://{s}.tiles.mapbox.com/v4/stroudcenter.1f06e119'
-                    '/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoic3Ryb3VkY2VudGVyIiwiYSI6ImNpd2NhMmZiMDA1enUyb2xrdjlhYzV6N24ifQ.3dFii4MfQFOqYEDg9kVguA',  # NOQA
+            'url': 'https://api.mapbox.com/styles/v1/stroudcenter/'
+                   'ck41nno7j13nj1cphp3ew8igk/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1Ijoic3Ryb3VkY2VudGVyIiwiYSI6ImNpdzJpYTQzYzBjajQyeWxvb2Z5ZzFlM2gifQ.CpASF54p0qQzY_qSiu4Dvw',  # NOQA
             'attribution': 'Map data &copy; <a href="http://openstreetmap.org">'
                            'OpenStreetMap</a> contributors, '
                            '<a href="http://creativecommons.org/licenses/by-sa/'


### PR DESCRIPTION
## Overview

Mapbox is increasing its Raster Tiles API pricing, causing us to use one of the newer APIs which has newly styled tiles. The tiles have been styled to generally match the previous cartography, although minor differences will persist.

This new Static Tiles API will be cheaper and more sustainably priced than the increased Raster Tiles API.

Connects #3204 

### Demo

![2019-12-11 14 12 20](https://user-images.githubusercontent.com/1430060/70652266-54797a80-1c20-11ea-91d0-25de0476c3b6.gif)

## Testing Instructions

* Check out this branch
* Go to [:8000/](http://localhost:8000/)
  - [x] Ensure you see the new basemap
  - [x] Ensure it maintains the look and feel of the previous basemap
