### PR TITLE
Unversion Firefox, Upgrade PostGIS to 3.3

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -20,7 +20,7 @@ postgresql_support_repository_channel: "main"
 postgresql_support_libpq_version: "13.*.pgdg20.04+1"
 postgresql_support_psycopg2_version: "2.8.*"
 postgis_version: "3"
-postgis_package_version: "3.2*pgdg20.04+1"
+postgis_package_version: "3.3*pgdg20.04+1"
 
 daemontools_version: "1:0.76-7"
 

--- a/deployment/ansible/roles/model-my-watershed.app/tasks/dev-and-test-dependencies.yml
+++ b/deployment/ansible/roles/model-my-watershed.app/tasks/dev-and-test-dependencies.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Firefox for UI tests
-  apt: pkg="firefox=9*" state=present
+  apt: pkg="firefox" state=present
 
 - name: Install Xvfb for JavaScript tests
   apt: pkg="xvfb=2:1.20.*" state=present


### PR DESCRIPTION
## Overview

We use Firefox for JS testing. Every 10 versions we have to update the version string. Firefox has been stable for the last few years, and the tests have not broken. By unversioning it we will get the latest version every time, which should be fine given the stability over the last few years.

PostGIS 3.3 is needed because a step in provisioning requests ST_TriangulatePolygon, which is only available in PostGIS 3.3. It is unclear what is requesting that. This does not have an impact on us, because we're not using any feature that is deprecated in PostGIS 3.3.

This is a copy of #3567, targeting the `hotfix/1.33.8` branch, to get CI to run correctly.

### Demo

http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-pull-requests/4468/console