### PR TITLE
Prevent Worker Crashes

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/tasks/celery-service.yml
@@ -15,3 +15,8 @@
     special_time: daily
     job: /usr/sbin/service celeryd restart
     state: present
+
+- name: Configure Celery log rotation
+  template: src=celery-logrotate.j2
+            dest=/etc/logrotate.d/celery
+            mode=0755

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/templates/celery-logrotate.j2
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/templates/celery-logrotate.j2
@@ -1,0 +1,5 @@
+{{ celery_log_dir }}/* {
+    rotate 3
+    daily
+    compress
+}

--- a/deployment/packer/mmw.json
+++ b/deployment/packer/mmw.json
@@ -63,6 +63,12 @@
             "ami_name": "mmw-worker-{{timestamp}}-{{user `version`}}",
             "ami_block_device_mappings": [
                 {
+                    "device_name": "/dev/sda1",
+                    "volume_type": "gp2",
+                    "volume_size": 12,
+                    "delete_on_termination": true
+                },
+                {
                     "device_name": "/dev/sdf",
                     "snapshot_id": "snap-0211cbbff8a81266f",
                     "volume_type": "gp2",


### PR DESCRIPTION
## Overview

Configures `logrotate` to compress Celery logs, and delete those older than 3 days, to prevent the worker instance running out of space.

Also increases the EBS Volume size on workers make sure they have more space.

Connects #3515 

### Demo

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/1430060/209814099-8d3c1ea5-b610-4a1d-8883-267b3682570e.png">

Worker system before the change:

```console
$ df -h .

Filesystem      Size  Used Avail Use% Mounted on
/dev/root       7.6G  7.5G  141M  99% /
```

After the change:

```console
$ df -h .

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        12G  7.3G  4.3G  64% /
```

## Testing Instructions

* Use the `mmw-stg` credentials in BitWarden to log in to AWS website
* Inspect the **Storage** of the [running worker instances](https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Instances:instanceState=running;tag:Name=Worker;v=3;$case=tags:true%5C,client:false;$regex=tags:false%5C,client:false)
  * [x] Ensure it says 12G instead of 8