### PR TITLE
Upgrade Deployment Code to Python 3

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -25,6 +25,7 @@ postgis_package_version: "2.5.*.pgdg20.04+1"
 daemontools_version: "1:0.76-7"
 
 python_version: "3.8.*"
+ansible_python_interpreter: "/usr/bin/python3"
 
 yarn_version: "1.19.*"
 app_nodejs_version: "12.11.1"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -7,7 +7,7 @@
 - src: azavea.git
   version: 0.1.0
 - src: azavea.nginx
-  version: 0.3.1
+  version: 1.0.0
 - src: azavea.daemontools
   version: 0.1.0
 - src: azavea.postgresql
@@ -21,6 +21,6 @@
 - src: azavea.build-essential
   version: 0.1.0
 - src: azavea.java
-  version: 0.6.2
+  version: 0.7.0
 - src: azavea.docker
   version: 6.0.0

--- a/deployment/ansible/roles/model-my-watershed.base/tasks/papertrail.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/tasks/papertrail.yml
@@ -2,7 +2,7 @@
   get_url:
     url: https://papertrailapp.com/tools/papertrail-bundle.pem
     dest: /etc/papertrail-bundle.pem
-    checksum: sha256:79ea479e9f329de7075c40154c591b51eb056d458bc4dff76d9a4b9c6c4f6d0b
+    checksum: sha256:ae31ecb3c6e9ff3154cb7a55f017090448f88482f0e94ac927c0c67a1f33b9cf
 
 - name: Install rsyslog TLS utils
   apt: name=rsyslog-gnutls

--- a/deployment/ansible/roles/model-my-watershed.python/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.python/tasks/main.yml
@@ -5,10 +5,6 @@
           "python3-distutils={{ python_version }}"]
     state: present
 
-- name: Make python3 default
-  shell: update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-  become: yes
-
 - name: Install pip
   shell: curl -sL https://bootstrap.pypa.io/get-pip.py | sudo python3
   args:

--- a/deployment/ansible/roles/model-my-watershed.rwd/tasks/app.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/tasks/app.yml
@@ -4,7 +4,7 @@
         state=directory
 
 - name: Configure RWD service definition
-  docker_service:
+  docker_compose:
     project_name: mmw
     state: present
     definition:
@@ -22,5 +22,3 @@
             driver: syslog
             options:
               tag: mmw-rwd
-  vars:
-    ansible_python_interpreter: /usr/bin/python

--- a/deployment/cfn/application.py
+++ b/deployment/cfn/application.py
@@ -12,9 +12,9 @@ from troposphere import (
     autoscaling as asg
 )
 
-from utils.cfn import get_recent_ami
+from cfn.utils.cfn import get_recent_ami
 
