### PR TITLE
Split Active River Area across NLCD

### DIFF
--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -14,11 +14,24 @@
     </thead>
     <tbody>
     </tbody>
+    <tfoot>
+    <tr>
+        <th>Total</th>
+        {% if isLandTable %}
+            <!-- Empty column for NLCD -->
+            <th class="hidden-analyze-table-column" data-tableexport-display="always"></th>
+        {% endif %}
+        <th class="text-right">{{ areaTotal|round(2)|toLocaleString(2) }}</th>
+        <th class="text-right">{{ coverageTotal|round(1)|toLocaleString(1) }}</th>
+        {% if isLandTable %}
+            <th class="text-right">
+                {% if araNull %}
+                    No Data
+                {% else %}
+                    {{ araTotal|round(2)|toLocaleString(2) }}
+                {% endif %}
+            </th>
+        {% endif %}
+    </tr>
+    </tfoot>
 </table>
-{% if isLandTable and not araNull %}
-<div id="land-tab-ara-section">
-    <div class="land-tab-ara-line-item">
-        Active river area = {{ araTotal|round(2)|toLocaleString(2) }} {{ headerUnits }}
-    </div>
-</div>
-{% endif %}

--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -7,6 +7,9 @@
             {% endif %}
             <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Area ({{ headerUnits }})</th>
             <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Coverage (%)</th>
+            {% if isLandTable %}
+                <th class="text-right" data-sortable="true" data-sorter="window.numericSort">Active River Area ({{ headerUnits }})</th>
+            {% endif %}
         </tr>
     </thead>
     <tbody>

--- a/src/mmw/js/src/analyze/templates/tableRow.html
+++ b/src/mmw/js/src/analyze/templates/tableRow.html
@@ -4,3 +4,12 @@
 {% endif %}
 <td class="strong text-right">{{ scaledArea|round(2)|toLocaleString(2) }}</td>
 <td class="strong text-right">{{ coveragePct|toFixed(1) }}</td>
+{% if isLandTable %}
+    <td class="strong text-right">
+        {% if araNull %}
+            No Data
+        {% else %}
+            {{ ara|round(2)|toLocaleString(2) }}
+        {% endif %}
+    </td>
+{% endif %}

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -105,9 +105,15 @@ function landTableFormatter(categories) {
     return collection.map(function(category) {
         var name = category.get('type'),
             areaKm2 = category.get('area') / coreUnits.METRIC.AREA_XL.factor,
-            coverage = category.get('coverage') * 100;
+            coverage = category.get('coverage') * 100,
+            ara = category.get('active_river_area') / coreUnits.METRIC.AREA_XL.factor;
 
-        return [name, areaKm2.toFixed(2), coverage.toFixed(1)];
+        return [
+            name,
+            areaKm2.toFixed(2),
+            coverage.toFixed(1),
+            ara.toFixed(2),
+        ];
     });
 }
 
@@ -192,7 +198,7 @@ var dataFormatters = {
 };
 
 var tableHeaders = {
-    land: ['Type', 'Area (km²)', 'Coverage (%)'],
+    land: ['Type', 'Area (km²)', 'Coverage (%)', 'Active River Area (km²)'],
     protected_lands: ['Type', 'Area (km²)', 'Coverage (%)'],
     soil: ['Type', 'Area (km²)', 'Coverage (%)'],
     animals: ['Animal', 'Count'],

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -711,14 +711,19 @@ var TableView = Marionette.CompositeView.extend({
     templateHelpers: function() {
         var scheme = settings.get('unit_scheme'),
             units = this.options.units,
+            data = _(this.collection.toJSON()),
             isLandTable = this.options.modelName === 'land',
-            araData = isLandTable && _(this.collection.toJSON()).map('active_river_area'),
+            areaTotal = data.map('area').sum(),
+            coverageTotal = data.map('coverage').sum(),
+            araData = isLandTable && data.map('active_river_area'),
             araTotal = isLandTable && araData.sum(),
             araNull = isLandTable && araData.every(_.isNull);
 
         return {
             headerUnits: coreUnits[scheme][units].name,
             isLandTable: isLandTable,
+            areaTotal: coreUnits.get(units, areaTotal).value,
+            coverageTotal: coverageTotal * 100,
             araTotal: araTotal && coreUnits.get(units, araTotal).value,
             araNull: araNull,
         };

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -683,6 +683,8 @@ var TableRowView = Marionette.ItemView.extend({
         var area = this.model.get('area'),
             units = this.options.units,
             isLandTable = this.options.isLandTable,
+            ara = isLandTable ? this.model.get('active_river_area') : null,
+            araNull = _.isNull(ara),
             code = isLandTable ? this.model.get('nlcd') : null;
 
         return {
@@ -690,6 +692,8 @@ var TableRowView = Marionette.ItemView.extend({
             coveragePct: (this.model.get('coverage') * 100),
             // Scale the area to display units.
             scaledArea: coreUnits.get(units, area).value,
+            ara: coreUnits.get(units, ara).value,
+            araNull: araNull,
             code: code,
             isLandTable: isLandTable
         };


### PR DESCRIPTION
## Overview

Currently the Active River Area total only is shown in the user interface. However, our users want to see the ARA split across each land use type. This adds a column to the Land Analysis table for the Active River Area value, allowing users to see how the ARA is divided between land uses.

For regions outside the Mid-Atlantic and North-East, where ARA data is not available, "No Data" is shown.

Also adds a Total row at the bottom of the Land, Protected Lands, and Soil tables to sum the columns.

Connects #3233 

### Demo

In Philadelphia, within the ARA region:

![image](https://user-images.githubusercontent.com/1430060/72931152-5b210480-3d2b-11ea-891d-eb5e599e9661.png)

In Phoenix, outside the ARA region:

![image](https://user-images.githubusercontent.com/1430060/72931189-6c6a1100-3d2b-11ea-914a-56dbe0aba70a.png)

### Notes

For areas of interest outside the ARA region, I elected to have "No Data" appear in the ARA column. This has some precedent in the app, e.g. the Point Sources tab:

![image](https://user-images.githubusercontent.com/1430060/72931326-a4715400-3d2b-11ea-85f1-6528dcab5f1b.png)

Another option is to hide the column completely. This would give the table more breathing room, and be identical in function to current behavior for areas of interest outside the ARA region. This is current behavior on staging:

![image](https://user-images.githubusercontent.com/1430060/72931482-ee5a3a00-3d2b-11ea-851a-759624faaf3b.png)

However, this would lead to the output table having different structures in different areas of interest, which is arguably more egregious than having "No Data" in most of the country.

I can be convinced to go the other way if it is considered better though.

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/) and select an area within the Mid-Atlantic North-East region
* Switch to the Land Analysis tab
  - [x] Ensure you see a new column in the table
  - [x] Turn on the ARA layer and ensure the numbers roughly make sense
  - [x] Ensure you see a totals row at the bottom of the table
  - [x] Click "Download this data" and ensure the downloaded CSV has all the data shown
* Switch to Protected Lands
  - [x] Ensure table has a new totals row and its numbers are correct
* Switch to Soil tab
  - [ ] Ensure table has a new totals row and its numbers are correct