### PR TITLE
Merge pull request #3240 from WikiWatershed/tt/unit-conversion-missing-conversion

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -18,6 +18,7 @@ var _ = require('lodash'),
     PrecipitationView = require('../modeling/controls').PrecipitationView,
     modConfigUtils = require('../modeling/modificationConfigUtils'),
     gwlfeConfig = require('../modeling/gwlfeModificationConfig'),
+    GWLFE_LAND_COVERS = require('../modeling/constants').GWLFE_LAND_COVERS,
     compareModalTmpl = require('./templates/compareModal.html'),
     compareTabPanelTmpl = require('./templates/compareTabPanel.html'),
     compareInputsTmpl = require('./templates/compareInputs.html'),
@@ -504,13 +505,27 @@ var CompareModificationsPopoverView = Marionette.ItemView.extend({
     templateHelpers: function() {
         var isTr55 = App.currentProject.get('model_package') ===
                      coreUtils.TR55_PACKAGE,
+            scheme = settings.get('unit_scheme'),
             gwlfeModifications = isTr55 ? [] : _.flatten(
                 this.model.map(function(m) {
                     return _.map(m.get('userInput'), function(value, key) {
+                        var unit = gwlfeConfig.displayUnits[key],
+                            areaUnit = unit && coreUnits[scheme][unit].name,
+                            modKey = m.get('modKey'),
+                            name = modKey,
+                            input = gwlfeConfig.displayNames[key];
+
+                        if (modKey === 'entry_landcover') {
+                            name = _.find(GWLFE_LAND_COVERS, { id: parseInt(key.substring(6)) }).label;
+                            input = coreUnits[scheme].AREA_L_FROM_HA.name;
+                        } else {
+                            input = input.replace('AREAUNITNAME', areaUnit);
+                        }
+
                         return {
-                            name: m.get('modKey'),
+                            name: name,
                             value: value,
-                            input: gwlfeConfig.displayNames[key],
+                            input: input,
                         };
                     });
                 })

--- a/src/mmw/js/src/modeling/constants.js
+++ b/src/mmw/js/src/modeling/constants.js
@@ -6,5 +6,17 @@ module.exports = {
         MODEL_CREATE_EVENT: "project-create",
         MODEL_SCENARIO_EVENT: "scenario-create",
         MODEL_MOD_EVENT: "-modification-create",
-    }
+    },
+    GWLFE_LAND_COVERS: [
+        {id: 0, label: "Hay / Pasture"},
+        {id: 1, label: "Cropland"},
+        {id: 2, label: "Wooded Areas"},
+        {id: 3, label: "Wetlands"},
+        {id: 6, label: "Open Land"},
+        {id: 7, label: "Barren Areas"},
+        {id: 10, label: "Low-Density Mixed"},
+        {id: 11, label: "Medium-Density Mixed"},
+        {id: 12, label: "High-Density Mixed"},
+        {id: 13, label: "Low-Density Open Space"},
+    ]
 };

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -7,6 +7,7 @@ var _ = require('lodash'),
     coreUnits = require('../../../core/units'),
     round = require('../../../core/utils').round,
     CropTillageEfficiencyValues = require('../../gwlfeModificationConfig').CropTillageEfficiencyValues,
+    GWLFE_LAND_COVERS = require('../../constants').GWLFE_LAND_COVERS,
     models = require('./models'),
     calcs = require('./calcs'),
     fieldTmpl = require('./templates/field.html'),
@@ -999,88 +1000,17 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
 function showLandCoverModal(dataModel, modifications, addModification) {
     var scheme = settings.get('unit_scheme'),
         areaLUnits = coreUnits[scheme].AREA_L_FROM_HA.name,
-        fields = models.makeFieldCollection('landcover', dataModel, modifications, [
-            {
-                name: 'Area__0',
-                label: 'Hay / Pasture (' + areaLUnits + ')',
+        landCovers = _(GWLFE_LAND_COVERS).sortBy('id').map(function(lc) {
+            return {
+                name: 'Area__' + lc.id,
+                label: lc.label + ' (' + areaLUnits + ')',
                 unit: 'AREA_L_FROM_HA',
                 calculator: calcs.ArrayIndex,
                 decimalPlaces: 1,
-                minValue: 0
-            },
-            {
-                name: 'Area__1',
-                label: 'Cropland (' + areaLUnits + ')',
-                unit: 'AREA_L_FROM_HA',
-                calculator: calcs.ArrayIndex,
-                decimalPlaces: 1,
-                minValue: 0
-            },
-            {
-                name: 'Area__2',
-                label: 'Wooded Areas (' + areaLUnits + ')',
-                unit: 'AREA_L_FROM_HA',
-                calculator: calcs.ArrayIndex,
-                decimalPlaces: 1,
-                minValue: 0
-            },
-            {
-                name: 'Area__3',
-                label: 'Wetlands (' + areaLUnits + ')',
-                unit: 'AREA_L_FROM_HA',
-                calculator: calcs.ArrayIndex,
-                decimalPlaces: 1,
-                minValue: 0
-            },
-            {
-                name: 'Area__6',
-                label: 'Open Land (' + areaLUnits + ')',
-                unit: 'AREA_L_FROM_HA',
-                calculator: calcs.ArrayIndex,
-                decimalPlaces: 1,
-                minValue: 0
-            },
-            {
-                name: 'Area__7',
-                label: 'Barren Areas (' + areaLUnits + ')',
-                unit: 'AREA_L_FROM_HA',
-                calculator: calcs.ArrayIndex,
-                decimalPlaces: 1,
-                minValue: 0
-            },
-            {
-                name: 'Area__10',
-                label: 'Low-Density Mixed (' + areaLUnits + ')',
-                unit: 'AREA_L_FROM_HA',
-                calculator: calcs.ArrayIndex,
-                decimalPlaces: 1,
-                minValue: 0
-            },
-            {
-                name: 'Area__11',
-                label: 'Medium-Density Mixed (' + areaLUnits + ')',
-                unit: 'AREA_L_FROM_HA',
-                calculator: calcs.ArrayIndex,
-                decimalPlaces: 1,
-                minValue: 0
-            },
-            {
-                name: 'Area__12',
-                label: 'High-Density Mixed (' + areaLUnits + ')',
-                unit: 'AREA_L_FROM_HA',
-                calculator: calcs.ArrayIndex,
-                decimalPlaces: 1,
-                minValue: 0
-            },
-            {
-                name: 'Area__13',
-                label: 'Low-Density Open Space (' + areaLUnits + ')',
-                unit: 'AREA_L_FROM_HA',
-                calculator: calcs.ArrayIndex,
-                decimalPlaces: 1,
-                minValue: 0
-            },
-        ]),
+                minValue: 0,
+            };
+        }).value(),
+        fields = models.makeFieldCollection('landcover', dataModel, modifications, landCovers),
         windowModel = new models.LandCoverWindowModel({
             dataModel: dataModel,
             title: 'Land Cover',


### PR DESCRIPTION
## Overview

Fixes the missing unit conversion templating in MapShed's Compare View.

Connects #3179 

### Demo

![image](https://user-images.githubusercontent.com/1430060/73106793-42028a00-3eca-11ea-97db-42adc19f51ea.png)

### Notes

I'll make a separate card for handling land cover entries, so that when you reduce land cover it doesn't say +0, but -256 or whatever.

## Testing Instructions

* Create a MapShed project
* Add Cover Crops conservation practice
* Add a couple Land Cover entries
* Open Compare View, and hover on the scenarios
  - [x] Ensure the templates are correctly replaced by actual units
  - [x] Ensure land cover entries have proper names