### PR TITLE
Upgrade Redis to 5.0

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -8,6 +8,7 @@ To install the Python deployment dependencies, use `pip`:
 
 ```bash
 $ cd deployment
+$ pip install "setuptools<58"
 $ pip install -r requirements.txt
 ```
 

--- a/deployment/cfn/data_plane.py
+++ b/deployment/cfn/data_plane.py
@@ -418,7 +418,7 @@ class DataPlane(StackNode):
 
         elasticache_parameter_group = self.add_resource(ec.ParameterGroup(
             'ecpgCacheCluster',
-            CacheParameterGroupFamily='redis2.8',
+            CacheParameterGroupFamily='redis5.0',
             Description='Parameter group for the ElastiCache instances',
             Properties={'maxmemory-policy': 'allkeys-lru'}
         ))
@@ -431,7 +431,7 @@ class DataPlane(StackNode):
             CacheParameterGroupName=Ref(elasticache_parameter_group),
             CacheSubnetGroupName=Ref(elasticache_subnet_group),
             Engine='redis',
-            EngineVersion='2.8.19',
+            EngineVersion='5.0.6',
             NotificationTopicArn=Ref(self.notification_topic_arn),
             NumCacheClusters=2,
             PreferredCacheClusterAZs=Ref(self.availability_zones),


### PR DESCRIPTION
## Overview

We've been on Redis 2 in production for a long time, and it is being EOL'd. We've been using Redis 5 in development since https://github.com/WikiWatershed/model-mywatershed/commit/5bf37aadd9c7572fb48947afc1cf8c4a4b125d8c in August 2021. Thus, with this experience, we upgrade the live instance to Redis 5 as well.

These files are updated for the record, but the actual  upgrade was performed via the UI. A full record of actions taken can be seen here: https://github.com/WikiWatershed/model-my-watershed/issues/3576#issuecomment-1384390400

This has been done for staging already, and is now being done for production.

Closes #3576 