### PR TITLE
Add layer config for preliminary IO LULC static tileset

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -96,6 +96,22 @@ LAYER_GROUPS = {
     ],
     'coverage': [
         {
+            'display': 'IO Global LULC 2023',
+            'code': 'io-lulc-2023',
+            'css_class_prefix': 'io-lulc-2023 nlcd',
+            'short_display': 'IO LULC 2023',
+            'helptext': 'Global land use/land cover dataset produced by '
+                        'Impact Observatory, Microsoft, and Esri, derived from '
+                        'ESA Sentinel-2 imagery at 10 meter resolution.',
+            'url': 'https://{s}.tiles.azavea.com/io-lulc-2023-10m/{z}/{x}/{y}/0695d32d7723e4c3b53f1ec897e108282dd8ae2c919250f333f4600fe78ebbed.png',
+            'maxNativeZoom': 8,
+            'maxZoom': 18,
+            'opacity': 0.618,
+            'has_opacity_slider': True,
+            'legend_mapping': { key: names[1] for key, names in NLCD.items()},
+            'big_cz': True,
+        },
+        {
             'display': 'Land Use/Cover 2019 (NLCD19)',
             'code': 'nlcd-2019_2019',
             'css_class_prefix': 'nlcd-2019-30m nlcd',


### PR DESCRIPTION
## Overview

Adds the 2023 IO LULC layer to the layer settings, pointing at the static tiles that were generated and uploaded to the Datahub S3 bucket. This is just a preview of the layer, since the tiles were only generated through z8 and this static source will ultimately be replaced by a hybrid static/dynamic TiTiler setup (see
https://github.com/WikiWatershed/mmw-tiler/issues/10 and https://github.com/WikiWatershed/mmw-tiler/issues/11).

Connects https://github.com/WikiWatershed/mmw-tiler/issues/9

### Demo

![image](https://github.com/user-attachments/assets/69c71372-e16e-4497-aa89-bb6b4abe4b16)

### Notes

- ~At the moment, the tile for zoomlevel zero is missing. The tiles for z3 and below have to be generated locally because they take longer than the maximum Lambda timeout, and z0 still timed out when I set the limit to 90 minutes.  I'll try again overnight, but if that doesn't work I'll give up, since this is just a preview.~ Update: the z0 tile is up now. It took 4.5 hours to generate, per the `time` utility, though my computer had a charger issue and went to sleep for a while during the process, so that might be inflated.
- More details about the tile generation process will be coming soon in a PR on the [mmw-tiler](https://github.com/WikiWatershed/mmw-tiler/) repo.

## Testing Instructions

- Load the site, select the "Coverage Grid" tab from the map layers list, and activate the new "IO Global LULC 2023" layer at the top.
- If you're on the default view, the layer will show up but look very fuzzy since it's over-zoomed from z8 up to z12.
- Open the dev tools network tab and confirm that you get tiles from the new layer (they'll be the ones with a crazy hash for a filename, you'll have to hover to see the z/x/y values) for z8 through z1.
- Confirm that the layer shows up everywhere in the world (though the tiles are empty/invisible in the ocean)
