### PR TITLE
Further Validate GWLF-E Input

### DIFF
--- a/src/mmw/apps/geoprocessing_api/validation.py
+++ b/src/mmw/apps/geoprocessing_api/validation.py
@@ -97,10 +97,9 @@ def validate_gwlfe_prepare(data):
 
 
 def validate_gwlfe_run(input):
-    if not check_gwlfe_run_input(input):
-        error = ("Invalid input: Please use the full result "
-                 "of gwlf-e/prepare endpoint's result object")
-        raise ValidationError(error)
+    missing_keys = [k for k in GWLFE_INPUT_KEYS if k not in input]
+    if missing_keys:
+        raise ValidationError(f'Provided `input` is missing: {missing_keys}')
 
 
 def check_exactly_one_provided(one_of: list, params: dict):
@@ -130,11 +129,6 @@ def check_streams_layer_overrides(layers):
     return layers['__STREAMS__'] in STREAM_LAYER_OVERRIDES
 
 
-def check_gwlfe_run_input(input):
-    result = all(el in input for el in settings.GWLFE_DEFAULTS.keys())
-    return result
-
-
 def create_layer_overrides_keys_not_valid_msg(layers):
     error = 'These layers are not standard layers for layer overrides: '
     for layler in layers:
@@ -157,3 +151,14 @@ LAND_LAYER_OVERRIDES = [
 ]
 
 STREAM_LAYER_OVERRIDES = ['drb', 'nhdhr', 'nhd']
+
+# These are not present in GWLFE_DEFAULTS, but are necessary for running GWLF-E
+GWLFE_INPUT_KEYS = list(settings.GWLFE_DEFAULTS.keys()) + [
+    'AEU', 'Acoef', 'AgLength', 'AgSlope3', 'AgSlope3To8', 'Area', 'AvKF',
+    'AvSlope', 'CN', 'DayHrs', 'GrNitrConc', 'GrPhosConc', 'Grow', 'KF', 'KV',
+    'LS', 'ManNitr', 'ManPhos', 'MaxWaterCap', 'NumNormalSys', 'P', 'PhosConc',
+    'PointFlow', 'PointNitr', 'PointPhos', 'Prec', 'RecessionCoef',
+    'SedAFactor', 'SedDelivRatio', 'SedNitr', 'SedPhos', 'StreamLength',
+    'Temp', 'TotArea', 'UrbAreaTotal', 'UrbLength', 'WeatherStations',
+    'WxYrBeg', 'WxYrEnd', 'WxYrs', 'n23', 'n23b', 'n24', 'n24b', 'n41', 'n41j',
+    'n41k', 'n41l', 'n42', 'n42b', 'n46e', 'n46f']

--- a/src/mmw/apps/geoprocessing_api/validation.py
+++ b/src/mmw/apps/geoprocessing_api/validation.py
@@ -96,30 +96,11 @@ def validate_gwlfe_prepare(data):
         raise ValidationError(error)
 
 
-def validate_gwlfe_run(input, job_uuid):
-    if not check_gwlfe_only_one([input, job_uuid]):
-        error = ('Invalid parameter: Only one type of prepared input'
-                 '(input JSON or job_uuid) is allowed')
-        raise ValidationError(error)
-
+def validate_gwlfe_run(input):
     if not check_gwlfe_run_input(input):
         error = ("Invalid input: Please use the full result "
                  "of gwlf-e/prepare endpoint's result object")
         raise ValidationError(error)
-
-
-def check_gwlfe_only_one(params):
-    if sum(map(check_is_none, params)) == 1:
-        return True
-    else:
-        return False
-
-
-def check_is_none(v):
-    if v is None:
-        return 0
-    else:
-        return 1
 
 
 def check_exactly_one_provided(one_of: list, params: dict):

--- a/src/mmw/apps/geoprocessing_api/validation.py
+++ b/src/mmw/apps/geoprocessing_api/validation.py
@@ -74,15 +74,9 @@ def validate_uuid(uuid):
 
 
 def validate_gwlfe_prepare(data):
-    area_of_interest = data.get('area_of_interest')
-    wkaoi = data.get('wkaoi')
-    huc = data.get('huc')
     layer_overrides = data.get('layer_overrides', {})
 
-    if not check_gwlfe_only_one([area_of_interest, wkaoi, huc]):
-        error = ('Invalid parameter: One and only one type of area object'
-                 ' (area_of_interest, wkaoi, or huc) is allowed')
-        raise ValidationError(error)
+    check_exactly_one_provided(['area_of_interest', 'wkaoi', 'huc'], data)
 
     not_valid_layers = check_layer_overrides_keys(layer_overrides)
 
@@ -126,6 +120,17 @@ def check_is_none(v):
         return 0
     else:
         return 1
+
+
+def check_exactly_one_provided(one_of: list, params: dict):
+    # Dictionary for just the keys of which we want one of
+    one_of_params = {k: params.get(k) for k in one_of}
+    # List of keys with not None values
+    not_none_keys = [k for k, v in one_of_params.items() if v is not None]
+    if len(not_none_keys) != 1:
+        raise ValidationError(
+            f'Must provide exactly one of: {one_of}. '
+            f'You provided values for: {not_none_keys}')
 
 
 def check_layer_overrides_keys(layers):

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -1713,6 +1713,7 @@ def _parse_gwlfe_input(request, raw_input=True):
 
         if model_input:
             validate_gwlfe_run(model_input)
