### PR TITLE
Make modifications list pop-up scrollable

### DIFF
--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -201,6 +201,9 @@ header {
     }
 
     #modifications {
+      max-height: calc(100vh - 152px);
+      overflow-y: scroll;
+
       .modification-type {
         min-width: 140px;
       }


### PR DESCRIPTION
## Overview

Previously the modifications list pop-up would overflow beyond a short viewport and be cut off from view. By adding an explicit `max-height` we ensure that the pop-up always stays within the viewport, and with `overflow-y` we ensure that there is a scrollbar for vertical scrolling when required.

Connects #3198 

### Demo

On macOS, with an implicit scrollbar:

![2020-01-20 14 31 38](https://user-images.githubusercontent.com/1430060/72754000-96d59600-3b94-11ea-8ea5-2e7efb0afdc3.gif)

On Windows, with an explicit scrollbar:

![2020-01-20 15 23 25](https://user-images.githubusercontent.com/1430060/72755631-f6ce3b80-3b98-11ea-99ec-18e01947d39e.gif)

## Testing Instructions

* Check out this branch and `./scripts/bundle.sh --debug`
* Go to [:8000/](http://localhost:8000/) and create a new TR-55 project
* Add a large number of modifications, like so:

    ![image](https://user-images.githubusercontent.com/1430060/72754066-cd131580-3b94-11ea-8c6f-bd7ded3f8ea9.png)

* Open the modifications pop-up on a short screen, such that you cannot see all the modifications in one screen
    - [ ] Ensure you can scroll the pop-up to bring the lower ones up into view