### PR TITLE
Add Catchment-level Source Loads Fields in Subbasin/Run

### DIFF
--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -210,9 +210,10 @@ def format_subbasin(huc12_gwlfe_results, srat_catchment_results, gmss):
         return {
             'Loads': loads,
             'SummaryLoads': summary_loads,
-            'Catchments': {comid: format_catchment(result, catchment_loads_template)
-                           for comid, result
-                           in srat_huc12['catchments'].items()},
+            'Catchments': {
+                comid: format_catchment(result, catchment_loads_template)
+                for comid, result in srat_huc12['catchments'].items()},
+            'Raw': huc12_gwlfe_results[srat_huc12['huc12']]
         }
 
     aggregate = {

--- a/src/mmw/apps/modeling/tasks.py
+++ b/src/mmw/apps/modeling/tasks.py
@@ -127,7 +127,17 @@ def format_subbasin(huc12_gwlfe_results, srat_catchment_results, gmss):
             'Area': area,
         }
 
-    def format_catchment(srat_catchment):
+    def format_catchment(srat_catchment, loads_template):
+        for key, value in srat_catchment.items():
+            # A sample load source key is 'tnload_hp'.
+            # The first half 'tnload' indicates which kinds of loads
+            # The second half 'hp' is the acronym of the source of loads
+            if '_' in key:
+                load_type, load_source = key.split('_')
+                for load in loads_template:
+                    if load_source == settings.SRAT_KEYS[load['Source']]:
+                        add_load_by_key(load_type, value, load)
+
         return {
             'TotalLoadingRates': {
                 'TotalN': srat_catchment['tnloadrate_total'],
@@ -139,7 +149,28 @@ def format_subbasin(huc12_gwlfe_results, srat_catchment_results, gmss):
                 'TotalP': srat_catchment['tploadrate_conc'],
                 'Sediment': srat_catchment['tssloadrate_conc'],
             },
+            'Loads': loads_template
         }
+
+    def add_load_by_key(load_type, value, load):
+        type_mapping = {
+            'tpload': 'TotalP',
+            'tnload': 'TotalN',
+            'tssload': 'Sediment'
+        }
+
+        if load_type in type_mapping:
+            load[type_mapping[load_type]] = value
+
+        return load
+
+    def catchment_template(keys_template):
+        return [{
+            'Source': key_name,
+            'TotalN': 0,
+            'TotalP': 0,
+            'Sediment': 0
+        } for key_name in keys_template.keys()]
 
     def sum_loads(loads):
         def add_load(sums, load):
@@ -168,6 +199,7 @@ def format_subbasin(huc12_gwlfe_results, srat_catchment_results, gmss):
         loads = [add_huc12_source(s, srat_huc12, source_areas, area)
                  for s in aggregate['Loads']]
         summary_loads = build_summary_loads(loads, area)
+        catchment_loads_template = catchment_template(settings.SRAT_KEYS)
 
         # Build up the full AOI's values with the huc-12's
         aggregate['SummaryLoads']['Area'] += area
