### PR TITLE
Align Analyze and Modeling APIs

### DIFF
--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -115,8 +115,8 @@ JOB_STARTED_RESPONSE = Schema(
     title='Job Started Response',
     type=TYPE_OBJECT,
     properties={
-        'job': Schema(type=TYPE_STRING, format=FORMAT_UUID,
-                      example='6e514e69-f46b-47e7-9476-c1f5be0bac01'),
+        'job_uuid': Schema(type=TYPE_STRING, format=FORMAT_UUID,
+                           example='6e514e69-f46b-47e7-9476-c1f5be0bac01'),
         'status': Schema(type=TYPE_STRING, example=JobStatus.STARTED),
         'messages': Schema(type=TYPE_ARRAY, items=Schema(type=TYPE_STRING),
                            description='Optional messages provided by the API,'

--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -138,6 +138,9 @@ JOB_STARTED_RESPONSE = Schema(
         'job': Schema(type=TYPE_STRING, format=FORMAT_UUID,
                       example='6e514e69-f46b-47e7-9476-c1f5be0bac01'),
         'status': Schema(type=TYPE_STRING, example=JobStatus.STARTED),
+        'messages': Schema(type=TYPE_ARRAY, items=Schema(type=TYPE_STRING),
+                           description='Optional messages provided by the API,'
+                                       ' e.g. deprecation notices, etc.')
     }
 )
 

--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from drf_yasg.openapi import (
     Parameter, Schema,
-    IN_PATH, IN_QUERY,
+    IN_PATH,
     FORMAT_DATETIME, FORMAT_UUID,
     TYPE_ARRAY, TYPE_BOOLEAN, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING
 )
@@ -48,26 +48,6 @@ DRB_2100_LAND_KEY = Parameter(
                 ),
     type=TYPE_STRING,
     required=True,
-)
-
-WKAOI = Parameter(
-    'wkaoi',
-    IN_QUERY,
-    description='The table and ID for a well-known area of interest, '
-                'such as a HUC. '
-                'Format "table__id", eg. "huc12__55174" will analyze '
-                'the HUC-12 City of Philadelphia-Schuylkill River.',
-    type=TYPE_STRING,
-)
-
-HUC = Parameter(
-    'huc',
-    IN_QUERY,
-    description='The Hydrologic Unit Code (HUC) of the area of interest. '
-                'Should be an 8, 10, or 12 digit string of numbers, e.g. '
-                '"020402031008" will analyze the HUC-12 City of Philadelphia-'
-                'Schuylkill River.',
-    type=TYPE_STRING,
 )
 
 MULTIPOLYGON = Schema(
@@ -235,7 +215,7 @@ LAYER_OVERRIDES = Schema(
     },
 )
 
-WKAOI_SCHEMA = Schema(
+WKAOI = Schema(
     title='Well-Known Area of Interest',
     type=TYPE_STRING,
     example='huc12__55174',
@@ -245,7 +225,7 @@ WKAOI_SCHEMA = Schema(
                 'the HUC-12 City of Philadelphia-Schuylkill River.',
 )
 
-HUC_SCHEMA = Schema(
+HUC = Schema(
     title='Hydrologic Unit Code',
     type=TYPE_STRING,
     example='020402031008',
@@ -255,13 +235,23 @@ HUC_SCHEMA = Schema(
                 'City of Philadelphia-Schuylkill River.',
 )
 
+ANALYZE_REQUEST = Schema(
+    title='Analyze Request',
+    type=TYPE_OBJECT,
+    properties={
+        'area_of_interest': MULTIPOLYGON,
+        'wkaoi': WKAOI,
+        'huc': HUC,
+    },
+)
+
 MODELING_REQUEST = Schema(
     title='Modeling Request',
     type=TYPE_OBJECT,
     properties={
         'area_of_interest': MULTIPOLYGON,
-        'wkaoi': WKAOI_SCHEMA,
-        'huc': HUC_SCHEMA,
+        'wkaoi': WKAOI,
+        'huc': HUC,
         'layer_overrides': LAYER_OVERRIDES,
     },
 )
@@ -287,8 +277,8 @@ SUBBASIN_REQUEST = Schema(
     title='Subbasin Request',
     type=TYPE_OBJECT,
     properties={
-        'wkaoi': WKAOI_SCHEMA,
-        'huc': HUC_SCHEMA,
+        'wkaoi': WKAOI,
+        'huc': HUC,
         'layer_overrides': LAYER_OVERRIDES,
     },
 )

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -1594,8 +1594,14 @@ def start_celery_job(task_list, job_input, user=None, link_error=True,
 
     data = {
         'job': task_chain.id,
+        'job_uuid': task_chain.id,
         'status': JobStatus.STARTED,
     }
+
+    messages.append(
+        'The `job` field will be deprecated in an upcoming release. Please '
+        'switch to using `job_uuid` instead.'
+    )
 
     if messages:
         data['messages'] = messages

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -1394,8 +1394,7 @@ def start_modeling_gwlfe_prepare(request, format=None):
     `wkaoi`, then `huc`.
 
     The `result` should be used with the gwlf-e/run endpoint, by sending at as
-    the `input`. Alternatively, the `job` UUID can be used as well by sending
-    it as the `job_uuid`.
+    the `input`. Alternatively, the `job_uuid` can be used as well.
     """
     user = request.user if request.user.is_authenticated else None
     area_of_interest, wkaoi = _parse_modeling_input(request)
@@ -1472,8 +1471,7 @@ def start_modeling_subbasin_prepare(request, format=None):
     the same as those of `gwlf-e/prepare`, for each HUC-12.
 
     The `result` should be used with the subbasin/run endpoint, by sending at
-    as the `input`. Alternatively, the `job` UUID can be used as well by
-    sending it as the `job_uuid`.
+    as the `input`. Alternatively, the `job_uuid` can be used as well.
     """
     user = request.user if request.user.is_authenticated else None
     area_of_interest, wkaoi, huc = _parse_subbasin_input(request)
@@ -1598,6 +1596,7 @@ def start_celery_job(task_list, job_input, user=None, link_error=True,
         'status': JobStatus.STARTED,
     }
 
+    # TODO Remove this message when `job` is deprecated
     messages.append(
         'The `job` field will be deprecated in an upcoming release. Please '
         'switch to using `job_uuid` instead.'

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -422,7 +422,7 @@ def start_analyze_land(request, nlcd_year, format=None):
     </details>
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     geop_input = {'polygon': [area_of_interest]}
 
@@ -438,7 +438,7 @@ def start_analyze_land(request, nlcd_year, format=None):
         geoprocessing.run.s('nlcd_ara', geop_input, wkaoi,
                             layer_overrides=layer_overrides),
         tasks.analyze_nlcd.s(area_of_interest, nlcd_year)
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -524,14 +524,14 @@ def start_analyze_soil(request, format=None):
     </details>
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     geop_input = {'polygon': [area_of_interest]}
 
     return start_celery_job([
         geoprocessing.run.s('soil', geop_input, wkaoi),
         tasks.analyze_soil.s(area_of_interest)
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -653,7 +653,7 @@ def start_analyze_streams(request, datasource, format=None):
     </details>
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     if datasource not in settings.STREAM_TABLES:
         raise ValidationError(f'Invalid stream datasource: {datasource}.'
@@ -668,7 +668,7 @@ def start_analyze_streams(request, datasource, format=None):
                             cache_key=datasource),
         nlcd_streams.s(),
         tasks.analyze_streams.s(area_of_interest, datasource, wkaoi)
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -743,11 +743,11 @@ def start_analyze_animals(request, format=None):
     </details>
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     return start_celery_job([
         tasks.analyze_animals.s(area_of_interest)
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -803,7 +803,7 @@ def start_analyze_pointsource(request, format=None):
     </details>
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     return start_celery_job([
         tasks.analyze_pointsource.s(area_of_interest)
@@ -890,11 +890,11 @@ def start_analyze_catchment_water_quality(request, format=None):
     </details>
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     return start_celery_job([
         tasks.analyze_catchment_water_quality.s(area_of_interest)
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -952,13 +952,13 @@ def start_analyze_climate(request, format=None):
     """
     user = request.user if request.user.is_authenticated else None
 
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
     shape = [{'id': wkaoi or geoprocessing.NOCACHE, 'shape': area_of_interest}]
 
     return start_celery_job([
         geoprocessing.multi.s('climate', shape, None),
         tasks.analyze_climate.s(wkaoi or geoprocessing.NOCACHE),
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -1018,14 +1018,14 @@ def start_analyze_terrain(request, format=None):
     </details>
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     geop_input = {'polygon': [area_of_interest]}
 
     return start_celery_job([
         geoprocessing.run.s('terrain', geop_input, wkaoi),
         tasks.analyze_terrain.s()
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -1154,14 +1154,14 @@ def start_analyze_protected_lands(request, format=None):
     </details>
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     geop_input = {'polygon': [area_of_interest]}
 
     return start_celery_job([
         geoprocessing.run.s('protected_lands', geop_input, wkaoi),
         tasks.analyze_protected_lands.s(area_of_interest)
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -1322,7 +1322,7 @@ def start_analyze_drb_2100_land(request, key=None, format=None):
     </details>
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, wkaoi = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     errs = []
     if not key:
@@ -1348,7 +1348,7 @@ def start_analyze_drb_2100_land(request, key=None, format=None):
 
     return start_celery_job([
         tasks.analyze_drb_2100_land.s(area_of_interest, key)
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -1373,11 +1373,11 @@ def start_modeling_worksheet(request, format=None):
     to get the actual Excel files.
     """
     user = request.user if request.user.is_authenticated else None
-    area_of_interest, _ = _parse_analyze_input(request)
+    area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 
     return start_celery_job([
         tasks.collect_worksheet.s(area_of_interest),
-    ], area_of_interest, user)
+    ], area_of_interest, user, messages=msg)
 
 
 @swagger_auto_schema(method='post',
@@ -1604,8 +1604,8 @@ def start_celery_job(task_list, job_input, user=None, link_error=True,
     job.save()
 
     data = {
-            'job': task_chain.id,
-            'status': JobStatus.STARTED,
+        'job': task_chain.id,
+        'status': JobStatus.STARTED,
     }
 
     if messages:
@@ -1619,9 +1619,45 @@ def start_celery_job(task_list, job_input, user=None, link_error=True,
 
 
 def _parse_analyze_input(request):
-    return _parse_aoi(data={'area_of_interest': request.data,
-                            'wkaoi': request.query_params.get('wkaoi'),
-                            'huc': request.query_params.get('huc')})
+    """
+    Parses analyze requests and returns area_of_interest, wkaoi, and msg.
+
+    Old style analyze requests put the area of interest GeoJSON in the POST
+    body, and wkaoi and huc as query parameters. We are transitioning to a
+    new model where all input is provided in the POST body, in the format:
+
+    {
+        area_of_interest: <GeoJSON?>,
+        wkaoi: <string?>,
+        huc: <string?>
+    }
+
+    If the request is in the old style, returns a msg list which includes a
+    message for users warning about upcoming deprecation.
+    """
+    msg = []
+
+    if ('area_of_interest' in request.data or
+            'wkaoi' in request.data or
+            'huc' in request.data):
+        area_of_interest, wkaoi = _parse_aoi(request.data)
+        return area_of_interest, wkaoi, msg
+
+    # TODO Remove this message when old style /analyze/ input is deprecated
+    msg = [
+        'The /analyze/ APIs will be updated to match the /modeling/ APIs in '
+        'an upcoming release. Instead of sending GeoJSON of the area of '
+        'interest in the request body, and wkaoi and huc as query parameters, '
+        'please send all in the request body, as { area_of_interest, wkaoi, '
+        'huc }. Consult the API documentation for details.'
+    ]
+
+    area_of_interest, wkaoi = _parse_aoi(data={
+        'area_of_interest': request.data,
+        'wkaoi': request.query_params.get('wkaoi'),
+        'huc': request.query_params.get('huc')})
+
+    return area_of_interest, wkaoi, msg
 
 
 def _parse_modeling_input(request):

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -250,10 +250,8 @@ def start_rwd(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.NLCD_YEAR,
-                                        schemas.WKAOI,
-                                        schemas.HUC],
-                     request_body=schemas.MULTIPOLYGON,
+                     manual_parameters=[schemas.NLCD_YEAR],
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,
@@ -442,8 +440,7 @@ def start_analyze_land(request, nlcd_year, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI, schemas.HUC],
-                     request_body=schemas.MULTIPOLYGON,
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,
@@ -535,9 +532,8 @@ def start_analyze_soil(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.STREAM_DATASOURCE,
-                                        schemas.WKAOI],
-                     request_body=schemas.MULTIPOLYGON,
+                     manual_parameters=[schemas.STREAM_DATASOURCE],
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,
@@ -672,8 +668,7 @@ def start_analyze_streams(request, datasource, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI, schemas.HUC],
-                     request_body=schemas.MULTIPOLYGON,
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,
@@ -751,8 +746,7 @@ def start_analyze_animals(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI, schemas.HUC],
-                     request_body=schemas.MULTIPOLYGON,
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,
@@ -811,8 +805,7 @@ def start_analyze_pointsource(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI, schemas.HUC],
-                     request_body=schemas.MULTIPOLYGON,
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,
@@ -898,8 +891,7 @@ def start_analyze_catchment_water_quality(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI, schemas.HUC],
-                     request_body=schemas.MULTIPOLYGON,
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,
@@ -962,8 +954,7 @@ def start_analyze_climate(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI, schemas.HUC],
-                     request_body=schemas.MULTIPOLYGON,
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,
@@ -1029,8 +1020,7 @@ def start_analyze_terrain(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.WKAOI, schemas.HUC],
-                     request_body=schemas.MULTIPOLYGON,
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,
@@ -1165,9 +1155,8 @@ def start_analyze_protected_lands(request, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     manual_parameters=[schemas.DRB_2100_LAND_KEY,
-                                        schemas.WKAOI],
-                     request_body=schemas.MULTIPOLYGON,
+                     manual_parameters=[schemas.DRB_2100_LAND_KEY],
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE,
                                 400: schemas.DRB_2100_LAND_ERROR_RESPONSE})
 @decorators.api_view(['POST'])
@@ -1352,7 +1341,7 @@ def start_analyze_drb_2100_land(request, key=None, format=None):
 
 
 @swagger_auto_schema(method='post',
-                     request_body=schemas.MULTIPOLYGON,
+                     request_body=schemas.ANALYZE_REQUEST,
                      responses={200: schemas.JOB_STARTED_RESPONSE})
 @decorators.api_view(['POST'])
 @decorators.authentication_classes((SessionAuthentication,

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -326,12 +326,13 @@ SWAGGER_SETTINGS = {
         'Do not use the Django Login / Logout buttons. This API uses Token Authentication only. '  # NOQA
         '</p>'
         '<p>'
-        'All <strong>analyze</strong> endpoints take <em>either</em> a MultiPolygon request body <em>or</em> a well-known area of interest query parameter <em>or</em> a HUC query parameter. '  # NOQA
+        'All <strong>analyze</strong> endpoints take a JSON request body which has <em>one of</em> an <code>area_of_interest</code> key with a MultiPolygon GeoJSON value <em>or</em> a well-known area of interest <code>wkaoi</code> <em>or</em> a Hydrologic Unit Code <code>huc</code>. '  # NOQA
         'The shape of their result object is documented individually. '
         '</p>'
         '<p>'
-        'All <strong>analyze</strong> and <strong>watershed</strong> endpoints return a <strong>Job Started Response</strong> on success. '  # NOQA
-        'This response has a <code>job</code> value, as well as a <code>Location</code> header, either of which can be used with the <strong>jobs</strong> endpoint to get the result. '  # NOQA
+        'All <strong>analyze</strong>, <strong>modeling</strong>, and <strong>watershed</strong> endpoints return a <strong>Job Started Response</strong> on success. '  # NOQA
+        'This response has a <code>job_uuid</code> value, as well as a <code>Location</code> header, either of which can be used with the <strong>jobs</strong> endpoint to get the result. '  # NOQA
+        'This may also include a <code>messages</code> key, which has an array of messages for the API user, such as deprecation warnings and upcoming changes.'  # NOQA
         '</p>'
         '<p>'
         'The <strong>jobs</strong> endpoint has a <code>status</code> key, whose value is either <strong>started</strong>, <strong>complete</strong>, or <strong>failed</strong>. '  # NOQA

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -975,7 +975,7 @@ MODEL_PACKAGES = [
                        'SLAMM, TR-55, and EPA\'s STEP-L model algorithms. '
                        'Designed primarily for use with smaller, more '
                        'developed areas.',
-        'help_link': 'https://wikiwatershed.org/documentation/mmw-tech/#site-storm-model',
+        'help_link': 'https://wikiwatershed.org/documentation/mmw-tech/#site-storm-model',  # NOQA
     },
     {
         'name': GWLFE,
@@ -983,7 +983,7 @@ MODEL_PACKAGES = [
         'description': 'Simulates 30-years of daily data by the GWLF-E '
                        '(MapShed) model. Designed primarily for use with '
                        'larger, more rural areas.',
-        'help_link': 'https://wikiwatershed.org/documentation/mmw-tech/#watershed-multi-year-model',
+        'help_link': 'https://wikiwatershed.org/documentation/mmw-tech/#watershed-multi-year-model',  # NOQA
     },
 ]
 


### PR DESCRIPTION
## Overview

The `/modeling/` APIs take a JSON object as input, while `/analyze/` took a combination of GeoJSON and query parameters. This makes it so that `/analyze/` supports the `/modeling/` style API, while maintaining support for the old `/analyze/` style as well. Users of the old style are given warnings about changes in a new `messages` key. The Job Started Response has also been upgraded to include a `job_uuid`, which is more standard.

Connects #3497 

### Demo

New style:

```shell
xh --verbose :8000/api/analyze/soil/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" huc=020402031001
```
```http
POST /api/analyze/soil/ HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Authorization: Token b0c671e1424f37e58c81670ce8118e8eff0f0c14
Connection: keep-alive
Content-Length: 22
Content-Type: application/json
Host: localhost:8000
User-Agent: xh/0.13.0

{
    "huc": "020402031001"
}



HTTP/1.1 200 OK
Allow: POST, OPTIONS
Connection: keep-alive
Content-Type: application/json
Date: Wed, 23 Mar 2022 13:56:53 GMT
Location: /api/jobs/fbd6e474-cc20-4ff0-831a-c8e1a9c2aa36/
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie, Origin

{
    "job": "fbd6e474-cc20-4ff0-831a-c8e1a9c2aa36",
    "job_uuid": "fbd6e474-cc20-4ff0-831a-c8e1a9c2aa36",
    "status": "started",
    "messages": [
        "The `job` field will be deprecated in an upcoming release. Please switch to using `job_uuid` instead."
    ]
}
```

Old style:

```shell
xh --verbose POST :8000/api/analyze/soil/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" huc==020402031001
```
```http
POST /api/analyze/soil/?huc=020402031001 HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Authorization: Token b0c671e1424f37e58c81670ce8118e8eff0f0c14
Connection: keep-alive
Host: localhost:8000
User-Agent: xh/0.13.0

HTTP/1.1 200 OK
Allow: POST, OPTIONS
Connection: keep-alive
Content-Type: application/json
Date: Wed, 23 Mar 2022 13:57:54 GMT
Location: /api/jobs/8d6eba2c-7037-42fc-84c1-cb5fbe2c8a75/
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie, Origin

{
    "job": "8d6eba2c-7037-42fc-84c1-cb5fbe2c8a75",
    "job_uuid": "8d6eba2c-7037-42fc-84c1-cb5fbe2c8a75",
    "status": "started",
    "messages": [
        "The /analyze/ APIs will be updated to match the /modeling/ APIs in an upcoming release. Instead of sending GeoJSON of the area of interest in the request body, and wkaoi and huc as query parameters, please send all in the request body, as { area_of_interest, wkaoi, huc }. Consult the API documentation for details.",
        "The `job` field will be deprecated in an upcoming release. Please switch to using `job_uuid` instead."
    ]
}
```

## Testing Instructions

* Check out this branch
* Go to http://localhost:8000/api/docs
  - [x] Ensure the documentation makes sense
* Post to `/analyze/soil/` in the old style and ensure it still works:
  - [x] A GeoJSON
  - [x] A WKAOI
  - [x] A HUC
* Post to `/analyze/soil/` in the new style and ensure it still works:
  - [x] An `area_of_interest`
  - [x] A `wkaoi`
  - [x] A `huc`