### PR TITLE
Enable Recent Weather

### DIFF
--- a/src/mmw/js/src/modeling/constants.js
+++ b/src/mmw/js/src/modeling/constants.js
@@ -27,16 +27,16 @@ module.exports = {
     },
     // In sync with apps.modeling.models.WeatherType.simulations
     Simulations: [
-        // {
-        //     group: 'Recent Weather',
-        //     items: [
-        //         {
-        //             name: 'NASA_NLDAS_2000_2019',
-        //             label: 'NASA NLDAS 2000-2019',
-        //         },
-        //     ],
-        //     in_drb: true,
-        // },
+        {
+            group: 'Recent Weather',
+            items: [
+                {
+                    name: 'NASA_NLDAS_2000_2019',
+                    label: 'NASA NLDAS 2000-2019',
+                },
+            ],
+            in_drb: true,
+        },
         {
             group: 'Future Weather Simulations',
             items: [

--- a/src/mmw/js/src/modeling/gwlfe/runoff/views.js
+++ b/src/mmw/js/src/modeling/gwlfe/runoff/views.js
@@ -56,12 +56,18 @@ var ResultView = Marionette.LayoutView.extend({
             gis_data = this.scenario.getModifiedGwlfeGisData(),
             weather_type = this.scenario.get('weather_type'),
             weather_simulation = this.scenario.get('weather_simulation'),
+            weather_simulation_label = weather_simulation &&
+                _.chain(modelingConstants.Simulations)
+                    .flatMap(function(g) { return g.items; })
+                    .find(function(i) { return i.name === weather_simulation; })
+                    .value()
+                    .label,
             weather_custom = this.scenario.get('weather_custom');
 
         return {
             lengthUnit: lengthUnit,
             weather_type: weather_type,
-            weather_simulation: modelingConstants.Simulations[weather_simulation],
+            weather_simulation: weather_simulation_label,
             weather_custom: modelingUtils.getFileName(weather_custom, '.csv'),
             years: gis_data.WxYrs,
         };


### PR DESCRIPTION
## Overview

Recent Weather was originally added in #3341. It was turned off in #3361. Now the clients are ready for this to go out, so we turn it on again.

Connects #3491 

### Demo

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/1430060/156635030-747ac7fa-21bd-45b1-8f35-261fa0e963d5.png">

## Testing Instructions

* Check out this branch and bundle
    ```
    ./scripts/bundle.sh --debug
    ```
* Go to http://localhost:8000/ and log in
* Create a Watershed Multi-Year project, and click "Add Changes to this Area" to make a new scenario
* Click the Weather Data button in the top right
  - [x] Ensure that in the Available Data dropdown, you see the NASA NLDAS option
  - [x] Ensure this is only available for the Delaware River Basin (Philadelphia area), not outside
  - [x] Ensure selecting it changes the results from the default value
  - [x] Ensure the sidebar shows the name of the correct selected Weather dataset