### PR TITLE
Custom Weather: Serializer, Endpoint, Tests

### DIFF
--- a/src/mmw/apps/modeling/serializers.py
+++ b/src/mmw/apps/modeling/serializers.py
@@ -88,7 +88,8 @@ class ProjectSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'area_of_interest', 'area_of_interest_name',
                   'scenarios', 'model_package', 'created_at', 'modified_at',
                   'is_private', 'is_activity', 'gis_data', 'mapshed_job_uuid',
-                  'subbasin_mapshed_job_uuid', 'wkaoi', 'user', 'hydroshare')
+                  'subbasin_mapshed_job_uuid', 'wkaoi', 'user', 'hydroshare',
+                  'uses_custom_weather', 'custom_weather_dataset')
 
     user = UserSerializer(default=serializers.CurrentUserDefault())
     gis_data = JsonField(required=False, allow_null=True)
@@ -112,7 +113,8 @@ class ProjectListingSerializer(serializers.ModelSerializer):
         model = Project
         fields = ('id', 'name', 'area_of_interest_name', 'is_private',
                   'model_package', 'created_at', 'modified_at', 'user',
-                  'hydroshare')
+                  'hydroshare', 'uses_custom_weather',
+                  'custom_weather_dataset')
 
     hydroshare = HydroShareResourceSerializer(read_only=True)
 
@@ -126,7 +128,8 @@ class ProjectUpdateSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'area_of_interest', 'area_of_interest_name',
                   'model_package', 'created_at', 'modified_at',
                   'is_private', 'is_activity', 'gis_data', 'mapshed_job_uuid',
-                  'subbasin_mapshed_job_uuid', 'wkaoi', 'user')
+                  'subbasin_mapshed_job_uuid', 'wkaoi', 'user',
+                  'uses_custom_weather')
 
     user = UserSerializer(default=serializers.CurrentUserDefault(),
                           read_only=True)

--- a/src/mmw/apps/modeling/urls.py
+++ b/src/mmw/apps/modeling/urls.py
@@ -19,6 +19,8 @@ app_name = 'modeling'
 urlpatterns = [
     url(r'projects/$', views.projects, name='projects'),
     url(r'projects/(?P<proj_id>[0-9]+)$', views.project, name='project'),
+    url(r'projects/(?P<proj_id>[0-9]+)/custom-weather-data/?$',
+        views.project_custom_weather_data, name='project_custom_weather_data'),
     url(r'scenarios/$', views.scenarios, name='scenarios'),
     url(r'scenarios/(?P<scen_id>[0-9]+)$', views.scenario, name='scenario'),
     url(r'mapshed/$', views.start_mapshed, name='start_mapshed'),


### PR DESCRIPTION
## Overview

Adds serializers, an endpoint, and tests for accepting and manipulating Custom Weather Data.

Connects #3270 

### Demo

Log in with a test user:

```http
❯ http --session=test --form :8000/user/login username=test1 password=test

HTTP/1.1 200 OK
Allow: POST, OPTIONS, GET
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Thu, 09 Apr 2020 22:46:36 GMT
Server: nginx
Set-Cookie: csrftoken=CPaKpYJJkx4pdSEtPmiF7VWCMW6gs0NQt1oAbm45H6OhnI5TynyqSpM2yzbbiEGB; expires=Thu, 08-Apr-2021 22:46:36 GMT; Max-Age=31449600; Path=/
Set-Cookie: sessionid=ikvfcnzdwr6gzib2ph04sorsree0fj12; expires=Thu, 23-Apr-2020 22:46:36 GMT; httponly; Max-Age=1209600; Path=/
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie

{
    "guest": false,
    "has_seen_hotspot_info": false,
    "hydroshare": true,
    "id": 2,
    "itsi": false,
    "profile": {
        "country": "US",
        "first_name": "",
        "last_name": "",
        "organization": "",
        "postal_code": "",
        "unit_scheme": "USCUSTOMARY",
        "user_type": "Unspecified"
    },
    "profile_is_complete": true,
    "profile_was_skipped": true,
    "result": "success",
    "username": "test1"
}
```

Send the sample CSV to an existing project:

```http
❯ http --session=test --verbose --form :8000/mmw/modeling/projects/2/custom-weather-data/ weather@src/mmw/apps/modeling/templates/weather_data_sample.csv X-CSRFToken:CPaKpYJJkx4pdSEtPmiF7VWCMW6gs0NQt1oAbm45H6OhnI5TynyqSpM2yzbbiEGB

POST /mmw/modeling/projects/2/custom-weather-data/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 680
Content-Type: multipart/form-data; boundary=25f29d0b194b32fb4e2fd2dca865a839
Cookie: csrftoken=CPaKpYJJkx4pdSEtPmiF7VWCMW6gs0NQt1oAbm45H6OhnI5TynyqSpM2yzbbiEGB; sessionid=ikvfcnzdwr6gzib2ph04sorsree0fj12
Host: localhost:8000
User-Agent: HTTPie/2.0.0
X-CSRFToken: CPaKpYJJkx4pdSEtPmiF7VWCMW6gs0NQt1oAbm45H6OhnI5TynyqSpM2yzbbiEGB

--25f29d0b194b32fb4e2fd2dca865a839
Content-Disposition: form-data; name="weather"; filename="weather_data_sample.csv"
Content-Type: text/csv

DATE,PRCP,TAVG
1/1/2001,0,22
1/2/2001,0,19
1/3/2001,0,18
1/4/2001,0,21
1/5/2001,0.04,25
1/6/2001,0.01,28
1/7/2001,0,33
1/8/2001,0.05,28
1/9/2001,0,19
1/10/2001,0,28
1/11/2001,0,36
1/12/2001,0,30
1/13/2001,0,29
1/14/2001,0,29
1/15/2001,0,34
1/16/2001,0,34
1/17/2001,0,31
1/18/2001,0.01,30
1/19/2001,0.4,31
1/20/2001,0.21,27
1/21/2001,0,18
1/22/2001,0,17
1/23/2001,0,19
1/24/2001,0,32
1/25/2001,0,22
1/26/2001,0,20
1/27/2001,0,30
1/28/2001,0,23
1/29/2001,0,23
1/30/2001,0.57,38
1/31/2001,0.01,37

--25f29d0b194b32fb4e2fd2dca865a839--

HTTP/1.1 200 OK
Allow: POST, DELETE, OPTIONS, GET, PATCH
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Thu, 09 Apr 2020 22:50:48 GMT
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie

{
    "area_of_interest_name": "Lower Schuylkill River, HUC-10 Watershed (ID 0204020310)",
    "created_at": "2019-08-28T13:57:19.915671-04:00",
    "custom_weather_dataset": "/media/project_2/weather_data_sample.csv",
    "hydroshare": null,
    "id": 2,
    "is_private": false,
    "model_package": "gwlfe",
    "modified_at": "2020-04-09T18:50:48.903388-04:00",
    "name": "Custom Weather Data",
    "user": 2,
    "uses_custom_weather": true
}
```

### Notes

The tests add about 4.5s of runtime. I think that's okay.

## Testing Instructions

* Read through the code
* Ensure the tests pass