### PR TITLE
Upgrade GWLF-E to 3.1.0 to fix SummaryLoad calcs

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -15,7 +15,7 @@ cryptography==36.0.1
 pyOpenSSL==21.0.0
 markdown==3.3.6
 tr55==1.3.0
-gwlf-e==3.0.0
+gwlf-e==3.1.0
 requests[security]==2.26.0
 rollbar==0.16.2
 retry==0.9.2


### PR DESCRIPTION
## Overview

Previously the SummaryLoad calculations did not take into account the changes from https://github.com/WikiWatershed/gwlf-e/pull/84. This was fixed in https://github.com/WikiWatershed/gwlf-e/pull/89 and is pulled in here.

Connects https://github.com/WikiWatershed/gwlf-e/pull/89
Connects #3374

## Testing Instructions

- Check out this branch and provision the `app` and `worker`
    ```
    vagrant provision app worker
    ```
- Go to http://localhost:8000 and draw a new shape
- Model it with Watershed Multi-Year Model
- Switch to the Water Quality tab of the results
  - [x] Ensure the value of **Total Loads (kg)** of **Sediment** in the top table is equal to the sum of **Sediment (kg)** loads of all the **Sources** in the bottom table