### PR TITLE
Ensure Correct Point Sources Are Used For MapShed

### DIFF
--- a/src/mmw/apps/modeling/mapshed/tasks.py
+++ b/src/mmw/apps/modeling/mapshed/tasks.py
@@ -34,7 +34,7 @@ from apps.modeling.mapshed.calcs import (day_lengths,
 NLU = settings.GWLFE_CONFIG['NLU']
 NRur = settings.GWLFE_DEFAULTS['NRur']
 AG_NLCD_CODES = settings.GWLFE_CONFIG['AgriculturalNLCDCodes']
-DRB = settings.DRB_PERIMETER
+DRB = settings.DRB_SIMPLE_PERIMETER
 ANIMAL_KEYS = settings.GWLFE_CONFIG['AnimalKeys']
 ACRES_PER_SQM = 0.000247105
 HECTARES_PER_SQM = 0.0001

--- a/src/mmw/js/src/modeling/constants.js
+++ b/src/mmw/js/src/modeling/constants.js
@@ -27,16 +27,16 @@ module.exports = {
     },
     // In sync with apps.modeling.models.WeatherType.simulations
     Simulations: [
-        // {
-        //     group: 'Recent Weather',
-        //     items: [
-        //         {
-        //             name: 'NASA_NLDAS_2000_2019',
-        //             label: 'NASA NLDAS 2000-2019',
-        //         },
-        //     ],
-        //     in_drb: true,
-        // },
+        {
+            group: 'Recent Weather',
+            items: [
+                {
+                    name: 'NASA_NLDAS_2000_2019',
+                    label: 'NASA NLDAS 2000-2019',
+                },
+            ],
+            in_drb: true,
+        },
         {
             group: 'Future Weather Simulations',
             items: [


### PR DESCRIPTION
## Overview

We use `DRB_SIMPLE_PERIMITER` in most cases, and had missed this one. Because of this incongruity, certain HUC-8s had significantly lower Point Source Pollution values, since they were using the `ms_pointsource` dataset instead of the `ms_pointsource_drb`.

By fixing this, we ensure that the correct dataset is used when needed.

Connects #3490 

### Demo

![image](https://user-images.githubusercontent.com/1430060/158415678-0cad7c38-e3f9-4ccb-bbce-0de0b10062a4.png)

### Notes

The second commit is to re-enable Recent Weather on staging, after it was disabled for production in the 1.33.6 release.

## Testing Instructions

* Check out this branch and
    ```shell
    vagrant ssh worker -c 'sudo service celeryd restart'
    ./scripts/bundle.sh --debug
    ```
* Go to http://localhost:8000/ and select the Cohansey-Maurice HUC-08.
* Run the Watershed Multi-Year Model on it
  - [ ] In the Water Quality tab, ensure there's non-zero values for Nitrogen and Phosphorus under Point Sources
* Compare the same shape on production https://modelmywatershed.org
  - [ ] Ensure that has all 0s