-from utils.constants import (
+from cfn.utils.constants import (
     ALLOW_ALL_CIDR,
     EC2_INSTANCE_TYPES,
     HTTP,

--- a/deployment/cfn/data_plane.py
+++ b/deployment/cfn/data_plane.py
@@ -12,9 +12,9 @@ from troposphere import (
     route53 as r53
 )
 
-from utils.cfn import get_recent_ami
+from cfn.utils.cfn import get_recent_ami
 
-from utils.constants import (
+from cfn.utils.constants import (
     ALLOW_ALL_CIDR,
     CANONICAL_ACCOUNT_ID,
     EC2_INSTANCE_TYPES,

--- a/deployment/cfn/stacks.py
+++ b/deployment/cfn/stacks.py
@@ -1,18 +1,18 @@
 from majorkirby import GlobalConfigNode
 
-from vpc import VPC
-from s3_vpc_endpoint import S3VPCEndpoint
-from private_hosted_zone import PrivateHostedZone
-from data_plane import DataPlane
-from application import Application
-from tiler import Tiler
-from tile_delivery_network import TileDeliveryNetwork
-from worker import Worker
-from public_hosted_zone import PublicHostedZone
+from cfn.vpc import VPC
+from cfn.s3_vpc_endpoint import S3VPCEndpoint
+from cfn.private_hosted_zone import PrivateHostedZone
+from cfn.data_plane import DataPlane
+from cfn.application import Application
+from cfn.tiler import Tiler
+from cfn.tile_delivery_network import TileDeliveryNetwork
+from cfn.worker import Worker
+from cfn.public_hosted_zone import PublicHostedZone
 
 from boto import cloudformation as cfn
 
-import ConfigParser
+import configparser
 import sys
 
 
@@ -23,13 +23,13 @@ def get_config(mmw_config_path, profile):
     :param mmw_config_path: Path to the config file
     :param profile: Config profile to read
     """
-    mmw_config = ConfigParser.ConfigParser()
+    mmw_config = configparser.ConfigParser()
     mmw_config.optionxform = str
     mmw_config.read(mmw_config_path)
 
     try:
         section = mmw_config.items(profile)
-    except ConfigParser.NoSectionError:
+    except configparser.NoSectionError:
         sys.stderr.write('There is no section [{}] in the configuration '
                          'file\n'.format(profile))
         sys.stderr.write('you specified. Did you specify the correct file?')

--- a/deployment/cfn/tile_delivery_network.py
+++ b/deployment/cfn/tile_delivery_network.py
@@ -10,7 +10,7 @@ from troposphere import (
     s3
 )
 
-from utils.constants import (
+from cfn.utils.constants import (
     AMAZON_S3_HOSTED_ZONE_ID,
     AMAZON_S3_WEBSITE_DOMAIN,
 )
@@ -89,7 +89,7 @@ class TileDeliveryNetwork(StackNode):
                         DomainName=Join('.',
                                         ['tile-cache',
                                          Ref(self.public_hosted_zone_name)]),
-                        CustomOriginConfig=cf.CustomOrigin(
+                        CustomOriginConfig=cf.CustomOriginConfig(
                             OriginProtocolPolicy='http-only'
                         )
                     )
@@ -112,7 +112,7 @@ class TileDeliveryNetwork(StackNode):
                         DomainName=Join('.',
                                         ['tile-cache',
                                          Ref(self.public_hosted_zone_name)]),
-                        CustomOriginConfig=cf.CustomOrigin(
+                        CustomOriginConfig=cf.CustomOriginConfig(
                             OriginProtocolPolicy='http-only'
                         )
                     )

--- a/deployment/cfn/tiler.py
+++ b/deployment/cfn/tiler.py
@@ -13,9 +13,9 @@ from troposphere import (
     route53 as r53
 )
 
-from utils.cfn import get_recent_ami
+from cfn.utils.cfn import get_recent_ami
 
-from utils.constants import (
+from cfn.utils.constants import (
     ALLOW_ALL_CIDR,
     EC2_INSTANCE_TYPES,
     HTTP,

--- a/deployment/cfn/vpc.py
+++ b/deployment/cfn/vpc.py
@@ -7,13 +7,13 @@ from troposphere import (
     ec2
 )
 
-from utils.cfn import (
+from cfn.utils.cfn import (
     get_availability_zones,
     get_recent_ami,
     get_subnet_cidr_block
 )
 
-from utils.constants import (
+from cfn.utils.constants import (
     ALLOW_ALL_CIDR,
     EC2_INSTANCE_TYPES,
     HTTP,

--- a/deployment/cfn/worker.py
+++ b/deployment/cfn/worker.py
@@ -13,9 +13,9 @@ from troposphere import (
     route53 as r53
 )
 
-from utils.cfn import get_recent_ami
+from cfn.utils.cfn import get_recent_ami
 
-from utils.constants import (
+from cfn.utils.constants import (
     ALLOW_ALL_CIDR,
     EC2_INSTANCE_TYPES,
     HTTP,

--- a/deployment/packer/mmw.json
+++ b/deployment/packer/mmw.json
@@ -92,7 +92,7 @@
                 "sudo apt-get install python2 python2-dev -y",
                 "sudo ln -s /usr/bin/python2 /usr/bin/python",
                 "curl -sL https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python",
-                "sudo pip install ansible==2.7.18",
+                "sudo pip install ansible==2.9.27",
                 "sudo /bin/sh -c 'echo {{user `branch`}} {{user `description`}} > /srv/version.txt'"
             ]
         },

--- a/deployment/packer/mmw.json
+++ b/deployment/packer/mmw.json
@@ -89,9 +89,8 @@
             "inline": [
                 "sleep 5",
                 "sudo apt-get update -qq",
-                "sudo apt-get install python2 python2-dev -y",
-                "sudo ln -s /usr/bin/python2 /usr/bin/python",
-                "curl -sL https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python",
+                "sudo apt-get install python3 python3-dev python3-distutils -y",
+                "curl -sL https://bootstrap.pypa.io/get-pip.py | sudo python3",
                 "sudo pip install ansible==2.9.27",
                 "sudo /bin/sh -c 'echo {{user `branch`}} {{user `description`}} > /srv/version.txt'"
             ]

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,5 +1,6 @@
-ansible==2.6.18
-majorkirby>=0.2.0,<0.2.99
-troposphere==1.1.0
-boto==2.39.0
+cryptography==3.2.1
+ansible==2.9.27
+troposphere==2.4.9
+majorkirby==1.0.0
+boto==2.49.0
 awscli>=1.9.15

--- a/scripts/aws/staging-deployment.sh
+++ b/scripts/aws/staging-deployment.sh
@@ -32,7 +32,7 @@ fi
 pushd deployment
 
 # Attempt to launch a new stack & cutover DNS
-python mmw_stack.py launch-stacks \
+python3 mmw_stack.py launch-stacks \
   --aws-profile "${MMW_AWS_PROFILE}" \
   --mmw-profile "${MMW_PROFILE}" \
   --mmw-config-path "${MMW_CONFIG_PATH}" \
@@ -40,7 +40,7 @@ python mmw_stack.py launch-stacks \
   --activate-dns
 
 # Remove old stack
-python mmw_stack.py remove-stacks \
+python3 mmw_stack.py remove-stacks \
   --aws-profile "${MMW_AWS_PROFILE}" \
   --mmw-profile "${MMW_PROFILE}" \
   --mmw-config-path "${MMW_CONFIG_PATH}" \

--- a/src/mmw/manage.py
+++ b/src/mmw/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -9,7 +9,6 @@ django-extensions==2.2.5
 python-omgeo==6.1.0
 rauth==0.7.1
 djangorestframework-gis==0.14.0
-ruamel.yaml==0.17.6
 drf_yasg==1.16.0
 django-cors-headers==3.0.2
 cryptography==2.7
@@ -26,7 +25,6 @@ django_celery_results==1.0.1
 pandas==1.3.3
 ulmo==0.8.5
 hs_restclient==1.3.4
-six==1.11.0
 fiona==1.8.20
 redis==3.5.3
 numpy==1.20.3


### PR DESCRIPTION
## Overview

Upgrades deployment code to Python 3 and unblocks staging deployments. We're limited by our Jenkins instance to only go up to Python 3.5 (which is EOLing soon), but since there's other projects on that instance that use Python 3.5 (particularly OTM), we are unable to upgrade Python 3 without affecting other projects.

This also installs Python 3 in the Packer VM used for building the AMIs, and uses `python3` for both provisioning and running Django.

Connects #3437 
Supersedes #3438 

### Demo

http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-packer-app-and-worker/1387/
http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-staging-deployment/1450/

```bash
http --body https://staging.modelmywatershed.org/version.txt

origin/tt/upgrade-deployment-python-3 b1.32.2-102-gc9511631df4d72486cb500792e3fcbdf791afffc
```

![image](https://user-images.githubusercontent.com/1430060/146227238-d22364f5-8177-41b7-bd71-14042f889588.png)

### Notes

This took many attempts to get right. The key insight preventing the successful provisioning on AWS was the presence of `six`, removed in ef2a55e, whose presence kept failing `cloud-init` with the following message:

```
[  164.076543] cloud-init[434]: 2021-12-09 18:26:04,629 - url_helper.py[WARNING]: Calling 'http://169.254.169.254/latest/api/token' failed [13/120s]: request error [Failed to parse: http://169.254.169.254/latest/api/token]
```

While all the other attempts / commits / branches will be deleted once this is merged, I'm recording them here to capture the effort it took:

![image](https://user-images.githubusercontent.com/1430060/146228591-e6bec163-f340-4d72-85fc-4273de23bef7.png)

## Testing Instructions

* Go to https://staging.modelmywatershed.org
  - [x] Ensure site works as expected
* Open the Jenkins jobs in the demo (you'll need to be on the VPN for that)
  - [x] Ensure they passed successfully
* Destroy and reprovision your `app`, `worker`, and `tiler` VMs
    ```bash
    vagrant destroy -f app worker tiler && vagrant up
    ```
  - [x] Ensure it finishes successfully