### PR TITLE
AWS 2-8: Global Watershed Delineation Back-end

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -13,6 +13,7 @@ where options are one or more of: \n
     -s  load/reload stream data\n
     -S  load/reload Hi Res stream data (very large)\n
     -t  load/reload TDX Hydro stream data (EXTREMELY LARGE)\n
+    -B  load/reload TDX Basins data subset\n
     -d  load/reload DRB stream data\n
     -m  load/reload mapshed data\n
     -p  load/reload DEP data\n
@@ -29,12 +30,13 @@ file_to_load=
 load_stream=false
 load_hires_stream=false
 load_tdx_streams=false
+load_tdx_basins=false
 load_mapshed=false
 load_water_quality=false
 load_catchment=false
 should_purge_cache=false
 
-while getopts ":hbsSdtpmqcf:x:" opt; do
+while getopts ":hbsSdtBpmqcf:x:" opt; do
     case $opt in
         h)
             echo -e $usage
@@ -49,6 +51,8 @@ while getopts ":hbsSdtpmqcf:x:" opt; do
             load_drb_streams=true ;;
         t)
             load_tdx_streams=true ;;
+        B)
+            load_tdx_basins=true ;;
         p)
             load_dep=true ;;
         m)
@@ -177,6 +181,15 @@ if [ "$load_tdx_streams" = "true" ] ; then
 
     download_and_load $FILES
     purge_tile_cache $PATHS
+fi
+
+if [ "$load_tdx_basins" = "true" ] ; then
+    # The actual full dataset is 95GB compressed, 570GB decompressed.
+    # For development we use a subset that is centered around Philadelphia,
+    # in a circle of radius about 200 miles.
+    FILES=("tdxbasins_dev.sql.gz")
+
+    download_and_load $FILES
 fi
 
 if [ "$load_mapshed" = "true" ] ; then

--- a/src/mmw/apps/geoprocessing_api/schemas.py
+++ b/src/mmw/apps/geoprocessing_api/schemas.py
@@ -174,6 +174,18 @@ RWD_REQUEST = Schema(
     required=['location'],
 )
 
+GLOBAL_RWD_REQUEST = Schema(
+    title='Global Rapid Watershed Delineation Request',
+    type=TYPE_OBJECT,
+    properties={
+        'location': Schema(type=TYPE_ARRAY, items=Schema(type=TYPE_NUMBER),
+                           example=[39.67185812402583, -75.76742706298828],
+                           description='The point to delineate. '
+                                       'Format is [lat, lng].'),
+    },
+    required=['location'],
+)
+
 nlcd_override_allowed_values = '", "'.join([
     'nlcd-2019-30m-epsg5070-512-uint8raw',
     'nlcd-2016-30m-epsg5070-512-uint8raw',

--- a/src/mmw/apps/geoprocessing_api/tasks.py
+++ b/src/mmw/apps/geoprocessing_api/tasks.py
@@ -37,6 +37,7 @@ from apps.geoprocessing_api.calcs import (animal_population,
                                           streams_for_huc12s,
                                           huc12s_with_aois,
                                           drexel_fast_zonal,
+                                          tdx_watershed_for_point,
                                           )
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,30 @@ def start_rwd_job(location, snapping, simplify, data_source):
         raise Exception(response_json['error'])
 
     return response_json
+
+
+@shared_task
+def start_global_rwd_job(location):
+    """
+    Delineates a watershed using the TDX Basins dataset
+    """
+    lat, lng = location
+    watershed = tdx_watershed_for_point(location)
+
+    return {
+        'input_pt': {
+            'type': 'Feature',
+            'properties': {
+                'Lat': lat,
+                'Lon': lng,
+            },
+            'geometry': {
+                'type': 'Point',
+                'coordinates': [lng, lat],
+            },
+        },
+        'watershed': watershed,
+    }
 
 
 @shared_task

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -62,4 +62,7 @@ urlpatterns = [
             views.start_modeling_subbasin_run,
             name='start_modeling_subbasin_run'),
     re_path(r'watershed/$', views.start_rwd, name='start_rwd'),
+    re_path(r'global-watershed/$',
+            views.start_global_rwd,
+            name='start_global_rwd'),
 ]

--- a/src/mmw/apps/geoprocessing_api/validation.py
+++ b/src/mmw/apps/geoprocessing_api/validation.py
@@ -35,6 +35,14 @@ def validate_rwd(location, data_source, snapping, simplify):
     pass
 
 
+def validate_global_rwd(location):
+    if not check_location_format(location):
+        error = create_invalid_rwd_location_format_error_msg(location)
+        raise ValidationError(error)
+
+    pass
+
+
 def create_invalid_rwd_location_format_error_msg(loc):
     return (f'Invalid required `location` parameter value `{loc}`. Must be a '
             '`[lat, lng]` where `lat` and `lng` are numeric.')


### PR DESCRIPTION
## Overview

Adds development data for TDX Basins, used for global watershed delineation. This subset is 200 miles around Philadelphia.

![image](https://github.com/user-attachments/assets/4f2d4ebd-770f-436d-95cc-89fb6b536704)

This also adds URLs, Views, Tasks, and Calcs to allow for delineation. The actual algorithm uses the nested set index developed in https://github.com/WikiWatershed/global-hydrography/?tab=readme-ov-file#modified-nested-set-index.

Even though this is highly performant, enough to be a synchronous response, we still use the async job workflow for two reasons:

  1. To maintain conformity with the rest of the API
  2. To log requests in the back-end, so that we have a record of them

Closes #3658 

### Demo

When the watershed resulting from the default point is loaded in QGIS, it looks like this:

![image](https://github.com/user-attachments/assets/66e9fc04-1eed-4cf0-801b-8d1fbca100ed)

## Testing Instructions

- Check out this branch
- Bring up the VMS
    ```console
    vagrant up
    ```
- Load the development subset of TDX Basins data:
    ```console
    vagrant ssh app -c 'cd /vagrant && ./scripts/aws/setupdb.sh -B'
    ```
  - [ ] Ensure it succeeds in a reasonable time
- Go to http://localhost:8000/ and log in (create an account if you don't have one)
- Go to http://localhost:8000/api/docs/
- Exercise the `global-watersheds` API endpoint, using the default values
- Query the returned job id
  - [ ] Ensure it has a successful result