### PR TITLE
Add Timeout Environment Variable, Use Throughout, Up to 200s

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -44,8 +44,9 @@ docker_compose_version: "1.26.*"
 geop_host: "localhost"
 geop_port: 8090
 
-geop_version: "5.1.0"
+geop_version: "5.2.0"
 geop_cache_enabled: 1
+geop_timeout: 200
 
 nginx_cache_dir: "/var/cache/nginx"
 

--- a/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
@@ -13,6 +13,7 @@ envdir_config:
   MMW_GEOPROCESSING_HOST: "{{ geop_host }}"
   MMW_GEOPROCESSING_PORT: "{{ geop_port }}"
   MMW_GEOPROCESSING_VERSION: "{{ geop_version }}"
+  MMW_GEOPROCESSING_TIMEOUT: "{{ geop_timeout }}"
   MMW_ITSI_CLIENT_ID: "{{ itsi_client_id }}"
   MMW_ITSI_SECRET_KEY: "{{ itsi_secret_key }}"
   MMW_ITSI_BASE_URL: "{{ itsi_base_url }}"

--- a/deployment/ansible/roles/model-my-watershed.geoprocessing/templates/systemd-geoprocessing.service.j2
+++ b/deployment/ansible/roles/model-my-watershed.geoprocessing/templates/systemd-geoprocessing.service.j2
@@ -4,7 +4,9 @@ After=network.target
 
 [Service]
 {% if ['development', 'test'] | some_are_in(group_names) -%}
-Environment=AWS_PROFILE={{ aws_profile }}
+Environment=MMW_GEOPROCESSING_TIMEOUT={{ geop_timeout }}s AWS_PROFILE={{ aws_profile }}
+{% else %}
+Environment=MMW_GEOPROCESSING_TIMEOUT={{ geop_timeout }}s
 {% endif %}
 User=mmw
 WorkingDirectory={{ geop_home }}

--- a/src/mmw/apps/home/views.py
+++ b/src/mmw/apps/home/views.py
@@ -362,6 +362,7 @@ def get_client_settings(request):
             },
             'enabled_features': settings.ENABLED_FEATURES,
             'unit_scheme': unit_scheme,
+            'celery_task_time_limit': settings.CELERY_TASK_TIME_LIMIT,
         }),
         'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,
         'title': title,

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -609,13 +609,9 @@ var LayerTabCollection = Backbone.Collection.extend({
 var TaskModel = Backbone.Model.extend({
     defaults: {
         pollInterval: 1000,
-        /* The timeout is set to 160 seconds here. It may be set
-           differently in other parts of the app, in most cases less.
-           The front-end timeout is the highest to allow for patient
-           users time to let large processing finish (subbasin, large
-           areas of interest, etc). In most cases, back-end jobs will
-           finish or fail before this is hit. */
-        timeout: 160000,
+        
+        // As many seconds as the max configured limit in the back-end
+        timeout: settings.get('celery_task_time_limit') * 1000,
     },
 
     // Log a debug mesasge if available, plain otherwise

--- a/src/mmw/js/src/core/settings.js
+++ b/src/mmw/js/src/core/settings.js
@@ -22,6 +22,7 @@ var defaultSettings = {
     enabled_features: [],
     branch: null,
     gitDescribe: null,
+    celery_task_time_limit: 120,
 };
 
 var settings = (function() {

--- a/src/mmw/js/src/modeling/views.js
+++ b/src/mmw/js/src/modeling/views.js
@@ -1472,17 +1472,14 @@ function getExpectedWaitTime(modelPackage, resultName, isGatheringData) {
         case coreUtils.TR55_PACKAGE:
             return null;
         case coreUtils.GWLFE:
-            if (resultName !== 'subbasin') {
-                if (isGatheringData) {
-                    return 'This may take up to 30 seconds';
-                }
-
+            if (resultName !== 'subbasin' && !isGatheringData) {
+                // Running GWLFE for one shape
                 return 'This may take a few seconds';
             }
-            if (isGatheringData) {
-                return 'This may take up to a minute';
-            }
-            return 'This may take up to 3 minutes';
+
+            // Running Mapshed for one or more shapes,
+            // running GWLFE for multiple shapes
+            return 'This may take a few minutes';
         default:
             console.log('Model package ' + modelPackage + ' not supported.');
     }

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -127,10 +127,7 @@ CELERY_TASK_QUEUES = {
 CELERY_TASK_DEFAULT_EXCHANGE = 'tasks'
 CELERY_TASK_DEFAULT_ROUTING_KEY = "task.%s" % STACK_COLOR
 
-# The longest running tasks contain geoprocessing requests
-# Keep the task and request time limit above, but in the ballpark of
-# https://github.com/WikiWatershed/mmw-geoprocessing/blob/develop/api/src/main/resources/application.conf#L9
-CELERY_TASK_TIME_LIMIT = 120
+CELERY_TASK_TIME_LIMIT = int(environ.get('MMW_GEOPROCESSING_TIMEOUT', 120))
 TASK_REQUEST_TIMEOUT = CELERY_TASK_TIME_LIMIT - 10
 # END CELERY CONFIGURATION
 


### PR DESCRIPTION
## Overview

We noticed that despite #3448 and https://github.com/WikiWatershed/mmw-geoprocessing/pull/98, which fixed timeouts for the Schuylkill HUC-8 in development, we were still seeing timeouts on Staging. This could be because of multiple users requesting runs at the same time. This PR further ups that to 200s.

Updates to mmw-geoprocessing 5.2.0, which exposes environment variable overrides for certain settings. See https://github.com/WikiWatershed/mmw-geoprocessing/pull/100.

Adds an `MMW_GEOPROCESSING_TIMEOUT` environment variable that is used in the `mmw-geoprocessing` service definition to set a timeout value of 200 seconds, up from the 120 baked in.

Also wires in that environment variable to be used for Celery, and the front-end, up from the 120 seconds as previously configured. Also updates messaging to be more appropriate.

Connects #3446 

## Testing Instructions

Since this was already working in development and not staging, the true test is on staging.

* Checkout this PR run:
    ```
    MMW_SRAT_CATCHMENT_API_KEY=*** vagrant provision app worker
    ```
* Run sub-basin on the Schuylkill HUC-8
  - [x] Ensure it succeeds