### PR TITLE
Upgrade omgeo to fix search

### DIFF
--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -6,7 +6,7 @@ djangorestframework==3.13.1
 django-filter==21.1
 django-registration-redux==2.9
 django-extensions==3.1.5
-python-omgeo==6.1.0
+-e git+https://github.com/azavea/python-omgeo.git@6.2.0#egg=python-omgeo
 rauth==0.7.3
 djangorestframework-gis==0.17.0
 drf_yasg==1.20.0


### PR DESCRIPTION
## Overview

Location search was broken because of https://github.com/azavea/python-omgeo/issues/67. By upgrading to the latest version of omgeo that includes https://github.com/azavea/python-omgeo/pull/68, this issue is fixed.

PyPI release of omgeo is blocked for now https://github.com/azavea/python-omgeo/issues/70, so we use the tag directly from GitHub instead.

Closes #3605 

### Demo

https://github.com/azavea/python-omgeo/assets/1430060/74a6f48e-f058-4015-8a80-1ab36b7569b4

## Testing Instructions

- Check out this branch and `vagrant provision app`
- Go to http://localhost:8000 and try searching for "Philadelphia"
  - [x] Ensure upon clicking the result you are taken to Philadelphia and a marker is placed on the map