### PR TITLE
Replace non-functioning Google layers with ESRI

### DIFF
--- a/src/mmw/mmw/settings/layer_settings.py
+++ b/src/mmw/mmw/settings/layer_settings.py
@@ -126,15 +126,23 @@ LAYER_GROUPS = {
             'big_cz': True,
         },
         {
-            'display': 'Satellite with Roads',
-            'googleType': 'HYBRID',  # SATELLITE, ROADMAP, HYBRID, or TERRAIN
-            'maxZoom': 18,  # Max zoom changes based on location. Safe default
+            'display': 'Streets',
+            'url': 'https://server.arcgisonline.com/arcgis/rest/services/'
+                   'World_Street_Map/MapServer/tile/{z}/{y}/{x}',
+            'attribution': 'Map data from <a href="http://www.arcgis.com/home/'
+                           'item.html?id=8bf7167d20924cbf8e25e7b11c7c502c" '
+                           'target="_blank">ESRI</a>',
+            'maxZoom': 19,
             'big_cz': True,
         },
         {
             'display': 'Terrain',
-            'googleType': 'TERRAIN',  # SATELLITE, ROADMAP, HYBRID, or TERRAIN
-            'maxZoom': 20,
+            'url': 'https://server.arcgisonline.com/arcgis/rest/services/'
+                   'NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}',
+            'attribution': 'Map data from <a href="http://www.arcgis.com/home/'
+                           'item.html?id=d94dcdbe78e141c2b2d3a91d5ca8b9c9" '
+                           'target="_blank">ESRI</a>',
+            'maxZoom': 16,
             'big_cz': True,
         },
     ],


### PR DESCRIPTION
## Overview

Replaces non-functioning Google basemaps with ESRI layers.

These are not direct equivalents, but pretty close. ESRI does have more equivalent basemaps available, but they are in vector formats with multiple layers, which are hard for us to implement with the current setup.

Closes #3678 

### Demo

https://github.com/user-attachments/assets/4bed071f-b1e2-4d58-a5dd-4f4e1c268ed4

### Notes

These layers are not direct equivalents, but alternatives that we can work with. We're sourcing these layers from this server: https://server.arcgisonline.com/arcgis/rest/services/

While ESRI itself does have newer layer versions and better layers available here: https://www.arcgis.com/home/group.html?sortField=title&sortOrder=asc&contentstatus=authoritative&id=702026e41f6641fb85da88efe79dc166#content, those use vector tiles for labels, and are multiple layers that work together to make the final image, rather than a flat tile, that our current setup uses. To use these vector layers, we would have to upgrade Leaflet, our mapping engine, and change our basemap configuration to specify multiple layers in order. That's a large refactor, and can only be done with proper funding.

## Testing Instructions

- This has been deployed to Staging
- Go to https://staging.modelmywatershed.org/ and select the different basemap layers in the Layer Selector
  - [x] Ensure they all work