### PR TITLE
AWS 2-7: Global Streams, Basins Label Updates

### DIFF
--- a/src/mmw/js/src/draw/views.js
+++ b/src/mmw/js/src/draw/views.js
@@ -883,7 +883,7 @@ var WatershedDelineationView = DrawToolBaseView.extend({
             {
                 id: utils.NHD,
                 dataSource: utils.NHD,
-                title: 'Continental US Medium Resolution',
+                title: 'Continental US from NHDplus v2',
                 info: 'Click on the map to select the nearest downhill ' +
                       'point on the medium resolution flow lines of the ' +
                       'National Hydrography Dataset (NHDplus v2). The ' +
@@ -902,7 +902,7 @@ var WatershedDelineationView = DrawToolBaseView.extend({
             {
                 id: utils.DRB,
                 dataSource: utils.DRB,
-                title: 'Delaware High Resolution',
+                title: 'Delaware River Basin from 10m NED',
                 info: 'Click on the map to select the nearest downhill ' +
                       'point on our Delaware River Basin high resolution ' +
                       'stream network. The watershed area upstream of this ' +
@@ -921,8 +921,14 @@ var WatershedDelineationView = DrawToolBaseView.extend({
                 id: utils.TDX,
                 dataSource: utils.TDX,
                 taskName: 'global-watershed',
-                title: 'TDX Global Basins',
-                info: '',
+                title: 'Global Basins from TDX-Hydro',
+                info: 'Click on the map to select the nearest stream ' +
+                      'reach from the global TDX-Hydro hydrographic ' +
+                      'dataset. The watershed area including and upstream ' +
+                      'of the selected stream reach is automatically ' +
+                      'delineated.<br />See ' +
+                      '<a href=\'https://wikiwatershed.org/documentation/mmw-tech/#delineate-watershed\' target=\'_blank\' rel=\'noreferrer noopener\'>' +
+                      'our documentation on Delineate Watershed.</a>',
                 shapeType: 'stream',
                 snappingOn: false,
                 minZoom: 0,

--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -630,6 +630,12 @@ LAYER_GROUPS = {
             'big_cz': True,
         },
         {
+            'code': 'tdxhydro_streams_v1',
+            'display': ('Global Stream Network from TDX-Hydro'),
+            'table_name': 'tdxstreams',
+            'minZoom': 0,
+        },
+        {
             'code': 'drb_streams_v2',
             'display': ('Delaware River Basin High Resolution' +
                         ' Stream Network'),
@@ -689,12 +695,6 @@ LAYER_GROUPS = {
             },
             'perimeter': PERIMETERS['CONUS']['json'],
             'big_cz': False,
-        },
-        {
-            'code': 'tdxhydro_streams_v1',
-            'display': ('TDX Hydro'),
-            'table_name': 'tdxstreams',
-            'minZoom': 0,
         },
     ],
 }


### PR DESCRIPTION
## Overview

Updates labels for RWD options. Updates info text for Global Basins. Updates label for Global Stream Network. Positions Global Stream Network to be third from top in the layer selector. All of these are based on recommendations from @aufdenkampe.

### Demo

![image](https://github.com/user-attachments/assets/f074c7ab-6c34-4170-b802-b582e83a2e43)
