### PR TITLE
Allow Mass Restoration of TR-55 Projects

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -44,7 +44,7 @@ docker_compose_version: "1.26.*"
 geop_host: "localhost"
 geop_port: 8090
 
-geop_version: "5.2.0"
+geop_version: "5.3.0"
 geop_cache_enabled: 1
 geop_timeout: 200
 

--- a/src/mmw/apps/modeling/migrations/0040_clear_nlcd2019_tr55_results.py
+++ b/src/mmw/apps/modeling/migrations/0040_clear_nlcd2019_tr55_results.py
@@ -19,7 +19,9 @@ def clear_nlcd2019_tr55_results(apps, schema_editor):
         project__created_at__gte='2022-01-17'
     ).update(
         results='[]',
-        modification_hash=''
+        modification_hash='',
+        aoi_census='{}',
+        modification_censuses='{}',
     )
 
 

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -201,10 +201,14 @@ def format_subbasin(huc12_gwlfe_results, srat_catchment_results, gmss):
 
 
 @shared_task(throws=Exception)
-def nlcd_soil(result):
-    if 'error' in result:
-        raise Exception(f'[nlcd_soil] {result["error"]}')
+def nlcd_soil_tr55(results):
+    if 'error' in results:
+        raise Exception(f'[nlcd_soil_tr55] {results["error"]}')
 
+    return [nlcd_soil(result) for result in results]
+
+
+def nlcd_soil(result):
     dist = {}
     total_count = 0
 
@@ -222,10 +226,10 @@ def nlcd_soil(result):
                 count + (dist[label]['cell_count'] if label in dist else 0)
             )}
 
-    return [{
+    return {
         'cell_count': total_count,
         'distribution': dist,
-    }]
+    }
 
 
 @shared_task

--- a/src/mmw/apps/modeling/tests.py
+++ b/src/mmw/apps/modeling/tests.py
@@ -18,7 +18,7 @@ from apps.modeling.models import Scenario, WeatherType
 
 @shared_task
 def get_test_histogram():
-    return {
+    return [{
         'List(21,1)': 22,
         'List(21,2)': 1,
         'List(21,4)': 5,
@@ -31,12 +31,12 @@ def get_test_histogram():
         'List(24,1)': 537,
         'List(24,2)': 268,
         'List(24,4)': 279,
-    }
+    }]
 
 
 class ExerciseGeoprocessing(TestCase):
     def test_census(self):
-        histogram = {
+        histogram = [{
             'List(11, 1)': 434,
             'List(82, 4)': 202,
             'List(23, 4)': 1957,
@@ -79,7 +79,7 @@ class ExerciseGeoprocessing(TestCase):
             'List(31, 2)': 25,
             'List(31, 1)': 37,
             'List(43, 2)': 800
-        }
+        }]
 
         expected = [{
             'cell_count': 136100,
@@ -128,7 +128,7 @@ class ExerciseGeoprocessing(TestCase):
                 'd:woody_wetlands': {'cell_count': 1093}
             }
         }]
-        actual = tasks.nlcd_soil(histogram)
+        actual = tasks.nlcd_soil_tr55(histogram)
         self.assertEqual(actual, expected)
 
 
