### PR TITLE
Fix Compare View Crash

### DIFF
--- a/src/mmw/js/src/compare/templates/compareModificationsPopover.html
+++ b/src/mmw/js/src/compare/templates/compareModificationsPopover.html
@@ -20,7 +20,7 @@
 
 {% macro gwlfeModificationsTable(caption, mods) %}
 <table class="compare-modifications-table -gwlfe">
-{% if modifications.length > 0 %}
+{% if mods.length > 0 %}
     <h5>{{ caption }}</h5>
 {% endif %}
     <tbody>
@@ -30,7 +30,7 @@
                 {{ mod.name | replace("_", " ") | title }}
             </td>
             <td class="modification-area -gwlfe">
-                +{{ mod.value }} {{ mod.input }}
+                {{ mod.value }} {{ mod.input }}
             </td>
         </tr>
     {% endfor %}
@@ -43,5 +43,7 @@
 {{ modificationsTable('Land Cover', landCovers) }}
 {{ modificationsTable('Conservation Practices', conservationPractices) }}
 {% else %}
-{{ gwlfeModificationsTable('Conservation Practices', gwlfeModifications) }}
+{{ gwlfeModificationsTable('Land Cover', gwlfeLandCovers) }}
+{{ gwlfeModificationsTable('Conservation Practices', gwlfeConservationPractices) }}
+{{ gwlfeModificationsTable('Settings', gwlfeSettings) }}
 {% endif %}

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -536,6 +536,7 @@ var CompareModificationsPopoverView = Marionette.ItemView.extend({
                         }
 
                         return {
+                            modKey: modKey,
                             name: name,
                             value: value,
                             input: input,
@@ -546,7 +547,15 @@ var CompareModificationsPopoverView = Marionette.ItemView.extend({
 
         return {
             isTr55: isTr55,
-            gwlfeModifications: gwlfeModifications,
+            gwlfeLandCovers: gwlfeModifications.filter(function(m) {
+                return m.modKey.startsWith('entry_landcover');
+            }),
+            gwlfeConservationPractices: gwlfeModifications.filter(function(m) {
+                return !m.modKey.startsWith('entry_');
+            }),
+            gwlfeSettings: gwlfeModifications.filter(function(m) {
+                return m.modKey.startsWith('entry_') && !m.modKey.startsWith('entry_landcover');
+            }).map(function(m) { m.name = m.name.substring(6); return m; }),
             conservationPractices: this.model.filter(function(modification) {
                 return modification.get('name') === 'conservation_practice';
             }),

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -518,6 +518,19 @@ var CompareModificationsPopoverView = Marionette.ItemView.extend({
                         if (modKey === 'entry_landcover') {
                             name = _.find(GWLFE_LAND_COVERS, { id: parseInt(key.substring(6)) }).label;
                             input = coreUnits[scheme].AREA_L_FROM_HA.name;
+                        } else if (modKey === 'entry_landcover_preset') {
+                            var task = App.getAnalyzeCollection()
+                                          .findWhere({ name: 'land' })
+                                          .get('tasks')
+                                          .findWhere({ name: value });
+
+                            if (!task) {
+                                console.error('Unknown entry_landcover_preset: ' + value);
+                            }
+
+                            name = 'Land Cover Preset';
+                            value = null;
+                            input = task && task.get('displayName');
                         } else {
                             input = input.replace('AREAUNITNAME', areaUnit);
                         }

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -517,6 +517,7 @@ var CompareModificationsPopoverView = Marionette.ItemView.extend({
 
                         if (modKey === 'entry_landcover') {
                             name = _.find(GWLFE_LAND_COVERS, { id: parseInt(key.substring(6)) }).label;
+                            value = value.toFixed(1);
                             input = coreUnits[scheme].AREA_L_FROM_HA.name;
                         } else if (modKey === 'entry_landcover_preset') {
                             var task = App.getAnalyzeCollection()

--- a/src/mmw/js/src/compare/views.js
+++ b/src/mmw/js/src/compare/views.js
@@ -513,7 +513,7 @@ var CompareModificationsPopoverView = Marionette.ItemView.extend({
                             areaUnit = unit && coreUnits[scheme][unit].name,
                             modKey = m.get('modKey'),
                             name = modKey,
-                            input = gwlfeConfig.displayNames[key];
+                            input = gwlfeConfig.displayNames[key] || key;
 
                         if (modKey === 'entry_landcover') {
                             name = _.find(GWLFE_LAND_COVERS, { id: parseInt(key.substring(6)) }).label;

--- a/src/mmw/sass/pages/_compare.scss
+++ b/src/mmw/sass/pages/_compare.scss
@@ -538,6 +538,11 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
     display: flex;
     flex-flow: row nowrap;
     transition: margin 0.3s ease-in-out;
+
+    .popover-content h5 {
+      margin-top: 2rem;
+      margin-bottom: 0;
+    }
   }
 
   .compare-scenario-samplechartplaceholder {


### PR DESCRIPTION
## Overview

Fixes Compare View crashes when a scenario has modifications that don't have display names. The previous implementation only considered the Conservation Practices in the Compare View, but since now we also have a number of Manual Entry modifications, they need to be handled explicitly.

If a display name is not found for a modification, we fallback to its key instead. This prevents crashes in the present. Names for those modifications will be added in the future #3350. Also, weather data is currently not represented in this popup, this will be handled in #3351.

Connects #3349 

### Demo

![image](https://user-images.githubusercontent.com/1430060/87830021-2dd29080-c84e-11ea-8df0-8cc07c0fdd27.png)

## Testing Instructions

* Check out this branch and `bundle`
* Create a Mapshed project
* To a new scenario, add conservation practices, land cover modifications, and some changes to the "Settings" menu
* Open the compare view
  - [x] Ensure it does not crash
  - [x] Ensure all modifications listed herein are shown correctly