### PR TITLE
Validate, Cache Global Land Analysis

### DIFF
--- a/src/mmw/apps/geoprocessing_api/stac.py
+++ b/src/mmw/apps/geoprocessing_api/stac.py
@@ -1,4 +1,6 @@
 from celery import shared_task
+from django.core.cache import cache
+from django.conf import settings
 from pystac_client import Client
 from rasterio.coords import BoundingBox
 from rasterio.enums import Resampling
@@ -18,7 +20,15 @@ import tempfile
 
 
 @shared_task
-def query_histogram(geojson, url, collection, asset, filter):
+def query_histogram(geojson, url, collection, asset, filter, cachekey=''):
+    # Check if cached and return that if possible
+    stac_cachekey = ''
+    if settings.GEOP['cache'] and cachekey:
+        stac_cachekey = f'stac__{collection}_{cachekey}'
+        cached = cache.get(stac_cachekey)
+        if cached:
+            return cached
+
     aoi = shape(json.loads(geojson))
 
     # Get list of intersecting tiffs from catalog
@@ -80,10 +90,16 @@ def query_histogram(geojson, url, collection, asset, filter):
     for temp_file in clips:
         os.remove(temp_file)
 
-    return {
+    result = {
         'result': histogram,
         'pixel_size': pixel_size,
     }
+
+    # Cache if appropriate
+    if stac_cachekey:
+        cache.set(stac_cachekey, result, None)
+
+    return result
 
 
 @shared_task

--- a/src/mmw/apps/geoprocessing_api/stac.py
+++ b/src/mmw/apps/geoprocessing_api/stac.py
@@ -34,7 +34,15 @@ def query_histogram(geojson, url, collection, asset, filter):
     # method, using the first image for overlapping pixels.
     tiffs = sorted(tiffs)
 
-    # TODO Handle empty tiff list
+    # Raise error if no overlapping tiffs are found
+    if not tiffs:
+        return {
+            'error': (
+                f'No overlapping tiffs found in collection {collection} '
+                f'with filter {filter} '
+                f'with AoI {geojson[:255]} ...'
+            )
+        }
 
     # Find the Albers Equal Area CRS for this AoI
     dst_crs = get_albers_crs_for_aoi(aoi)

--- a/src/mmw/apps/geoprocessing_api/stac.py
+++ b/src/mmw/apps/geoprocessing_api/stac.py
@@ -19,8 +19,6 @@ import tempfile
 
 @shared_task
 def query_histogram(geojson, url, collection, asset, filter):
-    # TODO Validate inputs
-
     aoi = shape(json.loads(geojson))
 
     # Get list of intersecting tiffs from catalog

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -550,6 +550,17 @@ def start_analyze_global_land(request, year, format=None):
 
     </details>
     """
+    # Validate year
+    AVAILABLE_IO_YEARS = [
+        '2017', '2018', '2019', '2020', '2021', '2022', '2023'
+    ]
+
+    if year not in AVAILABLE_IO_YEARS:
+        raise ValidationError(
+            f'Year {year} is not available for analysis. '
+            f'Only the following are: {", ".join(AVAILABLE_IO_YEARS)}.'
+        )
+
     user = request.user if request.user.is_authenticated else None
     area_of_interest, wkaoi, msg = _parse_analyze_input(request)
 

--- a/src/mmw/apps/geoprocessing_api/views.py
+++ b/src/mmw/apps/geoprocessing_api/views.py
@@ -569,7 +569,7 @@ def start_analyze_global_land(request, year, format=None):
         "args": [{"property": "id"}, f"%-{year}"],
     }
 
-    # TODO Implement caching
+    cachekey = f'{wkaoi}_{year}' if wkaoi else ''
 
     return start_celery_job([
         stac.query_histogram.s(
@@ -577,7 +577,8 @@ def start_analyze_global_land(request, year, format=None):
             url='https://api.impactobservatory.com/stac-aws',
             collection='io-10m-annual-lulc',
             asset='supercell',
-            filter=filter
+            filter=filter,
+            cachekey=cachekey
         ),
         stac.format_as_mmw_geoprocessing.s(),
         tasks.analyze_global_land.s(year),


### PR DESCRIPTION
## Overview

Adds validation that checks if the requested year is available for STAC analysis or not. Wires through errors on no overlapping tiffs found. Caches the results if working with a well known area of interest (WKAoI).

Connects #3634 

### Demo

https://github.com/user-attachments/assets/af18e42c-5cf7-441d-901e-e63d8c1f1d65

## Testing Instructions

- Check out this branch and run `./scripts/debugcelery.sh`
- Try requesting analysis for a year that's not available:
    ```bash
    curl -X POST -d '{"huc": "0204020310"}' -H "Authorization: Token $YOUR_API_TOKEN" -H "Content-Type: application/json" http://localhost:8000/api/analyze/global-land/2009/
    ```
    - [ ] Ensure you get a validation error
- Edit the [`AVAILABLE_IO_YEARS`](https://github.com/WikiWatershed/model-my-watershed/blob/tt/3634/validate-cache-global-land-analysis/src/mmw/apps/geoprocessing_api/views.py#L554-L556) list to add `2024`
- Stop and restart `debugcelery` to pick up changes to tasks
- Try requesting analysis for 2024:
    ```bash
    curl -X POST -d '{"huc": "0204020310"}' -H "Authorization: Token $YOUR_API_TOKEN" -H "Content-Type: application/json" http://localhost:8000/api/analyze/global-land/2024/
    ```
    - [ ] Ensure that when you query the corresponding job, it has the "no matching tiffs" error message
- In the front-end, request an analysis for a standard HUC
- After it completes once, select "Change Area" and request it again for the same HUC
  - [ ] Ensure the second run is much faster as this should use the cache