### PR TITLE
Parameterize Geoprocessing Rasters

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ $ vagrant ssh worker -c 'sudo service celeryd restart'
 
 To enable the geoprocessing cache simply set it to `1` and restart the `celeryd` service.
 
+In some cases, it may be necessary to remove all cached values. This can be done with:
+
+```bash
+$ vagrant ssh services -c 'redis-cli -n 1 --raw KEYS ":1:geop_*" | xargs redis-cli -n 1 DEL'
+```
+
 ### Test Mode
 
 In order to run the app in test mode, which simulates the production static asset bundle, reprovision with `VAGRANT_ENV=TEST vagrant provision`.

--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -11,10 +11,14 @@ from drf_yasg.openapi import (
 
 from django.conf import settings
 
-nlcd_year_allowed_values = sorted(
-    [n[5:14] for n in settings.GEOP['json'].keys()
-     if n[:4] == 'nlcd' and n[-3:] == 'ara'],
-    reverse=True)
+nlcd_year_allowed_values = [
+    '2019_2019',
+    '2019_2016',
+    '2019_2011',
+    '2019_2006',
+    '2019_2001',
+    '2011_2011',
+]
 NLCD_YEAR = Parameter(
     'nlcd_year',
     IN_PATH,

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -413,9 +413,18 @@ def start_analyze_land(request, nlcd_year, format=None):
 
     geop_input = {'polygon': [area_of_interest]}
 
+    layer_overrides = {}
+    if nlcd_year == '2011_2011':
+        layer_overrides['__LAND__'] = 'nlcd-2011-30m-epsg5070-512-int8'
+
+    nlcd, year = nlcd_year.split('_')
+    if nlcd == '2019' and year in ['2019', '2016', '2011', '2006', '2001']:
+        layer_overrides['__LAND__'] = 'nlcd-{}-30m-epsg5070-512-byte'.format(
+            year)
+
     return start_celery_job([
-        geoprocessing.run.s(
-            'nlcd_{}_ara'.format(nlcd_year), geop_input, wkaoi),
+        geoprocessing.run.s('nlcd_ara', geop_input, wkaoi,
+                            layer_overrides=layer_overrides),
         tasks.analyze_nlcd.s(area_of_interest, nlcd_year)
     ], area_of_interest, user)
 

--- a/src/mmw/apps/modeling/geoprocessing.py
+++ b/src/mmw/apps/modeling/geoprocessing.py
@@ -7,6 +7,7 @@ import requests
 import json
 
 from ast import literal_eval as make_tuple
+from copy import deepcopy
 
 from celery import shared_task
 from celery.exceptions import Retry
@@ -77,7 +78,7 @@ def run(self, opname, input_data, wkaoi=None, cache_key='',
         if cached:
             return cached
 
-    data = settings.GEOP['json'][opname].copy()
+    data = deepcopy(settings.GEOP['json'][opname])
     data['input'].update(input_data)
 
     # Populate layers
@@ -194,7 +195,7 @@ def multi(self, opname, shapes, stream_lines, layer_overrides={}):
     we are using the same cache naming scheme as run, any operation cached via
     `multi` can be reused by `run`.
     """
-    data = settings.GEOP['json'][opname].copy()
+    data = deepcopy(settings.GEOP['json'][opname])
     data['shapes'] = []
 
     # Don't include the RasterLinesJoin operation if the AoI does

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -486,77 +486,12 @@ GEOP = {
         '__SOILP__': 'soilpallland2-epsg5070',
     },
     'json': {
-        'nlcd_2011_2011_ara': {
+        'nlcd_ara': {
             'input': {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
                     '__LAND__',
-                    '__ARA__'
-                ],
-                'rasterCRS': 'ConusAlbers',
-                'operationType': 'RasterGroupedCount',
-                'zoom': 0
-            }
-        },
-        'nlcd_2019_2019_ara': {
-            'input': {
-                'polygon': [],
-                'polygonCRS': 'LatLng',
-                'rasters': [
-                    'nlcd-2019-30m-epsg5070-512-byte',
-                    '__ARA__'
-                ],
-                'rasterCRS': 'ConusAlbers',
-                'operationType': 'RasterGroupedCount',
-                'zoom': 0
-            }
-        },
-        'nlcd_2019_2016_ara': {
-            'input': {
-                'polygon': [],
-                'polygonCRS': 'LatLng',
-                'rasters': [
-                    'nlcd-2016-30m-epsg5070-512-byte',
-                    '__ARA__'
-                ],
-                'rasterCRS': 'ConusAlbers',
-                'operationType': 'RasterGroupedCount',
-                'zoom': 0
-            }
-        },
-        'nlcd_2019_2011_ara': {
-            'input': {
-                'polygon': [],
-                'polygonCRS': 'LatLng',
-                'rasters': [
-                    'nlcd-2011-30m-epsg5070-512-byte',
-                    '__ARA__'
-                ],
-                'rasterCRS': 'ConusAlbers',
-                'operationType': 'RasterGroupedCount',
-                'zoom': 0
-            }
-        },
-        'nlcd_2019_2006_ara': {
-            'input': {
-                'polygon': [],
-                'polygonCRS': 'LatLng',
-                'rasters': [
-                    'nlcd-2006-30m-epsg5070-512-byte',
-                    '__ARA__'
-                ],
-                'rasterCRS': 'ConusAlbers',
-                'operationType': 'RasterGroupedCount',
-                'zoom': 0
-            }
-        },
-        'nlcd_2019_2001_ara': {
-            'input': {
-                'polygon': [],
-                'polygonCRS': 'LatLng',
-                'rasters': [
-                    'nlcd-2001-30m-epsg5070-512-byte',
                     '__ARA__'
                 ],
                 'rasterCRS': 'ConusAlbers',

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -470,6 +470,7 @@ GEOP = {
     'host': environ.get('MMW_GEOPROCESSING_HOST', 'localhost'),
     'port': environ.get('MMW_GEOPROCESSING_PORT', '8090'),
     'args': 'context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
+    # Clear all cached geop_ values when changing this
     'layers': {
         '__ARA__': 'ara-30m-epsg5070-512',
         '__AWC__': 'us-ssurgo-aws100-30m-epsg5070-512',

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -471,6 +471,7 @@ GEOP = {
     'port': environ.get('MMW_GEOPROCESSING_PORT', '8090'),
     'args': 'context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
     # Clear all cached geop_ values when changing this
+    # https://github.com/WikiWatershed/model-my-watershed#caching
     'layers': {
         '__ARA__': 'ara-30m-epsg5070-512',
         '__AWC__': 'us-ssurgo-aws100-30m-epsg5070-512',

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -470,14 +470,28 @@ GEOP = {
     'host': environ.get('MMW_GEOPROCESSING_HOST', 'localhost'),
     'port': environ.get('MMW_GEOPROCESSING_PORT', '8090'),
     'args': 'context=geoprocessing&appName=geoprocessing-%s&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob' % environ.get('MMW_GEOPROCESSING_VERSION', '0.1.0'),  # NOQA
+    'layers': {
+        '__ARA__': 'ara-30m-epsg5070-512',
+        '__AWC__': 'us-ssurgo-aws100-30m-epsg5070-512',
+        '__BFI__': 'bfi48grd-epsg5070',
+        '__GWN__': 'us-groundwater-nitrogen-30m-epsg5070-512',
+        '__KFACTOR__': 'us-ssugro-kfactor-30m-epsg5070-512',
+        '__LAND__': 'nlcd-2011-30m-epsg5070-512-int8',
+        '__NED__': 'ned-nhdplus-30m-epsg5070-512',
+        '__PROTECTED_LANDS__': 'protected-lands-30m-epsg5070-512',
+        '__SLOPE__': 'us-percent-slope-30m-epsg5070-512',
+        '__SOIL__': 'ssurgo-hydro-groups-30m-epsg5070-512-int8',
+        '__SOILN__': 'soiln-epsg5070',
+        '__SOILP__': 'soilpallland2-epsg5070',
+    },
     'json': {
         'nlcd_2011_2011_ara': {
             'input': {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
-                    'nlcd-2011-30m-epsg5070-512-int8',
-                    'ara-30m-epsg5070-512'
+                    '__LAND__',
+                    '__ARA__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -490,7 +504,7 @@ GEOP = {
                 'polygonCRS': 'LatLng',
                 'rasters': [
                     'nlcd-2019-30m-epsg5070-512-byte',
-                    'ara-30m-epsg5070-512'
+                    '__ARA__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -503,7 +517,7 @@ GEOP = {
                 'polygonCRS': 'LatLng',
                 'rasters': [
                     'nlcd-2016-30m-epsg5070-512-byte',
-                    'ara-30m-epsg5070-512'
+                    '__ARA__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -516,7 +530,7 @@ GEOP = {
                 'polygonCRS': 'LatLng',
                 'rasters': [
                     'nlcd-2011-30m-epsg5070-512-byte',
-                    'ara-30m-epsg5070-512'
+                    '__ARA__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -529,7 +543,7 @@ GEOP = {
                 'polygonCRS': 'LatLng',
                 'rasters': [
                     'nlcd-2006-30m-epsg5070-512-byte',
-                    'ara-30m-epsg5070-512'
+                    '__ARA__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -542,7 +556,7 @@ GEOP = {
                 'polygonCRS': 'LatLng',
                 'rasters': [
                     'nlcd-2001-30m-epsg5070-512-byte',
-                    'ara-30m-epsg5070-512'
+                    '__ARA__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -554,7 +568,7 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
-                    'ssurgo-hydro-groups-30m-epsg5070-512-int8'
+                    '__SOIL__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -566,8 +580,8 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
-                    'nlcd-2011-30m-epsg5070-512-int8',
-                    'ssurgo-hydro-groups-30m-epsg5070-512-int8'
+                    '__LAND__',
+                    '__SOIL__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -581,7 +595,7 @@ GEOP = {
                 'vector': [],
                 'vectorCRS': 'LatLng',
                 'rasters': [
-                    'nlcd-2011-30m-epsg5070-512-int8'
+                    '__LAND__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterLinesJoin',
@@ -593,7 +607,7 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
-                    'us-groundwater-nitrogen-30m-epsg5070-512'
+                    '__GWN__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -603,7 +617,7 @@ GEOP = {
         'avg_awc': {
             'input': {
                 'polygon': [],
-                'targetRaster': 'us-ssurgo-aws100-30m-epsg5070-512',
+                'targetRaster': '__AWC__',
                 'rasters': [],
                 'rasterCRS': 'ConusAlbers',
                 'polygonCRS': 'LatLng',
@@ -616,8 +630,8 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
-                    'nlcd-2011-30m-epsg5070-512-int8',
-                    'us-percent-slope-30m-epsg5070-512'
+                    '__LAND__',
+                    '__SLOPE__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -629,7 +643,7 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [],
-                'targetRaster': 'us-percent-slope-30m-epsg5070-512',
+                'targetRaster': '__SLOPE__',
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedAverage',
                 'zoom': 0
@@ -640,9 +654,9 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
-                    'nlcd-2011-30m-epsg5070-512-int8'
+                    '__LAND__'
                 ],
-                'targetRaster': 'us-ssugro-kfactor-30m-epsg5070-512',
+                'targetRaster': '__KFACTOR__',
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedAverage',
                 'zoom': 0
@@ -653,7 +667,7 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [],
-                'targetRaster': 'soiln-epsg5070',
+                'targetRaster': '__SOILN__',
                 'pixelIsArea': True,
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedAverage',
@@ -665,7 +679,7 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [],
-                'targetRaster': 'soilpallland2-epsg5070',
+                'targetRaster': '__SOILP__',
                 'pixelIsArea': True,
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedAverage',
@@ -677,7 +691,7 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [],
-                'targetRaster': 'bfi48grd-epsg5070',
+                'targetRaster': '__BFI__',
                 'pixelIsArea': True,
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedAverage',
@@ -689,8 +703,8 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
-                    'ned-nhdplus-30m-epsg5070-512',
-                    'us-percent-slope-30m-epsg5070-512',
+                    '__NED__',
+                    '__SLOPE__',
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterSummary',
@@ -702,7 +716,7 @@ GEOP = {
                 'polygon': [],
                 'polygonCRS': 'LatLng',
                 'rasters': [
-                    'protected-lands-30m-epsg5070-512'
+                    '__PROTECTED_LANDS__'
                 ],
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedCount',
@@ -717,72 +731,72 @@ GEOP = {
                     'name': 'RasterGroupedCount',
                     'label': 'nlcd_soil',
                     'rasters': [
-                        'nlcd-2011-30m-epsg5070-512-int8',
-                        'ssurgo-hydro-groups-30m-epsg5070-512-int8'
+                        '__LAND__',
+                        '__SOIL__'
                     ]
                 },
                 {
                     'name': 'RasterLinesJoin',
                     'label': 'nlcd_streams',
                     'rasters': [
-                        'nlcd-2011-30m-epsg5070-512-int8'
+                        '__LAND__'
                     ]
                 },
                 {
                     'name': 'RasterGroupedCount',
                     'label': 'gwn',
                     'rasters': [
-                        'us-groundwater-nitrogen-30m-epsg5070-512'
+                        '__GWN__'
                     ]
                 },
                 {
                     'name': 'RasterGroupedAverage',
                     'label': 'avg_awc',
-                    'targetRaster': 'us-ssurgo-aws100-30m-epsg5070-512',
+                    'targetRaster': '__AWC__',
                     'rasters': [
-                        'us-groundwater-nitrogen-30m-epsg5070-512'
+                        '__GWN__'
                     ]
                 },
                 {
                     'name': 'RasterGroupedCount',
                     'label': 'nlcd_slope',
                     'rasters': [
-                        'nlcd-2011-30m-epsg5070-512-int8',
-                        'us-percent-slope-30m-epsg5070-512'
+                        '__LAND__',
+                        '__SLOPE__'
                     ]
                 },
                 {
                     'name': 'RasterGroupedAverage',
                     'label': 'slope',
-                    'targetRaster': 'us-percent-slope-30m-epsg5070-512',
+                    'targetRaster': '__SLOPE__',
                     'rasters': []
                 },
                 {
                     'name': 'RasterGroupedAverage',
                     'label': 'nlcd_kfactor',
-                    'targetRaster': 'us-ssugro-kfactor-30m-epsg5070-512',
+                    'targetRaster': '__KFACTOR__',
                     'rasters': [
-                        'nlcd-2011-30m-epsg5070-512-int8'
+                        '__LAND__'
                     ]
                 },
                 {
                     'name': 'RasterGroupedAverage',
                     'label': 'soiln',
-                    'targetRaster': 'soiln-epsg5070',
+                    'targetRaster': '__SOILN__',
                     'rasters': [],
                     'pixelIsArea': True
                 },
                 {
                     'name': 'RasterGroupedAverage',
                     'label': 'soilp',
-                    'targetRaster': 'soilpallland2-epsg5070',
+                    'targetRaster': '__SOILP__',
                     'rasters': [],
                     'pixelIsArea': True
                 },
                 {
                     'name': 'RasterGroupedAverage',
                     'label': 'recess_coef',
-                    'targetRaster': 'bfi48grd-epsg5070',
+                    'targetRaster': '__BFI__',
                     'rasters': [],
                     'pixelIsArea': True
                 }
@@ -796,14 +810,14 @@ GEOP = {
                     'name': 'RasterGroupedCount',
                     'label': 'nlcd',
                     'rasters': [
-                        'nlcd-2011-30m-epsg5070-512-int8'
+                        '__LAND__'
                     ]
                 },
                 {
                     'name': 'RasterLinesJoin',
                     'label': 'nlcd_streams',
                     'rasters': [
-                        'nlcd-2011-30m-epsg5070-512-int8'
+                        '__LAND__'
                     ]
                 }
             ]


### PR DESCRIPTION
## Overview

Previously, the raster layer names were hardcoded in specific JSON blocks of configuration. Now, since we may use a variant for different types of raster layers (land, soil, etc), we parameterize the configuration, replacing a token with the real layer name at run time.

There is a default set of layers that will be used if no overrides are provided. Only those layers that are being overridden need to be provided, the rest will come from the default.

When using the default layers, the existing cache keys will be used. When using overridden layers, those layer names will be added to the cache key. If the default layers are ever changed, we'll have to clear the geoprocessing cache. This PR only tokenizes the layers, and does not change the default ones.

This will mainly be used for MapShed modeling, but we also refactor Land analysis to use this, which cuts down on lines of code and demos the feature.

Connects #3405 

## Testing Instructions

* Check out this branch
* Delete all cached geoprocessing runs:
    ```console
    $ vagrant ssh services -c 'redis-cli -n 1 --raw KEYS ":1:geop_*" | xargs redis-cli -n 1 DEL'
    ```
  This is necessary whenever we change the default layers. Not the case in this PR, but might as well.
* Restart celery:
    ```console
    $ vagrant ssh worker -c 'sudo service celeryd restart'
    ```
* Go to [:8000](http://localhost:8000/) and find a shape that has variation between 2001 and 2019 land covers. Or just type in "Van Sciver Lake" into the search box in the top right, and select the "Van Sciver Lake-Delaware River, HUC-12 Subwatershed" shape (it may take a while to show up, wait for the spinner to end)
* In the Land Analysis, ensure that the 2001 and 2019 have different results in the chart and table (compare the value of Deciduous Forest if using Van Sciver Lake), and compare with the same shape on https://staging.modelmywatershed.org/ to confirm