### PR TITLE
Restart celeryd with absolute path to /usr/sbin/service

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
@@ -13,5 +13,5 @@
   cron:
     name: celery-restart
     special_time: daily
-    job: service celeryd restart
+    job: /usr/sbin/service celeryd restart
     state: present


### PR DESCRIPTION
## Overview

For debugging purposes, I made the cronjob execute every minute:

```bash
ubuntu@ip-10-0-5-169:~$ sudo crontab -l
#Ansible: celery-restart
* * * * * service celeryd restart
```

The cronjob was failing and had nowhere to send output:

```bash
Apr 10 11:33:01 ip-10-0-5-169 CRON: pam_unix(cron:session): session opened for user root by (uid=0)
Apr 10 11:33:01 ip-10-0-5-169 CRON: (root) CMD (service celeryd restart)
Apr 10 11:33:01 ip-10-0-5-169 CRON: (CRON) info (No MTA installed, discarding output)
Apr 10 11:33:01 ip-10-0-5-169 CRON: pam_unix(cron:session): session closed for user root
```

After installing `postfix`, I found the root cause:

```bash
ubuntu@ip-10-0-5-169:~$ sudo apt-get install postfix
. . .
ubuntu@ip-10-0-5-169:~$ sudo tail -f /var/mail/root
Content-Transfer-Encoding: 8bit
X-Cron-Env: <SHELL=/bin/sh>
X-Cron-Env: <HOME=/root>
X-Cron-Env: <PATH=/usr/bin:/bin>
X-Cron-Env: <LOGNAME=root>
Message-Id: <20200410153601.A246D455@ip-10-0-5-169.ec2.internal>
Date: Fri, 10 Apr 2020 15:36:01 +0000 (UTC)

/bin/sh: 1: service: not found
```

This happens because `sbin` is not in the path, [by default](https://salsa.debian.org/debian/cron/-/blob/master/pathnames.h#L80), when run via cron.

This PR invokes `service` via an absolute path.

Resolves #3279 

## Testing Instructions

After applying this modification on staging, cron was able to restart Celery workers:

```bash
Apr 10 11:40:01 ip-10-0-5-169 CRON: (root) CMD (/usr/sbin/service celeryd restart)
Apr 10 11:40:01 ip-10-0-5-169 systemd: Stopping celeryd...
Apr 10 11:40:05 ip-10-0-5-169 sh: #033[1;36mcelery multi v4.1.0 (latentcall)#033[0m
Apr 10 11:40:05 ip-10-0-5-169 sh: #033[1;34m> Stopping nodes...#033[0m
Apr 10 11:40:05 ip-10-0-5-169 sh: #011> Green-worker1@ip-10-0-5-169: TERM -> 12814
Apr 10 11:40:05 ip-10-0-5-169 sh: #011> Green-worker0@ip-10-0-5-169: TERM -> 12799
Apr 10 11:40:05 ip-10-0-5-169 sh: #033[1;34m> Waiting for 2 nodes -> 12814, 12799...#033[0m...
Apr 10 11:40:05 ip-10-0-5-169 sh: #011> Green-worker1@ip-10-0-5-169: #033[1;32mOK#033[0m
Apr 10 11:40:05 ip-10-0-5-169 sh: > Green-worker1@ip-10-0-5-169: #033[1;35mDOWN#033[0m
Apr 10 11:40:05 ip-10-0-5-169 sh: #033[1;34m> Waiting for 2 nodes -> None, None...#033[0m.
Apr 10 11:40:05 ip-10-0-5-169 sh: #011> Green-worker0@ip-10-0-5-169: #033[1;32mOK#033[0m
Apr 10 11:40:05 ip-10-0-5-169 sh: > Green-worker0@ip-10-0-5-169: #033[1;35mDOWN#033[0m
Apr 10 11:40:05 ip-10-0-5-169 sh: #033[1;34m> Waiting for 1 node -> None...#033[0m
Apr 10 11:40:06 ip-10-0-5-169 systemd: Stopped celeryd.
Apr 10 11:40:06 ip-10-0-5-169 systemd: Starting celeryd...
Apr 10 11:40:08 ip-10-0-5-169 sh: #033[1;36mcelery multi v4.1.0 (latentcall)#033[0m
Apr 10 11:40:08 ip-10-0-5-169 sh: > Starting nodes...
Apr 10 11:40:08 ip-10-0-5-169 sh: #011> Green-worker0@ip-10-0-5-169: #033[1;32mOK#033[0m
Apr 10 11:40:08 ip-10-0-5-169 sh: #011> Green-worker1@ip-10-0-5-169: #033[1;32mOK#033[0m
Apr 10 11:40:08 ip-10-0-5-169 systemd: Started celeryd.
Apr 10 11:40:08 ip-10-0-5-169 CRON: pam_unix(cron:session): session closed for user root
```