### PR TITLE
Add Analyze Back-end for Protected Lands

### DIFF
--- a/src/mmw/apps/geoprocessing_api/tasks.py
+++ b/src/mmw/apps/geoprocessing_api/tasks.py
@@ -16,6 +16,8 @@ import requests
 
 from django.conf import settings
 
+from mmw.settings import layer_classmaps
+
 from apps.modeling.geoprocessing import multi, parse
 from apps.modeling.tr55.utils import aoi_resolution
 
@@ -142,7 +144,7 @@ def analyze_nlcd(result, area_of_interest=None):
         total_count += count
         histogram[nlcd] = count + histogram.get(nlcd, 0)
 
-    for nlcd, (code, name) in settings.NLCD_MAPPING.iteritems():
+    for nlcd, (code, name) in layer_classmaps.NLCD.iteritems():
         categories.append({
             'area': area(histogram, nlcd),
             'active_river_area': area(result, (nlcd, 1)) if has_ara else None,
@@ -179,7 +181,7 @@ def analyze_soil(result, area_of_interest=None):
         s = s if s != settings.NODATA else 3  # Map NODATA to 3
         histogram[s] = count + histogram.get(s, 0)
 
-    for soil, (code, name) in settings.SOIL_MAPPING.iteritems():
+    for soil, (code, name) in layer_classmaps.SOIL.iteritems():
         categories.append({
             'area': histogram.get(soil, 0) * pixel_width * pixel_width,
             'code': code,
@@ -316,7 +318,7 @@ def collect_nlcd(histogram, geojson=None):
         'code': code,
         'nlcd': nlcd,
         'type': name,
-    } for nlcd, (code, name) in settings.NLCD_MAPPING.iteritems()]
+    } for nlcd, (code, name) in layer_classmaps.NLCD.iteritems()]
 
     return {'categories': categories}
 

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -31,6 +31,8 @@ urlpatterns = [
         name='start_analyze_streams'),
     url(r'analyze/terrain/$', views.start_analyze_terrain,
         name='start_analyze_terrain'),
+    url(r'analyze/protected-lands/$', views.start_analyze_protected_lands,
+        name='start_analyze_protected_lands'),
     url(r'jobs/' + uuid_regex, get_job, name='get_job'),
     url(r'modeling/worksheet/$', views.start_modeling_worksheet,
         name='start_modeling_worksheet'),

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -15,6 +15,8 @@ from celery import shared_task
 
 from django.conf import settings
 
+from mmw.settings import layer_classmaps
+
 from apps.core.models import Job
 from apps.modeling.calcs import apply_subbasin_gwlfe_modifications
 from apps.modeling.tr55.utils import (aoi_resolution,
@@ -215,10 +217,10 @@ def nlcd_soil(result):
         # Map [NODATA, ad, bd] to c, [cd] to d
         s2 = 3 if s in [settings.NODATA, 5, 6] else 4 if s == 7 else s
         # Only count those values for which we have mappings
-        if n in settings.NLCD_MAPPING and s2 in settings.SOIL_MAPPING:
+        if n in layer_classmaps.NLCD and s2 in layer_classmaps.SOIL:
             total_count += count
-            label = '{soil}:{nlcd}'.format(soil=settings.SOIL_MAPPING[s2][0],
-                                           nlcd=settings.NLCD_MAPPING[n][0])
+            label = '{soil}:{nlcd}'.format(soil=layer_classmaps.SOIL[s2][0],
+                                           nlcd=layer_classmaps.NLCD[n][0])
             dist[label] = {'cell_count': (
                 count + (dist[label]['cell_count'] if label in dist else 0)
             )}

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -202,6 +202,13 @@ function createAnalyzeTaskCollection(aoi, wkaoi) {
             wkaoi: wkaoi,
             taskName: "analyze/catchment-water-quality"
         },
+        {
+            name: "protected_lands",
+            displayName: "Protected Lands",
+            area_of_interest: aoi,
+            wkaoi: wkaoi,
+            taskName: "analyze/protected-lands"
+        },
     ];
 
     // Remove analyses which aren't available for catalog search mode

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1585,6 +1585,7 @@ var AnalyzeResultViews = {
     climate: ClimateResultView,
     streams: StreamResultView,
     terrain: TerrainResultView,
+    protected_lands: LandResultView,
 };
 
 module.exports = {

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -623,6 +623,18 @@ GEOP = {
                 'zoom': 0
             }
         },
