### PR TITLE
Shippensburg Land Projections: Add to Land Cover Modification Dialog

### DIFF
--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -562,6 +562,8 @@ def landuse_pcts(n_count):
     Given a dictionary mapping NLCD Codes to counts of cells, returns an
     array mapping MapShed Land Use Types (as the index) to percent
     area covered.
+
+    In sync with js/src/modeling/utils.js:nlcdToMapshedLandCover
     """
 
     total = sum(n_count.values())

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -504,9 +504,9 @@ var GwlfeLandCoverView = ControlView.extend({
 
         entryViews.showLandCoverModal(
             this.model.get('dataModel'),
-            currentScenario.get('modifications'),
-            this.addModification,
-            App.currentProject.get('in_drb')
+            currentScenario,
+            App.currentProject.get('in_drb'),
+            App.getAnalyzeCollection()
         );
     },
 });

--- a/src/mmw/js/src/modeling/controls.js
+++ b/src/mmw/js/src/modeling/controls.js
@@ -505,7 +505,8 @@ var GwlfeLandCoverView = ControlView.extend({
         entryViews.showLandCoverModal(
             this.model.get('dataModel'),
             currentScenario.get('modifications'),
-            this.addModification
+            this.addModification,
+            App.currentProject.get('in_drb')
         );
     },
 });

--- a/src/mmw/js/src/modeling/gwlfe/entry/models.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/models.js
@@ -108,6 +108,7 @@ var LandCoverWindowModel = WindowModel.extend({
         autoTotal: 0,
         userTotal: 0,
         fields: null, // FieldCollection
+        in_drb: false,
     }, WindowModel.prototype.defaults),
 
     initialize: function(attrs) {

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/landCoverModal.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/landCoverModal.html
@@ -27,8 +27,8 @@
                                 <option value="">NLCD 2011</option>
                             </optgroup>
                             <optgroup label="Future Simulations{{ ' (DRB Only)' if not in_drb }}">
-                                <option value="drb_2100_land_centers" {{ 'disabled' if not in_drb }}>DRB 2100 land forecast (Centers)</option>
-                                <option value="drb_2100_land_corridors" {{ 'disabled' if not in_drb }}>DRB 2100 land forecast (Corridors)</option>
+                                <option value="drb_2100_land_centers" {{ 'selected' if preset == 'drb_2100_land_centers' }} {{ 'disabled' if not in_drb }}>DRB 2100 land forecast (Centers)</option>
+                                <option value="drb_2100_land_corridors" {{ 'selected' if preset == 'drb_2100_land_corridors' }} {{ 'disabled' if not in_drb }}>DRB 2100 land forecast (Corridors)</option>
                             </optgroup>
                         </select>
                     </div>

--- a/src/mmw/js/src/modeling/gwlfe/entry/templates/landCoverModal.html
+++ b/src/mmw/js/src/modeling/gwlfe/entry/templates/landCoverModal.html
@@ -14,7 +14,28 @@
             </div>
         </div>
         <div class="modal-body">
-            <div class="rows"></div>
+            <div class="rows">
+                <div class="row mapshed-manual-entry">
+                    <div class="col-sm-4">
+                        <div class="mapshed-manual-entry-label">
+                            Landcover Preset
+                        </div>
+                    </div>
+                    <div class="col-sm-8">
+                        <select id="land-cover-preset" class="form-control">
+                            <optgroup label="Default">
+                                <option value="">NLCD 2011</option>
+                            </optgroup>
+                            <optgroup label="Future Simulations{{ ' (DRB Only)' if not in_drb }}">
+                                <option value="drb_2100_land_centers" {{ 'disabled' if not in_drb }}>DRB 2100 land forecast (Centers)</option>
+                                <option value="drb_2100_land_corridors" {{ 'disabled' if not in_drb }}>DRB 2100 land forecast (Corridors)</option>
+                            </optgroup>
+                        </select>
+                    </div>
+                </div>
+                <hr />
+                <div id="fields-region"></div>
+            </div>
         </div>
         <div class="modal-footer">
             <div class="footer-content">

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -2,12 +2,14 @@
 
 var _ = require('lodash'),
     Marionette = require('../../../../shim/backbone.marionette'),
+    App = require('../../../app'),
     modalViews = require('../../../core/modals/views'),
     settings = require('../../../core/settings'),
     coreUnits = require('../../../core/units'),
     round = require('../../../core/utils').round,
     CropTillageEfficiencyValues = require('../../gwlfeModificationConfig').CropTillageEfficiencyValues,
     GWLFE_LAND_COVERS = require('../../constants').GWLFE_LAND_COVERS,
+    modelingUtils = require('../../utils'),
     models = require('./models'),
     calcs = require('./calcs'),
     fieldTmpl = require('./templates/field.html'),
@@ -29,10 +31,12 @@ var LandCoverModal = modalViews.ModalBaseView.extend({
 
     ui: {
         saveButton: '.btn-active',
+        landCoverPreset: '#land-cover-preset',
     },
 
     events: _.defaults({
         'click @ui.saveButton': 'saveAndClose',
+        'change @ui.landCoverPreset': 'onPresetChange',
     }, modalViews.ModalBaseView.prototype.events),
 
     regions: {
@@ -87,6 +91,63 @@ var LandCoverModal = modalViews.ModalBaseView.extend({
             userTotal = round(get(this.model.get('userTotal')), 1);
 
         this.ui.saveButton.prop('disabled', autoTotal !== userTotal);
+    },
+
+    onPresetChange: function(e) {
+        var self = this;
+
+        if (e.target.value) {
+            // One of the non-default presets has been selected. Fetch the
+            // NLCD-style landcover distribution from the relevant Analyze
+            // results, convert them to Mapshed-style, and populate all the
+            // field boxes. Then recalculate the total to ensure it still
+            // fits.
+            var task = App.getAnalyzeCollection()
+                          .findWhere({ name: 'land' })
+                          .get('tasks')
+                          .findWhere({ name: e.target.value });
+
+            if (!task) {
+                throw new Error('Could not find analysis results for ' + e.target.value);
+            }
+
+            task.fetchAnalysisIfNeeded()
+                .then(function() {
+                    var categories = task.get('result').survey.categories;
+
+                    if (!categories) {
+                        throw new Error('Invalid analysis results for ' + e.target.value);
+                    }
+
+                    var m2ToHa = function(m2) { return m2 / coreUnits.METRIC.AREA_L.factor; },
+                        // Convert list of NLCD results to dictionary mapping
+                        // NLCD to Hectares
+                        nlcd = categories.reduce(function(acc, category) {
+                                acc[category.nlcd] = category.area;
+                                return acc;
+                            }, {}),
+                        landcover = modelingUtils.nlcdToMapshedLandCover(nlcd).map(m2ToHa);
+
+                    self.model.get('fields').forEach(function(field) {
+                        var index = parseInt(field.get('name').split('__')[1]);
+
+                        field.set('userValue', landcover[index]);
+                    });
+                    self.fieldsRegion.currentView.render();
+
+                    self.model.set('userTotal', _.sum(landcover));
+                    self.validateModal();
+                });
+        } else {
+            // Default NLCD 2011. Reset all fields.
+            self.model.get('fields').forEach(function(field) {
+                field.set('userValue', null);
+            });
+            self.fieldsRegion.currentView.render();
+
+            self.model.set('userTotal', _.sum(self.model.get('dataModel')['Area']));
+            self.validateModal();
+        }
     },
 
     saveAndClose: function() {

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -2,7 +2,6 @@
 
 var _ = require('lodash'),
     Marionette = require('../../../../shim/backbone.marionette'),
-    App = require('../../../app'),
     modalViews = require('../../../core/modals/views'),
     settings = require('../../../core/settings'),
     coreUnits = require('../../../core/units'),
@@ -45,7 +44,7 @@ var LandCoverModal = modalViews.ModalBaseView.extend({
     },
 
     initialize: function(options) {
-        this.mergeOptions(options, ['addModification']);
+        this.mergeOptions(options, ['scenario', 'analyzeCollection']);
 
         var onFieldUpdated = _.bind(this.onFieldUpdated, this),
             fields = this.model.get('fields');
@@ -102,10 +101,10 @@ var LandCoverModal = modalViews.ModalBaseView.extend({
             // results, convert them to Mapshed-style, and populate all the
             // field boxes. Then recalculate the total to ensure it still
             // fits.
-            var task = App.getAnalyzeCollection()
-                          .findWhere({ name: 'land' })
-                          .get('tasks')
-                          .findWhere({ name: e.target.value });
+            var task = self.analyzeCollection
+                           .findWhere({ name: 'land' })
+                           .get('tasks')
+                           .findWhere({ name: e.target.value });
 
             if (!task) {
                 throw new Error('Could not find analysis results for ' + e.target.value);
@@ -151,7 +150,7 @@ var LandCoverModal = modalViews.ModalBaseView.extend({
     },
 
     saveAndClose: function() {
-        this.addModification(this.model.getOutput());
+        this.scenario.addModification(this.model.getOutput());
 
         this.hide();
     }
@@ -1058,7 +1057,7 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
     }).render();
 }
 
-function showLandCoverModal(dataModel, modifications, addModification, in_drb) {
+function showLandCoverModal(dataModel, scenario, in_drb, analyzeCollection) {
     var scheme = settings.get('unit_scheme'),
         areaLUnits = coreUnits[scheme].AREA_L_FROM_HA.name,
         landCovers = _(GWLFE_LAND_COVERS).sortBy('id').map(function(lc) {
@@ -1071,6 +1070,7 @@ function showLandCoverModal(dataModel, modifications, addModification, in_drb) {
                 minValue: 0,
             };
         }).value(),
+        modifications = scenario.get('modifications'),
         fields = models.makeFieldCollection('landcover', dataModel, modifications, landCovers),
         windowModel = new models.LandCoverWindowModel({
             dataModel: dataModel,
@@ -1081,7 +1081,8 @@ function showLandCoverModal(dataModel, modifications, addModification, in_drb) {
 
     new LandCoverModal({
         model: windowModel,
-        addModification: addModification,
+        scenario: scenario,
+        analyzeCollection: analyzeCollection,
     }).render();
 }
 

--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -36,7 +36,7 @@ var LandCoverModal = modalViews.ModalBaseView.extend({
     }, modalViews.ModalBaseView.prototype.events),
 
     regions: {
-        fieldsRegion: '.rows',
+        fieldsRegion: '#fields-region',
         totalRegion: '.total-content',
     },
 
@@ -997,7 +997,7 @@ function showSettingsModal(title, dataModel, modifications, addModification) {
     }).render();
 }
 
-function showLandCoverModal(dataModel, modifications, addModification) {
+function showLandCoverModal(dataModel, modifications, addModification, in_drb) {
     var scheme = settings.get('unit_scheme'),
         areaLUnits = coreUnits[scheme].AREA_L_FROM_HA.name,
         landCovers = _(GWLFE_LAND_COVERS).sortBy('id').map(function(lc) {
@@ -1015,6 +1015,7 @@ function showLandCoverModal(dataModel, modifications, addModification) {
             dataModel: dataModel,
             title: 'Land Cover',
             fields: fields,
+            in_drb: in_drb,
         });
 
     new LandCoverModal({

--- a/src/mmw/js/src/modeling/utils.js
+++ b/src/mmw/js/src/modeling/utils.js
@@ -24,4 +24,34 @@ module.exports = {
         return filenameWithQuerystring.substring(
             0, filenameWithQuerystring.indexOf(ext) + ext.length);
     },
+
+    /**
+     * Takes an object mapping NLCD keys to values, and returns
+     * a Mapshed equivalent array of values.
+     *
+     * In sync with app.modeling.mapshed.calcs.landuse_pcts
+     */
+    nlcdToMapshedLandCover: function(input) {
+        var nlcd = function(v) { return _.get(input, v, 0); };
+
+        return [
+            nlcd(81),  // Hay/Pasture
+            nlcd(82),  // Cropland
+            nlcd(41) + nlcd(42) +
+            nlcd(43) + nlcd(52),  // Forest
+            nlcd(90) + nlcd(95),  // Wetland
+            0,  // Disturbed
+            0,  // Turf Grass
+            nlcd(71),  // Open Land
+            nlcd(12) + nlcd(31),  // Bare Rock
+            0,  // Sandy Areas
+            0,  // Unpaved Road
+            nlcd(22),  // Low Density Mixed
+            nlcd(23),  // Medium Density Mixed
+            nlcd(24),  // High Density Mixed
+            nlcd(21),  // Low Density Residential
+            0,  // Medium Density Residential
+            0,  // High Density Residential
+        ];
+    },
 };

--- a/src/mmw/sass/components/_modals.scss
+++ b/src/mmw/sass/components/_modals.scss
@@ -582,6 +582,10 @@
     }
   }
 
+  select.form-control {
+    color: $ui-primary;
+  }
+
   .btn-undo {
     display: none;
     position: absolute;


### PR DESCRIPTION
## Overview

Adds a dropdown to the Land Cover Modification Dialog to auto-populate the fields with values from the selected Land Cover analysis results. This takes advantage of the current implementation, with minor edits to populate the values and remember which preset was used.

The connecting issue mentions two implementation details that are deferred for later:

* Using the preset values to populate the gray "auto values" rather than the black "user values"
  - This layered modification will likely require something akin to the [ring approach](https://github.com/WikiWatershed/model-my-watershed/issues/3333#issuecomment-656975031), which was too complex to implement here
* Having these values affect other modifications, such as conservation practices
  - These are known drawbacks of the current implementation (see #3158 and #3159), and would be too complex to implement here

Connects #3333 

### Demo

![2020-07-16 15 33 45](https://user-images.githubusercontent.com/1430060/87714839-63a64500-c77a-11ea-9e87-5fcd7e6243a8.gif)

### Notes

Instead of adding another endpoint to fetch the values from the Drexel API again, I chose to reuse the values already fetched during analysis. This creates a new dependency on Analyze results, saves a lot of code.

The area total for the DRB numbers does not match exactly (because the NLCD numbers come from our own geoprocessing service and the DRB numbers from from Drexel's fast zonal API). I could not come up with a way to resolve this discrepancy, and is left to the user to manage.

Once you save Land Cover modifications, wait for the results to save, and refresh the page, it calculates the results again. This is existing behavior, logged in #3343.

The code for getting the appropriately modified GMS for a scenario is currently spread across many functions, and needs to be unified. I'll make a follow up `enhancement` card for that.

## Testing Instructions

* Check out this PR and `bundle`
* Go to [:8000/](http://localhost:8000/) and select a shape within the DRB
* Create a Mapshed project with it. Add changes to the area.
* Open the Land Cover Modification dialog
  - [x] Ensure you see a preset dropdown at the top
* Select a preset
  - [x] Ensure values are appropriately filled out for the preset, and that the total is updated
* Ensure the total matches, then click "Save"
  - [x] Ensure the scenario results are recalculated with the new updates
* Open the Land Cover Modification dialog again
  - [x] Ensure the land cover edits are persisted
  - [x] Ensure the preset selects the right dropdown
* Select the default preset
  - [x] Ensure all fields are emptied
* Save and open the Land Cover Modification dialog again
  - [x] Ensure the scenario results are recalculated with the new updates
  - [x] Ensure the land cover edits are persisted
  - [x] Ensure the preset selects the right dropdown