### PR TITLE
Upgrade Geoprocessing Service to 6.1

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,4 +1,6 @@
 ---
+aws_region: "us-east-1"
+
 redis_port: 6379
 postgresql_port: 5432
 

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -46,7 +46,7 @@ docker_compose_version: "1.26.*"
 geop_host: "localhost"
 geop_port: 8090
 
-geop_version: "5.4.0"
+geop_version: "6.1.0"
 geop_cache_enabled: 1
 geop_timeout: 200s
 geop_bucket: datahub-catalogs-us-east-1

--- a/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.base/defaults/main.yml
@@ -1,6 +1,7 @@
 envdir_home: "/etc/mmw.d/env"
 
 envdir_config:
+  AWS_REGION: "{{ aws_region }}"
   MMW_DB_NAME: "{{ postgresql_database }}"
   MMW_DB_USER: "{{ postgresql_username }}"
   MMW_DB_PASSWORD: "{{ postgresql_password }}"


### PR DESCRIPTION
## Overview

Recent work on the MMW Geoprocessing service upgrades it to latest Scala and GeoTrellis. This will allow us to query COG files. This updates MMW to use the new Geoprocessing service.

Closes #3614 

## Testing Instructions

- Check out this branch and provision the worker VM
  ```
  vagrant provision worker
  ```
- Go to http://localhost:8000/ and try out various shapes, ensure they run