### PR TITLE
Switch to boto3 for sending emails

### DIFF
--- a/src/mmw/apps/core/mail/backends/boto_ses_mailer.py
+++ b/src/mmw/apps/core/mail/backends/boto_ses_mailer.py
@@ -7,7 +7,7 @@ import json
 import logging
 import sys
 import traceback
-import boto.ses
+import boto3
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
@@ -101,7 +101,13 @@ class BotoMailer():
         self.send_message_bytes(message.as_string(), from_email, to)
 
     def send_message_bytes(self, message_bytes, from_email, to):
-        return self._connection().send_raw_email(message_bytes, from_email, to)
+        kwargs = {
+            "Source": from_email,
+            "Destinations": to,
+            "RawMessage": {"Data": message_bytes},
+        }
+
+        return self._connection().send_raw_email(**kwargs)
 
     def get_remaining_message_quota(self):
         response = self._connection().get_send_quota()
@@ -111,4 +117,4 @@ class BotoMailer():
         return limit - sent_count
 
     def _connection(self):
-        return boto.ses.connect_to_region(self.aws_region)
+        return boto3.client('ses', region_name=self.aws_region)


### PR DESCRIPTION
## Overview

Boto email capabilities have been deprecated, preventing new user sign up emails going out. These edits are inspired by https://github.com/azavea/django-amazon-ses/blob/develop/django_amazon_ses.py.

See https://rollbar.com/WikiWatershed/ModelMyWatershed/items/134

Connects #3388 

### Demo

![Screen Shot 2021-04-13 at 7 55 40 PM](https://user-images.githubusercontent.com/1430060/114635532-ea993700-9c92-11eb-9e97-f6babfd6569d.png)

### Notes

This PR is mainly for review. The branch has already been merged onto the Release branch, so that it can be deployed to staging for testing. Will deploy that to production once this is reviewed.

## Testing Instructions

* Go to https://staging.modelmywatershed.org/
* Click "Login" in the top right, then click "Register" in the bottom of the dialog
* Register for a new account
  - [ ] Ensure that you get a confirmation email
* Click the link in the confirmation email
* Attempt to login afterwards
  - [ ] Ensure that you are able to login successfully