### PR TITLE
Add Recent Weather

### DIFF
--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -169,6 +169,10 @@ def get_weather_simulation_for_project(project, category):
             data.append(ws_data)
             errs += ws_errs
 
+    # Respond with errors, if any
+    if errs:
+        return {}, errs
+
     # Check that the datasets have the same characteristics
     for c in ['WxYrBeg', 'WxYrEnd', 'WxYrs']:
         s = set([d[c] for d in data])

--- a/src/mmw/apps/modeling/models.py
+++ b/src/mmw/apps/modeling/models.py
@@ -101,6 +101,7 @@ class WeatherType:
 
     # Valid Simulations currently supported in the app
     simulations = [
+        'NASA_NLDAS_2000_2019',
         'RCP45_2080_2099',
         'RCP85_2080_2099',
     ]

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -132,9 +132,10 @@ def project_weather(request, proj_id, category):
     """
     Get weather data for project given a category, if available.
 
-    Current categories are RCP45_2080_2099 and RCP85_2080_2099, and only
-    support shapes within the DRB. Given a project within the DRB, we find the
-    N=2 nearest weather stations and average their values.
+    Current categories are NASA_NLDAS_2000_2019, RCP45_2080_2099 and
+    RCP85_2080_2099, and only support shapes within the DRB. Given a project
+    within the DRB, we find the N=2 nearest weather stations and
+    average their values.
     """
     project = get_object_or_404(Project, id=proj_id, user=request.user)
 

--- a/src/mmw/js/src/modeling/constants.js
+++ b/src/mmw/js/src/modeling/constants.js
@@ -26,8 +26,30 @@ module.exports = {
         CUSTOM: 'CUSTOM',
     },
     // In sync with apps.modeling.models.WeatherType.simulations
-    Simulations: {
-        RCP45_2080_2099: 'RCP 4.5 2080-2099',
-        RCP85_2080_2099: 'RCP 8.5 2080-2099',
-    }
+    Simulations: [
+        {
+            group: 'Recent Weather',
+            items: [
+                {
+                    name: 'NASA_NLDAS_2000_2019',
+                    label: 'NASA NLDAS 2000-2019',
+                },
+            ],
+            in_drb: true,
+        },
+        {
+            group: 'Future Weather Simulations',
+            items: [
+                {
+                    name: 'RCP45_2080_2099',
+                    label: 'RCP 4.5 2080-2099',
+                },
+                {
+                    name: 'RCP85_2080_2099',
+                    label: 'RCP 8.5 2080-2099',
+                },
+            ],
+            in_drb: true,
+        },
+    ],
 };

--- a/src/mmw/js/src/modeling/gwlfe/weather/templates/modal.html
+++ b/src/mmw/js/src/modeling/gwlfe/weather/templates/modal.html
@@ -31,11 +31,13 @@
                     <optgroup label="Default">
                         <option value="DEFAULT" {{ 'selected' if available_data == 'DEFAULT' }}>USEPA National Climate 1960&ndash;1990</option>
                     </optgroup>
-                    <optgroup label="Future Weather Simulations {{ '(DRB Only)' if not in_drb }}">
-                        {%  for key, label in Simulations %}
-                            <option value="{{ key }}" {{ 'selected' if available_data == key }} {{ 'disabled' if not in_drb }}>{{ label }}</option>
-                        {% endfor %}
-                    </optgroup>
+                    {% for s in Simulations %}
+                        <optgroup label="{{ s.group }} {{ '(DRB Only)' if s.in_drb and not in_drb }}">
+                            {% for i in s.items %}
+                                <option value="{{ i.name }}" {{ 'selected' if available_data == i.name }} {{ 'disabled' if s.in_drb and not in_drb }}>{{ i.label }}</option>
+                            {% endfor %}
+                        </optgroup>
+                    {% endfor %}
                 </select>
 
             </div>


### PR DESCRIPTION
## Overview

Adds 2000-2019 weather data to the front-end. The data was added to the weather.modelmywatershed.org bucket in mmw-prd as public files.

~~The current set of files we were given has some formatting errors. We've requested fresh ones. Marking this PR as draft until that is finalized.~~

Updated files received, they were edited to have LF endings instead of CRLF. This PR is now ready for review.

Connects #3341 

### Demo

![image](https://user-images.githubusercontent.com/1430060/87189988-aa4df800-c2bf-11ea-9d4e-e955d4a52fdd.png)

![image](https://user-images.githubusercontent.com/1430060/87471494-7428b500-c5ec-11ea-8895-d3b4d32b6e11.png)

## Testing Instructions

* Before checking out this branch, ensure you have an existing project within the DRB with one of the RCP weather data options applied
* Check out this branch and `bundle`
* Go to the same project and edit the Weather Data
  - [ ] Ensure your previous option is still selected
  - [ ] Ensure a new Recent Data option group exists
  - [ ] Ensure selecting it updates the weather correctly
* Create a project outside the DRB
* Open the Weather Data dialog
  - [ ] Ensure all Recent Weather and Future Weather Simulations options are grayed out