### PR TITLE
Switch back to old basemap temporarily

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -64,8 +64,8 @@ LAYER_GROUPS = {
     'basemap': [
         {
             'display': 'Streets',
-            'url': 'https://api.mapbox.com/styles/v1/stroudcenter/'
-                   'ck41nno7j13nj1cphp3ew8igk/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1Ijoic3Ryb3VkY2VudGVyIiwiYSI6ImNpdzJpYTQzYzBjajQyeWxvb2Z5ZzFlM2gifQ.CpASF54p0qQzY_qSiu4Dvw',  # NOQA
+            'url': 'https://{s}.tiles.mapbox.com/v4/stroudcenter.1f06e119'
+                    '/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoic3Ryb3VkY2VudGVyIiwiYSI6ImNpd2NhMmZiMDA1enUyb2xrdjlhYzV6N24ifQ.3dFii4MfQFOqYEDg9kVguA',  # NOQA
             'attribution': 'Map data &copy; <a href="http://openstreetmap.org">'
                            'OpenStreetMap</a> contributors, '
                            '<a href="http://creativecommons.org/licenses/by-sa/'


### PR DESCRIPTION
## Overview

In c74f8f0, #3204, #3208, and #3213  we switched to a new basemap, as we had been alerted by Mapbox that the API we were previously using (the Raster Tiles API) would undergo a price increase, and were encouraged to switch to the newer Static Tiles API.

Unfortunately, the Static Tiles API is even more expensive than the increased-in-price Raster Tiles API. So for now we're switching back to the Raster Tiles API. Going forward we may look into other basemap providers which are more reasonably priced.

Some more discussion can be found here: https://azavea.slack.com/archives/C044CG212/p1580415229032500

Connects #3246 

### Demo

![image](https://user-images.githubusercontent.com/1430060/73555693-14629700-441c-11ea-9502-b9d7fe76709d.png)