### PR TITLE
Downgrade Docker to Fix RWD

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -39,7 +39,7 @@ java_version: "8u*"
 java_major_version: "8"
 java_flavor: "openjdk"
 
-docker_version: "5:26.*"
+docker_version: "5:25.*"
 docker_containerd_version: "1.6.*"
 docker_python_version: "4.4.*"
 docker_compose_version: "1.29.*"

--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -2,7 +2,7 @@
 rwd_data_path: "/opt/rwd-data"
 rwd_host: "localhost"
 rwd_port: 5000
-rwd_docker_image: "quay.io/wikiwatershed/rwd:2.0.0"
+rwd_docker_image: "ghcr.io/wikiwatershed/rwd:3.0.0"
 
 app_config:
   RWD_HOST: "{{ rwd_host }}"

--- a/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+++ b/deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
@@ -2,7 +2,7 @@
 rwd_data_path: "/opt/rwd-data"
 rwd_host: "localhost"
 rwd_port: 5000
-rwd_docker_image: "ghcr.io/wikiwatershed/rwd:3.0.0"
+rwd_docker_image: "quay.io/wikiwatershed/rwd:2.0.0"
 
 app_config:
   RWD_HOST: "{{ rwd_host }}"


### PR DESCRIPTION
## Overview

The Ubuntu upgrade of #3631 also upgrade Docker to v26, which was incompatible with the old RWD images. For that, we upgraded TauDEM and RWD to the new Docker image format in https://github.com/WikiWatershed/rapid-watershed-delineation/issues/84, https://github.com/WikiWatershed/rapid-watershed-delineation/issues/83, https://github.com/WikiWatershed/docker-taudem/issues/2, https://github.com/WikiWatershed/docker-taudem/issues/1, and https://github.com/WikiWatershed/docker-taudem/issues/5.

Unfortunately, using the new Docker image results in failures recorded here: https://github.com/WikiWatershed/rapid-watershed-delineation/issues/87. Rather than spend more time fixing those, it is easier to downgrade Docker to v25 to work with the old images for now. That's what this PR does.

Closes #3629 

### Demo

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/da38984a-b08a-4830-86e8-95f5da625c4b">

## Testing Instructions

Note: this review does not require checking locally, only on staging

- Go to https://staging.modelmywatershed.org/version.txt
  - [x] Ensure you see this branch deployed to staging
- https://staging.modelmywatershed.org/draw and delineate a watershed
  - [x] Ensure it succeeds