### PR TITLE
Fix Subbasin Errors by Deepcopying Default Dictionary

### DIFF
--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from copy import deepcopy
 from celery import shared_task
 from django.conf import settings
 
@@ -50,7 +51,7 @@ def collect_data(geop_results, geojson, watershed_id=None, weather=None,
     area = geom.transform(5070, clone=True).area  # Square Meters
 
     # Data Model is called z by convention
-    z = settings.GWLFE_DEFAULTS.copy()
+    z = deepcopy(settings.GWLFE_DEFAULTS)
 
     z['watershed_id'] = watershed_id
 

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -1,5 +1,6 @@
 import rollbar
 
+from copy import deepcopy
 from uuid import uuid1
 
 from django.contrib.auth import (authenticate,
@@ -110,7 +111,7 @@ def login(request):
 @decorators.api_view(['POST'])
 @decorators.permission_classes((IsAuthenticated, ))
 def profile(request):
-    data = request.data.copy()
+    data = deepcopy(request.data)
     if 'was_skipped' in data:
         data['was_skipped'] = str(data['was_skipped']).lower() == 'true'
         data['is_complete'] = not data['was_skipped']


### PR DESCRIPTION
## Overview

Previously we were using `dict.copy()` to make a copy of the default GWLFE dictionary before augmenting it with real values for calculated fields. This caused unexpected runtime errors, as `dict.copy()` is only one level deep, i.e. while the first level of values are copied, the values of values are still references. Changing those affected the default dictionary, which affected subsequent calculations.

By using `copy.deepcopy`, we ensure that we always start with a clean copy of all the default values, and can change them in isolation without affecting the global defaults.

This default dictionary corruption / bleeding was observed by Barry when running subbasin, but it could potentially have interfered with other operations as well. The true impact of this can not be calculated.

For details see:

- https://docs.python.org/3/library/stdtypes.html#dict.copy
- https://docs.python.org/3/library/copy.html#copy.deepcopy
- https://github.com/WikiWatershed/model-my-watershed/issues/3457#issuecomment-1024624915

Connects #3457 

### Demo

See here: https://github.com/WikiWatershed/model-my-watershed/issues/3457#issuecomment-1024627107

## Testing Instructions

* Check out this branch
* Add the following line for observation:
    ```diff
    diff --git a/src/mmw/apps/modeling/tasks.py b/src/mmw/apps/modeling/tasks.py
    index 8fa654e4..bdd2481a 100644
    --- a/src/mmw/apps/modeling/tasks.py
    +++ b/src/mmw/apps/modeling/tasks.py
    @@ -347,6 +347,8 @@ def run_gwlfe(model_input, inputmod_hash, watershed_id=None):
         result['inputmod_hash'] = inputmod_hash
         result['watershed_id'] = watershed_id

    +    print(f'==> Total Sediment: {result["SummaryLoads"][0]["Sediment"]}')
         return result
    ```
* Run `./scripts/debugcelery.sh`
* Go to http://localhost:8000/
* Search for and select the **Upper Wissahickon HUC-12** and run the Watershed Multi-Year Model
* In the debugcelery output, note the value of "Total Subbasin" shown in yellow
* Search for and select the **Lower Wissahickon HUC-12** and run the Watershed Multi-Year Model
* In the debugcelery output, note the value of "Total Subbasin" shown in yellow
* Search for and select the **Wissahickon HUC-10** and run the Watershed Multi-Year Model
* Click the Water Quality tab and select "Subbasin Attenuated Results"
* In the debugcelery output, note the values of "Total Subbasin" shown in yellow
  - [x] Ensure they match those of the solo HUC-12 runs