### PR TITLE
Hide hi res streams layer below zoom 8

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -549,7 +549,7 @@ LAYER_GROUPS = {
             'display': ('Continental US High Resolution' +
                         ' Stream Network'),
             'table_name': 'nhdflowlinehr',
-            'minZoom': 3,
+            'minZoom': 8,
             'big_cz': True,
         },
         {


### PR DESCRIPTION
## Overview

This is the min zoom used for HUC-12 and other layers as well.
This will reduce the loads on the database as there can be a very high number of streams at lower zoom levels.

Connects #3465 

### Demo

![2022-01-25 16 21 59](https://user-images.githubusercontent.com/1430060/151062686-cad4b249-90c2-4e2c-8f34-6fddca49dddb.gif)
