### PR TITLE
Cache and reuse Stream Analyses for WKAoIs

### DIFF
--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -652,7 +652,7 @@ def start_analyze_streams(request, datasource, format=None):
                             wkaoi,
                             cache_key=datasource),
         nlcd_streams.s(),
-        tasks.analyze_streams.s(area_of_interest, datasource)
+        tasks.analyze_streams.s(area_of_interest, datasource, wkaoi)
     ], area_of_interest, user)
 
 


### PR DESCRIPTION
## Overview

Previously we would only cache geoprocessing results, since they were the most expensive (by time, compute resources) operations. Database operations so far have been pretty instantaneous.

However, with the high resolution streams, some database queries have become very expensive. To ameliorate this, we now cache the results of those queries where possible.

Just as for geoprocessing, if operating on a WKAoI, the results will be cached, for instantaneous reuse. As this cache builds up, the apps performance will improve, and the load on the database will significantly decrease.

This work follows the caching pattern used in geoprocessing:

https://github.com/WikiWatershed/model-my-watershed/blob/7a906dce56c5084b91dcb2e6f9c5f96f152e1af3/src/mmw/apps/modeling/geoprocessing.py#L67-L72

https://github.com/WikiWatershed/model-my-watershed/blob/7a906dce56c5084b91dcb2e6f9c5f96f152e1af3/src/mmw/apps/modeling/geoprocessing.py#L101-L104

Connects #3424 

## Testing Instructions

* Check out this branch and make the following local changes:
    ```diff
    diff --git a/src/mmw/apps/geoprocessing_api/tasks.py b/src/mmw/apps/geoprocessing_api/tasks.py
    index 67f7b69d..b726e7d8 100644
    --- a/src/mmw/apps/geoprocessing_api/tasks.py
    +++ b/src/mmw/apps/geoprocessing_api/tasks.py
    @@ -100,12 +100,15 @@ def analyze_streams(results, area_of_interest, datasource='nhdhr', wkaoi=None):
             key = f'db_{wkaoi}__{datasource}__stream_data'
             cached = cache.get(key)
             if cached:
    +            print(f'==> CACHE HIT {key}')
                 return {'survey': cached}
    
    +    print('==> CACHE MISS')
         survey = stream_data(results, area_of_interest, datasource)
    
         if key:
             cache.set(key, survey, None)
    +        print(f'==> CACHE SAVE {key}')
    
         return {'survey': survey}
    ```
* Run `./scripts/debugcelery.sh`
* Go to http://localhost:8000/ and select a large shape, such as a HUC-8
* Observe the Celery output
  - [x] Ensure you see CACHE MISS and CACHE SAVE messages in yellow
* Click "Change Area" and reselect the same shape as before
  - [x] Ensure you see CACHE HIT message in yellow
  - [x] Ensure the stream analysis completes faster this time
* Click "Change Area" and draw an area, instead of selecting one
  - [x] Ensure you see CACHE MISS message in yellow, but no CACHE SAVE
  - [x] Ensure the results still complete