### PR TITLE
AWS 2-8: Implement Global Watershed Delineation Front-end

### DIFF
--- a/src/mmw/apps/geoprocessing_api/calcs.py
+++ b/src/mmw/apps/geoprocessing_api/calcs.py
@@ -462,8 +462,8 @@ def tdx_watershed_for_point(point):
           )
           FROM tdxbasins
           WHERE root_id = (SELECT root_id FROM target)
-            AND discover_time <= (SELECT discover_time FROM target)
-            AND finish_time >= (SELECT finish_time FROM target)
+            AND discover_time >= (SELECT discover_time FROM target)
+            AND finish_time <= (SELECT finish_time FROM target)
           '''
 
     with connection.cursor() as cursor:

--- a/src/mmw/apps/geoprocessing_api/stac.py
+++ b/src/mmw/apps/geoprocessing_api/stac.py
@@ -62,13 +62,18 @@ def query_histogram(geojson, url, collection, asset, filter, cachekey=''):
     # Reproject the tiffs and clip to the AoI to make tiles
     clips = []
     for tiff in tiffs:
-        clip_data, clip_transform, clip_meta = clip_and_reproject_tile(
-            tiff, aoi, dst_crs
-        )
-        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.tif')
-        with rio.open(temp_file.name, 'w', **clip_meta) as dst:
-            dst.write(clip_data)
-        clips.append(temp_file.name)
+        try:
+            clip_data, clip_transform, clip_meta = clip_and_reproject_tile(
+                tiff, aoi, dst_crs
+            )
+            temp_file = tempfile.NamedTemporaryFile(
+                delete=False, suffix='.tif'
+            )
+            with rio.open(temp_file.name, 'w', **clip_meta) as dst:
+                dst.write(clip_data)
+            clips.append(temp_file.name)
+        except ValueError as e:
+            print(f"Problem: {str(e)} with tiff: {tiff}")
 
     # Merge the clipped rasters
     datasets = [rio.open(clip_path) for clip_path in clips]

--- a/src/mmw/apps/geoprocessing_api/urls.py
+++ b/src/mmw/apps/geoprocessing_api/urls.py
@@ -62,7 +62,4 @@ urlpatterns = [
             views.start_modeling_subbasin_run,
             name='start_modeling_subbasin_run'),
     re_path(r'watershed/$', views.start_rwd, name='start_rwd'),
-    re_path(r'global-watershed/$',
-            views.start_global_rwd,
-            name='start_global_rwd'),
 ]

--- a/src/mmw/js/src/draw/models.js
+++ b/src/mmw/js/src/draw/models.js
@@ -55,6 +55,7 @@ var ToolbarModel = Backbone.Model.extend({
 // Used for running Rapid Watershed Delineation tasks.
 var RwdTaskModel = coreModels.TaskModel.extend({
     defaults: _.extend( {
+            name: 'rwd',
             taskName: 'watershed',
             taskType: 'api',
             token: settings.get('api_token')

--- a/src/mmw/js/src/draw/utils.js
+++ b/src/mmw/js/src/draw/utils.js
@@ -259,6 +259,7 @@ module.exports = {
     NHD: 'nhd',
     NHDHR: 'nhdhr',
     DRB: 'drb',
+    TDX: 'tdx',
     CANCEL_DRAWING: CANCEL_DRAWING,
     POINT: 'point',
     STREAM: 'stream',

--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -140,9 +140,11 @@ function validatePointWithinDataSourceBounds(latlng, dataSource) {
             perimeter = _.find(streamLayers, {code: 'drb_streams_v2'}).perimeter;
             point_outside_message = 'Selected point is outside the Delaware River Basin';
             break;
+        // Bound checking done by delineateWatershed in de600cb
         case utils.NHDHR:
         case utils.NHD:
-            // Bounds checking disabled until #1656 is complete.
+        // No bounds for TDX, it is global
+        case utils.TDX:
             d.resolve(latlng);
             return d.promise();
         default:
@@ -914,6 +916,18 @@ var WatershedDelineationView = DrawToolBaseView.extend({
                 minZoom: 0,
                 directions: 'Click a point to delineate a watershed.',
                 conusOnly: true,
+            },
+            {
+                id: utils.TDX,
+                dataSource: utils.TDX,
+                taskName: 'global-watershed',
+                title: 'TDX Global Basins',
+                info: '',
+                shapeType: 'stream',
+                snappingOn: false,
+                minZoom: 0,
+                directions: 'Click a point to delineate a watershed.',
+                conusOnly: false,
             }
         ];
     },


### PR DESCRIPTION
## Overview

Adds front-end support for delineation using the TDX Global Basins dataset. Also fixes an edge case described in #3638.

Closes #3659 
Closes #3638 

### Demo

[Screencast from 2024-11-26 10-25-34.webm](https://github.com/user-attachments/assets/a717a122-604a-4249-bbca-29ac2bf60c05)

### Notes

This doesn't have the help text yet. Will ask clients for that.

~~I may attempt a small tweak to the API design to see if we can nest the global watershed work under `watershed/` rather than having a separate endpoint for it.~~ [684c53f](https://github.com/WikiWatershed/model-my-watershed/pull/3664/commits/684c53fa76b983ccce7cc65de26a4b01bccd6f8f)

## Testing Instructions

- Check out this branch
- Run `scripts/debugcelery.sh`
- Run `scripts/bundle.sh --debug`
- Go to http://localhost:8000/
- Delineate using TDX Global Basins around 30th Street Station in Philadelphia
  - [x] Ensure you get the Schuylkill HUC-08 shape
- Click "Change Area" to reset
- Upload this shape: [1 Square Km.geojson.txt](https://github.com/user-attachments/files/17925574/1.Square.Km.geojson.txt)
  - [ ] Ensure you see a yellow warning message in `debugcelery` output
  - [x] Ensure analysis completes