### PR TITLE
Custom Weather: Rewrite Button for Scenarios

### DIFF
--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -8,6 +8,7 @@ var $ = require('jquery'),
     drawUtils = require('../draw/utils'),
     settings = require('../core/settings'),
     coreUnits = require('../core/units'),
+    modalViews = require('../core/modals/views'),
     models = require('./models'),
     modificationConfigUtils = require('./modificationConfigUtils'),
     gwlfeConfig = require('./gwlfeModificationConfig'),
@@ -19,6 +20,7 @@ var $ = require('jquery'),
     thumbSelectTmpl = require('./templates/controls/thumbSelect.html'),
     settingsTmpl = require('./templates/controls/settings.html'),
     greenButtonTmpl = require('./templates/controls/greenButton.html'),
+    customWeatherTmpl = require('./templates/controls/customWeather.html'),
     modDropdownTmpl = require('./templates/controls/modDropdown.html');
 
 var ENTER_KEYCODE = 13;
@@ -438,6 +440,44 @@ var ConservationPracticeView = ModificationsView.extend({
     }
 });
 
+var GwlfeCustomWeatherView = ControlView.extend({
+    template: customWeatherTmpl,
+
+    events: {
+        'click button': 'showCustomWeatherModal',
+    },
+
+    getControlName: function() {
+        return 'gwlfe_custom_weather';
+    },
+
+    initialize: function(options) {
+        ControlView.prototype.initialize.apply(this, [options]);
+
+        this.model.set({
+            controlName: this.getControlName(),
+            controlDisplayName: 'Custom Weather',
+            dataModel: gwlfeConfig.cleanDataModel(App.currentProject.get('gis_data')),
+            errorMessages: null,
+            infoMessages: null,
+        });
+    },
+
+    showCustomWeatherModal: function() {
+        if (App.user.get('guest')) {
+            App.getUserOrShowLogin();
+        } else {
+            var currentScenario = App.currentProject.get('scenarios')
+                                     .findWhere({ active: true }),
+                cwdModal = new modalViews.CustomWeaterDataView({
+                    model: currentScenario,
+                });
+
+            cwdModal.render();
+        }
+    },
+});
+
 var GwlfeLandCoverView = ControlView.extend({
     template: greenButtonTmpl,
 
@@ -632,6 +672,8 @@ function getControlView(controlName) {
             return LandCoverView;
         case 'conservation_practice':
             return ConservationPracticeView;
+        case 'gwlfe_custom_weather':
+            return GwlfeCustomWeatherView;
         case 'gwlfe_landcover':
             return GwlfeLandCoverView;
         case 'gwlfe_conservation_practice':

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1870,6 +1870,7 @@ function getControlsForModelPackage(modelPackageName, options) {
             return new ModelPackageControlsCollection();
         } else {
             return new ModelPackageControlsCollection([
+                new ModelPackageControlModel({ name: 'gwlfe_custom_weather' }),
                 new ModelPackageControlModel({ name: 'gwlfe_landcover' }),
                 new ModelPackageControlModel({ name: 'gwlfe_conservation_practice' }),
                 new ModelPackageControlModel({ name: 'gwlfe_settings' }),

--- a/src/mmw/js/src/modeling/templates/controls/customWeather.html
+++ b/src/mmw/js/src/modeling/templates/controls/customWeather.html
@@ -1,0 +1,3 @@
+<button class="btn btn-sm btn-active" type="button">
+    <i class="fa fa-cloud-upload"></i> {{ controlDisplayName }}
+</button>

--- a/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
+++ b/src/mmw/js/src/modeling/templates/scenarioAddChangesButton.html
@@ -13,9 +13,4 @@
         <i class="fa fa-plus-circle"></i> Add changes to this area
     </button>
     {% endif %}
-    {% if isCurrentConditions and isGwlfe %}
-    <button id="custom-weather-data" class="btn btn-sm btn-default inverted btn-scenario" type="button" aria-expanded="true">
-        <i class="fa fa-cloud-upload"></i> Custom Weather
-    </button>
-    {% endif %}
 </div>

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -863,13 +863,11 @@ var ScenarioToolbarView = Marionette.CompositeView.extend({
         addChangesButton: '#add-changes',
         downloadGmsFile: '#download-cc-gms',
         exportGmsForm: '#export-gms-form',
-        customWeatherDataButton: '#custom-weather-data',
     },
 
     events: {
         'click @ui.addChangesButton': 'onAddChangesClick',
         'click @ui.downloadGmsFile': 'onGmsDownloadClick',
-        'click @ui.customWeatherDataButton': 'onCustomWeatherDataClick',
     },
 
     collectionEvents: {
@@ -917,31 +915,17 @@ var ScenarioToolbarView = Marionette.CompositeView.extend({
         this.ui.exportGmsForm.trigger('submit');
     },
 
-    onCustomWeatherDataClick: function() {
-        if (App.user.get('guest')) {
-            App.getUserOrShowLogin();
-        } else {
-            var cwdModal = new modalViews.CustomWeaterDataView({
-                    model: this.model,
-                });
-
-            cwdModal.render();
-        }
-    },
-
     templateHelpers: function() {
         // We don't need to apply modifications to gis_data here
         // because it's only downloadable from this view if
         // the only scenario is current conditions (ie no modifications)
         var gisData = this.model.get('gis_data'),
             isGwlfe = this.modelPackage === utils.GWLFE && !_.isEmpty(gisData),
-            isCurrentConditions = this.currentConditions.get('active'),
             isOnlyCurrentConditions = this.collection.length === 1 &&
                 this.collection.first().get('is_current_conditions'),
             editable = isEditable(this.model);
 
         return {
-            isCurrentConditions: isCurrentConditions,
             isOnlyCurrentConditions: isOnlyCurrentConditions,
             isGwlfe: isGwlfe,
             csrftoken: csrf.getToken(),


### PR DESCRIPTION
## Overview

Previously the button was associated with Current Conditions to affect the entire project. Now it is associated with editable scenarios to affect only that one.

Still uses the dummy modal. The actual modal is to be implemented in #3287.

Connects #3298 

### Demo

![2020-04-30 23 44 54](https://user-images.githubusercontent.com/1430060/80780482-16ccae00-8b3d-11ea-8916-db18c97a428d.gif)

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000](http://localhost:8000/) and log in
* Create a MapShed project
    - [x] Ensure there's no Custom Weather button in Current Conditions
* Add a scenario
    - [x] Ensure you see the Custom Weather button