+
             return model_input, job_uuid, mods, hash
 
     if not validate_uuid(job_uuid):
@@ -1728,7 +1729,6 @@ def _parse_gwlfe_input(request, raw_input=True):
             f'The prepare job {job_uuid} has failed.')
 
     model_input = json.loads(input_job.result)
-
     validate_gwlfe_run(model_input)
 
     return model_input, job_uuid, mods, hash

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -1712,8 +1712,11 @@ def _parse_gwlfe_input(request, raw_input=True):
             return model_input, job_uuid, mods, hash
 
     if not job_uuid:
-        raise ValidationError('Either `input` or `job_uuid` '
-                              'must be specified.')
+        if raw_input:
+            raise ValidationError('Either `input` or `job_uuid` '
+                                  'must be specified.')
+
+        raise ValidationError('`job_uuid` must be specified.')
 
     if not validate_uuid(job_uuid):
         raise ValidationError(f'Invalid `job_uuid`: {job_uuid}')

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -1729,6 +1729,5 @@ def _parse_gwlfe_input(request, raw_input=True):
             f'The prepare job {job_uuid} has failed.')
 
     model_input = json.loads(input_job.result)
-    validate_gwlfe_run(model_input)
 
     return model_input, job_uuid, mods, hash


### PR DESCRIPTION
## Overview

Enhances the validation added in #3504 by specifying which keys are missing from the payload. Consolidates logic checking for exactly one input.

Also fixes a mistake I introduced in #3504 which broke subbasin runs, since it would try to validate subbasin input as gwlf-e input. This is now fixed.

Connects #3509 

### Demo

```shell
http --verbose :8000/api/modeling/gwlf-e/prepare/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" wkaoi=huc12__55174 huc=020402031008
```
```http
POST /api/modeling/gwlf-e/prepare/ HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate
Authorization: Token b0c671e1424f37e58c81670ce8118e8eff0f0c14
Connection: keep-alive
Content-Length: 48
Content-Type: application/json
Host: localhost:8000
User-Agent: HTTPie/3.1.0

{
    "huc": "020402031008",
    "wkaoi": "huc12__55174"
}


HTTP/1.1 400 Bad Request
Allow: OPTIONS, POST
Connection: keep-alive
Content-Length: 112
Content-Type: application/json
Date: Mon, 04 Apr 2022 17:20:21 GMT
Server: nginx
Vary: Accept, Cookie, Origin

[
    "Must provide exactly one of: ['area_of_interest', 'wkaoi', 'huc']. You provided values for: ['wkaoi', 'huc']"
]
```

Save the output of a successful run to test with:

```shell
http :8000/api/jobs/dc6a44f3-7455-4c68-a657-e549336f5e91/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" | jq '{"input": .result, "job_uuid": .job_uuid}' > test-input.json
```

Currently `test-input.json` has `input` and `job_uuid` both. If we try to send that:

```shell
http :8000/api/modeling/gwlf-e/run/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" < test-input.json
```
```http
HTTP/1.1 400 Bad Request
Allow: OPTIONS, POST
Connection: keep-alive
Content-Length: 102
Content-Type: application/json
Date: Mon, 04 Apr 2022 18:05:16 GMT
Server: nginx
Vary: Accept, Cookie, Origin

[
    "Must provide exactly one of: ['input', 'job_uuid']. You provided values for: ['input', 'job_uuid']"
]
```

If we remove `job_uuid`:

```shell
jq 'del(.job_uuid)' < test-input.json > test-input2.json
```

and then run the file it works correctly:

```shell
http :8000/api/modeling/gwlf-e/run/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" < test-input2.json
```
```http
HTTP/1.1 200 OK
Allow: OPTIONS, POST
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Mon, 04 Apr 2022 18:07:17 GMT
Location: /api/jobs/abbb1396-20c1-43c7-b630-d727f5357dd2/
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept, Cookie, Origin

{
    "job": "abbb1396-20c1-43c7-b630-d727f5357dd2",
    "job_uuid": "abbb1396-20c1-43c7-b630-d727f5357dd2",
    "messages": [
        "The `job` field will be deprecated in an upcoming release. Please switch to using `job_uuid` instead."
    ],
    "status": "started"
}
```

Now let's delete some keys from the input:

```shell
jq '{input: (.input | del(.SedNitr, .P, .LS, .InitSnow))}' < test-input2.json > test-input3.json
```

and run that:

```shell
http :8000/api/modeling/gwlf-e/run/ Authorization:"Token b0c671e1424f37e58c81670ce8118e8eff0f0c14" < test-input3.json
```
```http
HTTP/1.1 400 Bad Request
Allow: OPTIONS, POST
Connection: keep-alive
Content-Length: 52
Content-Type: application/json
Date: Mon, 04 Apr 2022 18:13:51 GMT
Server: nginx
Vary: Accept, Cookie, Origin

[
    "Provided `input` is missing: ['InitSnow', 'LS', 'P', 'SedNitr']"
]
```

## Testing Instructions

* Run the `gwlf-e/prepare`, `gwlf-e/run`, `subbasin/prepare`, and `subbasin/run` endpoints with various inputs
  - [x] Ensure you get appropriate feedback
  - [x] Ensure you are told which specific keys are missing in each case