### PR TITLE
Remove JavaScript test prompt from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,3 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Start after checking out this branch
  * Include any setup required, such as bundling scripts, restarting services, etc.
  * Include test case, and expected output
-
-## Checklist
-
-- [ ] All JavaScript tests pass `./scripts/testem.sh`


### PR DESCRIPTION
## Overview

Since JavaScript tests have been enabled on the CI for pull requests and are now working correctly and not hanging, we no longer need to prompt developers to manually run tests.

Connects #3230 

### Demo

![image](https://user-images.githubusercontent.com/1430060/72743170-24a38800-3b79-11ea-8703-565bc6527fb2.png)

## Testing Instructions

* Ensure JavaScript tests are run successfully for this PR: http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-pull-requests/4146/console