### PR TITLE
Pin llvmlite to 0.31.0 to fix builds

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -51,6 +51,7 @@ nginx_cache_dir: "/var/cache/nginx"
 
 enabled_features: ''
 
+llvmlite_version: "0.31.0"
 numba_version: "0.38.1"
 phantomjs_version: "2.1.*"
 

--- a/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/dependencies.yml
@@ -1,6 +1,9 @@
 ---
 - name: Install numba
-  pip: name=numba version={{ numba_version }}
+  pip: name="{{ item.name }}" version={{ item.version }} state=present
+  with_items:
+    - { name: "llvmlite", version: "{{ llvmlite_version }}" }
+    - { name: "numba", version: "{{ numba_version }}" }
 
 - name: Install application Python dependencies for development and test
   pip: requirements="{{ app_home }}/requirements/{{ item }}.txt"


### PR DESCRIPTION
## Overview

With the release of llvmlite [v0.32.0](https://github.com/numba/llvmlite/releases/tag/v0.32.0) 2 days ago being auto-picked up by numba, builds were breaking. By pinning llvmlite to 0.31.0, the latest working version, we protect ourselves from the breakage.

We've been using the same version of numba for a few years now, which started with llvmlite 0.23.0, so we're okay by not always using the latest version.

Connects #3292 

## Testing Instructions

Destroy and reprovision app. Ensure it builds successfully.