### PR TITLE
Add, configure django-cookies-samesite

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -254,6 +254,8 @@ TEMPLATES = [
 # MIDDLEWARE CONFIGURATION
 # See: https://docs.djangoproject.com/en/1.11/topics/http/middleware/
 MIDDLEWARE = (
+    # Django Cookies Samesite Middleware must be first
+    'django_cookies_samesite.middleware.CookiesSameSite',
     # Default Django middleware.
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -298,6 +300,10 @@ THIRD_PARTY_APPS = (
 )
 
 # THIRD-PARTY CONFIGURATION
+
+# django-cookies-samesite
+SESSION_COOKIE_SAMESITE = 'None'  # Allows for cross site embedding into LARA
+SESSION_COOKIE_SECURE = True      # Only set cookies in HTTPS connections
 
 # rest_framework
 REST_FRAMEWORK = {

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -32,3 +32,4 @@ redis==2.10.6
 numpy==1.16.4
 dictdiffer==0.8.0
 BMPxlsx==0.0.4
+django-cookies-samesite==0.6.6


### PR DESCRIPTION
## Overview

Recent versions of Chrome require cookies be set with explicit Cross Site policies. Since MMW is embedded within the LARA educational system, logging in requires cookies to be tagged with "SameSite=None; Secure".

This configuration is [available out of the box in Django 2.1+](https://docs.djangoproject.com/en/2.1/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE), in order to use it in Django 1.11 we add the [`django-cookies-samesite`](https://pypi.org/project/django-cookies-samesite/) package.

This configuration can cause issues with some older browsers, a full list of which can be seen here:

https://www.chromium.org/updates/same-site/incompatible-clients

However, since our official policy is to support the two most recent versions of popular browsers, all of which implement this functionality correctly, we shouldn't have to worry about them.

Browser support data: https://caniuse.com/#feat=mdn-http_headers_set-cookie_samesite_none

![image](https://user-images.githubusercontent.com/1430060/88432219-caa2aa00-cdc9-11ea-94fa-6b390aaea526.png)

Notably, IE11 is missing from this list.

Connects #3358 

### Demo

![image](https://user-images.githubusercontent.com/1430060/88420900-9c1ad400-cdb5-11ea-8a1c-41ef89b7648a.png)

## Testing Instructions

### Preparation

* Ensure you have an account and saved projects in both local and staging
* Using Chrome, go to chrome://flags, search for "same site", and enable both options:
    ![image](https://user-images.githubusercontent.com/1430060/88427781-9c20d100-cdc1-11ea-8ce9-cae1b8cef4d1.png)

### Testing the Bug

* In Chrome, go to https://concord-consortium.github.io/lara-interactive-api/
* In the iframe box's URL, put in https://staging.modelmywatershed.org/
* Open the developer tool's network tab
* Log in to your account
* Inspect the network response for POST login
  - [x] Ensure it sets a cookie without "Same Site=None; Secure" tags
* Click on "Projects" to load your list of projects
  - [x] Ensure the list doesn't load, and returns a 403 in the network tab

### Testing the Fix

* Check out this branch
* Run `ngrok`
* In Chrome, go to https://concord-consortium.github.io/lara-interactive-api/
* In the iframe box's URL, put in the ngrok URL
* Open the developer tool's network tab
* Log in to your account
* Inspect the network response for POST login
  - [x] Ensure it sets a cookie with "Same Site=None; Secure" tags
* Click on "Projects" to load your list of projects
  - [x] Ensure the list does load, and returns a 200 in the network tab
