### PR TITLE
Switch to ESRI World Topography as Default Basemap

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -55,36 +55,14 @@ NHD_REGION2_PERIMETER = json.load(nhd_region2_simple_perimeter_file)
 LAYER_GROUPS = {
     'basemap': [
         {
-            'display': 'Streets',
-            'url': 'https://{s}.tiles.mapbox.com/v4/stroudcenter.1f06e119'
-                    '/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoic3Ryb3VkY2VudGVyIiwiYSI6ImNpd2NhMmZiMDA1enUyb2xrdjlhYzV6N24ifQ.3dFii4MfQFOqYEDg9kVguA',  # NOQA
-            'attribution': '<a href="https://www.mapbox.com/about/maps/">&copy; Mapbox | </a>'
-                           '<a href="http://www.openstreetmap.org/copyright">&copy; OpenStreetMap | </a>'
-                           '<a href="https://www.mapbox.com/map-feedback/" target="_blank"><strong>Improve this map</strong>',
-            'maxZoom': 18,
-            'default': True,
-            'big_cz': True,
-        },
-        {
-            'display': 'ESRI World Topo',
+            'display': 'Topography',
             'url': 'https://server.arcgisonline.com/arcgis/rest/services/'
                    'World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
-            'attribution': 'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ,'
-                           ' TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN,'
-                           ' GeoBase, Kadaster NL, Ordnance Survey,'
-                           ' Esri Japan, METI, Esri China (Hong Kong),'
-                           ' and the GIS User Community',
+            'attribution': 'Map data from <a href="http://www.arcgis.com/home/'
+                           'item.html?id=30e5fe3149c34df1ba922e6f5bbf808f" '
+                           'target="_blank">ESRI</a>',
+            'default': True,
             'maxZoom': 19,
-            'big_cz': True,
-        },
-        {
-            'display': 'National Geographic',
-            'url': 'https://server.arcgisonline.com/arcgis/rest/services/'
-                   'NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}',
-            'attribution': 'Tiles &copy; Esri &mdash; National Geographic,'
-                           ' Garmin, HERE, UNEP-WCMC, USGS, NASA, ESA, METI,'
-                           ' NRCAN, GEBCO, NOAA, increment P Corp.',
-            'maxZoom': 17,
             'big_cz': True,
         },
         {
@@ -92,8 +70,8 @@ LAYER_GROUPS = {
             'url': 'https://server.arcgisonline.com/arcgis/rest/services/'
                    'World_Imagery/MapServer/tile/{z}/{y}/{x}',
             'attribution': 'Map data from <a href="http://www.arcgis.com/home/'
-                           'item.html?id=10df2279f9684e4a9f6a7f08febac2a9">ESRI'
-                           '</a>',
+                           'item.html?id=10df2279f9684e4a9f6a7f08febac2a9" '
+                           'target="_blank">ESRI</a>',
             'maxZoom': 19,
             'big_cz': True,
         },

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -66,6 +66,28 @@ LAYER_GROUPS = {
             'big_cz': True,
         },
         {
+            'display': 'ESRI World Topo',
+            'url': 'https://server.arcgisonline.com/arcgis/rest/services/'
+                   'World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
+            'attribution': 'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ,'
+                           ' TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN,'
+                           ' GeoBase, Kadaster NL, Ordnance Survey,'
+                           ' Esri Japan, METI, Esri China (Hong Kong),'
+                           ' and the GIS User Community',
+            'maxZoom': 19,
+            'big_cz': True,
+        },
+        {
+            'display': 'National Geographic',
+            'url': 'https://server.arcgisonline.com/arcgis/rest/services/'
+                   'NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}',
+            'attribution': 'Tiles &copy; Esri &mdash; National Geographic,'
+                           ' Garmin, HERE, UNEP-WCMC, USGS, NASA, ESA, METI,'
+                           ' NRCAN, GEBCO, NOAA, increment P Corp.',
+            'maxZoom': 17,
+            'big_cz': True,
+        },
+        {
             'display': 'Satellite',
             'url': 'https://server.arcgisonline.com/arcgis/rest/services/'
                    'World_Imagery/MapServer/tile/{z}/{y}/{x}',


### PR DESCRIPTION
## Overview

Since Mapbox is shutting down the classic tiles, and the new APIs are prohibitively expensive, we have to switch to a different default basemap provider. ESRI's World Topography Map is sophisticated, well maintained, and a worthy replacement.

Connects #3256 

### Demo

![image](https://user-images.githubusercontent.com/1430060/81183454-302a8b80-8f7d-11ea-8478-f47a3c383d0b.png)

## Testing Instructions

* Check out this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/)
    - [ ] Ensure you see the new basemap