### PR TITLE
AWS 2-5: Better Style TDX Streams

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -712,7 +712,7 @@ LAYER_GROUPS = {
             'code': 'tdxhydro_streams_v1',
             'display': ('TDX Hydro'),
             'table_name': 'tdxstreams',
-            'minZoom': 5,
+            'minZoom': 0,
         },
     ],
 }

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -691,24 +691,6 @@ LAYER_GROUPS = {
             'big_cz': False,
         },
         {
-            'code': 'TDX_streamnet_7020038340_02',
-            'display': 'TDX Streamnet 7020038340',
-            'minZoom': 3,
-            'maxNativeZoom': 12,
-            'maxZoom': 18,
-            'vectorType': True,
-            'url': 'https://{s}.tiles.azavea.com/TDX_streamnet_7020038340_02/{z}/{x}/{y}.pbf',  # NOQA
-        },
-        {
-            'code': 'TDX_streamnet_7020038340_03',
-            'display': 'TDX Streamnet 7020038340 - Ordered',
-            'minZoom': 0,
-            'maxNativeZoom': 13,
-            'maxZoom': 18,
-            'vectorType': True,
-            'url': 'https://{s}.tiles.azavea.com/TDX_streamnet_7020038340_01/{z}/{x}/{y}.pbf',  # NOQA
-        },
-        {
             'code': 'tdxhydro_streams_v1',
             'display': ('TDX Hydro'),
             'table_name': 'tdxstreams',

--- a/src/tiler/styles/streams.mss
+++ b/src/tiler/styles/streams.mss
@@ -284,79 +284,118 @@
 }
 
 #tdxstreams[zoom<=4] {
-  [stream_order=10] {
-    line-width: 5.0 * @zoomBase;
-  }
-  [stream_order=9] {
-    line-width: 3.0 * @zoomBase;
-  }
-  [stream_order<=8] {
+  [stream_order=8] {
     line-width: 2.0 * @zoomBase;
+  }
+  [stream_order=7] {
+    line-width: 1.0 * @zoomBase;
+  }
+  [stream_order=6] {
+    line-width: 0.5 * @zoomBase;
   }
 }
 
 #tdxstreams[zoom>=5][zoom<=6] {
