### PR TITLE
Add HUC Parameter to Public Analyze, Model APIs

### DIFF
--- a/src/mmw/apps/geoprocessing_api/calcs.py
+++ b/src/mmw/apps/geoprocessing_api/calcs.py
@@ -3,8 +3,6 @@ import json
 import requests
 from operator import itemgetter
 
-from rest_framework.exceptions import NotFound, ValidationError
-
 from django.contrib.gis.geos import GEOSGeometry
 
 from django.conf import settings
@@ -368,30 +366,3 @@ def drexel_fast_zonal(geojson, key):
     result = {int(k): v for k, v in res.json()[key].items()}
 
     return result
-
-
-def wkaoi_from_huc(huc):
-    huc_len = len(huc)
-    if huc_len not in [8, 10, 12]:
-        raise ValidationError(f'Specified HUC {huc} is {huc_len} digits. '
-                              'Must be 8, 10, or 12.')
-
-    if huc_len == 8:
-        huc_col = 'huc08'
-    else:
-        huc_col = f'huc{huc_len}'
-
-    sql = f'''
-          SELECT id
-          FROM boundary_{huc_col}
-          WHERE {huc_col} = %s
-          '''
-
-    with connection.cursor() as cursor:
-        cursor.execute(sql, [huc])
-        row = cursor.fetchone()
-        if not row:
-            raise NotFound(f'No shape found for HUC {huc}')
-
-        wkaoi = f'huc{huc_len}__{row[0]}'
-        return wkaoi

--- a/src/mmw/apps/geoprocessing_api/calcs.py
+++ b/src/mmw/apps/geoprocessing_api/calcs.py
@@ -3,6 +3,8 @@ import json
 import requests
 from operator import itemgetter
 
+from rest_framework.exceptions import NotFound, ValidationError
+
 from django.contrib.gis.geos import GEOSGeometry
 
 from django.conf import settings
@@ -366,3 +368,30 @@ def drexel_fast_zonal(geojson, key):
     result = {int(k): v for k, v in res.json()[key].items()}
 
     return result
+
+
+def wkaoi_from_huc(huc):
+    huc_len = len(huc)
+    if huc_len not in [8, 10, 12]:
+        raise ValidationError(f'Specified HUC {huc} is {huc_len} digits. '
+                              'Must be 8, 10, or 12.')
+
+    if huc_len == 8:
+        huc_col = 'huc08'
+    else:
+        huc_col = f'huc{huc_len}'
+
+    sql = f'''
+          SELECT id
+          FROM boundary_{huc_col}
+          WHERE {huc_col} = %s
+          '''
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql, [huc])
+        row = cursor.fetchone()
+        if not row:
+            raise NotFound(f'No shape found for HUC {huc}')
+
+        wkaoi = f'huc{huc_len}__{row[0]}'
+        return wkaoi

--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -60,6 +60,16 @@ WKAOI = Parameter(
     type=TYPE_STRING,
 )
 
+HUC = Parameter(
+    'huc',
+    IN_QUERY,
+    description='The Hydrologic Unit Code (HUC) of the area of interest. '
+                'Should be an 8, 10, or 12 digit string of numbers, e.g. '
+                '"020402031008" will analyze the HUC-12 City of Philadelphia-'
+                'Schuylkill River.',
+    type=TYPE_STRING,
+)
+
 MULTIPOLYGON = Schema(
     title='Area of Interest',
     description='A valid single-ringed Multipolygon GeoJSON '
@@ -235,6 +245,15 @@ MODELING_REQUEST = Schema(
                         'such as a HUC. '
                         'Format "table__id", eg. "huc12__55174" will analyze '
                         'the HUC-12 City of Philadelphia-Schuylkill River.',
+        ),
+        'huc': Schema(
+            title='Hydrologic Unit Code',
+            type=TYPE_STRING,
+            example='020402031008',
+            description='The Hydrologic Unit Code (HUC) of the area of '
+                        'interest. Should be an 8, 10, or 12 digit string of '
+                        'numbers, e.g. "020402031008" will analyze the HUC-12 '
+                        'City of Philadelphia-Schuylkill River.',
         ),
         'layer_overrides': LAYER_OVERRIDES,
     },

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -33,7 +33,6 @@ from apps.modeling.mapshed.tasks import (collect_data,
 from apps.modeling.serializers import AoiSerializer
 
 from apps.geoprocessing_api import exceptions, schemas, tasks
-from apps.geoprocessing_api.calcs import wkaoi_from_huc
 from apps.geoprocessing_api.permissions import AuthTokenSerializerAuthentication  # noqa
 from apps.geoprocessing_api.throttling import (BurstRateThrottle,
                                                SustainedRateThrottle)
@@ -1521,26 +1520,13 @@ def start_celery_job(task_list, job_input, user=None, link_error=True):
 
 
 def _parse_analyze_input(request):
-    wkaoi = request.query_params.get('wkaoi')
-
-    if not wkaoi:
-        huc = request.query_params.get('huc')
-        if huc:
-            wkaoi = wkaoi_from_huc(huc)
-
     return _parse_aoi(data={'area_of_interest': request.data,
-                            'wkaoi': wkaoi})
+                            'wkaoi': request.query_params.get('wkaoi'),
+                            'huc': request.query_params.get('huc')})
 
 
 def _parse_modeling_input(request):
