### PR TITLE
Remove provisioning for portal.bigcz.org

### DIFF
--- a/deployment/cfn/application.py
+++ b/deployment/cfn/application.py
@@ -49,8 +49,6 @@ class Application(StackNode):
         'AppServerAutoScalingScheduleEndCapacity': ['global:AppServerAutoScalingScheduleEndCapacity'],  # NOQA
         'AppServerAutoScalingScheduleEndRecurrence': ['global:AppServerAutoScalingScheduleEndRecurrence'],  # NOQA
         'SSLCertificateARN': ['global:SSLCertificateARN'],
-        'BackwardCompatSSLCertificateARN':
-        ['global:BackwardCompatSSLCertificateARN'],
         'PublicSubnets': ['global:PublicSubnets', 'VPC:PublicSubnets'],
         'PrivateSubnets': ['global:PrivateSubnets', 'VPC:PrivateSubnets'],
         'PublicHostedZoneName': ['global:PublicHostedZoneName'],
@@ -190,12 +188,6 @@ class Application(StackNode):
             Description='ARN for a SSL certificate stored in IAM'
         ), 'SSLCertificateARN')
 
-        self.backward_compat_ssl_certificate_arn = self.add_parameter(
-            Parameter(
-                'BackwardCompatSSLCertificateARN', Type='String',
-                Description='ARN for a SSL certificate stored in IAM'
-            ), 'BackwardCompatSSLCertificateARN')
-
         self.public_subnets = self.add_parameter(Parameter(
             'PublicSubnets', Type='CommaDelimitedList',
             Description='A list of public subnets'
@@ -283,26 +275,16 @@ class Application(StackNode):
 
         app_server_lb_security_group, \
             app_server_security_group = self.create_security_groups()
-        app_server_lb, \
-            backward_compat_app_server_lb = self.create_load_balancers(
-                app_server_lb_security_group)
+        app_server_lb = self.create_load_balancer(app_server_lb_security_group)
 
         self.create_auto_scaling_resources(app_server_security_group,
-                                           app_server_lb,
-                                           backward_compat_app_server_lb)
+                                           app_server_lb)
 
         self.add_output(Output('AppServerLoadBalancerEndpoint',
                                Value=GetAtt(app_server_lb, 'DNSName')))
         self.add_output(Output('AppServerLoadBalancerHostedZoneNameID',
                                Value=GetAtt(app_server_lb,
                                             'CanonicalHostedZoneNameID')))
-        self.add_output(Output('BackwardCompatAppServerLoadBalancerEndpoint',
-                               Value=GetAtt(backward_compat_app_server_lb,
-                                            'DNSName')))
-        self.add_output(
-            Output('BackwardCompatAppServerLoadBalancerHostedZoneNameID',
-                   Value=GetAtt(backward_compat_app_server_lb,
-                                'CanonicalHostedZoneNameID')))
 
     def get_recent_app_server_ami(self):
         try:
@@ -375,12 +357,10 @@ class Application(StackNode):
 
         return app_server_lb_security_group, app_server_security_group
 
-    def create_load_balancers(self, app_server_lb_security_group):
+    def create_load_balancer(self, app_server_lb_security_group):
         app_server_lb_name = 'elbAppServer'
-        backward_compat_app_server_lb_name = 'elbBackwardCompatAppServer'
 
-        return [
-            self.add_resource(elb.LoadBalancer(
+        return self.add_resource(elb.LoadBalancer(
                 app_server_lb_name,
                 ConnectionDrainingPolicy=elb.ConnectionDrainingPolicy(
                     Enabled=True,
@@ -410,43 +390,10 @@ class Application(StackNode):
                 ),
                 Subnets=Ref(self.public_subnets),
                 Tags=self.get_tags(Name=app_server_lb_name)
-            )),
-            self.add_resource(elb.LoadBalancer(
-                backward_compat_app_server_lb_name,
-                ConnectionDrainingPolicy=elb.ConnectionDrainingPolicy(
-                    Enabled=True,
-                    Timeout=300,
-                ),
-                CrossZone=True,
-                SecurityGroups=[Ref(app_server_lb_security_group)],
-                Listeners=[
-                    elb.Listener(
-                        LoadBalancerPort='80',
-                        InstancePort='80',
-                        Protocol='HTTP',
-                    ),
-                    elb.Listener(
-                        LoadBalancerPort='443',
-                        InstancePort='80',
-                        Protocol='HTTPS',
-                        SSLCertificateId=Ref(
-                            self.backward_compat_ssl_certificate_arn)
-                    )
-                ],
-                HealthCheck=elb.HealthCheck(
-                    Target='HTTP:80/health-check/',
-                    HealthyThreshold='3',
-                    UnhealthyThreshold='2',
-                    Interval='30',
-                    Timeout='5',
-                ),
-                Subnets=Ref(self.public_subnets),
-                Tags=self.get_tags(Name=backward_compat_app_server_lb_name)
-            ))]
+        ))
 
     def create_auto_scaling_resources(self, app_server_security_group,
-                                      app_server_lb,
-                                      backward_compat_app_server_lb):
+                                      app_server_lb):
         self.add_condition('BlueCondition', Equals('Blue', Ref(self.color)))
         self.add_condition('GreenCondition', Equals('Green', Ref(self.color)))
 
