### PR TITLE
Shippensburg Land Projections: Proportion land cover distribution to match

### DIFF
--- a/src/mmw/js/src/modeling/gwlfe/entry/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/entry/views.js
@@ -135,7 +135,14 @@ var LandCoverModal = modalViews.ModalBaseView.extend({
                                 acc[category.nlcd] = category.area;
                                 return acc;
                             }, {}),
-                        landcover = modelingUtils.nlcdToMapshedLandCover(nlcd).map(m2ToHa);
+                        landcoverRaw = modelingUtils.nlcdToMapshedLandCover(nlcd).map(m2ToHa),
+                        // Proportion land cover with base NLCD 2011 total
+                        // so that the user doesn't have to manually update it
+                        autoTotal = self.model.get('autoTotal'),
+                        presetTotal = _.sum(landcoverRaw),
+                        landcover = landcoverRaw.map(function(l) {
+                            return l * autoTotal / presetTotal;
+                        });
 
                     self.model.get('fields').forEach(function(field) {
                         var index = parseInt(field.get('name').split('__')[1]);


### PR DESCRIPTION
## Overview

The raw land cover numbers from the Drexel API don't match our internal NLCD 2011 numbers, and were slightly off, resulting in the user having to manually reconcile in the front-end.

Since these are future projections, the individual raw numbers are not the main feature, rather the distribution as a whole. By attuning it to the existing total, we ensure that the new distribution still reflects the forecasts but adds up to the same total, resulting in a more fluid experience.

Connects #3333 

### Demo

![2020-07-20 10 15 11](https://user-images.githubusercontent.com/1430060/87948461-b598e480-ca72-11ea-84d6-39eb60b94dd6.gif)

## Testing Instructions

* Check out this PR and `bundle`
* Go to [:8000/](http://localhost:8000/) and select a shape within the DRB
* Create a Mapshed project with it. Add changes to the area.
* Open the Land Cover Modification dialog
* Select a preset
  - [ ] Ensure you don't have to manually adjust the values to get the total to match