### PR TITLE
Upgrade to Postgres 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Local Development
 
-A combination of Vagrant 2.2+ and Ansible 2.5+ is used to setup the development environment for this project. The project consists of the following virtual machines:
+A combination of Vagrant 2.2+ and Ansible 2.8 is used to setup the development environment for this project. The project consists of the following virtual machines:
 
 - `app`
 - `services`
@@ -32,10 +32,16 @@ First, ensure that you have a set of Amazon Web Services (AWS) credentials with 
 $ aws configure --profile mmw-stg
 ```
 
+Ensure you have the [vagrant-disksize](https://github.com/sprotheroe/vagrant-disksize) plugin installed:
+
+```bash
+$ vagrant plugin install vagrant-disksize
+```
+
 Next, use the following command to bring up a local development environment:
 
 ```bash
-$ MMW_ITSI_SECRET_KEY="***" vagrant up
+$ vagrant up
 ```
 
 The application will now be running at [http://localhost:8000](http://localhost:8000).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,6 +90,11 @@ Vagrant.configure("2") do |config|
     end
 
     services.vm.provision "shell" do |s|
+      # The base box we use comes with a ~30GB disk. The physical disk is
+      # expanded to 64GB above using vagrant-disksize. The logical disk and
+      # the file system need to be expanded as well to make full use of the
+      # space. `lvextend` expands the logical disk, and `resize2fs` expands
+      # the files system.
       s.inline = <<-SHELL
         sudo lvextend -l +100%FREE /dev/ubuntu-vg/ubuntu-lv
         sudo resize2fs /dev/mapper/ubuntu--vg-ubuntu--lv

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -14,13 +14,13 @@ postgresql_username: mmw
 postgresql_password: mmw
 postgresql_database: mmw
 
-postgresql_version: "9.6"
-postgresql_package_version: "9.6.*.pgdg20.04+1"
+postgresql_version: "13"
+postgresql_package_version: "13.*.pgdg20.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "14*.pgdg20.04+1"
-postgresql_support_psycopg2_version: "2.8.6"
-postgis_version: "2.5"
-postgis_package_version: "2.5.*.pgdg20.04+1"
+postgresql_support_libpq_version: "13.*.pgdg20.04+1"
+postgresql_support_psycopg2_version: "2.8.*"
+postgis_version: "3"
+postgis_package_version: "3.2*pgdg20.04+1"
 
 daemontools_version: "1:0.76-7"
 

--- a/deployment/ansible/roles/model-my-watershed.app/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/defaults/main.yml
@@ -10,7 +10,7 @@ app_config:
   DJANGO_POSTGIS_VERSION: "{{ app_postgis_version }}"
   DJANGO_SECRET_KEY: "{{ app_secret_key }}"
 
-app_postgis_version: 2.1.3
+app_postgis_version: 3.1.4
 app_secret_key: "{{ postgresql_password | md5 }}"
 
 app_static_root: /var/www/mmw/static/

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/defaults/main.yml
@@ -10,7 +10,7 @@ app_config:
   DJANGO_POSTGIS_VERSION: "{{ app_postgis_version }}"
   DJANGO_SECRET_KEY: "{{ app_secret_key }}"
 
-app_postgis_version: 2.1.3
+app_postgis_version: 3.1.4
 app_secret_key: "{{ postgresql_password | md5 }}"
 
 celery_pid_dir: "/run/celery"

--- a/deployment/ansible/roles/model-my-watershed.postgresql-support/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.postgresql-support/tasks/main.yml
@@ -12,6 +12,7 @@
       - libpq5={{ postgresql_support_libpq_version }}
       - libpq-dev={{ postgresql_support_libpq_version }}
     state: present
+    force: true
 
 - name: Install PostgreSQL driver for Python
   pip: name=psycopg2-binary

--- a/deployment/ansible/roles/model-my-watershed.postgresql-support/tasks/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.postgresql-support/tasks/main.yml
@@ -7,8 +7,11 @@
                   state=present
 
 - name: Install client API libraries for PostgreSQL
-  apt: pkg=libpq-dev={{ postgresql_support_libpq_version }}
-       state=present
+  apt:
+    pkg:
+      - libpq5={{ postgresql_support_libpq_version }}
+      - libpq-dev={{ postgresql_support_libpq_version }}
+    state: present
 
 - name: Install PostgreSQL driver for Python
   pip: name=psycopg2-binary

--- a/deployment/cfn/data_plane.py
+++ b/deployment/cfn/data_plane.py
@@ -296,7 +296,7 @@ class DataPlane(StackNode):
             DBParameterGroupName=Ref(self.rds_parameter_group_name),
             DBSubnetGroupName=Ref(rds_subnet_group),
             Engine='postgres',
-            EngineVersion='9.6.22',
+            EngineVersion='9.6.23',
             MasterUsername=Ref(self.rds_username),
             MasterUserPassword=Ref(self.rds_password),
             MultiAZ=Ref(self.rds_multi_az),

--- a/deployment/cfn/data_plane.py
+++ b/deployment/cfn/data_plane.py
@@ -64,7 +64,7 @@ class DataPlane(StackNode):
         'KeyName': 'mmw-stg',
         'IPAccess': ALLOW_ALL_CIDR,
         'BastionHostInstanceType': 't2.medium',
-        'RDSInstanceType': 'db.t2.micro',
+        'RDSInstanceType': 'db.t3.micro',
         'RDSDbName': 'modelmywatershed',
         'RDSUsername': 'modelmywatershed',
         'RDSPassword': 'modelmywatershed',
@@ -111,7 +111,7 @@ class DataPlane(StackNode):
         ), 'BastionHostAMI')
 
         self.rds_instance_type = self.add_parameter(Parameter(
-            'RDSInstanceType', Type='String', Default='db.t2.micro',
+            'RDSInstanceType', Type='String', Default='db.t3.micro',
             Description='RDS instance type', AllowedValues=RDS_INSTANCE_TYPES,
             ConstraintDescription='must be a valid RDS instance type.'
         ), 'RDSInstanceType')

--- a/deployment/cfn/data_plane.py
+++ b/deployment/cfn/data_plane.py
@@ -296,7 +296,7 @@ class DataPlane(StackNode):
             DBParameterGroupName=Ref(self.rds_parameter_group_name),
             DBSubnetGroupName=Ref(rds_subnet_group),
             Engine='postgres',
-            EngineVersion='9.6.23',
+            EngineVersion='13.4',
             MasterUsername=Ref(self.rds_username),
             MasterUserPassword=Ref(self.rds_password),
             MultiAZ=Ref(self.rds_multi_az),

--- a/deployment/cfn/data_plane.py
+++ b/deployment/cfn/data_plane.py
@@ -296,7 +296,7 @@ class DataPlane(StackNode):
             DBParameterGroupName=Ref(self.rds_parameter_group_name),
             DBSubnetGroupName=Ref(rds_subnet_group),
             Engine='postgres',
-            EngineVersion='9.6.14',
+            EngineVersion='9.6.22',
             MasterUsername=Ref(self.rds_username),
             MasterUserPassword=Ref(self.rds_password),
             MultiAZ=Ref(self.rds_multi_az),

--- a/deployment/cfn/utils/constants.py
+++ b/deployment/cfn/utils/constants.py
@@ -8,10 +8,10 @@ EC2_INSTANCE_TYPES = [
 ]
 
 RDS_INSTANCE_TYPES = [
-    'db.t2.micro',
-    'db.t2.small',
-    'db.t2.medium',
-    'db.t2.large'
+    'db.t3.micro',
+    'db.t3.small',
+    'db.t3.medium',
+    'db.t3.large'
 ]
 
 ELASTICACHE_INSTANCE_TYPES = [

--- a/deployment/cfn/vpc.py
+++ b/deployment/cfn/vpc.py
@@ -94,9 +94,9 @@ class VPC(StackNode):
         self.add_output(Output('AvailabilityZones',
                                Value=','.join(self.default_azs)))
         self.add_output(Output('PrivateSubnets',
-                               Value=Join(',', map(Ref, self.default_private_subnets))))  # NOQA
+                               Value=Join(',', list(map(Ref, self.default_private_subnets)))))  # NOQA
         self.add_output(Output('PublicSubnets',
-                               Value=Join(',', map(Ref, self.default_public_subnets))))  # NOQA
+                               Value=Join(',', list(map(Ref, self.default_public_subnets)))))  # NOQA
         self.add_output(Output('RouteTableId', Value=Ref(public_route_table)))
 
     def get_recent_nat_ami(self):

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -98,7 +98,7 @@ DATABASES = {
 }
 
 POSTGIS_VERSION = tuple(
-    map(int, environ.get('DJANGO_POSTGIS_VERSION', '2.3.7').split("."))
+    map(int, environ.get('DJANGO_POSTGIS_VERSION', '3.1.4').split("."))
 )
 # END DATABASE CONFIGURATION
 


### PR DESCRIPTION
## Overview

Upgrades Postgres to 13.4, the latest available on RDS, from 9.6.22. Necessary as AWS is going to hard switch to 12 come January 18. This PR upgrades Postgres in development and staging. It will be upgraded on production in #3444.

Connects #3379 

### Demo

```
ssh mmw-stg "psql -h database.service.mmw.internal -d modelmywatershed -U modelmywatershed -c 'SELECT version();'"
Password for user modelmywatershed: ***

                                                 version
