### PR TITLE
Increase geoprocessing max length for large AoIs

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -47,6 +47,7 @@ geop_port: 8090
 geop_version: "5.2.0"
 geop_cache_enabled: 1
 geop_timeout: 200
+geop_maxlen: "150m"
 
 nginx_cache_dir: "/var/cache/nginx"
 

--- a/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
@@ -14,6 +14,7 @@ envdir_config:
   MMW_GEOPROCESSING_PORT: "{{ geop_port }}"
   MMW_GEOPROCESSING_VERSION: "{{ geop_version }}"
   MMW_GEOPROCESSING_TIMEOUT: "{{ geop_timeout }}"
+  MMW_GEOPROCESSING_MAXLEN: "{{ geop_maxlen }}"
   MMW_ITSI_CLIENT_ID: "{{ itsi_client_id }}"
   MMW_ITSI_SECRET_KEY: "{{ itsi_secret_key }}"
   MMW_ITSI_BASE_URL: "{{ itsi_base_url }}"

--- a/deployment/ansible/roles/model-my-watershed.geoprocessing/templates/systemd-geoprocessing.service.j2
+++ b/deployment/ansible/roles/model-my-watershed.geoprocessing/templates/systemd-geoprocessing.service.j2
@@ -4,9 +4,9 @@ After=network.target
 
 [Service]
 {% if ['development', 'test'] | some_are_in(group_names) -%}
-Environment=MMW_GEOPROCESSING_TIMEOUT={{ geop_timeout }}s AWS_PROFILE={{ aws_profile }}
+Environment=MMW_GEOPROCESSING_TIMEOUT={{ geop_timeout }}s MMW_GEOPROCESSING_MAXLEN={{ geop_maxlen }} AWS_PROFILE={{ aws_profile }}
 {% else %}
-Environment=MMW_GEOPROCESSING_TIMEOUT={{ geop_timeout }}s
+Environment=MMW_GEOPROCESSING_TIMEOUT={{ geop_timeout }}s MMW_GEOPROCESSING_MAXLEN={{ geop_maxlen }}
 {% endif %}
 User=mmw
 WorkingDirectory={{ geop_home }}


### PR DESCRIPTION
## Overview

In certain cases, the number of high resolution streams in the area of interest can exceed the 50m default, so we increase it to 150m.

The default value is set here:

https://github.com/WikiWatershed/mmw-geoprocessing/blob/412565a58d26ecfe141706faae55aba1648579de/api/src/main/resources/application.conf#L18

Connects #3478 

## Testing Instructions

* On `develop`, watch the geoprocessing logs:
    ```
    vagrant ssh worker -c 'sudo journalctl -u mmw-geoprocessing.service -f'
    ```
* Go to http://localhost:8000/ and select Lower White HUC-8 shape in Indiana:
    ![image](https://user-images.githubusercontent.com/1430060/152826123-ab3fccb4-2c5b-4064-bb30-64747cc4f712.png)
    - [x] Ensure you see the error in the geoprocessing logs
* Check out this branch and reprovision the worker:
    ```
    vagrant provision worker
    ```
* Watch the geoprocessing logs again:
    ```
    vagrant ssh worker -c 'sudo journalctl -u mmw-geoprocessing.service -f'
    ```
* Run the same shape again. It will still exceed the timeout and not finish correctly, BUT there should not be an `EntityStreamSizeException` anymore
    - [x] Ensure you don't see that error in the logs