### PR TITLE
Analyze High Resolution NHD Streams

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -3,14 +3,15 @@
 set -e
 set -x
 
-usage="$(basename "$0") [-h] [-b] [-s] \n
+usage="$(basename "$0") [-h] [options] \n
 --Sets up a postgresql database for MMW \n
 \n
-where: \n
+where options are one or more of: \n
     -h  show this help text\n
     -b  load/reload boundary data\n
     -f  load a named boundary sql.gz\n
     -s  load/reload stream data\n
+    -S  load/reload Hi Res stream data (very large)\n
     -d  load/reload DRB stream data\n
     -m  load/reload mapshed data\n
     -p  load/reload DEP data\n

--- a/src/mmw/apps/geoprocessing_api/calcs.py
+++ b/src/mmw/apps/geoprocessing_api/calcs.py
@@ -119,7 +119,7 @@ def stream_data(results, geojson, datasource='nhd'):
 
     return {
         'displayName': 'Streams',
-        'name': 'streams',
+        'name': 'streams_{}'.format(datasource),
         'categories': sorted(list(stream_data.values()),
                              key=itemgetter('order')),
     }

--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -11,6 +11,16 @@ from drf_yasg.openapi import (
 
 from django.conf import settings
 
+STREAM_DATASOURCE = Parameter(
+    'datasource',
+    IN_PATH,
+    description='The stream datasource to query.'
+                ' Must be one of: "{}"'.format(
+                    '", "'.join(settings.STREAM_TABLES.keys())),
+    type=TYPE_STRING,
+    required=True,
+)
+
 nlcd_year_allowed_values = [
     '2019_2019',
     '2019_2016',

--- a/src/mmw/apps/geoprocessing_api/tasks.py
+++ b/src/mmw/apps/geoprocessing_api/tasks.py
@@ -89,12 +89,12 @@ def start_rwd_job(location, snapping, simplify, data_source):
 
 
 @shared_task
-def analyze_streams(results, area_of_interest):
+def analyze_streams(results, area_of_interest, datasource='nhd'):
     """
     Given geoprocessing results with stream data and an area of interest,
     returns the streams and stream order within it.
     """
-    return {'survey': stream_data(results, area_of_interest)}
+    return {'survey': stream_data(results, area_of_interest, datasource)}
 
 
 @shared_task

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -27,7 +27,7 @@ urlpatterns = [
         name='start_analyze_catchment_water_quality'),
     url(r'analyze/climate/$', views.start_analyze_climate,
         name='start_analyze_climate'),
-    url(r'analyze/streams/$', views.start_analyze_streams,
+    url(r'analyze/streams/(?P<datasource>\w+)/?$', views.start_analyze_streams,
         name='start_analyze_streams'),
     url(r'analyze/terrain/$', views.start_analyze_terrain,
         name='start_analyze_terrain'),

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -556,7 +556,7 @@ def start_analyze_streams(request, datasource, format=None):
         {
             "survey": {
                 "displayName": "Streams",
-                "name": "streams",
+                "name": "streams_nhd",
                 "categories": [
                     {
                         "lengthkm": 2.598,

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -313,22 +313,25 @@ def ls_factor(stream_length, area, avg_slope, m):
         return ls
 
 
-def stream_length(geom, drb=False):
+def stream_length(geom, datasource='nhd'):
     """
     Given a geometry, finds the total length of streams in meters within it.
     If the drb flag is set, we use the Delaware River Basin dataset instead
     of NHD Flowline.
     """
+    if datasource not in settings.STREAM_TABLES:
+        raise Exception('Invalid stream datasource {}'.format(datasource))
+
     sql = '''
           SELECT ROUND(SUM(ST_Length(
               ST_Transform(
                   ST_Intersection(geom,
                                   ST_SetSRID(ST_GeomFromText(%s), 4326)),
                   5070))))
-          FROM {datasource}
+          FROM {stream_table}
           WHERE ST_Intersects(geom,
                               ST_SetSRID(ST_GeomFromText(%s), 4326));
-          '''.format(datasource='drb_streams_50' if drb else 'nhdflowline')
+          '''.format(stream_table=settings.STREAM_TABLES[datasource])
 
     with connection.cursor() as cursor:
         cursor.execute(sql, [geom.wkt, geom.wkt])
@@ -336,19 +339,22 @@ def stream_length(geom, drb=False):
         return cursor.fetchone()[0] or 0  # Aggregate query returns singleton
 
 
-def streams(geojson, drb=False):
+def streams(geojson, datasource='nhd'):
     """
     Given a GeoJSON, returns a list containing a single MultiLineString, that
     represents the set of streams that intersect with the geometry, in LatLng.
     If the drb flag is set, we use the Delaware River Basin dataset instead of
     NHD Flowline.
     """
+    if datasource not in settings.STREAM_TABLES:
+        raise Exception('Invalid stream datasource {}'.format(datasource))
+
     sql = '''
           SELECT ST_AsGeoJSON(ST_Collect(ST_Force2D(geom)))
-          FROM {datasource}
+          FROM {stream_table}
           WHERE ST_Intersects(geom,
                               ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326))
-          '''.format(datasource='drb_streams_50' if drb else 'nhdflowline')
+          '''.format(stream_table=settings.STREAM_TABLES[datasource])
 
     with connection.cursor() as cursor:
         cursor.execute(sql, [geojson])

--- a/src/mmw/apps/modeling/mapshed/calcs.py
+++ b/src/mmw/apps/modeling/mapshed/calcs.py
@@ -350,7 +350,7 @@ def streams(geojson, datasource='nhd'):
         raise Exception('Invalid stream datasource {}'.format(datasource))
 
     sql = '''
-          SELECT ST_AsGeoJSON(ST_Collect(ST_Force2D(geom)))
+          SELECT ST_AsGeoJSON(ST_Multi(geom))
           FROM {stream_table}
           WHERE ST_Intersects(geom,
                               ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326))

--- a/src/mmw/js/src/analyze/mocks.js
+++ b/src/mmw/js/src/analyze/mocks.js
@@ -472,7 +472,7 @@ module.exports = {
         },
         "started": "2020-01-17T21:19:06.880891Z",
         "status": "complete",
-        "taskName": "analyze/streams",
+        "taskName": "analyze/streams/nhd",
         "taskType": "api",
         "timeout": 160000,
         "token": "1831c4a26158079f2b5f1530f01beaeca6517544",

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -220,7 +220,15 @@ function createAnalyzeTaskGroupCollection(aoi, wkaoi) {
             displayName: "Streams",
             tasks: [
                 {
-                    name: "streams",
+                    name: "streams_nhdhr",
+                    displayName: "NHD High Resolution Streams",
+                    area_of_interest: aoi,
+                    wkaoi: wkaoi,
+                    taskName: "analyze/streams/nhdhr"
+                },
+                {
+                    name: "streams_nhd",
+                    displayName: "NHD Medium Resolution Streams",
                     area_of_interest: aoi,
                     wkaoi: wkaoi,
                     taskName: "analyze/streams/nhd"

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -223,7 +223,7 @@ function createAnalyzeTaskGroupCollection(aoi, wkaoi) {
                     name: "streams",
                     area_of_interest: aoi,
                     wkaoi: wkaoi,
-                    taskName: "analyze/streams"
+                    taskName: "analyze/streams/nhd"
                 },
             ]
         },

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1685,10 +1685,17 @@ var ClimateResultView = AnalyzeResultView.extend({
 
 var StreamResultView = AnalyzeResultView.extend({
     onShow: function() {
-        var title = 'Stream Network Statistics',
-            source = 'NHDplusV2',
+        var taskName = this.model.get('name'),
+            title = taskName === 'streams_nhdhr' ?
+                    'NHD High Resolution Stream Network Statistics' :
+                    'NHD Medium Resolution Stream Network Statistics',
+            source = taskName === 'streams_nhdhr' ?
+                     'NHDplusHR' :
+                     'NHDplusV2',
             helpText = 'For more information on the data source, see <a href=\'https://wikiwatershed.org/documentation/mmw-tech/#overlays-tab-in-layers-streams\' target=\'_blank\' >MMW Technical Documentation</a>',
-            associatedLayerCodes = ['nhd_streams_v2'],
+            associatedLayerCodes = taskName === 'streams_nhdhr' ?
+                                   ['nhd_streams_hr_v1'] :
+                                   ['nhd_streams_v2'],
             chart = null,
             streamOrderHelpText = [
                 {
@@ -1722,7 +1729,8 @@ var AnalyzeResultViews = {
     pointsource: PointSourceResultView,
     catchment_water_quality: CatchmentWaterQualityResultView,
     climate: ClimateResultView,
-    streams: StreamResultView,
+    streams_nhd: StreamResultView,
+    streams_nhdhr: StreamResultView,
     terrain: TerrainResultView,
     protected_lands: LandResultView,
     drb_2100_land_centers: LandResultView,

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -14,7 +14,7 @@ from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 
 from layer_settings import (LAYER_GROUPS, VIZER_URLS, VIZER_IGNORE, VIZER_NAMES,
-                            DRB_PERIMETER, DRB_SIMPLE_PERIMETER,
+                            DRB_PERIMETER, DRB_SIMPLE_PERIMETER, STREAM_TABLES,
                             NHD_REGION2_PERIMETER, CONUS_PERIMETER)  # NOQA
 from gwlfe_settings import (GWLFE_DEFAULTS, GWLFE_CONFIG, SOIL_GROUP, # NOQA
                             CURVE_NUMBER, NODATA, SRAT_KEYS, SUBBASIN_SOURCE_NORMALIZING_AREAS,  # NOQA

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -615,6 +615,13 @@ LAYER_GROUPS = {
 }
 
 
+# List of valid stream tables
+STREAM_TABLES = {
+    'nhd': 'nhdflowline',
+    'nhdhr': 'nhdflowlinehr',
+    'drb': 'drb_streams_50',
+}
+
 DRB_PERIMETER = GEOSGeometry(json.dumps(drb_perimeter['geometry']), srid=4326)
 DRB_SIMPLE_PERIMETER = \
     GEOSGeometry(json.dumps(drb_simple_perimeter['geometry']), srid=4326)


### PR DESCRIPTION
## Overview

Add analysis of NHD High Resolution Streams to the Analyze sidebar.

The existing NHD Medium Resolution Streams are still analyzed, but are relegated to a non-default dropdown selection.

The stream selection query was modified to work with `LineString`s from NHD Medium Resolution table `nhdflowline` and the `MultiLineString`s from NHD High Resolution table `nhdflowlinehr`. This change will actually make the processing faster, since we're doing fewer operations, `ST_Multi` instead of `ST_Collect` and `ST_Force2D`. `ST_Multi` would be a no-op for `nhflowlinehr`, make it even faster.

Also change current analyze streams endpoint to require an explicit stream datasource parameter. This is a breaking change, similar to the change made for Land analysis in #3399.

Connects #3418 

### Demo

![2021-10-21 12 51 06](https://user-images.githubusercontent.com/1430060/138326716-cd0a505a-81fb-4ecb-957b-eab8069b0be5.gif)

## Testing Instructions

* Ensure you have both NHD Streams datasets installed locally. Comment out [these lines](https://github.com/WikiWatershed/model-my-watershed/blob/aaaace876aaf53a8ca3e536e9103b42501f3142a/scripts/aws/setupdb.sh#L87-L89), then run:
    ```
    vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -sS
    ```
* Check out this branch and restart Celery to load the new tasks
    ```
    vagrant ssh worker -c 'sudo service celeryd restart'
    ```
* Go to http://localhost:8000/ and choose an area of interest
* In the analyze stage:
  - [x] Ensure you see a dropdown in the Stream tab
  - [x] Ensure both analyses complete successfully
  - [x] Ensure the values are different, and make sense (High Resolution having more stream length than Medium Resolution)