### PR TITLE
HydroShare Export: Fix GMS file export

### DIFF
--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -766,7 +766,7 @@ var ProjectModel = Backbone.Model.extend({
             isTR55 = self.get('model_package') === utils.TR55_PACKAGE,
             modelFiles = isTR55 ? getTR55ModelFiles() : getMapShedModelFiles(),
             getMapshedData = function(scenario) {
-                    var gisData = scenario.getGisData(),
+                    var gisData = scenario.getModifiedGwlfeGisData(),
                         scenarioName = lowerAndHyphenate(scenario.get('name'));
 
                     if (!gisData) {
@@ -775,7 +775,7 @@ var ProjectModel = Backbone.Model.extend({
 
                     return {
                         name: 'model_multiyear_' + scenarioName + '.gms',
-                        uuid: gisData.mapshed_job_uuid
+                        data: gisData,
                     };
                 },
             mapshedData = isTR55 ? [] : _.compact(scenarios.map(getMapshedData)),


### PR DESCRIPTION
## Overview

What 4c96a444 should have been.

Fixes GMS file exports so that each scenario's true GMS is exported to HydroShare. The `getModifiedGwlfeGisData` method was not available when the original commit was made, which does not excuse the mistake, but makes this fix much more straightforward.

Connects #3315

## Testing Instructions

#### Setup HydroShare

* Populate `/etc/mmw.d/env/MMW_HYDROSHARE_SECRET_KEY` in your `app` and `worker` VMs from the "HydroShare OAuth MMW Beta" `client-secret` from LastPass
    - `vagrant ssh app -c 'sudo vim /etc/mmw.d/env/MMW_HYDROSHARE_SECRET_KEY'`
    - `vagrant ssh worker -c 'sudo vim /etc/mmw.d/env/MMW_HYDROSHARE_SECRET_KEY'`
* Restart the relevant services
    - `vagrant ssh app -c 'sudo service mmw-app restart'`
    - `vagrant ssh worker -c 'sudo service celeryd restart'`
* Go to [:8000/](http://localhost:8000/) and log in
* Go to your account and then Linked Accounts, unlink (if applicable) then relink to HydroShare, using the credentials in the same LastPass entry

#### Test the Export

* Create a MapShed project
* Add a new scenario and add some modifications (custom weather / land use changes / conservation practices / settings)
* Export the Current Conditions and New Scenario GMS files
    - [x] Ensure they are not identical
* Share the project to HydroShare. This can take some time, be patient.
* Once shared, go to the resource in HydroShare and download the GMS files
    - [x] Ensure they are identical to the MMW downloads