### PR TITLE
Fix logrotate for Celery

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.celery-worker/templates/celery-logrotate.j2
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/templates/celery-logrotate.j2
@@ -1,4 +1,4 @@
-{{ celery_log_dir }}/* {
+{{ celery_log_dir }}/*.log {
     rotate 3
     daily
     compress

--- a/deployment/ansible/roles/model-my-watershed.celery-worker/templates/celery-logrotate.j2
+++ b/deployment/ansible/roles/model-my-watershed.celery-worker/templates/celery-logrotate.j2
@@ -1,5 +1,8 @@
 {{ celery_log_dir }}/*.log {
     rotate 3
     daily
+    missingok
     compress
+    delaycompress
+    notifempty
 }


### PR DESCRIPTION
## Overview

We had been noticing MMW Worker Crashes on a number of occasions [#3515](https://github.com/WikiWatershed/model-my-watershed/issues/3515). This was because those EC2 instances kept running out of space. These instances were provisioned with 8GB of startup hard disk space, but would be spawned 99% full. As soon as the Celery Logs filled the rest, the instances would become unresponsive, requiring them to be cycled out.

We fixed this issue in [#3585](https://github.com/WikiWatershed/model-my-watershed/pull/3585) in two ways:
1. Add log rotation for the Celery logs so that they don't grow forever, and delete the logs after 3 days
2. Increase the Worker VM size to 12 GB

This fixed the issue, and we no longer saw the worker crashes.

However, users started seeing that analyze jobs took longer and longer, and sometimes would not finish. This was because the Celery Service would sometimes fail because it did not recognize the gzipped rotated logs in the Celery log directory. This was because the log rotation configuration was incorrect, and was rotating not just the main log, but every backup log as well:

```
sudo journalctl -u celeryd.service
```

```
Feb 22 00:00:02 ip-10-0-3-53 systemd[1]: Stopping celeryd...
Feb 22 00:00:04 ip-10-0-3-53 sh[690794]: celery multi v5.2.0 (dawn-chorus)
Feb 22 00:00:04 ip-10-0-3-53 sh[690794]: > Stopping nodes...
Feb 22 00:00:04 ip-10-0-3-53 sh[690794]:         > Blue-worker0@ip-10-0-3-53: TERM -> 647136
Feb 22 00:00:04 ip-10-0-3-53 sh[690794]:         > Blue-worker1@ip-10-0-3-53: TERM -> 647625
Feb 22 00:00:06 ip-10-0-3-53 sh[690794]: > Waiting for 2 nodes -> 647136, 647625......
Feb 22 00:00:06 ip-10-0-3-53 sh[690794]:         > Blue-worker0@ip-10-0-3-53: OK
Feb 22 00:00:06 ip-10-0-3-53 sh[690794]: > Blue-worker0@ip-10-0-3-53: DOWN
Feb 22 00:00:08 ip-10-0-3-53 sh[690794]: > Waiting for 2 nodes -> None, None....
Feb 22 00:00:08 ip-10-0-3-53 sh[690794]:         > Blue-worker1@ip-10-0-3-53: OK
Feb 22 00:00:08 ip-10-0-3-53 sh[690794]: > Blue-worker1@ip-10-0-3-53: DOWN
Feb 22 00:00:08 ip-10-0-3-53 sh[690794]: > Waiting for 1 node -> None...
Feb 22 00:00:08 ip-10-0-3-53 systemd[1]: celeryd.service: Succeeded.
Feb 22 00:00:08 ip-10-0-3-53 systemd[1]: Stopped celeryd.
Feb 22 00:00:08 ip-10-0-3-53 systemd[1]: Starting celeryd...
Feb 22 00:00:08 ip-10-0-3-53 chown[691438]: /bin/chown: changing ownership of '/var/log/celery/Black-worker0.log.1.gz.1.gz.3.gz.1.gz.2.gz.1.gz.1': No such file or directory
Feb 22 00:00:08 ip-10-0-3-53 systemd[1]: celeryd.service: Control process exited, code=exited, status=1/FAILURE
Feb 22 00:00:08 ip-10-0-3-53 systemd[1]: celeryd.service: Failed with result 'exit-code'.
Feb 22 00:00:08 ip-10-0-3-53 systemd[1]: Failed to start celeryd.
```

This Celery Service startup failure was not caught by our automated systems. Furthermore, because the Celery services are restarted every night at midnight, they would complete all the pending jobs from the previous day. When we look at our job completion statistics, it would show those jobs as complete, hiding the true underlying issue.

I added a second report that looks at average job completion time, and in that we see a clear spike since a recent deployment, where they take an average of 12 hours to complete (essentially whenever the service stops until the next day). This behavior is not seen on staging because those instances are shut down every night and brought back up in the morning (to minimize hosting cost). But on production, where the worker instances are longer lived, the misconfigured log rotation happens, and affects Celery.

Currently, the logs look like this on a production Worker VM:

```
$ ls -1 Blue-worker0*

Blue-worker0.log
Blue-worker0.log.1.gz
Blue-worker0.log.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.3.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.2.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.3.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.3.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.3.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.3.gz.2.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.1.gz.1.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.1.gz.2.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.1.gz.3.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.2.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.2.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.2.gz.2.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.3.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.2.gz.3.gz.1.gz
Blue-worker0.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.3.gz
...
```

That is clearly wrong. This is likely due to this line: https://github.com/WikiWatershed/model-my-watershed/pull/3585/files#diff-d17bea8b1741bc4763caa4d0b39af3c0f640fe21ab0d408b2af8c488601dccafR1

```
{{ celery_log_dir }}/* {
  rotate 3
  daily
  compress
}
```

which should instead be:

```
{{ celery_log_dir }}/*.log {
  rotate 3
  daily
  compress
}
```

to limit the log rotation only to the log files, not the already compressed `.gz` files.

Connects #3593 