-    data = request.data
-
-    if not request.data.get('wkaoi'):
-        huc = request.data.get('huc')
-        if huc:
-            data['wkaoi'] = wkaoi_from_huc(huc)
-
-    return _parse_aoi(data)
+    return _parse_aoi(request.data)
 
 
 def _parse_aoi(data):

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -1394,8 +1394,9 @@ def start_modeling_gwlfe_prepare(request, format=None):
     By default, NLCD 2019 and NHD High Resolution Streams are used to prepare
     the input payload. This can be changed using the `layer_overrides` option.
 
-    Only one of `area_of_interest` or `wkaoi` should be provided. If both are
-    given, the `area_of_interest` will be used.
+    Only one of `area_of_interest`, `wkaoi`, or `huc` should be provided.
+    If multiple are given, the `area_of_interest` will be used first, then
+    `wkaoi`, then `huc`.
 
     The `result` should be used with the gwlf-e/run endpoint, by sending at as
     the `input`. Alternatively, the `job` UUID can be used as well by sending

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -246,7 +246,8 @@ def start_rwd(request, format=None):
 
 @swagger_auto_schema(method='post',
                      manual_parameters=[schemas.NLCD_YEAR,
-                                        schemas.WKAOI],
+                                        schemas.WKAOI,
+                                        schemas.HUC],
                      request_body=schemas.MULTIPOLYGON,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
@@ -436,7 +437,7 @@ def start_analyze_land(request, nlcd_year, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI],
+                     manual_parameters=[schemas.WKAOI, schemas.HUC],
                      request_body=schemas.MULTIPOLYGON,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
@@ -666,7 +667,7 @@ def start_analyze_streams(request, datasource, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI],
+                     manual_parameters=[schemas.WKAOI, schemas.HUC],
                      request_body=schemas.MULTIPOLYGON,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
@@ -745,7 +746,7 @@ def start_analyze_animals(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI],
+                     manual_parameters=[schemas.WKAOI, schemas.HUC],
                      request_body=schemas.MULTIPOLYGON,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
@@ -805,7 +806,7 @@ def start_analyze_pointsource(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI],
+                     manual_parameters=[schemas.WKAOI, schemas.HUC],
                      request_body=schemas.MULTIPOLYGON,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
@@ -892,7 +893,7 @@ def start_analyze_catchment_water_quality(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI],
+                     manual_parameters=[schemas.WKAOI, schemas.HUC],
                      request_body=schemas.MULTIPOLYGON,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
@@ -956,7 +957,7 @@ def start_analyze_climate(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI],
+                     manual_parameters=[schemas.WKAOI, schemas.HUC],
                      request_body=schemas.MULTIPOLYGON,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