+        'protected_lands': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'protected-lands-30m-epsg5070-512'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterGroupedCount',
+                'zoom': 0
+            }
+        },
         'mapshed': {
             'shapes': [],
             'streamLines': '',

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -18,7 +18,6 @@ from layer_settings import (LAYER_GROUPS, VIZER_URLS, VIZER_IGNORE, VIZER_NAMES,
                             NHD_REGION2_PERIMETER, CONUS_PERIMETER)  # NOQA
 from gwlfe_settings import (GWLFE_DEFAULTS, GWLFE_CONFIG, SOIL_GROUP, # NOQA
                             CURVE_NUMBER, NODATA, SRAT_KEYS, SUBBASIN_SOURCE_NORMALIZING_AREAS)  # NOQA
-from tr55_settings import (NLCD_MAPPING, SOIL_MAPPING)
 
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.

--- a/src/mmw/mmw/settings/layer_classmaps.py
+++ b/src/mmw/mmw/settings/layer_classmaps.py
@@ -2,7 +2,7 @@
 # rasters), and the values of the dictionary are arrays of length two.
 # The first element of each array is the name of the NLCD category in
 # the TR-55 code.  The second string is a short, human-readable name.
-NLCD_MAPPING = {
+NLCD = {
     11: ['open_water', 'Open Water'],
     12: ['perennial_ice', 'Perennial Ice/Snow'],
     21: ['developed_open', 'Developed, Open Space'],
@@ -27,7 +27,7 @@ NLCD_MAPPING = {
 # used for the corresponding soil-type in the TR-55 code.  The second
 # member of each array is a human-readable description of that
 # soil-type.
-SOIL_MAPPING = {
+SOIL = {
     1: ['a', 'A - High Infiltration'],
     2: ['b', 'B - Moderate Infiltration'],
     3: ['c', 'C - Slow Infiltration'],

--- a/src/mmw/mmw/settings/layer_classmaps.py
+++ b/src/mmw/mmw/settings/layer_classmaps.py
@@ -36,3 +36,18 @@ SOIL = {
     6: ['bd', 'B/D - Medium/Very Slow Infiltration'],
     7: ['cd', 'C/D - Medium/Very Slow Infiltration']
 }
+
+PROTECTED_LANDS = {
+    1: ['pra_f', 'Park or Recreational Area - Federal'],
+    2: ['pra_s', 'Park or Recreational Area - State'],
+    3: ['pra_l', 'Park or Recreational Area - Local'],
+    4: ['pra_p', 'Park or Recreational Area - Private'],
+    5: ['pra_u', 'Park or Recreational Area - Unknown'],
+    6: ['nra_f', 'Natural Resource Area - Federal'],
+    7: ['nra_s', 'Natural Resource Area - State'],
+    8: ['nra_l', 'Natural Resource Area - Local'],
+    9: ['nra_p', 'Natural Resource Area - Private'],
+    10: ['nra_u', 'Natural Resource Area - Unknown'],
+    11: ['con_ease', 'Conservation Easement'],
+    12: ['ag_ease', 'Agricultural Easement'],
+}

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 import json
 
 from django.contrib.gis.geos import GEOSGeometry
-from tr55_settings import NLCD_MAPPING, SOIL_MAPPING
+from layer_classmaps import NLCD, SOIL
 
 # [01, 02, ...] style list for layer time sliders
 MONTH_CODES = [str(m).zfill(2) for m in range(1, 13)]
@@ -111,7 +111,7 @@ LAYER_GROUPS = {
             'maxZoom': 18,
             'opacity': 0.618,
             'has_opacity_slider': True,
-            'legend_mapping': { key: names[1] for key, names in NLCD_MAPPING.iteritems()},
+            'legend_mapping': { key: names[1] for key, names in NLCD.iteritems()},
             'big_cz': True,
         },
         {
@@ -130,13 +130,13 @@ LAYER_GROUPS = {
             'opacity': 0.618,
             'has_opacity_slider': True,
             'legend_mapping': OrderedDict([
-                SOIL_MAPPING[1],
-                SOIL_MAPPING[2],
-                SOIL_MAPPING[3],
-                SOIL_MAPPING[5],
-                SOIL_MAPPING[6],
-                SOIL_MAPPING[7],
-                SOIL_MAPPING[4],
+                SOIL[1],
+                SOIL[2],
+                SOIL[3],
+                SOIL[5],
+                SOIL[6],
+                SOIL[7],
+                SOIL[4],
             ]),
             'big_cz': True,
         },


### PR DESCRIPTION
## Overview

Adds a new endpoint `analyze/protected-lands` for analyze the Protected Lands national raster. The output is very similar to that of NLCD or Soil analyses.

Connects #3201 

### Demo

![image](https://user-images.githubusercontent.com/1430060/72467798-b726de80-37a9-11ea-8849-96294e8b2fca.png)

![image](https://user-images.githubusercontent.com/1430060/72466240-7d080d80-37a6-11ea-8e37-6a85365bf3d3.png)

### Notes

The front-end bits in this PR are just for demo purposes, and should be removed before the final front-end is added.

## Testing Instructions

* Check out this branch and restart the Celery worker
    ```console
    $ vagrant ssh worker -c 'sudo service celeryd restart'
    ```
* Bundle the new front-end
    ```console
    $ ./scripts/bundle.sh --debug
    ```
* Go to [:8000/](http://localhost:8000/) and try analyzing a shape
    - [ ] Ensure you see a Protected Lands tab
    - [ ] Ensure all analyses complete correctly
    - [ ] Ensure Protected Lands tab has accurate analysis given its visual layer
* Go to [:8000/api/docs](http://localhost:8000/api/docs)
    - [ ] Ensure you see an entry for `analyze/protected-lands`