@@ -474,8 +421,7 @@ class Application(StackNode):
                 HealthCheckGracePeriod=600,
                 HealthCheckType='ELB',
                 LaunchConfigurationName=Ref(blue_app_server_launch_config),
-                LoadBalancerNames=[Ref(app_server_lb),
-                                   Ref(backward_compat_app_server_lb)],
+                LoadBalancerNames=[Ref(app_server_lb)],
                 MaxSize=Ref(self.app_server_auto_scaling_max),
                 MinSize=Ref(self.app_server_auto_scaling_min),
                 NotificationConfigurations=[
@@ -541,8 +487,7 @@ class Application(StackNode):
                 HealthCheckGracePeriod=600,
                 HealthCheckType='ELB',
                 LaunchConfigurationName=Ref(green_app_server_launch_config),
-                LoadBalancerNames=[Ref(app_server_lb),
-                                   Ref(backward_compat_app_server_lb)],
+                LoadBalancerNames=[Ref(app_server_lb)],
                 MaxSize=Ref(self.app_server_auto_scaling_max),
                 MinSize=Ref(self.app_server_auto_scaling_min),
                 NotificationConfigurations=[

--- a/deployment/cfn/public_hosted_zone.py
+++ b/deployment/cfn/public_hosted_zone.py
@@ -9,20 +9,12 @@ class PublicHostedZone(CustomActionNode):
     INPUTS = {
         'Region': ['global:Region'],
         'PublicHostedZoneName': ['global:PublicHostedZoneName'],
-        'BackwardCompatPublicHostedZoneName':
-        ['global:BackwardCompatPublicHostedZoneName'],
         'AppServerLoadBalancerEndpoint':
         ['global:AppServerLoadBalancerEndpoint',
          'Application:AppServerLoadBalancerEndpoint'],
         'AppServerLoadBalancerHostedZoneNameID':
         ['global:AppServerLoadBalancerHostedZoneNameID',
          'Application:AppServerLoadBalancerHostedZoneNameID'],
-        'BackwardCompatAppServerLoadBalancerEndpoint':
-        ['global:BackwardCompatAppServerLoadBalancerEndpoint',
-         'Application:BackwardCompatAppServerLoadBalancerEndpoint'],
-        'BackwardCompatAppServerLoadBalancerHostedZoneNameID':
-        ['global:BackwardCompatAppServerLoadBalancerHostedZoneNameID',
-         'Application:BackwardCompatAppServerLoadBalancerHostedZoneNameID'],
         'StackType': ['global:StackType'],
         'StackColor': ['global:StackColor'],
     }
@@ -44,13 +36,6 @@ class PublicHostedZone(CustomActionNode):
         app_lb_hosted_zone_id = self.get_input(
             'AppServerLoadBalancerHostedZoneNameID')
 
-        backward_compat_hosted_zone_name = self.get_input(
-            'BackwardCompatPublicHostedZoneName')
-        backward_compat_app_lb_endpoint = self.get_input(
-            'BackwardCompatAppServerLoadBalancerEndpoint')
-        backward_compat_app_lb_hosted_zone_id = self.get_input(
-            'BackwardCompatAppServerLoadBalancerHostedZoneNameID')
-
         route53_conn = r53.connect_to_region(region,
                                              profile_name=self.aws_profile)
 
@@ -64,18 +49,6 @@ class PublicHostedZone(CustomActionNode):
                                identifier='Primary',
                                failover='PRIMARY')
         record_sets.commit()
-
-        backward_compat_hosted_zone = route53_conn.get_zone(
-            backward_compat_hosted_zone_name)
-        backward_compat_record_sets = r53.record.ResourceRecordSets(
-            route53_conn, backward_compat_hosted_zone.id)
-        backward_compat_record_sets.add_change(
-            'UPSERT', backward_compat_hosted_zone_name, 'A',
-            alias_hosted_zone_id=backward_compat_app_lb_hosted_zone_id,
-            alias_dns_name=backward_compat_app_lb_endpoint,
-            alias_evaluate_target_health=True, identifier='Primary',
-            failover='PRIMARY')
-        backward_compat_record_sets.commit()
 
         s3_conn = s3.connect_to_region(region,
                                        profile_name=self.aws_profile,


### PR DESCRIPTION
## Overview

The SSL certificates were removed in #3610, which broke deployments. By removing references to all infrastructure that depended on those SSL certificates, we allow deployments to resume.

Also updated the `default.yml` file in 1Password, with a CHANGELOG capturing the updates.

Other feature references to portal.bigcz.org will be removed in #3613.

Closes #3617 

### Demo

<img width="1504" alt="image" src="https://github.com/WikiWatershed/model-my-watershed/assets/1430060/e4fd8376-86a0-475f-89d6-8cc727e7cf99">

## Testing Instructions

- Look at the successful deploy build on Jenkins here: http://civicci01.phl.corp.element84.com/view/mmw/job/model-my-watershed-staging-deployment/1545/console
  - Compare with the failing build here: http://civicci01.phl.corp.element84.com/view/mmw/job/model-my-watershed-staging-deployment/1543/console
- Look at the correctly working staging site here: https://staging.modelmywatershed.org/