### PR TITLE
Update TR-55 to work with new JSON payloads

### DIFF
--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -577,7 +577,11 @@ def start_tr55(request, format=None):
     user = request.user if request.user.is_authenticated else None
     created = now()
 
-    model_input = json.loads(request.POST['model_input'])
+    model_input = request.data.get('model_input')
+    if not model_input:
+        return Response('Missing model_input',
+                        status=status.HTTP_400_BAD_REQUEST)
+
     job = Job.objects.create(created_at=created, result='', error='',
                              traceback='', user=user, status='started')
     task_list = _initiate_tr55_job_chain(model_input, job.id)

--- a/src/mmw/js/src/modeling/models.js
+++ b/src/mmw/js/src/modeling/models.js
@@ -1671,7 +1671,7 @@ var ScenarioModel = Backbone.Model.extend({
                 }
 
                 return {
-                    model_input: JSON.stringify(modelInput)
+                    model_input: modelInput
                 };
 
             case utils.GWLFE:


### PR DESCRIPTION
## Overview

This was updated for GWLF-E in aab3d8c4, and consequently broke
TR-55. This fixes it.

Connects #3531 

## Testing Instructions

* Check out this branch
* Run `./scripts/bundle.sh --debug`
* Run `./scripts/debugcelery.sh`
* Go to http://localhost:8000/ and select an area of interest
* Go to the model tab and select Site Storm Model
  - [x] Ensure it completes successfully