### PR TITLE
Disable Recent Weather

### DIFF
--- a/src/mmw/js/src/modeling/constants.js
+++ b/src/mmw/js/src/modeling/constants.js
@@ -27,16 +27,16 @@ module.exports = {
     },
     // In sync with apps.modeling.models.WeatherType.simulations
     Simulations: [
-        {
-            group: 'Recent Weather',
-            items: [
-                {
-                    name: 'NASA_NLDAS_2000_2019',
-                    label: 'NASA NLDAS 2000-2019',
-                },
-            ],
-            in_drb: true,
-        },
+        // {
+        //     group: 'Recent Weather',
+        //     items: [
+        //         {
+        //             name: 'NASA_NLDAS_2000_2019',
+        //             label: 'NASA NLDAS 2000-2019',
+        //         },
+        //     ],
+        //     in_drb: true,
+        // },
         {
             group: 'Future Weather Simulations',
             items: [


### PR DESCRIPTION
## Overview

The NLDAS dataset is modeled, not observed, which may need further explanation to differentiate from Default Weather.

Will be enabled on staging after this for further consideration.

Connects #3361 

### Demo

![image](https://user-images.githubusercontent.com/1430060/88558674-da083a00-cff9-11ea-8e38-fcf2693d76e7.png)

## Testing Instructions

* Check out this branch and `bundle`
* Open the weather data dialog
  - [ ] Ensure you don't see Recent Weather in the Available Data dropdown