@@ -1023,7 +1024,7 @@ def start_analyze_terrain(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI],
+                     manual_parameters=[schemas.WKAOI, schemas.HUC],
                      request_body=schemas.MULTIPOLYGON,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -326,7 +326,7 @@ SWAGGER_SETTINGS = {
         'Do not use the Django Login / Logout buttons. This API uses Token Authentication only. '  # NOQA
         '</p>'
         '<p>'
-        'All <strong>analyze</strong> endpoints take <em>either</em> a MultiPolygon request body <em>or</em> a well-known area of interest query parameter. '  # NOQA
+        'All <strong>analyze</strong> endpoints take <em>either</em> a MultiPolygon request body <em>or</em> a well-known area of interest query parameter <em>or</em> a HUC query parameter. '  # NOQA
         'The shape of their result object is documented individually. '
         '</p>'
         '<p>'


### PR DESCRIPTION
## Overview

We've used MMW-specific WKAoIs for a while for caching purposes, and as shorthand for established shapes. This serves the many kinds of in-built boundaries we support, including HUCs, School Districts, and Congressional Districts.

Now that we're opening up the API, for the convenience of our users, we now add the ability to specify a HUC in the request. HUCs are more widely known in the industry, and by letting users analyze and model them directly, without having to translate them into GeoJSON or WKAoI, will make the API a lot easier to use.

Connects #3474 

### Demo

#### Success

##### Analyze

```shell
xh --verbose POST :8000/api/analyze/soil/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" huc==020402031008
```
```http
POST /api/analyze/soil/?huc=020402031008 HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Token b0c671e1424f37e58c81670ce8118e8eff0f0c14
Connection: keep-alive
Host: localhost:8000
User-Agent: xh/0.13.0

HTTP/1.1 200 OK
Allow: POST, OPTIONS
Connection: keep-alive
Content-Type: application/json
Date: Mon, 28 Feb 2022 22:24:29 GMT
Location: /api/jobs/9f947652-8515-4199-bf4b-8ae6e85a3547/
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie, Origin

{
    "job": "9f947652-8515-4199-bf4b-8ae6e85a3547",
    "status": "started"
}
```

```shell
xh --verbose :8000/api/jobs/9f947652-8515-4199-bf4b-8ae6e85a3547/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14"
```
```http
GET /api/jobs/9f947652-8515-4199-bf4b-8ae6e85a3547/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Token b0c671e1424f37e58c81670ce8118e8eff0f0c14
Connection: keep-alive
Host: localhost:8000
User-Agent: xh/0.13.0

HTTP/1.1 200 OK
Allow: GET, OPTIONS
Connection: keep-alive
Content-Type: application/json
Date: Mon, 28 Feb 2022 22:25:26 GMT
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie, Origin

{
    "job_uuid": "9f947652-8515-4199-bf4b-8ae6e85a3547",
    "status": "complete",
    "result": {
        "survey": {
            "name": "soil",
            "displayName": "Soil",
            "categories": [
                {
                    "area": 897.2539813519878,
                    "code": "a",
                    "coverage": 1.0505194818837915e-05,
                    "type": "A - High Infiltration"
                },
                {
                    "area": 3115265.823254102,
                    "code": "b",
                    "coverage": 0.036474036411005245,
                    "type": "B - Moderate Infiltration"
                },
                {
                    "area": 80847967.24370222,
                    "code": "c",
                    "coverage": 0.9465810843462092,
                    "type": "C - Slow Infiltration"
                },
                {
                    "area": 10767.047776223853,
                    "code": "d",
                    "coverage": 0.00012606233782605497,
                    "type": "D - Very Slow Infiltration"
                },
                {
                    "area": 0.0,
                    "code": "ad",
                    "coverage": 0.0,
                    "type": "A/D - High/Very Slow Infiltration"
                },
                {
                    "area": 151635.92284848593,
                    "code": "bd",
                    "coverage": 0.0017753779243836077,
                    "type": "B/D - Medium/Very Slow Infiltration"
                },
                {
                    "area": 1283970.4473146945,
                    "code": "cd",
                    "coverage": 0.015032933785757057,
                    "type": "C/D - Medium/Very Slow Infiltration"
                }
            ]
        }
    },
    "error": "",
    "started": "2022-02-28T22:24:29.689286Z",
    "finished": "2022-02-28T22:24:34.010561Z"
}
```

##### Model

```shell
xh --verbose :8000/api/modeling/gwlf-e/prepare/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" huc=020402031008
```
```http
POST /api/modeling/gwlf-e/prepare/ HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Authorization: Token b0c671e1424f37e58c81670ce8118e8eff0f0c14
Connection: keep-alive
Content-Length: 22
Content-Type: application/json
Host: localhost:8000
User-Agent: xh/0.13.0

{
    "huc": "020402031008"
}



HTTP/1.1 200 OK
Allow: POST, OPTIONS
Connection: keep-alive
Content-Type: application/json
Date: Mon, 28 Feb 2022 22:15:09 GMT
Location: /api/jobs/b660cbe4-ce47-49f0-915c-704a0a2104f1/
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie, Origin

{
    "job": "b660cbe4-ce47-49f0-915c-704a0a2104f1",
    "status": "started"
}
```

```shell
xh --verbose :8000/api/jobs/b660cbe4-ce47-49f0-915c-704a0a2104f1/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14"
```
```http
GET /api/jobs/b660cbe4-ce47-49f0-915c-704a0a2104f1/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Token b0c671e1424f37e58c81670ce8118e8eff0f0c14
Connection: keep-alive
Host: localhost:8000
User-Agent: xh/0.13.0

HTTP/1.1 200 OK
Allow: GET, OPTIONS
Connection: keep-alive
Content-Type: application/json
Date: Mon, 28 Feb 2022 22:16:17 GMT
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie, Origin

{
    "job_uuid": "b660cbe4-ce47-49f0-915c-704a0a2104f1",
    "status": "complete",
    "result": {
        "NRur": 10,
        "NUrb": 6,
        "TranVersionNo": "1.4.0",
        "SeepCoef": 0,
        "UnsatStor": 10,
        "SatStor": 0,
        "InitSnow": 0,
        "TileDrainRatio": 0,
        "TileDrainDensity": 0,
        "ETFlag": "<Hamon method>",
        ...
        },
    "error": "",
    "started": "2022-02-28T22:15:09.484303Z",
    "finished": "2022-02-28T22:15:14.107938Z"
}
```

#### Failure

##### Invalid HUC

```shell
xh --verbose :8000/api/modeling/gwlf-e/prepare/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" huc=02040203100
```
```http
POST /api/modeling/gwlf-e/prepare/ HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Authorization: Token b0c671e1424f37e58c81670ce8118e8eff0f0c14
Connection: keep-alive
Content-Length: 21
Content-Type: application/json
Host: localhost:8000
User-Agent: xh/0.13.0

{
    "huc": "02040203100"
}



HTTP/1.1 400 Bad Request
Allow: POST, OPTIONS
Connection: keep-alive
Content-Length: 65
Content-Type: application/json
Date: Mon, 28 Feb 2022 22:13:10 GMT
Server: nginx
Vary: Accept, Cookie, Origin

[
    "Specified HUC 02040203100 is 11 digits. Must be 8, 10, or 12."
]
```

##### HUC Not Found

```shell
xh --verbose :8000/api/modeling/gwlf-e/prepare/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" huc=02040203100X
```
```http
POST /api/modeling/gwlf-e/prepare/ HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Authorization: Token b0c671e1424f37e58c81670ce8118e8eff0f0c14
Connection: keep-alive
Content-Length: 22
Content-Type: application/json
Host: localhost:8000
User-Agent: xh/0.13.0

{
    "huc": "02040203100X"
}



HTTP/1.1 404 Not Found
Allow: POST, OPTIONS
Connection: keep-alive
Content-Type: application/json
Date: Mon, 28 Feb 2022 22:13:45 GMT
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie, Origin

{
    "detail": "No shape found for HUC 02040203100X"
}
```

### Notes

Initially we had assumed that the HUC lookups would be slow, and would require the addition of new indexes to make the queries performant. In practice, I found that was not the case. Since we use the same boundary tables in development as in staging and production, we should not see additional execution time in those environments either.

## Testing Instructions

* Check out this branch
* Test an Analyze endpoint with:
  - [x] GeoJSON input
  - [x] WKAoI input
  - [x] HUC input
* Test a Model endpoint with:
  - [x] GeoJSON input
  - [x] WKAoI input
  - [x] HUC input
