### PR TITLE
Add Validation to GWLF-E Endpoints

### DIFF
--- a/src/mmw/apps/geoprocessing_api/validation.py
+++ b/src/mmw/apps/geoprocessing_api/validation.py
@@ -102,6 +102,18 @@ def validate_gwlfe_prepare(data):
         raise ValidationError(error)
 
 
+def validate_gwlfe_run(input, job_uuid):
+    if not check_gwlfe_only_one([input, job_uuid]):
+        error = ('Invalid parameter: Only one type of prepared input'
+                 '(input JSON or job_uuid) is allowed')
+        raise ValidationError(error)
+
+    if not check_gwlfe_run_input(input):
+        error = ("Invalid input: Please use the full result "
+                 "of gwlf-e/prepare endpoint's result object")
+        raise ValidationError(error)
+
+
 def check_gwlfe_only_one(params):
     if sum(map(check_is_none, params)) == 1:
         return True
@@ -130,6 +142,11 @@ def check_land_layer_overrides(layers):
 
 def check_streams_layer_overrides(layers):
     return layers['__STREAMS__'] in STREAM_LAYER_OVERRIDES
+
+
+def check_gwlfe_run_input(input):
+    result = all(el in input for el in settings.GWLFE_DEFAULTS.keys())
+    return result
 
 
 def create_layer_overrides_keys_not_valid_msg(layers):

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -45,7 +45,8 @@ from apps.geoprocessing_api.throttling import (BurstRateThrottle,
 
 from apps.geoprocessing_api.validation import (validate_rwd,
                                                validate_uuid,
-                                               validate_gwlfe_prepare)
+                                               validate_gwlfe_prepare,
+                                               validate_gwlfe_run)
 
 
 @swagger_auto_schema(method='post',
@@ -1707,11 +1708,12 @@ def _parse_gwlfe_input(request, raw_input=True):
         model_input = request.data.get('input')
 
         if model_input:
-            # TODO #3484 Validate model_input
+            validate_gwlfe_run(model_input, job_uuid)
             return model_input, job_uuid, mods, hash
 
     if not job_uuid:
-        raise ValidationError('`job_uuid` must be specified')
+        raise ValidationError('Either `input` or `job_uuid` '
+                              'must be specified.')
 
     if not validate_uuid(job_uuid):
         raise ValidationError(f'Invalid `job_uuid`: {job_uuid}')
@@ -1727,5 +1729,6 @@ def _parse_gwlfe_input(request, raw_input=True):
 
     model_input = json.loads(input_job.result)
 
-    # TODO #3484 Validate model_input
+    validate_gwlfe_run(model_input, job_uuid)
+
     return model_input, job_uuid, mods, hash


### PR DESCRIPTION
## Overview
We have created the [`gwlf-e/prepare`](https://github.com/WikiWatershed/model-my-watershed/blob/4c8714ba7acdcd91118c1a04711a7a5115e26ec1/src/mmw/apps/geoprocessing_api/views.py#L1383-L1420) and [`gwlf-e/run`](https://github.com/WikiWatershed/model-my-watershed/blob/4c8714ba7acdcd91118c1a04711a7a5115e26ec1/src/mmw/apps/geoprocessing_api/views.py#L1423-L1454) endpoints to make previously internal APIs public, making running GWLF-E models easier. In order to help our users using the correct/recommended form of input, we add the following validations to the `gwlf-e/prepare/` and `gwlf-e/run/` endpoints:

For `/prepare/`
1. `area_of_interest`, `wkaoi`, and `huc` are not specified together
2. The keys in `layer_overrides` are within the standard layer overrides
options
3. The value of `__LAND__` and `__STREAMS__` layer overrides are within
its valid range

For `/run/`
1. `input` and `job_uuid` are not specified together
2. `input` has all the required valid keys to run the modeling

Connects #3484

### Demo

Examples of validation:

1. `/gwlf-e/prepare/`

Data object
```
{
"wkaoi":"huc12_9466",  
  "layer_overrides": {
    "__LAND__": "nlcd-2019-30m-epsg5070-512-byte",
    "__STREAMS__": "nhdh"
  }
}
```
Response
```
[
  "Invalid __STREAMS__ param: Must be `drb`, `nhdhr`, or `nhd`"
]
```
Data object
```
{
"wkaoi":"huc12_9466",  
  "layer_overrides": {
    "__LAND": "nlcd-2019-30m-epsg5070-512-byte",
    "__STREAMS": "nhdh"
  }
}
```
 Response
```
[
  "These layers are not standard layers for layer overrides: __LAND __STREAMS "
]
```

2. `/gwlf-e/run/`

Data object
```
{
  "input": {
    "NRur": 10
   }
}
```
Response
```
[
  "Invalid input: Please use the full result of gwlf-e/prepare endpoint's result object"
]
```

### Notes

 - In the original scope of #3484, tests for these two endpoints were included. We [decide](https://github.com/WikiWatershed/model-my-watershed/pull/3504#issuecomment-1082376223) to add tests in a separate issue since some tables related to modeling are not in the test database yet. 
 - We are not validating the value of the `input` in `/run/` since there are more than 400 keys in the `input` object

## Testing Instructions

 * Check out this branch and go to http://localhost:8000/api/docs/
 * Start a `gwlf-e/prepare` job with all kinds of parameters, including but not limit to:
    * Having different combinations of geographic inputs (could be zero, one, or more types)
    * In `"layer_overrides"`, with correct and wrong types of keys and values
    - [ ] Make sure all error codes and error messages make sense and provide useful information for users to correct the input
 * Start a `gwlf-e/run` job with all kinds of parameters, including but not limit to:
    * With or without an `job_uuid`
    * Different forms of `input` (missing some default keys, adding keys beside the default ones, wrong spelling of the default keys, empty object, etc )
    - [ ] Make sure all error codes and error messages make sense and provide useful information for users to correct the input