-  [stream_order=10] {
-    line-width: 7.0 * @zoomBase;
+  [stream_order=8] {
+    line-width: 3.0 * @zoomBase;
   }
-  [stream_order=9] {
+  [stream_order=7] {
+    line-width: 2.0 * @zoomBase;
+  }
+  [stream_order=6] {
+    line-width: 1.0 * @zoomBase;
+  }
+  [stream_order=5] {
+    line-width: 0.5 * @zoomBase;
+  }
+}
+
+#tdxstreams[zoom>=7][zoom<=8] {
+  [stream_order=8] {
     line-width: 4.0 * @zoomBase;
   }
-  [stream_order<=8] {
+  [stream_order=7] {
     line-width: 3.0 * @zoomBase;
+  }
+  [stream_order=6] {
+    line-width: 2.0 * @zoomBase;
+  }
+  [stream_order=5] {
+    line-width: 1.0 * @zoomBase;
+  }
+  [stream_order=4] {
+    line-width: 0.5 * @zoomBase;
   }
 }
 
 #tdxstreams[zoom>=9][zoom<=10] {
-  [stream_order>=9] {
-    line-width: 14.0 * @zoomBase;
-  }
-  [stream_order<=8][stream_order>=6] {
-    line-width: 10.0 * @zoomBase;
-  }
-  [stream_order<=5][stream_order>=4] {
+  [stream_order=8] {
     line-width: 5.0 * @zoomBase;
   }
-  [stream_order=3] {
+  [stream_order=7] {
+    line-width: 4.0 * @zoomBase;
+  }
+  [stream_order=6] {
     line-width: 3.0 * @zoomBase;
   }
-}
-
-#tdxstreams[zoom>=11][zoom<=12] {
-  [stream_order>=9] {
-    line-width: 18.0 * @zoomBase;
+  [stream_order=5] {
+    line-width: 2.0 * @zoomBase;
   }
-  [stream_order<=8][stream_order>=6] {
-    line-width: 12.0 * @zoomBase;
-  }
-  [stream_order<=5][stream_order>=4] {
-    line-width:  9.0 * @zoomBase;
+  [stream_order=4] {
+    line-width: 1.0 * @zoomBase;
   }
   [stream_order=3] {
-    line-width:  6.0 * @zoomBase;
-  }
-  [stream_order=2] {
-    line-width:  5.0 * @zoomBase;
-  }
-  [stream_order<=1][stream_order>=0] {
-    line-width:  4.0 * @zoomBase;
+    line-width: 0.5 * @zoomBase;
   }
 }
 
-#tdxstreams[zoom>=13] {
-  [stream_order>=9] {
-    line-width: 18.0 * @zoomBase;
+#tdxstreams[zoom>10][zoom<=11] {
+  [stream_order=8] {
+    line-width: 6.0 * @zoomBase;
   }
-  [stream_order<=8][stream_order>=6] {
-    line-width: 14.0 * @zoomBase;
+  [stream_order=7] {
+    line-width: 5.0 * @zoomBase;
   }
-  [stream_order<=5][stream_order>=3] {
-    line-width:  10.0 * @zoomBase;
+  [stream_order=6] {
+    line-width: 4.0 * @zoomBase;
+  }
+  [stream_order=5] {
+    line-width: 3.0 * @zoomBase;
+  }
+  [stream_order=4] {
+    line-width: 2.0 * @zoomBase;
+  }
+  [stream_order=3] {
+    line-width: 1.0 * @zoomBase;
   }
   [stream_order=2] {
-    line-width:  8.0 * @zoomBase;
+    line-width: 0.5 * @zoomBase;
   }
-  [stream_order<=1][stream_order>=0] {
-    line-width:  5.0 * @zoomBase;
+}
+
+#tdxstreams[zoom>=12] {
+  [stream_order=8] {
+    line-width: 7.0 * @zoomBase;
+  }
+  [stream_order=7] {
+    line-width: 6.0 * @zoomBase;
+  }
+  [stream_order=6] {
+    line-width: 5.0 * @zoomBase;
+  }
+  [stream_order=5] {
+    line-width: 4.0 * @zoomBase;
+  }
+  [stream_order=4] {
+    line-width: 3.0 * @zoomBase;
+  }
+  [stream_order=3] {
+    line-width: 2.0 * @zoomBase;
+  }
+  [stream_order=2] {
+    line-width: 1.0 * @zoomBase;
+  }
+  [stream_order=1] {
+    line-width: 0.5 * @zoomBase;
   }
 }

--- a/src/tiler/styles/streams.mss
+++ b/src/tiler/styles/streams.mss
@@ -285,117 +285,117 @@
 
 #tdxstreams[zoom<=4] {
   [stream_order=8] {
-    line-width: 2.0;
+    line-width: 3.0;
   }
   [stream_order=7] {
-    line-width: 1.0;
+    line-width: 2.0;
   }
   [stream_order=6] {
-    line-width: 0.5;
+    line-width: 1.0;
   }
 }
 
 #tdxstreams[zoom>=5][zoom<=6] {
   [stream_order=8] {
-    line-width: 3.0;
+    line-width: 4.0;
   }
   [stream_order=7] {
-    line-width: 2.0;
+    line-width: 3.0;
   }
   [stream_order=6] {
-    line-width: 1.0;
+    line-width: 2.0;
   }
   [stream_order=5] {
-    line-width: 0.5;
+    line-width: 1.0;
   }
 }
 
 #tdxstreams[zoom>=7][zoom<=8] {
   [stream_order=8] {
-    line-width: 4.0;
+    line-width: 5.0;
   }
   [stream_order=7] {
-    line-width: 3.0;
+    line-width: 4.0;
   }
   [stream_order=6] {
-    line-width: 2.0;
+    line-width: 3.0;
   }
   [stream_order=5] {
-    line-width: 1.0;
+    line-width: 2.0;
   }
   [stream_order=4] {
-    line-width: 0.5;
+    line-width: 1.0;
   }
 }
 
 #tdxstreams[zoom>=9][zoom<=10] {
   [stream_order=8] {
-    line-width: 5.0;
+    line-width: 8.0;
   }
   [stream_order=7] {
-    line-width: 4.0;
+    line-width: 7.0;
   }
   [stream_order=6] {
-    line-width: 3.0;
+    line-width: 6.0;
   }
   [stream_order=5] {
-    line-width: 2.0;
+    line-width: 5.0;
   }
   [stream_order=4] {
-    line-width: 1.0;
+    line-width: 3.0;
   }
   [stream_order=3] {
-    line-width: 0.5;
+    line-width: 1.0;
   }
 }
 
 #tdxstreams[zoom>10][zoom<=11] {
   [stream_order=8] {
-    line-width: 6.0;
+    line-width: 9.0;
   }
   [stream_order=7] {
-    line-width: 5.0;
+    line-width: 8.0;
   }
   [stream_order=6] {
-    line-width: 4.0;
+    line-width: 7.0;
   }
   [stream_order=5] {
-    line-width: 3.0;
+    line-width: 6.0;
   }
   [stream_order=4] {
-    line-width: 2.0;
+    line-width: 5.0;
   }
   [stream_order=3] {
-    line-width: 1.0;
+    line-width: 3.0;
   }
   [stream_order=2] {
-    line-width: 0.5;
+    line-width: 1.0;
   }
 }
 
 #tdxstreams[zoom>=12] {
   [stream_order=8] {
-    line-width: 7.0;
+    line-width: 10.0;
   }
   [stream_order=7] {
-    line-width: 6.0;
+    line-width: 9.0;
   }
   [stream_order=6] {
-    line-width: 5.0;
+    line-width: 8.0;
   }
   [stream_order=5] {
-    line-width: 4.0;
+    line-width: 7.0;
   }
   [stream_order=4] {
-    line-width: 3.0;
+    line-width: 6.0;
   }
   [stream_order=3] {
-    line-width: 2.0;
+    line-width: 5.0;
   }
   [stream_order=2] {
-    line-width: 1.0;
+    line-width: 3.0;
   }
   [stream_order=1] {
-    line-width: 0.5;
+    line-width: 1.0;
   }
 }

