### PR TITLE
Custom Weather: Add Button

### DIFF
--- a/src/mmw/js/src/core/modals/templates/customWeatherDataModal.html
+++ b/src/mmw/js/src/core/modals/templates/customWeatherDataModal.html
@@ -1,0 +1,26 @@
+<div class="modal-dialog modal-dialog-sm">
+    <div class="modal-content">
+        <form class="cwd-upload-form" action="/mmw/modeling/projects/{{ id }}/custom-weather-data/" method="POST" target="_blank">
+        <div class="modal-header">
+            <h2 class="light">Custom Weather Data</h2>
+        </div>
+        <div class="modal-body">
+            <p>Select a file to upload.</p>
+            <!-- TODO Add link to sample weather data -->
+            <!-- https://github.com/WikiWatershed/model-my-watershed/issues/3287 -->
+            <div class="custom-input-group">
+                <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrftoken }}">
+                <label class="modal-file-input-label">Select Weather CSV</label>
+                <input class="modal-file-input" name="weather" type="file" required />
+            </div>
+            <label class="error"></label>
+        </div>
+        <div class="modal-footer" style="text-align: right;">
+            <div class="footer-content">
+                <button type="button" class="btn btn-md btn-default" data-dismiss="modal">Cancel</button>
+                <button type="submit" class="btn btn-md btn-active upload" data-dismiss="modal">Upload</button>
+            </div>
+        </div>
+        </form>
+    </div>
+</div>

--- a/src/mmw/js/src/core/modals/views.js
+++ b/src/mmw/js/src/core/modals/views.js
@@ -22,6 +22,7 @@ var _ = require('lodash'),
     modalTosTmpl = require('./templates/tosModal.html'),
     modalPrivacyTmpl = require('./templates/privacyModal.html'),
     modalCookieTmpl = require('./templates/cookieModal.html'),
+    modalCustomWeatherDataTmpl = require('./templates/customWeatherDataModal.html'),
     settings = require('../settings'),
 
     ENTER_KEYCODE = 13,
@@ -867,6 +868,40 @@ var CookieModal = Marionette.ItemView.extend({
     },
 });
 
