### PR TITLE
Add weather stations to Observation tab.

### DIFF
--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -34,4 +34,6 @@ urlpatterns = [
         views.boundary_layer_search, name='boundary_layer_search'),
     url(r'export/gms/?$', views.export_gms, name='export_gms'),
     url(r'point-source/$', views.drb_point_sources, name='drb_point_sources'),
+    url(r'weather-stations/$', views.weather_stations,
+        name='weather_stations'),
 ]

--- a/src/mmw/js/src/core/layerPicker.js
+++ b/src/mmw/js/src/core/layerPicker.js
@@ -242,7 +242,7 @@ var LayerPickerGroupView = Marionette.LayoutView.extend({
 
     onShow: function() {
         if (this.model.get('name') === 'Observations' && !this.model.get('layers')) {
-            this.model.fetchLayers(this.leafletMap);
+            this.model.fetchLayersIfNeeded();
         } else {
             this.showChildView('layers', new LayerPickerLayerListView({
                 collection: this.model.get('layers'),

--- a/src/mmw/js/src/core/templates/weatherStationPopup.html
+++ b/src/mmw/js/src/core/templates/weatherStationPopup.html
@@ -1,0 +1,19 @@
+<div class="data-catalog-popover-result-region">
+    <div class="resource-wrapper">
+        <h3 class="resource-title">
+            Weather Station: {{ station }}</h2>
+        </h3>
+        <div class="resource-detail">
+            <i class="fa fa-star"></i> {{ location if location else '' }}
+        </div>
+        <div class="resource-detail">
+            <i class="fa fa-calendar"></i> {{ begyear }} - {{ endyear }}
+        </div>
+        <div class="resource-detail">
+            <i class="fa fa-leaf"></i> Grow Season: {{ grw_start }} - {{ grw_end }}
+        </div>
+        <div class="resource-detail">
+            <i class="fa fa-tint"></i> Mean precipitation: {{ meanprecip }} (in)
+        </div>
+    </div>
+</div>

--- a/src/mmw/js/src/core/vizerLayers.js
+++ b/src/mmw/js/src/core/vizerLayers.js
@@ -14,6 +14,10 @@ var $ = require('jquery'),
     vizerIgnore = require('./settings').get('vizer_ignore'),
     vizerNames = require('./settings').get('vizer_names');
 
+// TODO: Fix or delete, as this is no longer used in the Observation Tab.
+// See issue #3255.
+
+
 // These are likely temporary until we develop custom icons for each type
 var platformIcons = {
         'River Guage': '#10A579',

--- a/src/mmw/js/src/core/weatherStationLayer.js
+++ b/src/mmw/js/src/core/weatherStationLayer.js
@@ -1,0 +1,34 @@
+"use strict";
+
+var L = require('leaflet'),
+    Backbone = require('../../shim/backbone'),
+    Marionette = require('../../shim/backbone.marionette'),
+    weatherStationPopupTmpl = require('./templates/weatherStationPopup.html');
+
+var Layer = {
+    createLayer: function(geojsonFeatureCollection) {
+        return L.geoJson(geojsonFeatureCollection, {
+            pointToLayer: function (feature, latlng) {
+                return L.circleMarker(latlng, {
+                    fill: true,
+                    fillColor: 'steelblue',
+                    fillOpacity: 0.2
+                });
+            },
+
+            onEachFeature: function(feature, marker) {
+                var model = new Backbone.Model(feature.properties),
+                    view = new WeatherStationPopupView({ model: model });
+
+                marker.bindPopup(view.render().el, { className: 'data-catalog-popover'});
+            },
+        });
+    }
+};
+
+var WeatherStationPopupView = Marionette.ItemView.extend({
+    template: weatherStationPopupTmpl,
+    className: 'weather-station-popup',
+});
+
+module.exports.Layer = Layer;


### PR DESCRIPTION
## Overview

This PR adds weather stations to the observation tab, which allows
the user to show all weather stations on the map. There is a new
endpoint that returns each weather station and properties stored in
the ms_weather_station table. The markers are based on the CUASHI
water level data in from Monitor. A future card will add any
additional design treatment.

Connects #3243

### Demo

![observation-tab](https://user-images.githubusercontent.com/2320142/73685027-5d705080-4693-11ea-9a17-81445874796c.gif)

### Notes

VizLayers is no longer used in the Observation tab, so a note is made
to clean this up in a subsiquent card.
## Testing Instructions

 * Navigate to Observation Tab
 * Notice it does not show an error anymore.
 * Notice it shows the correct count of weather stations
 * Click to turn on the weather station layers
 * Click on weather stations to show popups, notice the info is correct.
 * Turn off the weather stations and see them disappear.
