### PR TITLE
Document host-only network restrictions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Starting with Virtualbox 6.1.28, [host-only networks](https://www.virtualbox.org
 We will need to do the following to override this restriction:
 
 ```bash
-mkdir /etc/vbox
+sudo mkdir /etc/vbox
 
 echo "
 * 192.168.56.0/21
-* 33.33.0.0/16" >> /etc/vbox/networks.conf
+* 33.33.0.0/16" | sudo tee /etc/vbox/networks.conf
 ```
 
 Next, use the following command to bring up a local development environment:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ Ensure you have the [vagrant-disksize](https://github.com/sprotheroe/vagrant-dis
 $ vagrant plugin install vagrant-disksize
 ```
 
+Starting with Virtualbox 6.1.28, [host-only networks](https://www.virtualbox.org/manual/ch06.html#network_hostonly) are restricted to `192.168.56.0/21` by default. 
+
+We will need to do the following to override this restriction:
+
+```bash
+mkdir /etc/vbox
+
+echo "
+* 192.168.56.0/21
+* 33.33.0.0/16" >> /etc/vbox/networks.conf
+```
+
 Next, use the following command to bring up a local development environment:
 
 ```bash


### PR DESCRIPTION
## Overview

in Virtualbox 6.1.28, host-only networks were restricted to a specific netblock, and these changes were necessary to override that restriction.

This restriction is in place for Linux, macOS, and Solaris hosts

## Testing Instructions

 * try to start up the development environment with at least of Virtualbox 6.1.28 without the file `/etc/vbox/networks.conf`present. You should receive an error.
 * populate the networks.conf file as per the readme
 * Building the development environment should now proceed as normal.
