### PR TITLE
Switch NLCD19 Products to Correctly Aligned Layers

### DIFF
--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -175,11 +175,11 @@ RWD_REQUEST = Schema(
 )
 
 nlcd_override_allowed_values = '", "'.join([
-    'nlcd-2019-30m-epsg5070-512-byte',
-    'nlcd-2016-30m-epsg5070-512-byte',
-    'nlcd-2011-30m-epsg5070-512-byte',
-    'nlcd-2006-30m-epsg5070-512-byte',
-    'nlcd-2001-30m-epsg5070-512-byte',
+    'nlcd-2019-30m-epsg5070-512-uint8raw',
+    'nlcd-2016-30m-epsg5070-512-uint8raw',
+    'nlcd-2011-30m-epsg5070-512-uint8raw',
+    'nlcd-2006-30m-epsg5070-512-uint8raw',
+    'nlcd-2001-30m-epsg5070-512-uint8raw',
     'nlcd-2011-30m-epsg5070-512-int8',
 ])
 LAYER_OVERRIDES = Schema(
@@ -192,12 +192,12 @@ LAYER_OVERRIDES = Schema(
     properties={
         '__LAND__': Schema(
             type=TYPE_STRING,
-            example='nlcd-2019-30m-epsg5070-512-byte',
+            example='nlcd-2019-30m-epsg5070-512-uint8raw',
             description='The NLCD layer to use. Valid options are: '
-                        f'"{nlcd_override_allowed_values}". All "-byte" '
+                        f'"{nlcd_override_allowed_values}". All "-uint8raw" '
                         'layers are from the NLCD19 product. The "-int8" '
                         'layer is from the NLCD11 product. The default value '
-                        'is NLCD19 2019 "nlcd-2019-30m-epsg5070-512-byte".',
+                        'is NLCD19 2019 "nlcd-2019-30m-epsg5070-512-uint8raw".'
         ),
         '__STREAMS__': Schema(
             type=TYPE_STRING,

--- a/src/mmw/apps/geoprocessing_api/validation.py
+++ b/src/mmw/apps/geoprocessing_api/validation.py
@@ -142,11 +142,11 @@ def create_layer_overrides_land_not_valid_msg(values):
 
 
 LAND_LAYER_OVERRIDES = [
-     'nlcd-2019-30m-epsg5070-512-byte',
-     'nlcd-2016-30m-epsg5070-512-byte',
-     'nlcd-2011-30m-epsg5070-512-byte',
-     'nlcd-2006-30m-epsg5070-512-byte',
-     'nlcd-2001-30m-epsg5070-512-byte',
+     'nlcd-2019-30m-epsg5070-512-uint8raw',
+     'nlcd-2016-30m-epsg5070-512-uint8raw',
+     'nlcd-2011-30m-epsg5070-512-uint8raw',
+     'nlcd-2006-30m-epsg5070-512-uint8raw',
+     'nlcd-2001-30m-epsg5070-512-uint8raw',
      'nlcd-2011-30m-epsg5070-512-int8',
 ]
 

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -434,7 +434,7 @@ def start_analyze_land(request, nlcd_year, format=None):
 
     nlcd, year = nlcd_year.split('_')
     if nlcd == '2019' and year in ['2019', '2016', '2011', '2006', '2001']:
-        layer_overrides['__LAND__'] = f'nlcd-{year}-30m-epsg5070-512-byte'
+        layer_overrides['__LAND__'] = f'nlcd-{year}-30m-epsg5070-512-uint8raw'
 
     return start_celery_job([
         geoprocessing.run.s('nlcd_ara', geop_input, wkaoi,

--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -400,7 +400,7 @@ def get_layer_value(layer, layer_overrides=dict):
     If the default config is something like:
 
     {
-        '__LAND__': 'nlcd-2019-30m-epsg5070-512-byte',
+        '__LAND__': 'nlcd-2019-30m-epsg5070-512-uint8raw',
         '__SOIL__': 'ssurgo-hydro-groups-30m-epsg5070-512-int8',
         '__STREAMS__': 'nhd',
     }

--- a/src/mmw/js/src/modeling/utils.js
+++ b/src/mmw/js/src/modeling/utils.js
@@ -64,11 +64,11 @@ module.exports = {
     layerOverrideToDefaultLandCoverType: function(layer_overrides) {
         var raster = layer_overrides && _.get(layer_overrides, "__LAND__"),
             mapping = {
-                "nlcd-2019-30m-epsg5070-512-byte": "land_2019_2019",
-                "nlcd-2016-30m-epsg5070-512-byte": "land_2019_2016",
-                "nlcd-2011-30m-epsg5070-512-byte": "land_2019_2011",
-                "nlcd-2006-30m-epsg5070-512-byte": "land_2019_2006",
-                "nlcd-2001-30m-epsg5070-512-byte": "land_2019_2001",
+                "nlcd-2019-30m-epsg5070-512-uint8raw": "land_2019_2019",
+                "nlcd-2016-30m-epsg5070-512-uint8raw": "land_2019_2016",
+                "nlcd-2011-30m-epsg5070-512-uint8raw": "land_2019_2011",
+                "nlcd-2006-30m-epsg5070-512-uint8raw": "land_2019_2006",
+                "nlcd-2001-30m-epsg5070-512-uint8raw": "land_2019_2001",
                 "nlcd-2011-30m-epsg5070-512-int8": "land_2011_2011",
             };
 

--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -479,7 +479,7 @@ GEOP = {
         '__BFI__': 'bfi48grd-epsg5070',
         '__GWN__': 'us-groundwater-nitrogen-30m-epsg5070-512',
         '__KFACTOR__': 'us-ssugro-kfactor-30m-epsg5070-512',
-        '__LAND__': 'nlcd-2019-30m-epsg5070-512-byte',
+        '__LAND__': 'nlcd-2019-30m-epsg5070-512-uint8raw',
         '__NED__': 'ned-nhdplus-30m-epsg5070-512',
         '__PROTECTED_LANDS__': 'protected-lands-30m-epsg5070-512',
         '__SLOPE__': 'us-percent-slope-30m-epsg5070-512',


### PR DESCRIPTION
## Overview

The previously ingested NLCD19 products (2001, 2006, 2011, 2016, and 2019) were all out of alignment with previous layers in the systems, as described here: https://github.com/WikiWatershed/mmw-geoprocessing/issues/102#issuecomment-1115325690. 

The fixed layers, shown here: https://github.com/WikiWatershed/mmw-geoprocessing/issues/102#issuecomment-1148918170, were ingested with `uint8raw` suffixes. This changes MMW to use the new `uint8raw` layers, rather than the old `byte` layers.

Connects https://github.com/WikiWatershed/mmw-geoprocessing/issues/102

### Demo

![image](https://user-images.githubusercontent.com/1430060/172437607-0075e609-92e5-48b6-9ecf-41161700ed5e.png)

### Notes

Since this changes geoprocessing results, we need to clear the cache when this is deployed:

```bash
redis-cli -h cache.service.mmw.internal -n 1 --raw KEYS ":1:geop*" | xargs redis-cli -h cache.service.mmw.internal -n 1 DEL
```

## Testing Instructions

* Check out this branch and `./scripts/bundle.sh --debug`
* Clear any saved geoprocessing results:
    ```bash
    vagrant ssh services -c 'redis-cli -n 1 --raw KEYS ":1:geop_*" | xargs redis-cli -n 1 DEL'
    ```
* Go to http://localhost:8000/ and select an east coast HUC-12
  - [ ] Ensure all Land Analyses complete correctly
* Run the Watershed Multi-Year Model
  - [ ] Ensure it completes correctly