### PR TITLE
Fix Migration

### DIFF
--- a/src/mmw/apps/modeling/migrations/0039_override_sedaadjust_for_old_scenarios.py
+++ b/src/mmw/apps/modeling/migrations/0039_override_sedaadjust_for_old_scenarios.py
@@ -19,7 +19,7 @@ def override_sedaadjust_for_old_projects(apps, schema_editor):
     for p in ps:
         for s in p.scenarios.all():
             mods = json.loads(s.modifications)
-            m_other = next((m for m in mods if m['modKey'] == 'entry_other'), None)
+            m_other = next((m for m in mods if m.get('modKey') == 'entry_other'), None)
 
             if m_other:
                 if 'SedAAdjust' not in m_other['output']:


### PR DESCRIPTION
## Overview

This was not working in cases when `modKey` was not present

Connects #3453 

## Testing Instructions

* Check out this branch and un-run the last migration:
    ```
    ./scripts/manage.sh migrate modeling 0038_alter_project_layer_overrides
    ```
* Run the migration:
    ```
    ./scripts/manage.sh migrate
    ```
  - [x] Ensure it runs successfully