### PR TITLE
Add Public Subbasin Prepare Endpoint

### DIFF
--- a/src/mmw/apps/geoprocessing_api/calcs.py
+++ b/src/mmw/apps/geoprocessing_api/calcs.py
@@ -366,3 +366,22 @@ def drexel_fast_zonal(geojson, key):
     result = {int(k): v for k, v in res.json()[key].items()}
 
     return result
+
+
+def huc12s_for_huc(huc):
+    """
+    Given a HUC code, returns a list of all HUC-12s starting with it.
+
+    This will effectively give a list of all HUC-12s within a HUC-8 or HUC-10,
+    given those codes. If a HUC-12 code is given, will return a singleton list.
+    If no HUC-12s are found, returns an empty list.
+    """
+    sql = '''
+          SELECT 'huc12__' || id, huc12, ST_AsGeoJSON(geom_detailed)
+          FROM boundary_huc12
+          WHERE huc12 LIKE %s
+          '''
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql, [f'{huc}%'])
+        return cursor.fetchall()

--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -232,29 +232,33 @@ LAYER_OVERRIDES = Schema(
     },
 )
 
+WKAOI_SCHEMA = Schema(
+    title='Well-Known Area of Interest',
+    type=TYPE_STRING,
+    example='huc12__55174',
+    description='The table and ID for a well-known area of interest, '
+                'such as a HUC. '
+                'Format "table__id", eg. "huc12__55174" will analyze '
+                'the HUC-12 City of Philadelphia-Schuylkill River.',
+)
+
+HUC_SCHEMA = Schema(
+    title='Hydrologic Unit Code',
+    type=TYPE_STRING,
+    example='020402031008',
+    description='The Hydrologic Unit Code (HUC) of the area of '
+                'interest. Should be an 8, 10, or 12 digit string of '
+                'numbers, e.g. "020402031008" will analyze the HUC-12 '
+                'City of Philadelphia-Schuylkill River.',
+)
+
 MODELING_REQUEST = Schema(
     title='Modeling Request',
     type=TYPE_OBJECT,
     properties={
         'area_of_interest': MULTIPOLYGON,
-        'wkaoi': Schema(
-            title='Well-Known Area of Interest',
-            type=TYPE_STRING,
-            example='huc12__55174',
-            description='The table and ID for a well-known area of interest, '
-                        'such as a HUC. '
-                        'Format "table__id", eg. "huc12__55174" will analyze '
-                        'the HUC-12 City of Philadelphia-Schuylkill River.',
-        ),
-        'huc': Schema(
-            title='Hydrologic Unit Code',
-            type=TYPE_STRING,
-            example='020402031008',
-            description='The Hydrologic Unit Code (HUC) of the area of '
-                        'interest. Should be an 8, 10, or 12 digit string of '
-                        'numbers, e.g. "020402031008" will analyze the HUC-12 '
-                        'City of Philadelphia-Schuylkill River.',
-        ),
+        'wkaoi': WKAOI_SCHEMA,
+        'huc': HUC_SCHEMA,
         'layer_overrides': LAYER_OVERRIDES,
     },
 )

--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -279,3 +279,13 @@ GWLFE_REQUEST = Schema(
         ),
     },
 )
+
+SUBBASIN_REQUEST = Schema(
+    title='Subbasin Request',
+    type=TYPE_OBJECT,
+    properties={
+        'wkaoi': WKAOI_SCHEMA,
+        'huc': HUC_SCHEMA,
+        'layer_overrides': LAYER_OVERRIDES,
+    },
+)

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -40,5 +40,8 @@ urlpatterns = [
             name='start_modeling_gwlfe_prepare'),
     re_path(r'modeling/gwlf-e/run/$', views.start_modeling_gwlfe_run,
             name='start_modeling_gwlfe_run'),
+    re_path(r'modeling/subbasin/prepare/$',
+            views.start_modeling_subbasin_prepare,
+            name='start_modeling_subbasin_prepare'),
     re_path(r'watershed/$', views.start_rwd, name='start_rwd'),
 ]

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import json
 
