### PR TITLE
AWS 2-5: Deprecate Water Quality Tab

### DIFF
--- a/src/mmw/js/src/analyze/models.js
+++ b/src/mmw/js/src/analyze/models.js
@@ -399,18 +399,6 @@ function createAnalyzeTaskGroupCollection(aoi, wkaoi) {
                 }
             ]
         },
-        {
-            name: "catchment_water_quality",
-            displayName: "Water Qual",
-            tasks: [
-                {
-                    name: "catchment_water_quality",
-                    area_of_interest: aoi,
-                    wkaoi: wkaoi,
-                    taskName: "analyze/catchment-water-quality"
-                }
-            ]
-        },
     ];
 
     if (settings.get('data_catalog_enabled')) {

--- a/src/mmw/sass/components/_tabs.scss
+++ b/src/mmw/sass/components/_tabs.scss
@@ -9,6 +9,7 @@
 
 .sidebar-tab-header-label {
     position: relative;
+    padding: 0 4px;
     &:after {
         position: absolute;
         left: 0;
@@ -25,12 +26,11 @@
 
 .sidebar-tab-header-label-icon {
     color: rgba(0, 0, 0, 0.54);
-    margin-right: 8px;
     position: absolute;
     bottom: 2px;
     height: auto;
     text-align: center;
-    width: 100%;
+    width: calc(100% - 8px);
     font-size: 8px;
 }
 


### PR DESCRIPTION
## Overview

Removes the Water Quality Tab, since those results are no longer accurate or used. Also adjusts the sidebar buttons to be more spread out so it doesn't look like something is missing.

Connects #3653 

### Demo

![image](https://github.com/user-attachments/assets/041f37ba-2802-432b-9510-870b943ab1c6)

## Testing Instructions

- Check out this branch and `./scripts/bundle.sh --debug`
- Go to http://localhost:8000/ and pick a shape to analyze
  - [x] Ensure water quality tab is not shown
  - [x] Ensure tabs look okay