--- a/src/tiler/styles/streams.mss
+++ b/src/tiler/styles/streams.mss
@@ -285,117 +285,117 @@
 
 #tdxstreams[zoom<=4] {
   [stream_order=8] {
-    line-width: 2.0 * @zoomBase;
+    line-width: 2.0;
   }
   [stream_order=7] {
-    line-width: 1.0 * @zoomBase;
+    line-width: 1.0;
   }
   [stream_order=6] {
-    line-width: 0.5 * @zoomBase;
+    line-width: 0.5;
   }
 }
 
 #tdxstreams[zoom>=5][zoom<=6] {
   [stream_order=8] {
-    line-width: 3.0 * @zoomBase;
+    line-width: 3.0;
   }
   [stream_order=7] {
-    line-width: 2.0 * @zoomBase;
+    line-width: 2.0;
   }
   [stream_order=6] {
-    line-width: 1.0 * @zoomBase;
+    line-width: 1.0;
   }
   [stream_order=5] {
-    line-width: 0.5 * @zoomBase;
+    line-width: 0.5;
   }
 }
 
 #tdxstreams[zoom>=7][zoom<=8] {
   [stream_order=8] {
-    line-width: 4.0 * @zoomBase;
+    line-width: 4.0;
   }
   [stream_order=7] {
-    line-width: 3.0 * @zoomBase;
+    line-width: 3.0;
   }
   [stream_order=6] {
-    line-width: 2.0 * @zoomBase;
+    line-width: 2.0;
   }
   [stream_order=5] {
-    line-width: 1.0 * @zoomBase;
+    line-width: 1.0;
   }
   [stream_order=4] {
-    line-width: 0.5 * @zoomBase;
+    line-width: 0.5;
   }
 }
 
 #tdxstreams[zoom>=9][zoom<=10] {
   [stream_order=8] {
-    line-width: 5.0 * @zoomBase;
+    line-width: 5.0;
   }
   [stream_order=7] {
-    line-width: 4.0 * @zoomBase;
+    line-width: 4.0;
   }
   [stream_order=6] {
-    line-width: 3.0 * @zoomBase;
+    line-width: 3.0;
   }
   [stream_order=5] {
-    line-width: 2.0 * @zoomBase;
+    line-width: 2.0;
   }
   [stream_order=4] {
-    line-width: 1.0 * @zoomBase;
+    line-width: 1.0;
   }
   [stream_order=3] {
-    line-width: 0.5 * @zoomBase;
+    line-width: 0.5;
   }
 }
 
 #tdxstreams[zoom>10][zoom<=11] {
   [stream_order=8] {
-    line-width: 6.0 * @zoomBase;
+    line-width: 6.0;
   }
   [stream_order=7] {
-    line-width: 5.0 * @zoomBase;
+    line-width: 5.0;
   }
   [stream_order=6] {
-    line-width: 4.0 * @zoomBase;
+    line-width: 4.0;
   }
   [stream_order=5] {
-    line-width: 3.0 * @zoomBase;
+    line-width: 3.0;
   }
   [stream_order=4] {
-    line-width: 2.0 * @zoomBase;
+    line-width: 2.0;
   }
   [stream_order=3] {
-    line-width: 1.0 * @zoomBase;
+    line-width: 1.0;
   }
   [stream_order=2] {
-    line-width: 0.5 * @zoomBase;
+    line-width: 0.5;
   }
 }
 
 #tdxstreams[zoom>=12] {
   [stream_order=8] {
-    line-width: 7.0 * @zoomBase;
+    line-width: 7.0;
   }
   [stream_order=7] {
-    line-width: 6.0 * @zoomBase;
+    line-width: 6.0;
   }
   [stream_order=6] {
-    line-width: 5.0 * @zoomBase;
+    line-width: 5.0;
   }
   [stream_order=5] {
-    line-width: 4.0 * @zoomBase;
+    line-width: 4.0;
   }
   [stream_order=4] {
-    line-width: 3.0 * @zoomBase;
+    line-width: 3.0;
   }
   [stream_order=3] {
-    line-width: 2.0 * @zoomBase;
+    line-width: 2.0;
   }
   [stream_order=2] {
-    line-width: 1.0 * @zoomBase;
+    line-width: 1.0;
   }
   [stream_order=1] {
-    line-width: 0.5 * @zoomBase;
+    line-width: 0.5;
   }
 }


### PR DESCRIPTION
## Overview

Improves styling of TDX Streams.

Closes #3625 

### Demo

This branch is currently deployed to staging: https://staging.modelmywatershed.org/

https://github.com/user-attachments/assets/5ef1949b-4a58-447c-af3b-853ab5ba23fc

### Notes

I cleared the previous tile cache since now we need new images, but that makes the layer slow to load as the new tile cache is slowly generated. I bumped up staging infrastructure to help with this:

- Staging DB Instance: t2.micro ➡️ t2.small
- Tile Server Count: 1 ➡️ 2
- Tile Server Size: t2.micro ➡️ t2.small

Will bump these back down after this is merged.

## Testing Instructions

- Go to staging: https://staging.modelmywatershed.org/
- Turn on the TDX Hydro global streams layer
- Go around the world, ensure the streams eventually load