+from operator import itemgetter
+
 from celery import chain
 
 from rest_framework.response import Response
@@ -1537,3 +1539,14 @@ def _parse_aoi(data):
     wkaoi = serializer.validated_data.get('wkaoi')
 
     return area_of_interest, wkaoi
+
+
+def _parse_subbasin_input(request):
+    if 'wkaoi' not in request.data and 'huc' not in request.data:
+        raise ValidationError('Must specify exactly one of: WKAoI ID or HUC')
+
+    serializer = AoiSerializer(data=request.data)
+    serializer.is_valid(raise_exception=True)
+
+    return itemgetter('area_of_interest', 'wkaoi', 'huc')(
+        serializer.validated_data)


### PR DESCRIPTION
## Overview

Adds a public endpoint for preparing a Subbasin Run request. Designed to work similarly to the GWLF-E prepare and run endpoints. This only works with HUCs, so does not take arbitrary AoI input, only WKAoI or HUC.

For a given HUC, finds all the HUC-12s within it, and runs the equivalent of GWLF-E prepare for them.

The output is a dictionary keyed by the HUC-12, and with the value of a GWLF-E prepared input.

The Subbasin Run endpoint will be implemented in #3494 

Connects #3493 

### Demo

Example output for input `{ huc: 1114020201 }`

```json
{
  "job_uuid": "51316dcb-906a-4b3e-aeee-10199f0b2b6a",
  "status": "complete",
  "result": {
    "111402020102": {
      "NRur": 10,
      "NUrb": 6,
      "TranVersionNo": "1.4.0",
      "SeepCoef": 0,
      "UnsatStor": 10,
      "SatStor": 0,
      "InitSnow": 0,
      "TileDrainRatio": 0,
      "TileDrainDensity": 0,
      "ETFlag": "<Hamon method>",
      "AntMoist": [
        0.0,
        0.0,
        0.0,
        0.0,
        0.0
      ],
      ...
    },
    "111402020101": {
      "NRur": 10,
      "NUrb": 6,
      "TranVersionNo": "1.4.0",
      "SeepCoef": 0,
      "UnsatStor": 10,
      "SatStor": 0,
      "InitSnow": 0,
      "TileDrainRatio": 0,
      "TileDrainDensity": 0,
      "ETFlag": "<Hamon method>",
      "AntMoist": [
        0.0,
        0.0,
        0.0,
        0.0,
        0.0
      ],
      ...
    }
  },
  "error": "",
  "started": "2022-03-08T03:42:25.334000Z",
  "finished": "2022-03-08T03:42:37.203970Z"
}
```

Error handling:

```
xh --body :8000/api/modeling/subbasin/prepare/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" huc=02040203100X

{
    "detail": "No shape found for HUC 02040203100X"
}
```
```
xh --body :8000/api/modeling/subbasin/prepare/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" wkaoi=schools__1234

[
    "Invalid wkaoi: schools__1234"
]
```
```
xh --body POST :8000/api/modeling/subbasin/prepare/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14"

[
    "Must specify exactly one of: WKAoI ID or HUC"
]
```
```
xh --body :8000/api/modeling/subbasin/prepare/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" huc=0204

[
    "Specified HUC 0204 is 4 digits. Must be 8, 10, or 12."
]
```

## Testing Instructions

* Check out this branch and reload celery
    ```
    vagrant ssh worker -c 'sudo service celeryd restart'
    ```
* Go to http://localhost:8000/api/docs
* Read the documentation of the new endpoint
  - [x] Ensure it makes sense
* Try the new endpoint with a `huc` parameter of `11140202`
  - [x] Ensure the results include 6 HUC-12s
* Try the new endpoint with a `huc` parameter of `1114020201`
  - [x] Ensure the results include 2 HUC-12s
* Try the new endpoint with a `huc` parameter of `111402020101`
  - [x] Ensure the results include 1 HUC-12
* Try the new endpoint with a `huc` parameter of `111402020103`
  - [x] Ensure you get an error message back
* Try to exercise the API in other ways