### PR TITLE
Upgrade Celery minor version to fix provisioning

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.celery/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.celery/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-celery_version: 5.2.0
+celery_version: 5.2.7


### PR DESCRIPTION
## Overview

pip upgraded to 24.1 which no longer recognizes the pytz(>dev) specification in Celery 5.2.0's dependencies. See failing builds here: http://civicci01.internal.azavea.com/view/mmw/job/model-my-watershed-packer-app-and-worker/1489/console

This was fixed in 5.2.1 https://github.com/celery/celery/blob/main/Changelog.rst#521, but we go all the way up to the latest 5.2.7 https://github.com/celery/celery/blob/main/Changelog.rst#527 to get all the fixes in that version.

## Testing Instructions

- Check out this branch, and destroy and reprovision the worker:
  ```
  vagrant destroy -f worker && vagrant up worker
  ```
- Run `debugcelery`
  ```
  ./scripts/debugcelery.sh
  ```  
- Go to http://localhost:8000/
  - [x] Ensure drawing an area of interest results in the analyses completing