### PR TITLE
Make NHD Medium Resolution Default, Don't Analyze NHD High Resolution Until Selected

### DIFF
--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -220,18 +220,18 @@ function createAnalyzeTaskGroupCollection(aoi, wkaoi) {
             displayName: "Streams",
             tasks: [
                 {
-                    name: "streams_nhdhr",
-                    displayName: "NHD High Resolution Streams",
-                    area_of_interest: aoi,
-                    wkaoi: wkaoi,
-                    taskName: "analyze/streams/nhdhr"
-                },
-                {
                     name: "streams_nhd",
                     displayName: "NHD Medium Resolution Streams",
                     area_of_interest: aoi,
                     wkaoi: wkaoi,
-                    taskName: "analyze/streams/nhd"
+                    taskName: "analyze/streams/nhd",
+                },
+                {
+                    name: "streams_nhdhr",
+                    displayName: "NHD High Resolution Streams",
+                    area_of_interest: aoi,
+                    wkaoi: wkaoi,
+                    taskName: "analyze/streams/nhdhr",
                 },
             ]
         },

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -76,6 +76,7 @@ var AnalyzeTaskModel = coreModels.TaskModel.extend({
             token: settings.get('api_token'),
             // Include this task in Catalog Search results (ie, BigCZ)
             enabledForCatalogMode: false,
+            lazy: false, // Will not execute immediately if lazy is true
         }, coreModels.TaskModel.prototype.defaults
     ),
 
@@ -167,11 +168,13 @@ var AnalyzeTaskGroupModel = Backbone.Model.extend({
     /**
      * Returns a promise that completes when Analysis has been fetched. If
      * fetching is not required, returns an immediatley resolved promise.
+     * Skips lazy analyses, which should be triggered explicitly on the task.
      */
     fetchAnalysisIfNeeded: function() {
-        var taskAnalysisFetches = this.get('tasks').map(function(t) {
-            return t.fetchAnalysisIfNeeded();
-        });
+        var taskAnalysisFetches =
+            this.get('tasks')
+                .filter(function(t) { return !t.get('lazy'); })
+                .map(function(t) { return t.fetchAnalysisIfNeeded(); });
 
         return $.when.apply($, taskAnalysisFetches);
     },
@@ -232,6 +235,7 @@ function createAnalyzeTaskGroupCollection(aoi, wkaoi) {
                     area_of_interest: aoi,
                     wkaoi: wkaoi,
                     taskName: "analyze/streams/nhdhr",
+                    lazy: true,
                 },
             ]
         },

--- a/src/mmw/js/src/analyze/views.js
+++ b/src/mmw/js/src/analyze/views.js
@@ -1568,6 +1568,7 @@ var TaskSelectorView = Marionette.ItemView.extend({
     updateTask: function() {
         var taskName = this.ui.selector.val();
         this.model.setActiveTask(taskName);
+        this.model.get('activeTask').fetchAnalysisIfNeeded();
     }
 });
 


### PR DESCRIPTION
## Overview

To lower usage loads, we're going to make NHD HR analysis lazy, so it will only be triggered when users explicitly select its tab. By default only the Medium Resolution will be shown.

Adds the concept of "lazy" analyses that are not fetched by default. When they are brought in to focus, the fetch is triggered. If the analysis has already been fetched, it will not be fetched again.

Closes #3568 

### Demo

https://user-images.githubusercontent.com/1430060/195915125-8d48d182-3d7d-4917-88e4-a1a0836bd292.mp4

## Testing Instructions

- Check out this branch and `./scripts/bundle.sh --debug`
- Go to http://localhost:8000/
- Draw a shape, move to Analyze
  - [x] Ensure that NHD Medium Resolution is the default analysis under Streams
  - [x] Ensure that NHD High Resolution is not analyzed until selected from the dropdown
  - [x] Ensure that you if you select another analysis, and come back NHD Hi Res, the results are already there, and no re-fetch is triggered