### PR TITLE
Alter precision for protected area graphs and tables

### DIFF
--- a/src/mmw/js/src/analyze/templates/table.html
+++ b/src/mmw/js/src/analyze/templates/table.html
@@ -22,7 +22,7 @@
             <th class="hidden-analyze-table-column" data-tableexport-display="always"></th>
         {% endif %}
         <th class="text-right">{{ areaTotal|round(2)|toLocaleString(2) }}</th>
-        <th class="text-right">{{ coverageTotal|round(1)|toLocaleString(1) }}</th>
+        <th class="text-right">{{ coverageTotal|round(1)|toLocaleString(2) }}</th>
         {% if isLandTable %}
             <th class="text-right">
                 {% if araNull %}

--- a/src/mmw/js/src/analyze/templates/tableRow.html
+++ b/src/mmw/js/src/analyze/templates/tableRow.html
@@ -3,7 +3,7 @@
     <td class="hidden-analyze-table-column" data-tableexport-display="always">{{ code }}</td>
 {% endif %}
 <td class="strong text-right">{{ scaledArea|round(2)|toLocaleString(2) }}</td>
-<td class="strong text-right">{{ coveragePct|toFixed(1) }}</td>
+<td class="strong text-right">{{ coveragePct|toFixed(2) }}</td>
 {% if isLandTable %}
     <td class="strong text-right">
         {% if araNull %}

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -111,7 +111,7 @@ function landTableFormatter(categories) {
         return [
             name,
             areaKm2.toFixed(2),
-            coverage.toFixed(1),
+            coverage.toFixed(2),
             ara.toFixed(2),
         ];
     });
@@ -125,7 +125,7 @@ function protectedLandsTableFormatter(categories) {
             areaKm2 = category.get('area') / coreUnits.METRIC.AREA_XL.factor,
             coverage = category.get('coverage') * 100;
 
-        return [name, areaKm2.toFixed(2), coverage.toFixed(1)];
+        return [name, areaKm2.toFixed(2), coverage.toFixed(2)];
     });
 }
 
@@ -137,7 +137,7 @@ function soilTableFormatter(categories) {
             areaKm2 = category.get('area') / coreUnits.METRIC.AREA_XL.factor,
             coverage = category.get('coverage') * 100;
 
-        return [name, areaKm2.toFixed(2), coverage.toFixed(1)];
+        return [name, areaKm2.toFixed(2), coverage.toFixed(2)];
     });
 }
 


### PR DESCRIPTION
## Overview

When the horizontal analyze charts have a maximum coverage value of <
1%, allow the y-axis label to show 2 digits of precision. Previously,
these values would show only whole integers, labeling each tick as 0%.
Max values > 1% will retain the previous functionality of whole numbers.

This adjustment was due to adding a sparse coverage layer, Protected
Lands, to the Analyze Land tab. These values are often below 1% and
displayed this undesired behavior. 

Switching this from using 2 digits to a single digit of precision would allow
for more compact and evenly distributed ticks (it would use 4 character per
label item instead of 5), however, the number of areas that would still show
0.0% is higher. I am willing to alter this from 2 to 1 if that tradeoff works better.

Additionally, a commit is added that expands the Coverage column in the
Analyze tables since the same low values would slice off  precision for the
display. This more closely matches the behavior of the horizontal bar charts
associated with these tables.

One drawback is that some protected areas are so small that the
rounding used in the sum displayed in the total row may not always
match the sum of the values in the table column, as they be be even
below the 2-digit of precision threshold.

Since this associated fix is not mentioned specifically in the issue, it may be
better to drop it, but it does keep the values between the two visualizations
better, if not perfectly, aligned.

Connects #3254 

### Demo

#### With default precision
![image](https://user-images.githubusercontent.com/1014341/75307426-adb57b00-5819-11ea-8fab-049ae8aab175.png)

#### With higher precision
![image](https://user-images.githubusercontent.com/1014341/75307373-8b236200-5819-11ea-98bb-c710fcec25ff.png)

## Testing Instructions

 * Visit an AoI with a very small proportion of Protected Areas, such as `Flatrock Creek-Auglaize River, HUC-10`
* Ensure the Land and Soil charts remain identical to staging, with whole number Coverage tick labels
* Check the Protected Area chart, and note that more significant digits of precision are used
* Visit AoI's of varying maximum (within a single class) Protected Area coverage and note the tradeoffs between display values and labels.