### PR TITLE
Add ARA output to Analyze Land tab

### DIFF
--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -12,3 +12,10 @@
     <tbody>
     </tbody>
 </table>
+{% if isLandTable and not araNull %}
+<div id="land-tab-ara-section">
+    <div class="land-tab-ara-line-item">
+        Active river area = {{ araTotal|round(2)|toLocaleString(2) }} {{ headerUnits }}
+    </div>
+</div>
+{% endif %}

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -698,11 +698,17 @@ var TableView = Marionette.CompositeView.extend({
     },
     templateHelpers: function() {
         var scheme = settings.get('unit_scheme'),
-            units = this.options.units;
+            units = this.options.units,
+            isLandTable = this.options.modelName === 'land',
+            araData = isLandTable && _(this.collection.toJSON()).map('active_river_area'),
+            araTotal = isLandTable && araData.sum(),
+            araNull = isLandTable && araData.every(_.isNull);
 
         return {
             headerUnits: coreUnits[scheme][units].name,
-            isLandTable: this.options.modelName === 'land'
+            isLandTable: isLandTable,
+            araTotal: araTotal && coreUnits.get(units, araTotal).value,
+            araNull: araNull,
         };
     },
     childViewContainer: 'tbody',

--- a/src/mmw/sass/components/_tabs.scss
+++ b/src/mmw/sass/components/_tabs.scss
@@ -311,10 +311,12 @@
   }
 }
 
+#land-tab-ara-section,
 #streams-tab-ag-section {
     padding-top: 1rem;
     margin-left: 0.3rem;
 
+    .land-tab-ara-line-item,
     .streams-tab-ag-line-item {
         font-weight: 800;
         font-size: 13px;


### PR DESCRIPTION
## Overview

The output, shown in square km, will be shown in the Analyze Land tab if the area of interest is within the ARA Perimeter.

In the code, we inspect all the values for ARA for all the land types. If some of them are NULL we treat it as 0, and still sum up all the values to a total. The value will be shown even if it is 0.

Only when all the values are NULL that we take it as a signal that the AoI must be outside the ARA Perimeter, in which case the entire line is hidden.

Connects #3202

### Demo

Within ARA Perimeter:

![image](https://user-images.githubusercontent.com/1430060/71600857-e0473e00-2b1e-11ea-9cb8-2a4c50a2088a.png)

Within ARA Perimeter avoiding ARA values:

![image](https://user-images.githubusercontent.com/1430060/71601115-11743e00-2b20-11ea-8920-5c91587bbabb.png)

Within ARA Perimeter for small AoIs, using smaller units:

![image](https://user-images.githubusercontent.com/1430060/71601450-7bd9ae00-2b21-11ea-9b07-f3512109bf3a.png)

Outside ARA Perimeter:

![image](https://user-images.githubusercontent.com/1430060/71600876-f0f7b400-2b1e-11ea-83a3-b04a0d3fe9f7.png)

### Notes

We are showing totals for data layer that has a corresponding visual layer. Usually, the entire Analyze tab is dedicated to a single layer, and has controls for turning on the related layers at the top.

The ARA line added to the bottom doesn't have the significance to deserve a top-level addition of the ARA layer for the chart and the table, yet it feels like something is missing. I'm not sure on the best way to proceed, and this may likely be a larger design conversation with Stroud and **#design**.

As such I'd rather defer this to a later card.

## Testing Instructions

* Check out this branch and `$ ./scripts/bundle.sh --debug`
* Analyze a shape within the ARA perimeter
  - [x] Ensure you see an "Active river area" line item at the bottom of the NLCD table
* Analyze a shape outside the ARA perimeter
  - [x] Ensure you see no such line