### PR TITLE
Don't use secure cookies in development environment

### DIFF
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -301,10 +301,6 @@ THIRD_PARTY_APPS = (
 
 # THIRD-PARTY CONFIGURATION
 
-# django-cookies-samesite
-SESSION_COOKIE_SAMESITE = 'None'  # Allows for cross site embedding into LARA
-SESSION_COOKIE_SECURE = True      # Only set cookies in HTTPS connections
-
 # rest_framework
 REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {

--- a/src/mmw/mmw/settings/production.py
+++ b/src/mmw/mmw/settings/production.py
@@ -99,3 +99,7 @@ GOOGLE_MAPS_API_KEY = 'AIzaSyCXdkywU7rps_i1CeKqWxlBi97vyGeXsqk'
 
 # Stroud account
 GOOGLE_ANALYTICS_ACCOUNT = 'UA-47047573-15'
+
+# django-cookies-samesite
+SESSION_COOKIE_SAMESITE = 'None'  # Allows for cross site embedding into LARA
+SESSION_COOKIE_SECURE = True      # Only set cookies in HTTPS connections


### PR DESCRIPTION
## Overview

Since we develop on http://localhost:8000, a non-https endpoint, the secure cookies are not saved. This change makes it so that they are set only in non-development environments.

Connects #3358 

## Demo

![Screen Shot 2020-07-27 at 11 49 32 AM](https://user-images.githubusercontent.com/1430060/88562900-49345d00-cfff-11ea-85d5-0f5ce7b2a638.png)

## Testing Instructions

* Check out this branch
* Go to [:8000/](http://localhost:8000/)
* Log in
* Reload the page
  - [ ] Ensure you stay logged in