### PR TITLE
Add UI for Analyzing Global Land

### DIFF
--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -294,6 +294,14 @@ function createAnalyzeTaskGroupCollection(aoi, wkaoi) {
                     enabledForCatalogMode: true
                 },
                 {
+                    name: "global_land_io_2023",
+                    displayName: "Global Annual LULC 2023",
+                    area_of_interest: aoi,
+                    wkaoi: wkaoi,
+                    taskName: "analyze/global-land/2023",
+                    lazy: true,
+                },
+                {
                     name: "protected_lands",
                     displayName: "Protected lands distribution",
                     area_of_interest: aoi,

--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -305,14 +305,16 @@ function createAnalyzeTaskGroupCollection(aoi, wkaoi) {
                     displayName: "DRB 2100 land forecast (Centers)",
                     area_of_interest: aoi,
                     wkaoi: wkaoi,
-                    taskName: "analyze/drb-2100-land/centers"
+                    taskName: "analyze/drb-2100-land/centers",
+                    lazy: true,
                 },
                 {
                     name: "drb_2100_land_corridors",
                     displayName: "DRB 2100 land forecast (Corridors)",
                     area_of_interest: aoi,
                     wkaoi: wkaoi,
-                    taskName: "analyze/drb-2100-land/corridors"
+                    taskName: "analyze/drb-2100-land/corridors",
+                    lazy: true,
                 },
             ]
         },

--- a/src/mmw/js/src/core/models.js
+++ b/src/mmw/js/src/core/models.js
@@ -797,6 +797,10 @@ var ProtectedLandsCensusCollection = Backbone.Collection.extend({
     comparator: 'class_id'
 });
 
+var GlobalLandUseCensusCollection = Backbone.Collection.extend({
+    comparator: 'ioclass'
+});
+
 var SoilCensusCollection = Backbone.Collection.extend({
     comparator: 'code'
 });
@@ -915,6 +919,7 @@ module.exports = {
     TaskMessageViewModel: TaskMessageViewModel,
     LandUseCensusCollection: LandUseCensusCollection,
     ProtectedLandsCensusCollection: ProtectedLandsCensusCollection,
+    GlobalLandUseCensusCollection: GlobalLandUseCensusCollection,
     SoilCensusCollection: SoilCensusCollection,
     AnimalCensusCollection: AnimalCensusCollection,
     ClimateCensusCollection: ClimateCensusCollection,

--- a/src/mmw/sass/components/_charts.scss
+++ b/src/mmw/sass/components/_charts.scss
@@ -24,6 +24,12 @@
     }
   }
 
+  @each $id, $color in $ioLulcColors {
+    .io-lulc-fill-#{$id} {
+      fill: $color;
+    }
+  }
+
   @each $id, $color in $protectedLandsColors {
     .protected-lands-fill-#{$id} {
       fill: $color;


### PR DESCRIPTION
## Overview

Adds UI for analyzing global land cover layer. Currently we only do it for 2023. The global land cover
charts have less margin on the left, because the category names are shorter. Global land cover analysis is also optional, so it doesn't fire by default.

Also disables the Future Land analysis from running by default, because that has been broken for more than a year now.

Closes #3636 

### Demo

https://github.com/user-attachments/assets/c1d5cb79-0fbd-446f-9e44-20bfb99e7aab

## Testing Instructions

- Check out this branch and `./scripts/bundle.sh --debug`
- Go to http://localhost:8000/
- Select / draw an area and move to Analyze
- Go to the land tab
- Select the Global Land Use 2023 item from the dropdown
  - [x] Ensure the analysis for that starts when you select the item
  - [x] Ensure it completes
  - [x] Ensure chart looks good
  - [x] Ensure table looks good
  - [x] Ensure download CSV behavior works correctly