### PR TITLE
Update ms_pointsource_drb

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -160,7 +160,7 @@ fi
 if [ "$load_mapshed" = "true" ] ; then
     # Fetch map shed specific vector features
     FILES=("ms_weather.sql.gz" "ms_weather_station_1523624744.sql.gz"
-           "ms_pointsource.sql.gz" "ms_pointsource_drb.sql.gz"
+           "ms_pointsource.sql.gz" "ms_pointsource_drb_20220413.sql.gz"
            "ms_county_animals.sql.gz")
 
     download_and_load $FILES


### PR DESCRIPTION
## Overview

New point source data was sent by Drexel / ANS and ingested into a local development database. It was then exported using:

```shell
pg_dump -h 33.33.34.30 -d mmw -U mmw -c --if-exists -O -t ms_pointsource_drb > ms_pointsource_drb_20220413.sql
```

from the App VM, then gzipped and uploaded to the `data.mmw.azavea.com` S3 bucket. I then went into S3 and gave that file public read permissions.

This has already been imported on staging, and will need to be imported in production when this release goes out.

Connects #3519 

### Demo

![image](https://user-images.githubusercontent.com/1430060/163228071-6bd5cf8b-0bfa-407f-b9e0-5166b736bcea.png)

## Testing Instructions

* Check out this branch
* From the `app` VM, import this table again:
  ```shell
  vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -f ms_pointsource_drb_20220413.sql.gz'
  ```
  - [x] Ensure you see 812 imported rows successfully:
    ```sql
    CREATE TABLE
    COPY 812
    ALTER TABLE
    CREATE INDEX
    ```
* Analyze a shape near Philadlephia
  - [x] Ensure you see point sources in the Pt Sources analyze tab