### PR TITLE
Fix failures in making external storage accessible to RWD

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -32,7 +32,7 @@ srat_catchment_api_key: "{{ lookup('env', 'MMW_SRAT_CATCHMENT_API_KEY') }}"
 
 tilecache_bucket_name: "{{ lookup('env', 'MMW_TILECACHE_BUCKET') | default('', true) }}"
 
-docker_options: "-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock --storage-driver=aufs"
+docker_options: "-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock"
 
 aws_profile: "mmw-stg"
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -29,4 +29,4 @@
 - src: azavea.java
   version: 0.6.2
 - src: azavea.docker
-  version: 4.0.0
+  version: 6.0.0


### PR DESCRIPTION
## Overview

This Ansible module upgrade addresses an issue with the prior version of `azavea.docker` that led to a version mismatch between the Docker daemon and Docker CLI being installed.

In addition, this change set removes an override to explicitly use the AUFS storage driver in development. Instead, we let the Docker installer chose the best default for the host operating system.

Fixes https://github.com/WikiWatershed/model-my-watershed/issues/3322

### Notes

During the last release, it was determined that the RWD service was not operating as expected after first boot. A closer inspection revealed that the additional storage volumes needed for the RWD service to do its thing were not accessible within the RWD container.

When the `Worker` starts up, it attempts to restart the RWD service _after_ it successfully mounts the additional RWD specific storage volumes:

https://github.com/WikiWatershed/model-my-watershed/blob/11ace7ea94023fad1cd91cb314daec828ac8a162/deployment/cfn/worker.py#L487

Unfortunately, that was not occuring because of a mismatch between the Docker daemon and Docker CLI. Manual attempts to issue `docker restart` commands from the CLI led to visible failures, which helped surface the protocol version mismatch.

See: https://github.com/azavea/ansible-docker/pull/18

## Testing Instructions

- This branch is currently deployed to staging. Interact with the RWD service to ensure that it is working correctly.
- SSH into one of the `Worker` virtual machines and ensure that the version of Docker is consistent across daemon and CLI:

```console
ubuntu@ip-10-0-3-215:~$ dockerd --version
Docker version 18.09.9, build 039a7df
ubuntu@ip-10-0-3-215:~$ docker --version
Docker version 18.09.9, build 039a7df9ba
```