### PR TITLE
Add Analyze Views for 2019 NLCD Products

### DIFF
--- a/doc/MMW_API_landproperties_demo.ipynb
+++ b/doc/MMW_API_landproperties_demo.ipynb
@@ -260,7 +260,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Issue job request: **analyze/land/**"
+    "#### Issue job request: **analyze/land/2011_2011/**"
    ]
   },
   {
@@ -269,7 +269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = analyze_api_request('land', s, api_url, json_payload)"
+    "result = analyze_api_request('land/2011_2011', s, api_url, json_payload)"
    ]
   },
   {

--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -11,6 +11,21 @@ from drf_yasg.openapi import (
 
 from django.conf import settings
 
+nlcd_year_allowed_values = sorted(
+    [n[5:14] for n in settings.GEOP['json'].keys()
+     if n[:4] == 'nlcd' and n[-3:] == 'ara'],
+    reverse=True)
+NLCD_YEAR = Parameter(
+    'nlcd_year',
+    IN_PATH,
+    description='The NLCD product version and target year to query.'
+                ' Must be one of: "{}"'.format(
+                    '", "'.join(nlcd_year_allowed_values)
+                ),
+    type=TYPE_STRING,
+    required=True,
+)
+
 DRB_2100_LAND_KEY = Parameter(
     'key',
     IN_PATH,

--- a/src/mmw/apps/geoprocessing_api/tasks.py
+++ b/src/mmw/apps/geoprocessing_api/tasks.py
@@ -123,9 +123,10 @@ def analyze_catchment_water_quality(area_of_interest):
 
 
 @shared_task(throws=Exception)
-def analyze_nlcd(result, area_of_interest=None):
+def analyze_nlcd(result, area_of_interest=None, nlcd_year='2011_2011'):
     if 'error' in result:
-        raise Exception('[analyze_nlcd] {}'.format(result['error']))
+        raise Exception('[analyze_nlcd_{}] {}'.format(
+            nlcd_year, result['error']))
 
     pixel_width = aoi_resolution(area_of_interest) if area_of_interest else 1
 
@@ -159,8 +160,10 @@ def analyze_nlcd(result, area_of_interest=None):
 
     return {
         'survey': {
-            'name': 'land',
-            'displayName': 'Land',
+            'name': 'land_{}'.format(nlcd_year),
+            'displayName':
+                'Land Use/Cover {} (NLCD{})'.format(
+                    nlcd_year[5:], nlcd_year[2:4]),
             'categories': categories,
         }
     }

--- a/src/mmw/apps/geoprocessing_api/tests.py
+++ b/src/mmw/apps/geoprocessing_api/tests.py
@@ -157,8 +157,8 @@ class ExerciseAnalyze(TestCase):
 
         expected = {
             "survey": {
-                "displayName": "Land",
-                "name": "land",
+                "displayName": "Land Use/Cover 2011 (NLCD11)",
+                "name": "land_2011_2011",
                 "categories": [
                     {
                         "code": "mixed_forest",
@@ -277,7 +277,7 @@ class ExerciseAnalyze(TestCase):
             }
         }
 
-        actual = tasks.analyze_nlcd(histogram)
+        actual = tasks.analyze_nlcd(histogram, nlcd_year='2011_2011')
         self.assertEqual(actual, expected)
 
     def test_survey_land_with_ara(self):
@@ -447,12 +447,12 @@ class ExerciseAnalyze(TestCase):
                         "type": "Barren Land (Rock/Sand/Clay)"
                     }
                 ],
-                "displayName": "Land",
-                "name": "land"
+                "displayName": "Land Use/Cover 2011 (NLCD11)",
+                "name": "land_2011_2011"
             }
         }
 
-        actual = tasks.analyze_nlcd(histogram)
+        actual = tasks.analyze_nlcd(histogram, nlcd_year='2011_2011')
         self.assertEqual(actual, expected)
 
     def test_survey_soil(self):

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -14,7 +14,7 @@ app_name = 'geoprocessing_api'
 urlpatterns = [
     url(r'^token/', views.get_auth_token,
         name="authtoken"),
-    url(r'analyze/land/(?P<nlcd_year>\w*)/?$', views.start_analyze_land,
+    url(r'analyze/land/(?P<nlcd_year>\w+)/?$', views.start_analyze_land,
         name='start_analyze_land'),
     url(r'analyze/soil/$', views.start_analyze_soil,
         name='start_analyze_soil'),

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -14,7 +14,7 @@ app_name = 'geoprocessing_api'
 urlpatterns = [
     url(r'^token/', views.get_auth_token,
         name="authtoken"),
-    url(r'analyze/land/$', views.start_analyze_land,
+    url(r'analyze/land/(?P<nlcd_year>\w*)/?$', views.start_analyze_land,
         name='start_analyze_land'),
     url(r'analyze/soil/$', views.start_analyze_soil,
         name='start_analyze_soil'),

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -240,7 +240,8 @@ def start_rwd(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI],
+                     manual_parameters=[schemas.NLCD_YEAR,
+                                        schemas.WKAOI],
                      request_body=schemas.MULTIPOLYGON,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
@@ -249,11 +250,13 @@ def start_rwd(request, format=None):
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
-def start_analyze_land(request, nlcd_year='2011_2011', format=None):
+def start_analyze_land(request, nlcd_year, format=None):
     """
-    Starts a job to produce a land-use histogram for a given area.
+    Starts a job to produce a land-use histogram for a given area and year.
 
-    Uses the National Land Cover Database (NLCD 2011)
+    Supports the years 2019, 2016, 2011, 2006, and 2001 from the NLCD 2019
+    product. Also supports the year 2011 from the NLCD 2011 product, which
+    used to be the default previously.
 
     For more information, see the
     [technical documentation](https://wikiwatershed.org/
@@ -272,8 +275,8 @@ def start_analyze_land(request, nlcd_year='2011_2011', format=None):
 
         {
             "survey": {
-                "displayName": "Land",
-                "name": "land",
+                "displayName": "Land Use/Cover 2019 (NLCD19)",
+                "name": "land_2019_2019",
                 "categories": [
                     {
                         "nlcd": 43,

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -103,9 +103,7 @@ def start_rwd(request, format=None):
     this point is automatically delineated using the 10m resolution national
     elevation model or the 30m resolution flow direction grid.
 
-    For more information, see the
-    [technical documentation](https://wikiwatershed.org/
-    documentation/mmw-tech/#delineate-watershed).
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#delineate-watershed).  # NOQA
 
     ## Request Body
 
@@ -258,9 +256,7 @@ def start_analyze_land(request, nlcd_year, format=None):
     product. Also supports the year 2011 from the NLCD 2011 product, which
     used to be the default previously.
 
-    For more information, see the
-    [technical documentation](https://wikiwatershed.org/
-    documentation/mmw-tech/#overlays-tab-coverage).
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-coverage).  # NOQA
 
     ## Response
 
@@ -440,9 +436,7 @@ def start_analyze_soil(request, format=None):
 
     Uses the Hydrologic Soil Groups From USDA gSSURGO 2016
 
-    For more information, see the
-    [technical documentation](https://wikiwatershed.org/
-    documentation/mmw-tech/#overlays-tab-coverage).
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-coverage).  # NOQA
 
     ## Response
 
@@ -534,9 +528,7 @@ def start_analyze_streams(request, format=None):
     Starts a job to display streams & stream order within a given area of
     interest.
 
-    For more information, see
-    the [technical documentation](https://wikiwatershedorg/documentation/
-    mmw-tech/#additional-data-layers)
+    For more information, see the [technical documentation](https://wikiwatershedorg/documentation/mmw-tech/#additional-data-layers)  # NOQA
 
     ## Response
 
@@ -666,9 +658,7 @@ def start_analyze_animals(request, format=None):
 
     Source USDA
 
-    For more information, see
-    the [technical documentation](https://wikiwatershed.org/documentation/
-    mmw-tech/#additional-data-layers)
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#additional-data-layers)  # NOQA
 
     ## Response
 
@@ -748,9 +738,7 @@ def start_analyze_pointsource(request, format=None):
 
     Source EPA NPDES
 
-    For more information, see the
-    [technical documentation](https://wikiwatershed.org/
-    documentation/mmw-tech/#additional-data-layers)
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#additional-data-layers)  # NOQA
 
     ## Response
 
@@ -811,9 +799,7 @@ def start_analyze_catchment_water_quality(request, format=None):
 
     Source Stream Reach Tool Assessment (SRAT)
 
-    For more information, see
-    the [technical documentation](https://wikiwatershed.org/
-    documentation/mmw-tech/#overlays-tab-coverage)
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-coverage)  # NOQA
 
     ## Response
 
@@ -899,9 +885,7 @@ def start_analyze_climate(request, format=None):
 
     Source PRISM Climate Group
 
-    For more information, see
-    the [technical documentation](https://wikiwatershed.org/
-    documentation/mmw-tech/#overlays-tab-coverage)
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-coverage)  # NOQA
 
     ## Response
 
@@ -965,9 +949,7 @@ def start_analyze_terrain(request, format=None):
 
     Source NHDPlus V2 NEDSnapshot DEM
 
-    For more information, see the
-    [technical documentation](https://wikiwatershed.org/
-    documentation/mmw-tech/#overlays-tab-coverage).
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-coverage).  # NOQA
 
     ## Response
 
@@ -1034,9 +1016,7 @@ def start_analyze_protected_lands(request, format=None):
     Uses the Protected Areas Database of the United States (PADUS),
     published by the U.S. Geological Survey Gap Analysis Program in 2016.
 
-    For more information, see the
-    [technical documentation](https://wikiwatershed.org/
-    documentation/mmw-tech/#overlays-tab-coverage).
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-coverage).  # NOQA
 
     ## Response
 
@@ -1176,9 +1156,7 @@ def start_analyze_drb_2100_land(request, key=None, format=None):
     Shippensburg University, serviced via APIs by Drexel University and the
     Academy of Natural Sciences.
 
-    For more information, see the
-    [technical documentation](https://wikiwatershed.org/
-    documentation/mmw-tech/#overlays-tab-coverage).
+    For more information, see the [technical documentation](https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-coverage).  # NOQA
 
     ## Response
 

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -249,7 +249,7 @@ def start_rwd(request, format=None):
 @decorators.permission_classes((IsAuthenticated, ))
 @decorators.throttle_classes([BurstRateThrottle, SustainedRateThrottle])
 @log_request
-def start_analyze_land(request, format=None):
+def start_analyze_land(request, nlcd_year='2011_2011', format=None):
     """
     Starts a job to produce a land-use histogram for a given area.
 
@@ -415,8 +415,9 @@ def start_analyze_land(request, format=None):
     geop_input = {'polygon': [area_of_interest]}
 
     return start_celery_job([
-        geoprocessing.run.s('nlcd_ara', geop_input, wkaoi),
-        tasks.analyze_nlcd.s(area_of_interest)
+        geoprocessing.run.s(
+            'nlcd_{}_ara'.format(nlcd_year), geop_input, wkaoi),
+        tasks.analyze_nlcd.s(area_of_interest, nlcd_year)
     ], area_of_interest, user)
 
 

--- a/src/mmw/js/src/analyze/mocks.js
+++ b/src/mmw/js/src/analyze/mocks.js
@@ -135,8 +135,8 @@ module.exports = {
                             "type": "Pasture/Hay"
                         }
                     ],
-                    "displayName": "Land",
-                    "name": "land"
+                    "displayName": "Land Use/Cover 2011 (NLCD11)",
+                    "name": "land_2011_2011"
                 },
                 {
                     "categories": [
@@ -488,13 +488,13 @@ module.exports = {
     "polling": false,
     "tasks": [
       {
-        "displayName": "Land cover distribution",
+        "displayName": "Land Use/Cover 2011 (NLCD11)",
         "enabledForCatalogMode": true,
         "error": "",
         "finished": "2020-01-17T21:19:31.041031Z",
         "job": "b9fe20fa-0747-423f-848a-f399b224aac5",
         "job_uuid": "b9fe20fa-0747-423f-848a-f399b224aac5",
-        "name": "land",
+        "name": "land_2011_2011",
         "pollInterval": 1000,
         "result": {
           "survey": {
@@ -628,13 +628,13 @@ module.exports = {
                 "type": "Barren Land (Rock/Sand/Clay)"
               }
             ],
-            "displayName": "Land",
-            "name": "land"
+            "displayName": "Land Use/Cover 2011 (NLCD11)",
+            "name": "land_2011_2011"
           }
         },
         "started": "2020-01-17T21:19:07.446246Z",
         "status": "complete",
-        "taskName": "analyze/land",
+        "taskName": "analyze/land/2011_2011",
         "taskType": "api",
         "timeout": 160000,
         "token": "1831c4a26158079f2b5f1530f01beaeca6517544",

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -232,11 +232,51 @@ function createAnalyzeTaskGroupCollection(aoi, wkaoi) {
             displayName: "Land",
             tasks: [
                 {
-                    name: "land",
-                    displayName: "Land cover distribution",
+                    name: "land_2019_2019",
+                    displayName: "Land Use/Cover 2019 (NLCD19)",
                     area_of_interest: aoi,
                     wkaoi: wkaoi,
-                    taskName: "analyze/land",
+                    taskName: "analyze/land/2019_2019",
+                    enabledForCatalogMode: true
+                },
+                {
+                    name: "land_2019_2016",
+                    displayName: "Land Use/Cover 2016 (NLCD19)",
+                    area_of_interest: aoi,
+                    wkaoi: wkaoi,
+                    taskName: "analyze/land/2019_2016",
+                    enabledForCatalogMode: true
+                },
+                {
+                    name: "land_2019_2011",
+                    displayName: "Land Use/Cover 2011 (NLCD19)",
+                    area_of_interest: aoi,
+                    wkaoi: wkaoi,
+                    taskName: "analyze/land/2019_2011",
+                    enabledForCatalogMode: true
+                },
+                {
+                    name: "land_2019_2006",
+                    displayName: "Land Use/Cover 2006 (NLCD19)",
+                    area_of_interest: aoi,
+                    wkaoi: wkaoi,
+                    taskName: "analyze/land/2019_2006",
+                    enabledForCatalogMode: true
+                },
+                {
+                    name: "land_2019_2001",
+                    displayName: "Land Use/Cover 2001 (NLCD19)",
+                    area_of_interest: aoi,
+                    wkaoi: wkaoi,
+                    taskName: "analyze/land/2019_2001",
+                    enabledForCatalogMode: true
+                },
+                {
+                    name: "land_2011_2011",
+                    displayName: "Land Use/Cover 2011 (NLCD11)",
+                    area_of_interest: aoi,
+                    wkaoi: wkaoi,
+                    taskName: "analyze/land/2011_2011",
                     enabledForCatalogMode: true
                 },
                 {

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -56,7 +56,8 @@ describe('Analyze', function() {
 
     describe('Views', function() {
         describe('AnalysisResultView', function() {
-            _.forEach(['land', 'soil', 'animals', 'pointsource', 'catchment_water_quality'], testAnalysisType);
+            _.forEach(['soil', 'animals', 'pointsource', 'catchment_water_quality'], testAnalysisType);
+            testAnalysisType('land_2011_2011', 'land');
             testAnalysisType('protected_lands', 'land');
         });
     });
@@ -189,7 +190,7 @@ function catchmentWaterQualityTableFormatter(categories) {
 }
 
 var dataFormatters = {
-    land: landTableFormatter,
+    land_2011_2011: landTableFormatter,
     protected_lands: protectedLandsTableFormatter,
     soil: soilTableFormatter,
     animals: animalTableFormatter,
@@ -198,7 +199,7 @@ var dataFormatters = {
 };
 
 var tableHeaders = {
-    land: ['Type', 'Area (km²)', 'Coverage (%)', 'Active River Area (km²)'],
+    land_2011_2011: ['Type', 'Area (km²)', 'Coverage (%)', 'Active River Area (km²)'],
     protected_lands: ['Type', 'Area (km²)', 'Coverage (%)'],
     soil: ['Type', 'Area (km²)', 'Coverage (%)'],
     animals: ['Animal', 'Count'],

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -471,12 +471,77 @@ GEOP = {
     'port': environ.get('MMW_GEOPROCESSING_PORT', '8090'),
     'args': 'context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
     'json': {
-        'nlcd_ara': {
+        'nlcd_2011_2011_ara': {
             'input': {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
                     'nlcd-2011-30m-epsg5070-512-int8',
+                    'ara-30m-epsg5070-512'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterGroupedCount',
+                'zoom': 0
+            }
+        },
+        'nlcd_2019_2019_ara': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'nlcd-2019-30m-epsg5070-512-byte',
+                    'ara-30m-epsg5070-512'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterGroupedCount',
+                'zoom': 0
+            }
+        },
+        'nlcd_2019_2016_ara': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'nlcd-2016-30m-epsg5070-512-byte',
+                    'ara-30m-epsg5070-512'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterGroupedCount',
+                'zoom': 0
+            }
+        },
+        'nlcd_2019_2011_ara': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'nlcd-2011-30m-epsg5070-512-byte',
+                    'ara-30m-epsg5070-512'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterGroupedCount',
+                'zoom': 0
+            }
+        },
+        'nlcd_2019_2006_ara': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'nlcd-2006-30m-epsg5070-512-byte',
+                    'ara-30m-epsg5070-512'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterGroupedCount',
+                'zoom': 0
+            }
+        },
+        'nlcd_2019_2001_ara': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    'nlcd-2001-30m-epsg5070-512-byte',
                     'ara-30m-epsg5070-512'
                 ],
                 'rasterCRS': 'ConusAlbers',

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -90,6 +90,21 @@ LAYER_GROUPS = {
     ],
     'coverage': [
         {
+            'display': 'Land Use/Cover 2019 (NLCD19)',
+            'code': 'nlcd-2019_2019',
+            'css_class_prefix': 'nlcd-2019-30m nlcd',
+            'short_display': 'NLCD 2019',
+            'helptext': 'National Land Cover Database defines'
+                        'land use across the U.S. From 2019 of NLCD19.',
+            'url': 'https://{s}.tiles.azavea.com/nlcd-2019-30m/{z}/{x}/{y}.png',
+            'maxNativeZoom': 13,
+            'maxZoom': 18,
+            'opacity': 0.618,
+            'has_opacity_slider': True,
+            'legend_mapping': { key: names[1] for key, names in NLCD.iteritems()},
+            'big_cz': True,
+        },
+        {
             'display': 'Land Use/Cover 2016 (NLCD19)',
             'code': 'nlcd-2019_2016',
             'css_class_prefix': 'nlcd-2016-30m nlcd',

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -90,12 +90,12 @@ LAYER_GROUPS = {
     ],
     'coverage': [
         {
-            'display': 'National Land Cover Database 2016',
-            'code': 'nlcd-2016-30m',
+            'display': 'Land Use/Cover 2016 (NLCD19)',
+            'code': 'nlcd-2019_2016',
             'css_class_prefix': 'nlcd-2016-30m nlcd',
             'short_display': 'NLCD 2016',
             'helptext': 'National Land Cover Database defines'
-                        'land use across the U.S. From 2016.',
+                        'land use across the U.S. From 2016 of NLCD19.',
             'url': 'https://{s}.tiles.azavea.com/nlcd-2016-30m/{z}/{x}/{y}.png',
             'maxNativeZoom': 13,
             'maxZoom': 18,
@@ -105,12 +105,12 @@ LAYER_GROUPS = {
             'big_cz': True,
         },
         {
-            'display': 'National Land Cover Database 2011',
-            'code': 'nlcd-2011-30m',
+            'display': 'Land Use/Cover 2011 (NLCD19)',
+            'code': 'nlcd-2019_2011',
             'css_class_prefix': 'nlcd-2011-30m nlcd',
             'short_display': 'NLCD 2011',
             'helptext': 'National Land Cover Database defines'
-                        'land use across the U.S. From 2011.',
+                        'land use across the U.S. From 2011 of NLCD19.',
             'url': 'https://{s}.tiles.azavea.com/nlcd-2011-30m/{z}/{x}/{y}.png',
             'maxNativeZoom': 13,
             'maxZoom': 18,
@@ -120,12 +120,12 @@ LAYER_GROUPS = {
             'big_cz': True,
         },
         {
-            'display': 'National Land Cover Database 2006',
-            'code': 'nlcd-2006-30m',
+            'display': 'Land Use/Cover 2006 (NLCD19)',
+            'code': 'nlcd-2019_2006',
             'css_class_prefix': 'nlcd-2006-30m nlcd',
             'short_display': 'NLCD 2006',
             'helptext': 'National Land Cover Database defines'
-                        'land use across the U.S. From 2006.',
+                        'land use across the U.S. From 2006 of NLCD19.',
             'url': 'https://{s}.tiles.azavea.com/nlcd-2006-30m/{z}/{x}/{y}.png',
             'maxNativeZoom': 13,
             'maxZoom': 18,
@@ -135,12 +135,12 @@ LAYER_GROUPS = {
             'big_cz': True,
         },
         {
-            'display': 'National Land Cover Database 2001',
-            'code': 'nlcd-2001-30m',
+            'display': 'Land Use/Cover 2001 (NLCD19)',
+            'code': 'nlcd-2019_2001',
             'css_class_prefix': 'nlcd-2001-30m nlcd',
             'short_display': 'NLCD 2001',
             'helptext': 'National Land Cover Database defines'
-                        'land use across the U.S. From 2001.',
+                        'land use across the U.S. From 2001 of NLCD19.',
             'url': 'https://{s}.tiles.azavea.com/nlcd-2001-30m/{z}/{x}/{y}.png',
             'maxNativeZoom': 13,
             'maxZoom': 18,
@@ -150,12 +150,12 @@ LAYER_GROUPS = {
             'big_cz': True,
         },
         {
-            'display': 'National Land Cover Database Old 2011',
-            'code': 'nlcd',
+            'display': 'Land Use/Cover 2011 (NLCD11)',
+            'code': 'nlcd-2011_2011',
             'css_class_prefix': 'nlcd',
             'short_display': 'NLCD',
             'helptext': 'National Land Cover Database defines'
-                        'land use across the U.S. Old 2011.',
+                        'land use across the U.S. From NLCD11.',
             'url': 'https://{s}.tiles.azavea.com/nlcd/{z}/{x}/{y}.png',
             'maxNativeZoom': 13,
             'maxZoom': 18,

--- a/src/mmw/sass/utils/_variables.scss
+++ b/src/mmw/sass/utils/_variables.scss
@@ -45,7 +45,7 @@ $analyze-tab-height: 40px;
 //Widths
 $sidebar-width: 460px;
 $secondary-sidebar-width: 300px;
-$layerpicker-width: 260px;
+$layerpicker-width: 240px;
 $search-width: 300px;
 
 //Border-radius


### PR DESCRIPTION
## Overview

Adds Analyze Views for 2019, 2016, 2011, 2006, and 2001 years of NLCD from the NLCD 2019 product ingested in #3397. Also renames the old NLCD 2011 layer to also be available.

Connects #3395 

### Demo

![2021-07-01 18 13 11](https://user-images.githubusercontent.com/1430060/124197275-2d9dc600-da9c-11eb-9c0e-232e8a0dedfa.gif)

### Notes

This adds 5 additional analyses that are kicked off on _every_ shape drawn / selected, which could increase our CPU and Network usage significantly. This may exacerbate the need for optimizations to the analyze view, such as #2745 and #3398. Those efforts are noted in separate cards for future prioritization.

This only changes the Analyze views. All other instances that use old NLCD 2011 (such as TR-55 Modeling, etc) still use it, and will be switched in future PRs.

## Testing Instructions

* Check out this branch and `bundle --debug` and `vagrant ssh worker -c 'sudo service celeryd restart'`
* Go to [:8000/](http://localhost:8000/) and pick / draw a shape
* Select the Land tab in the Analyze sidebar
  - [x] Ensure you default to 2019 NLCD
  - [x] Ensure there are options available for 2016, 2011, 2006, 2001, and old 2011
  - [x] Ensure each is appropriately described and connects to the correct visual layer
* Make a Site Storm Model project
  - [x] Ensure it is created successfully
* Make a Watershed Multi Year Model project
  - [x] Ensure it is created successfully
* Go to [:8000/api/docs](http://localhost:8000/api/docs)
  - [x] Ensure the Analyze Land API is described appropriately