@@ -178,7 +210,7 @@ def format_subbasin(huc12_gwlfe_results, srat_catchment_results, gmss):
         return {
             'Loads': loads,
             'SummaryLoads': summary_loads,
-            'Catchments': {comid: format_catchment(result)
+            'Catchments': {comid: format_catchment(result, catchment_loads_template)
                            for comid, result
                            in srat_huc12['catchments'].items()},
         }

--- a/src/mmw/requirements/development.txt
+++ b/src/mmw/requirements/development.txt
@@ -4,3 +4,4 @@ flake8==4.0.1
 jedi==0.17.2
 ipython==7.17.0
 ipdb==0.13.9
+curlify2==1.0.1


### PR DESCRIPTION
## Overview

As found in #3521, the new SRAT API includes detailed T/P/Sediment loads from different sources at catchment level. 

A new 'Loads' key is added to the catchment-level to include these new fields, in the same format as sources in HUC-12,
e.g.
```
{
        "Source": "Hay/Pasture",
        "TotalN": 0,
        "TotalP": 0,
        "Sediment": 0
 }
```

A new 'Raw' key is added to the HUC-12 level to include the raw GWLF-E output for individual HUC-12s. Fields include areas, flows, monthly loads, and the loads by source data

Connects #3522 and #3537

### Demo

**At catchment-level:**
```
"Catchments": {
          "4781987": {
            "TotalLoadingRates": {
              "TotalN": 1432.02392564478,
              "TotalP": 26.7762546161585,
              "Sediment": 51420.0663920353
            },
            "LoadingRateConcentrations": {
              "TotalN": 2.92429764861301,
              "TotalP": 0.0546790713552077,
              "Sediment": 105.003538382957
            },
            "Loads": [
              {
                "Source": "Hay/Pasture",
                "TotalN": 0,
                "TotalP": 0,
                "Sediment": 0
              },
              {
                "Source": "Cropland",
                "TotalN": 0,
                "TotalP": 0,
                "Sediment": 0
              },
              {
                "Source": "Wooded Areas",
                "TotalN": 0,
                "TotalP": 0,
                "Sediment": 0
              },
              {
                "Source": "Open Land",
                "TotalN": 0,
                "TotalP": 0,
                "Sediment": 0
              },
              {
                "Source": "Barren Areas",
                "TotalN": 0,
                "TotalP": 0,
                "Sediment": 0
              },
              {
                "Source": "Low-Density Mixed",
                "TotalN": 0.137064729952081,
                "TotalP": 0.0130705585777395,
                "Sediment": 4.78982553141844
              },
              {
                "Source": "Medium-Density Mixed",
                "TotalN": 2.46271005726897,
                "TotalP": 0.229387689343959,
                "Sediment": 86.8178229455849
              },
              {
                "Source": "High-Density Mixed",
                "TotalN": 1.59743905562763,
                "TotalP": 0.148792527466499,
                "Sediment": 56.3144575986497
              },
              {
                "Source": "Low-Density Open Space",
                "TotalN": 0.0685600370446117,
                "TotalP": 0.00653791811063927,
                "Sediment": 2.39587978604039
              },
              {
                "Source": "Farm Animals",
                "TotalN": 0,
                "TotalP": 0,
                "Sediment": 0
              },
              {
                "Source": "Stream Bank Erosion",
                "TotalN": 0.687650053634671,
                "TotalP": 0.411215122097006,
                "Sediment": 812996.302508092
              },
              {
                "Source": "Subsurface Flow",
                "TotalN": 0,
                "TotalP": 0,
                "Sediment": 0
              },
              {
                "Source": "Wetlands",
                "TotalN": 0.0660146565274818,
                "TotalP": 0.00312570525364461,
                "Sediment": 0.00156209017389706
              },
              {
                "Source": "Point Sources",
                "TotalN": 0,
                "TotalP": 0,
                "Sediment": 0
              },
              {
                "Source": "Septic Systems",
                "TotalN": 2.44127448227942,
                "TotalP": 0,
                "Sediment": 0
              }
            ]
          },
   }
```

**At HUC-12 level** 
```
"Raw": {
                    "meta": {
                        "NYrs": 30,
                        "NRur": 10,
                        "NUrb": 6,
                        "NLU": 16,
                        "SedDelivRatio": 0.10970338293506933,
                        "WxYrBeg": 1961,
                        "WxYrEnd": 1990
                    },
                    "AreaTotal": 11274.800000000001,
                    "MeanFlow": 51420515.41572052,
                    "MeanFlowPerSecond": 1.630533847530458,
                    "monthly": [
                        {
                            "AvPrecipitation": 6.690359999999999,
                            "AvEvapoTrans": 0.273151922216029,
                            "AvGroundWater": 4.549426699263946,
                            "AvRunoff": 0.5564440447746475,
                            "AvStreamFlow": 5.141212989403024,
                            "AvPtSrcFlow": 0.03534224536443019,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 6.472343333333333,
                            "AvEvapoTrans": 0.413576729954262,
                            "AvGroundWater": 5.046436478996837,
                            "AvRunoff": 0.7271779603203773,
                            "AvStreamFlow": 5.805536467388312,
                            "AvPtSrcFlow": 0.031922028071098243,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 7.401983333333333,
                            "AvEvapoTrans": 1.5779405620973839,
                            "AvGroundWater": 6.382485311728822,
                            "AvRunoff": 0.29885578803867674,
                            "AvStreamFlow": 6.716683345131929,
                            "AvPtSrcFlow": 0.03534224536443019,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 8.250343333333335,
                            "AvEvapoTrans": 3.4151042390938944,
                            "AvGroundWater": 5.976795502291471,
                            "AvRunoff": 0.3253137044818107,
                            "AvStreamFlow": 6.3363113797066015,
                            "AvPtSrcFlow": 0.03420217293331954,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 9.960610000000003,
                            "AvEvapoTrans": 7.292289040113448,
                            "AvGroundWater": 4.8403227845493735,
                            "AvRunoff": 0.10369029967445734,
                            "AvStreamFlow": 4.979355329588261,
                            "AvPtSrcFlow": 0.03534224536443019,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 9.811596666666668,
                            "AvEvapoTrans": 10.645064592920779,
                            "AvGroundWater": 3.268850078031437,
                            "AvRunoff": 0.20977080544156596,
                            "AvStreamFlow": 3.5128230564063228,
                            "AvPtSrcFlow": 0.03420217293331954,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 10.077026666666665,
                            "AvEvapoTrans": 11.391206927894507,
                            "AvGroundWater": 1.6916322304210802,
                            "AvRunoff": 0.17557853990511788,
                            "AvStreamFlow": 1.9025530156906283,
                            "AvPtSrcFlow": 0.03534224536443019,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 9.65581,
                            "AvEvapoTrans": 9.393103342606853,
                            "AvGroundWater": 0.8134770276092461,
                            "AvRunoff": 0.12022129903534702,
                            "AvStreamFlow": 0.9690405720090234,
                            "AvPtSrcFlow": 0.03534224536443019,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 9.192260000000001,
                            "AvEvapoTrans": 5.874390859285675,
                            "AvGroundWater": 0.6398048943436809,
                            "AvRunoff": 0.3657751596130058,
                            "AvStreamFlow": 1.0397822268900063,
                            "AvPtSrcFlow": 0.03420217293331954,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 7.26948,
                            "AvEvapoTrans": 3.335797296066952,
                            "AvGroundWater": 1.290798502927715,
                            "AvRunoff": 0.17003438750435995,
                            "AvStreamFlow": 1.496175135796505,
                            "AvPtSrcFlow": 0.03534224536443019,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 8.81972666666667,
                            "AvEvapoTrans": 1.5734339915926643,
                            "AvGroundWater": 2.5079113817589875,
                            "AvRunoff": 0.2638853717295923,
                            "AvStreamFlow": 2.8059989264218994,
                            "AvPtSrcFlow": 0.03420217293331954,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        },
                        {
                            "AvPrecipitation": 7.617459999999999,
                            "AvEvapoTrans": 0.5822775438629478,
                            "AvGroundWater": 4.470201032010064,
                            "AvRunoff": 0.3955719034462286,
                            "AvStreamFlow": 4.901115180820723,
                            "AvPtSrcFlow": 0.03534224536443019,
                            "AvTileDrain": 0.0,
                            "AvWithdrawal": 0.0
                        }
                    ],
                    "Loads": [
                        {
                            "Source": "Hay/Pasture",
                            "Sediment": 221703.01452685345,
                            "TotalN": 859.5916204546817,
                            "TotalP": 335.9106666776247
                        },
                        {
                            "Source": "Cropland",
                            "Sediment": 651771.1746414119,
                            "TotalN": 3062.138037852354,
                            "TotalP": 932.1441936169118
                        },
                        {
                            "Source": "Wooded Areas",
                            "Sediment": 12789.37381798571,
                            "TotalN": 385.2455960485659,
                            "TotalP": 33.5021158422105
                        },
                        {
                            "Source": "Wetlands",
                            "Sediment": 72.70657101728492,
                            "TotalN": 11.06401555154909,
                            "TotalP": 0.6575055450510741
                        },
                        {
                            "Source": "Open Land",
                            "Sediment": 9582.528191138137,
                            "TotalN": 91.75862988621735,
                            "TotalP": 12.709583276200668
                        },
                        {
                            "Source": "Barren Areas",
                            "Sediment": 35.35937435788883,
                            "TotalN": 28.763756380831957,
                            "TotalP": 0.9974637467640227
                        },
                        {
                            "Source": "Low-Density Mixed",
                            "Sediment": 3769.4879324203066,
                            "TotalN": 90.77592238039534,
                            "TotalP": 9.77252097428397
                        },
                        {
                            "Source": "Medium-Density Mixed",
                            "Sediment": 9184.531507666094,
                            "TotalN": 211.42348865182703,
                            "TotalP": 21.75229905655306
                        },
                        {
                            "Source": "High-Density Mixed",
                            "Sediment": 5625.97577057821,
                            "TotalN": 129.50725069574656,
                            "TotalP": 13.324349461308186
                        },
                        {
                            "Source": "Low-Density Open Space",
                            "Sediment": 10424.528280677683,
                            "TotalN": 251.04103979752952,
                            "TotalP": 27.0259311334439
                        },
                        {
                            "Source": "Farm Animals",
                            "Sediment": 0,
                            "TotalN": 4103.761403953755,
                            "TotalP": 1214.850372875529
                        },
                        {
                            "Source": "Stream Bank Erosion",
                            "Sediment": 1961650,
                            "TotalN": 1513,
                            "TotalP": 587
                        },
                        {
                            "Source": "Subsurface Flow",
                            "Sediment": 0,
                            "TotalN": 55830.24052837551,
                            "TotalP": 958.2216351083728
                        },
                        {
                            "Source": "Point Sources",
                            "Sediment": 0,
                            "TotalN": 11760.46642068797,
                            "TotalP": 1368.7872556308018
                        },
                        {
                            "Source": "Septic Systems",
                            "Sediment": 0,
                            "TotalN": 452.7857531999998,
                            "TotalP": 0.0
                        }
                    ],
                    "SummaryLoads": [
                        {
                            "Source": "Total Loads",
                            "Unit": "kg",
                            "Sediment": 2886608.680614107,
                            "TotalN": 78781.56346391693,
                            "TotalP": 5516.655892945056
                        },
                        {
                            "Source": "Loading Rates",
                            "Unit": "kg/ha",
                            "Sediment": 256.0230496872766,
                            "TotalN": 6.987402301053404,
                            "TotalP": 0.4892907983241437
                        },
                        {
                            "Source": "Mean Annual Concentration",
                            "Unit": "mg/l",
                            "Sediment": 56.13729573258224,
                            "TotalN": 1.5321037299410551,
                            "TotalP": 0.10728511467348066
                        },
                        {
                            "Source": "Mean Low-Flow Concentration",
                            "Unit": "mg/l",
                            "Sediment": 131.36097016569582,
                            "TotalN": 2.675144920945013,
                            "TotalP": 0.3326451530389938
                        }
                    ],
                    "inputmod_hash": "d751713988987e9331980363e24189ced751713988987e9331980363e24189ce"
                }
```

### Notes

curlify is added for future investigating and testing

## Testing Instructions

 * Check out this branch and restart celery:
```
vagrant ssh worker -c 'sudo service celeryd restart'
```
 * Go to the http://localhost:8000/api/docs/ and log in
 * Run `​/modeling​/subbasin​/prepare​/` and `/modeling​/subbasin/run/` endpoint with a HUC-8, HUC-10, and a HUC-12 respectively in the Delaware River Basin area (e.g. `02040203` for Schuylkill, HUC-8 Subbasin)
 * Save and check the `subbasin/run` response at `/jobs/{job_uuid}`
 - [x] Catchment-level: make sure there's `Loads` key under every catchment, with loads from different sources in the list
 - [x] HUC-12 level: make sure there's a new `Raw` key under every HUC-12