### PR TITLE
Use new API format in Front-end Analyze

### DIFF
--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -102,8 +102,9 @@ var AnalyzeTaskModel = coreModels.TaskModel.extend({
             var isWkaoi = utils.isWKAoIValid(wkaoi),
                 taskHelper = {
                     contentType: 'application/json',
-                    queryParams: isWkaoi ? { wkaoi: wkaoi } : null,
-                    postData: isWkaoi ? null : JSON.stringify(aoi)
+                    postData: isWkaoi ? 
+                        JSON.stringify({ wkaoi : wkaoi }) : 
+                        JSON.stringify({ area_of_interest : aoi })
                 },
                 promises = self.start(taskHelper);
 


### PR DESCRIPTION
## Overview

We switched the `/analyze/` endpoints to take a JSON object as input in #3503, while the old query param style is still compatible. This change makes the front-end Analyze feature uses the new JSON object style to keep them consistent. Instead of GeoJSON of the area of interest in the request body, and wkaoi and huc as query parameters, the new style send all in the request body, as `{ area_of_interest, wkaoi }`, which is consistent with the `/modeling/` endpoints.

Connects #3510

### Demo

![image](https://user-images.githubusercontent.com/60887686/162034278-e228825d-f836-4bff-a43c-df87979e9418.png)

## Testing Instructions

**Result with the old style as baseline**
 * Check out `develop`, go to http://localhost:8000/, select any HUC, and run Analyze
 * Download the result and name it `analyze-result-huc-old`
 * Click "Change Area " to start a new session. Use "Draw Area" to create a new area and run Analyze
 * Download the shape in geojson and name it `analyze-draw-shape`; Download the result and name it `analyze-result-draw-old`

**Result with the new style**
 * Check out this branch and run 
   ``` 
   vagrant ssh worker -c 'sudo service celeryd restart'
   ./scripts/bundle.sh --debug
    
   ```
 * Go to http://localhost:8000/, clear the cache if needed, select the same HUC, and then run Analyze
 * Open the Network tab, filter the requests by `analyze/` 
     - [ ] The payload in all filtered requests should be in JSON object style
![image](https://user-images.githubusercontent.com/60887686/162037382-890f3aef-34dc-4b2e-858a-50d28f9a5283.png)
     - [ ] There should be only one message in the response
 * Download the result and name it `analyze-result-huc-new`
     - [ ] Make sure the results -`analyze-result-huc-old.json` and `analyze-result-huc-new.json` - are the same
     - [ ] Check the tabs of different analyze result and all of the graphs and tables are loaded properly
 * Start a new session. Upload `analyze-draw-shape.geojson` 
 * Download the result and name it `analyze-result-draw-new`
     - [ ] Make sure the results -`analyze-result-draw-old.json` and `analyze-result-draw-new.json` - are the same
     - [ ] Check the tabs of different analyze result and all of the graphs and tables are loaded properly