+var CustomWeaterDataView = ModalBaseView.extend({
+    // model: modeling.ProjectModel,
+
+    template: modalCustomWeatherDataTmpl,
+
+    ui: {
+        form: 'form',
+        upload: '.upload',
+        deny: '.btn-default'
+    },
+
+    events: _.defaults({
+        'click @ui.upload': 'primaryAction',
+        'click @ui.deny': 'dismissAction'
+    }, ModalBaseView.prototype.events),
+
+    primaryAction: function() {
+        if (this.getDisabledState(this.ui.upload)) {
+            return;
+        }
+
+        // TODO Upload the file
+        // https://github.com/WikiWatershed/model-my-watershed/issues/3287
+        this.ui.form.submit();
+
+        this.triggerMethod('upload');
+        this.hide();
+    },
+
+    dismissAction: function() {
+        this.triggerMethod('deny');
+    }
+});
+
 module.exports = {
     AboutModal: AboutModal,
     TosModal: TosModal,
@@ -880,5 +915,6 @@ module.exports = {
     ConfirmLargeView: ConfirmLargeView,
     PlotView: PlotView,
     IframeView: IframeView,
+    CustomWeaterDataView: CustomWeaterDataView,
     AlertView: AlertView
 };

--- a/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
+++ b/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
@@ -13,4 +13,9 @@
         <i class="fa fa-plus-circle"></i> Add changes to this area
     </button>
     {% endif %}
+    {% if isCurrentConditions and isGwlfe %}
+    <button id="custom-weather-data" class="btn btn-sm btn-default inverted btn-scenario" type="button" aria-expanded="true">
+        <i class="fa fa-cloud-upload"></i> Custom Weather
+    </button>
+    {% endif %}
 </div>

--- a/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
+++ b/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
@@ -1,5 +1,5 @@
 {% if isOnlyCurrentConditions and isGwlfe %}
-<button id="download-cc-gms" class="btn btn-link" type="button" aria-expanded="true">
+<button id="download-cc-gms" class="btn btn-sm btn-default inverted btn-scenario" type="button" aria-expanded="true">
     <i class="fa fa-download"></i> Export GMS
 </button>
 

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -921,11 +921,13 @@ var ScenarioToolbarView = Marionette.CompositeView.extend({
         // the only scenario is current conditions (ie no modifications)
         var gisData = this.model.get('gis_data'),
             isGwlfe = this.modelPackage === utils.GWLFE && !_.isEmpty(gisData),
+            isCurrentConditions = this.currentConditions.get('active'),
             isOnlyCurrentConditions = this.collection.length === 1 &&
                 this.collection.first().get('is_current_conditions'),
             editable = isEditable(this.model);
 
         return {
+            isCurrentConditions: isCurrentConditions,
             isOnlyCurrentConditions: isOnlyCurrentConditions,
             isGwlfe: isGwlfe,
             csrftoken: csrf.getToken(),

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -863,11 +863,13 @@ var ScenarioToolbarView = Marionette.CompositeView.extend({
         addChangesButton: '#add-changes',
         downloadGmsFile: '#download-cc-gms',
         exportGmsForm: '#export-gms-form',
+        customWeatherDataButton: '#custom-weather-data',
     },
 
     events: {
         'click @ui.addChangesButton': 'onAddChangesClick',
         'click @ui.downloadGmsFile': 'onGmsDownloadClick',
+        'click @ui.customWeatherDataButton': 'onCustomWeatherDataClick',
     },
 
     collectionEvents: {
@@ -913,6 +915,18 @@ var ScenarioToolbarView = Marionette.CompositeView.extend({
 
         this.ui.exportGmsForm.find('.gms-filename').val(filename);
         this.ui.exportGmsForm.trigger('submit');
+    },
+
+    onCustomWeatherDataClick: function() {
+        if (App.user.get('guest')) {
+            App.getUserOrShowLogin();
+        } else {
+            var cwdModal = new modalViews.CustomWeaterDataView({
+                    model: this.model,
+                });
+
+            cwdModal.render();
+        }
     },
 
     templateHelpers: function() {

--- a/src/mmw/sass/base/_header.scss
+++ b/src/mmw/sass/base/_header.scss
@@ -231,6 +231,7 @@ header {
         flex-basis: 100%;
         flex-direction: row;
         height: 100%;
+        align-items: center;
 
         .right-controls-container {
             margin-left: auto;
@@ -239,11 +240,6 @@ header {
         #add-changes {
             color: $brand-primary;
             height: 100%;
-        }
-
-        #download-cc-gms {
-            font-size: 13px;
-            color: inherit;
         }
     }
 


### PR DESCRIPTION
## Overview

Adds a button to upload custom weather data for GWLF-E projects. This is available in the scenario bar for Current Conditions, but it will effect the entire project.

It includes a non-functional outline of an upload dialog for demo purposes, to be expanded in #3287.

Connects #3272 

### Demo

![2020-04-12 19 52 08](https://user-images.githubusercontent.com/1430060/79082785-3ec3b100-7cf7-11ea-80ce-0edfa449e79e.gif)

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/) and make sure you are not logged in
* Create a MapShed project
    - [x] Ensure you see the Custom Weather button
* Click the Custom Weather button
    - [x] Ensure you are prompted to log in
* Log in. Click the buton again.
    - [x] Ensure you see the basic modal
* Click "Add changes to this area"
    - [x] Ensure you don't see the Custom Weather button when New Scenario is selected
* Select Current Conditions
    - [x] Ensure you do see the Custom Weather button
* Create a TR-55 project
    - [x] Ensure you don't see the Custom Weather button