@@ -307,7 +307,7 @@ class TaskRunnerTestCase(TestCase):
 
         skipped_tasks = [
             'run',
-            'nlcd_soil'
+            'nlcd_soil_tr55'
         ]
 
         needed_tasks = [
@@ -344,7 +344,7 @@ class TaskRunnerTestCase(TestCase):
         # we still need to generate modification censuses
         needed_tasks = [
             'run',
-            'nlcd_soil',
+            'nlcd_soil_tr55',
             'run_tr55'
         ]
 
@@ -390,7 +390,7 @@ class TaskRunnerTestCase(TestCase):
 
         skipped_tasks = [
             'run',
-            'nlcd_soil',
+            'nlcd_soil_tr55',
         ]
 
         needed_tasks = [
@@ -450,7 +450,7 @@ class TaskRunnerTestCase(TestCase):
 
         needed_tasks = [
             'run',
-            'nlcd_soil',
+            'nlcd_soil_tr55',
             'run_tr55'
         ]
 
@@ -477,7 +477,7 @@ class TaskRunnerTestCase(TestCase):
 
         needed_tasks = [
             'run',
-            'nlcd_soil',
+            'nlcd_soil_tr55',
             'run_tr55'
         ]
 

--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -628,7 +628,7 @@ def _construct_tr55_job_chain(model_input, job_id):
 
         job_chain.append(tasks.run_tr55.s(censuses, aoi, model_input))
     else:
-        job_chain.append(tasks.nlcd_soil.s())
+        job_chain.append(tasks.nlcd_soil_tr55.s())
 
         if aoi_census and pieces:
             polygons = [m['shape']['geometry'] for m in pieces]
@@ -636,7 +636,7 @@ def _construct_tr55_job_chain(model_input, job_id):
 
             job_chain.insert(
                 0,
-                geoprocessing.run.s('nlcd_soil',
+                geoprocessing.run.s('nlcd_soil_tr55',
                                     geop_input,
                                     layer_overrides=layer_overrides))
             job_chain.append(tasks.run_tr55.s(aoi, model_input,
@@ -649,7 +649,7 @@ def _construct_tr55_job_chain(model_input, job_id):
 
             job_chain.insert(
                 0,
-                geoprocessing.run.s('nlcd_soil',
+                geoprocessing.run.s('nlcd_soil_tr55',
                                     geop_input,
                                     wkaoi,
                                     layer_overrides=layer_overrides))

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -525,6 +525,19 @@ GEOP = {
                 'zoom': 0
             }
         },
+        'nlcd_soil_tr55': {
+            'input': {
+                'polygon': [],
+                'polygonCRS': 'LatLng',
+                'rasters': [
+                    '__LAND__',
+                    '__SOIL__'
+                ],
+                'rasterCRS': 'ConusAlbers',
+                'operationType': 'RasterGroupedCountMany',
+                'zoom': 0
+            }
+        },
         'nlcd_streams': {
             'input': {
                 'polygon': [],


### PR DESCRIPTION
## Overview

We realized that the migration in #3528 did not fix the issue it was attempting to. This was because while we cleared the `results` and `modification_hash` fields, the `aoi_census` and `modification_censuses` were not, and with their cached values continued to have the same issue as before.

This PR includes an updated version of that migration that also clears those fields. Unfortunately, once those are gone, we realized that the code goes down a path not often trod:

https://github.com/WikiWatershed/model-my-watershed/blob/afebb0766dc38f03908035a1fc82d48930f77fd8/src/mmw/apps/modeling/views.py#L645-L656

This code path is only exercised when neither the AoI census nor the modification censuses are defined, which almost never happens in regular user interaction. Usually, the AoI census is calculated when the Current Conditions scenario is initialized, and then copied over to New Scenarios. When adding modifications, only one is added at a time, and previously cached modification censuses are used otherwise. This is important because the current geoprocessing service only works on one polygon at a time, and if multiple polygons are provided, it [unifies them](https://github.com/WikiWatershed/mmw-geoprocessing/blob/412565a58d26ecfe141706faae55aba1648579de/api/src/main/scala/Utils.scala#L72) into a single one and returns a combined result. The TR-55 code _does_ expect multiple items, one for each polygon:

https://github.com/WikiWatershed/model-my-watershed/blob/afebb0766dc38f03908035a1fc82d48930f77fd8/src/mmw/apps/modeling/tasks.py#L254-L259

but our geoprocessing summary returned the single result wrapped in a simple list:

https://github.com/WikiWatershed/model-my-watershed/blob/afebb0766dc38f03908035a1fc82d48930f77fd8/src/mmw/apps/modeling/tasks.py#L225-L228

which works correctly as long as only a single polygon is queried. However, when multiple polygons are queried, the result is a combined histogram, whereas we want individualized ones.

Hence, in https://github.com/WikiWatershed/mmw-geoprocessing/pull/101, we add a new operation `RasterGroupedCountMany`, which will be included in the upcoming 5.3.0 release of the geoprocessing service, that returns individualized histograms for each input polygon.

This PR switches TR-55 to use that new operation.

### Notes

While this should be tested ASAP, this cannot be merged until https://github.com/WikiWatershed/mmw-geoprocessing/pull/101 is merged and a `5.3.0` version of the geoprocessing service is tagged and released.

## Testing Instructions

### Preparation

The following is no longer needed as of the [5.3.0](https://github.com/WikiWatershed/mmw-geoprocessing/releases/tag/5.3.0) release.

* ~In a local install of `mmw-geoprocessing`, check out https://github.com/WikiWatershed/mmw-geoprocessing/pull/101, then run `./scripts/cibuild`~
* ~Copy the generated JAR file to your `model-my-watershed` directory:~
  ```shell
  cp mmw-geoprocessing/api/target/scala-2.11/api-assembly-5.2.0.jar model-my-watershed/
  ```
* ~Go into your `worker` VM, and replace the local JAR with this one:~
  ```shell
  vagrant ssh worker
  ```
  ```shell
  sudo mv /vagrant/api-assembly-5.2.0.jar /opt/geoprocessing/mmw-geoprocessing-5.2.0.jar
  sudo service mmw-geoprocessing stop && sudo service mmw-geoprocessing start
  ```

Instead, just reprovision the `worker` to get the latest mmw-geoprocessing JAR:

```shell
vagrant provision worker
```

### Evaluation

* On `master`, ensure you are logged in so that your work is saved
* Make a TR-55 project with this shape: [rivera.geojson.txt](https://github.com/WikiWatershed/model-my-watershed/files/8522711/rivera.geojson.txt)
* Draw some modifications on it
  - [x] Ensure it fails
* Check out this branch
* Run migrations
  ```shell
  ./scripts/manage migrate
  ```
* Restart Celery
  ```shell
  vagrant ssh worker -c 'sudo service celeryd restart'
  ```
* Go back to your saved project
  - [x] Ensure it succeeds