---------------------------------------------------------------------------------------------------------
 PostgreSQL 13.4 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 7.3.1 20180712 (Red Hat 7.3.1-12), 64-bit
(1 row)
```

![image](https://user-images.githubusercontent.com/1430060/148443419-5d1e818c-ecda-452a-aab6-e9c83eb5fb2c.png)

### Notes

Here's the full steps that were taken for the performing this ugprade on staging:

#### General Setup for Working with Deployments

1. Have a virtualenv with Python 3.5+ (preferably 3.8 or 3.9) for working with the deployment code in `~/deployment`. Activate it.
2. Install all the deployment requirements `pip install -r requirements.txt`
3. Ensure you have the `mmw-stg` AWS profile configured correctly
4. Ensure you have access to the `mmw-stg.pem` file for SSHing in to Bastion
5. Ensure you have a `staging.yml` deployment configuration file available locally, akin to the `default.yml` used for deployments in the fileshare.

#### Take a Database Snapshot

(this was not done for staging, but should be done for production)

1. Log in to AWS using the `mmw-stg` credentials in LastPass
2. Go to RDS, select Snapshots → Take snapshot, and name it "pre-postgres-upgrade"

#### Upgrade Bastion

The bastion currently runs on 16.04 Xenial, whereas everything else has been upgraded to 20.04 Focal.

1. Generate a plan for the data plane upgrade and save it as JSON:
    ```bash
    python mmw_stack.py launch-stacks --aws-profile "mmw-stg" --mmw-profile "staging" --mmw-config-path ~/azavea/model-my-watershed/scratch/staging.yml --data-plane --print-json > data-plane.json
    ```
2. In that plan, find the default value of `BastionHostAMI`:
    ```bash
    jq '.Parameters.BastionHostAMI.Default' data-plane.json
    "ami-06992628e0a8e044c"
    ```
3. Log in to AWS using the `mmw-stg` credentials in LastPass
4. Go to CloudFormation, select DataPlane → Change sets → Create change set
5. Select "Use current template" and update the `BastionHostAMI` with the value from above
5. Set `RDSParameterGroupName` to `mmw-postgres96`
6. Click Next, don't change any Stack options, click "Create change set" after reviewing it
7. In the description box, write "Upgrading Bastion to Ubuntu 20.04", and create it
8. Once it is created, "Execute" the change set. Choose to execute it immediately, than in a scheduled window
9. Observe the change set being executed. In case of failures, you'll see reasons for them in CloudFormation's DataPlan → Events. Fix them and try again.
10. Once the new Bastion is up, ensure you can SSH in to it using the `mmw-stg.pem` file
11. From within the Bastion, try SSHing in to an `app` or `worker` VM to ensure that still works
12. Install the postgres-client:
    ```bash
    sudo apt install postgres-client
    ```
13. Create a new tmux session for psql:
    ```bash
    tmux new-session -A -s psql
    ```
14. Start psql in the tmux session, and then detach from it using <kbd>Ctrl+B</kbd>, <kbd>D</kbd>
    ```bash
    psql -h database.service.mmw.internal -d modelmywatershed -U modelmywatershed
    ```

#### Upgrade Postgres to 9.6.23

This is the latest version of Postgres 9.6, and will make subsequent upgrades easier.

1. Go to RDS → Databases → dd1gc3iuv75ep7t (or whatever is the database ID) → Modify
2. Set DB engine version to `9.6.23`, DB Instance class to `db.t3.medium`
3. Click "Continue"
4. Select "Apply Immediately", and click "Modify DB Instance"
5. To see the progress, go to dd1gc3iuv75ep7t (or whatever is the database ID) → Logs & Events, and sort the Logs by "Last Written" in descending order
6. Open the most recent log to see the upgrade
8. Once the RDS instance is up, SSH in to the Bastion, and attach to the psql tmux instance
    ```bash
    tmux new-session -A -s psql
    ```
9. In psql, check the installed version of Postgres to ensure it is 9.6.23:
    ```sql
    SELECT version();
    ```
10. In psql, vaccuum the database
    ```sql
    SET maintenance_work_mem='2GB';
    \timing
    VACUUM (FREEZE, ANALYZE, VERBOSE);
    ```
    This took 33 minutes on staging.
11. Upgrade extensions to the very latest they can be:
    ```sql
    SELECT * FROM pg_available_extensions WHERE installed_version IS NOT NULL;

    SELECT * FROM pg_available_extension_versions WHERE name in ('postgis', 'pg_trgm', 'plpgsql');

    ALTER EXTENSION pg_trgm UPDATE;

    ALTER EXTENSION postgis UPDATE;

    SELECT PostGIS_Extensions_Upgrade();

    DROP EXTENSION postgis_raster;
    ```

#### Upgrade Postgres to 12.8

This is the higher version we can go with PostGIS 2.5, which is the highest version of PostGIS supported by Postgres 9.6.

1. Go to RDS → Parameter Groups → Create parameter group, and make one based off the default Postgres 12 group and call it `mmw-postgres12`
1. Go to RDS → Databases → dd1gc3iuv75ep7t (or whatever is the database ID) → Modify
2. Set DB engine version to `12.8`, DB parameter group to `mmw-postgres12`
3. Click "Continue"
4. Select "Apply Immediately", and click "Modify DB Instance"
5. To see the progress, go to dd1gc3iuv75ep7t (or whatever is the database ID) → Logs & Events, and sort the Logs by "Last Written" in descending order
6. Open the most recent log to see the upgrade output
9. In psql, check the installed version of Postgres to ensure it is 12.8:
    ```sql
    SELECT version();
    ```
10. In psql, vaccuum the database
    ```sql
    SET maintenance_work_mem='2GB';
    \timing
    VACUUM (FREEZE, ANALYZE, VERBOSE);
    ```
    This took 3.5 minutes on staging.
11. Upgrade extensions to the very latest they can be:
    ```sql
    SELECT * FROM pg_available_extensions WHERE installed_version IS NOT NULL;

    SELECT * FROM pg_available_extension_versions WHERE name in ('postgis', 'pg_trgm', 'plpgsql');

    ALTER EXTENSION pg_trgm UPDATE;

    ALTER EXTENSION postgis UPDATE;

    SELECT PostGIS_Extensions_Upgrade();

    DROP EXTENSION postgis_raster;
    ```

#### Upgrade Postgres to 13.4

Now with PostGIS at 3.1, we can upgrade to Postgres 13.4.

1. Go to RDS → Parameter Groups → Create parameter group, and make one based off the default Postgres 13 group and call it `mmw-postgres13`
1. Edit it so that `log_min_duration_statement` has a value of `500` (to match the `mmw-postgres96` parameter group)
1. Go to RDS → Databases → dd1gc3iuv75ep7t (or whatever is the database ID) → Modify
2. Set DB engine version to `13.4`, DB parameter group to `mmw-postgres13`
3. Click "Continue"
4. Select "Apply Immediately", and click "Modify DB Instance"
5. To see the progress, go to dd1gc3iuv75ep7t (or whatever is the database ID) → Logs & Events, and sort the Logs by "Last Written" in descending order
6. Open the most recent log to see the upgrade output
9. In psql, check the installed version of Postgres to ensure it is 12.8:
    ```sql
    SELECT version();
    ```
10. In psql, vaccuum the database
    ```sql
    SET maintenance_work_mem='2GB';
    \timing
    VACUUM (FREEZE, ANALYZE, VERBOSE);
    ```
    This took 3.5 minutes on staging.
11. Upgrade extensions to the very latest they can be:
    ```sql
    SELECT * FROM pg_available_extensions WHERE installed_version IS NOT NULL;

    SELECT * FROM pg_available_extension_versions WHERE name in ('postgis', 'pg_trgm', 'plpgsql');

    ALTER EXTENSION pg_trgm UPDATE;

    ALTER EXTENSION postgis UPDATE;

    SELECT PostGIS_Extensions_Upgrade();

    DROP EXTENSION postgis_raster;
    ```

#### Downgrade RDS Instance to t3.micro

Since the instance was set to t2.micro before, we reduce it from t3.medium to t3.micro.

1. Go to RDS → Databases → dd1gc3iuv75ep7t (or whatever is the database ID) → Modify
2. Set the `RDSInstanceType` to `db.t3.micro`
3. Click "Continue"
4. Select "Apply Immediately", and click "Modify DB Instance"
5. To see the progress, go to dd1gc3iuv75ep7t (or whatever is the database ID) → Logs & Events, and sort the Logs by "Last Written" in descending order
6. Open the most recent log to see the upgrade output

#### Resolve CloudFormation Template

Now, with everything updated manually, run the CloudFormation data plane plan to ensure everything matches:

```bash
python mmw_stack.py launch-stacks --aws-profile "mmw-stg" --mmw-profile "staging" --mmw-config-path ~/azavea/model-my-watershed/scratch/staging.yml --data-plane
```

## Testing Instructions

* Go to https://staging.modelmywatershed.org
* Select an area, run an analysis
  - [x] Ensure it finishes correctly