### PR TITLE
Fix Concord Login

### DIFF
--- a/src/mmw/apps/user/backends.py
+++ b/src/mmw/apps/user/backends.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth.backends import BaseBackend
 from django.contrib.auth.models import User
 
 from apps.user.models import ItsiUser, ConcordUser
 
 
-class SSOAuthenticationBackend(object):
+class SSOAuthenticationBackend(BaseBackend):
     """
     A custom authentication back-end for Single Sign On providers.
 

--- a/src/mmw/apps/user/backends.py
+++ b/src/mmw/apps/user/backends.py
@@ -21,7 +21,7 @@ class SSOAuthenticationBackend(BaseBackend):
         self.SSOUserModel = model
         self.SSOField = field
 
-    def authenticate(self, sso_id=None):
+    def authenticate(self, request=None, sso_id=None):
         if sso_id is not None:
             try:
                 query = {self.SSOField: sso_id}

--- a/src/mmw/apps/user/views.py
+++ b/src/mmw/apps/user/views.py
@@ -283,7 +283,11 @@ def concord_auth(request):
         concord_user = session.get_user()
     except Exception as e:
         # Report OAuth error
-        rollbar.report_message(f'Concord OAuth Error: {e.message}', 'error')
+        message = 'Concord OAuth Error'
+        if hasattr(e, 'message'):
+            message += f': {e.message}'
+
+        rollbar.report_message(message, 'error')
         return redirect('/error/sso')
 
     user = authenticate(sso_id=concord_user['id'])


### PR DESCRIPTION
## Overview

Users of the educational platform Concord Learn Portal have been unable to login since the Django upgrade. This happened because the signature that Django looks for in custom backends changed. By changing the signature of our custom backends to bring them back in line with what Django expects, we ensure that Concord users can log in again.

Note that this targets `release/1.33.3`, not `develop`.

Connects #3467 

### Demo

![2022-02-22 16 39 56](https://user-images.githubusercontent.com/1430060/155225173-1e586dac-5be9-4fe9-8ed0-c02b23ad2890.gif)

## Testing Instructions

### Setup

* Copy the secret password from LastPass for `oAuth (MMW_ITSI_SECRET_KEY / MMW_CONCORD_SECRET_KEY)`
* Go into the `app` VM and populate the `MMW_CONCORD_SECRET_KEY` variable:
    ```bash
    vagrant ssh app -c 'echo *** | sudo tee /etc/mmw.d/env/MMW_CONCORD_SECRET_KEY'
    ```
* Restart the `mmw-app` service so it picks up the new variable:
    ```bash
    vagrant ssh app -c 'sudo service mmw-app restart'
    ```
* Go to http://localhost:8000/ and ensure you are not logged in
* Try to log in using the "Learn Portal" link
  - In the Learn Portal, use the credentials from the `MMW Teacher Learn Portal Concord` entry in LastPass
  - [x] Ensure a new account is created correctly for you
* Log out of the account, and try to log back in using Lean Portal again
  - [x] Ensure you are able to log back in to the same account