### PR TITLE
Add Zoom to AoI Button

### DIFF
--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -588,6 +588,7 @@ var Tr55ScenarioItemView = Marionette.ItemView.extend({
             }),
             el: this.ui.mapContainer,
             addZoomControl: false,
+            addFitToAoiControl: false,
             addLocateMeButton: false,
             addSidebarToggleControl: false,
             showLayerAttribution: false,

--- a/src/mmw/js/src/core/fitToAoiControl.js
+++ b/src/mmw/js/src/core/fitToAoiControl.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var L = require('leaflet'),
+    Marionette = require('../../shim/backbone.marionette'),
+    fitToAoiControlButtonTmpl = require('./templates/fitToAoiControlButton.html');
+
+module.exports = L.Control.extend({
+    options: {
+        position: 'bottomright'
+    },
+
+    initialize: function(options) {
+        this.mapModel = options.model;
+        this.fitToAoi = options.fitToAoi;
+    },
+
+    onAdd: function() {
+        return new FitToAoiControlButton({ model: this.mapModel,
+                                           fitToAoi: this.fitToAoi }).render().el;
+    }
+});
+
+var FitToAoiControlButton = Marionette.ItemView.extend({
+    // model: MapModel,
+    template: fitToAoiControlButtonTmpl,
+    className: 'leaflet-control leaflet-control-fit-to-aoi',
+
+    ui: {
+        button: '.leaflet-bar-button'
+    },
+
+    events: {
+        'click @ui.button': 'fitToAoi'
+    },
+
+    modelEvents: {
+        'change:size': 'render',
+        'change:areaOfInterest': 'render'
+    },
+
+    initialize: function(options) {
+        this.fitToAoi = options.fitToAoi;
+    },
+
+    templateHelpers: function() {
+        return {
+            hidden: this.model.get('areaOfInterest') === null
+        };
+    }
+});

--- a/src/mmw/js/src/core/templates/fitToAoiControlButton.html
+++ b/src/mmw/js/src/core/templates/fitToAoiControlButton.html
@@ -1,0 +1,5 @@
+<div class="layer-control-button-container leaflet-bar {{"hidden-control" if hidden }}">
+    <a class="leaflet-bar leaflet-bar-button " href="#" title="Zoom to Area of Interest">
+        <span class="fa fa-bullseye"></span>
+    </a>
+</div>

--- a/src/mmw/js/src/core/tests.js
+++ b/src/mmw/js/src/core/tests.js
@@ -39,6 +39,7 @@ describe('Core', function() {
             'LayerSelector',
             'LocateMeButton',
             'ZoomControl',
+            'FitToAoiControl',
         ]);
     });
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -934,6 +934,7 @@ MAP_CONTROLS = [
     'LayerSelector',
     'LocateMeButton',
     'ZoomControl',
+    'FitToAoiControl',
     'SidebarToggleControl',
 ]
 

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -108,6 +108,7 @@ MAP_CONTROLS = [
     'LayerSelector',
     'LocateMeButton',
     'ZoomControl',
+    'FitToAoiControl',
     'SidebarToggleControl',
 ]
 

--- a/src/mmw/sass/base/_map.scss
+++ b/src/mmw/sass/base/_map.scss
@@ -136,6 +136,10 @@
         height: 38px;
         width: 38px;
     }
+
+    &.hidden-control {
+        visibility: hidden;
+    }
 }
 
 .leaflet-control {


### PR DESCRIPTION
## Overview

This PR adds a button to the map that zooms to an AOI if one exists.

Connects #3242

### Demo

If there is not an AOI set, the button is hidden on the map:

<img width="923" alt="Screen Shot 2020-01-30 at 10 50 15 AM" src="https://user-images.githubusercontent.com/2320142/73467346-3511ea80-4351-11ea-91a3-590c6a8c1996.png">

Once an AOI is selected, the button shows up on the bottom right of the map:

<img width="931" alt="Screen Shot 2020-01-30 at 10 51 01 AM" src="https://user-images.githubusercontent.com/2320142/73467393-422ed980-4351-11ea-9de2-fc4cac2d2784.png">

Here's what happens when you press it:

![zoom-to-aoi](https://user-images.githubusercontent.com/2320142/73467408-49ee7e00-4351-11ea-8652-102786a2291c.gif)

## Notes

I implemented analogous entries for the `SidebarToggleControl` control everywhere I found it, as I believe that gave the best coverage for where the new control needed to be referenced (tests, settings, compare map). However a second look on what other areas of the app should be considered from someone with broader knowledge would be great!

## Testing Instructions

 * Notice there is no button on the initial page
 * Select an AOI
 * Notice the button with the target icon; hover over to confirm correct tooltip
 * Zoom to somewhere that isn't centered on the AOI
 * Press the button: You're back!
 * "Change area" to clear the AOI. No more button!
