### PR TITLE
Apply area-derived modifications first, then user-specified ones

### DIFF
--- a/src/mmw/apps/modeling/calcs.py
+++ b/src/mmw/apps/modeling/calcs.py
@@ -293,10 +293,20 @@ def apply_gwlfe_modifications(gms, modifications):
     for mod in modifications:
         for key, value in mod.items():
             if '__' in key:
-                array_mods.append({key: value})
+                if key[:6] == 'Area__':
+                    # Extract area modifications early, since we need them to
+                    # derive other modifications
+                    gmskey, i = key.split('__')
+                    modified_gms[gmskey][int(i)] = value
+                else:
+                    array_mods.append({key: value})
             else:
                 key_mods.append({key: value})
 
+    # Apply modifications derived from area first, so they can be overridden
+    modified_gms = area_calculations(modified_gms['Area'], modified_gms)
+
+    # Now apply user specified modifications, which take final precedence
     for mod in array_mods:
         for key, value in mod.items():
             gmskey, i = key.split('__')
@@ -304,9 +314,6 @@ def apply_gwlfe_modifications(gms, modifications):
 
     for mod in key_mods:
         modified_gms.update(mod)
-
-    # Update keys that derive values from other keys
-    modified_gms = area_calculations(modified_gms['Area'], modified_gms)
 
     return modified_gms
 


### PR DESCRIPTION
## Overview

Previously, we would apply all user-specified modifications first, then apply the area-derived ones. This was done in #3151, and was a mistake, since the area-derived modifications would override the user-specified ones.

This was not caught until users tried to update Normal Septic Systems in #3694, which is a field that is area-derived.

By making this change, we ensure that all area-derived modifications are applied first, and then user-specified are applied last. This ensures that all user-specified modifications do take effect in the final calculations.

I looked in to adding a test for this, but ran into issues with our current MapShed tests. I documented those in #3697 and am deferring that for the future.

Closes #3694 

### Demo

<img width="1031" height="1152" alt="image" src="https://github.com/user-attachments/assets/fdf3e4ec-8ed4-401f-a87b-a372609a4cfb" />

## Testing Instructions

- Check out this branch
- Go to http://localhost:8000/ and select an area of interest
- Create a Watershed Multi-Year project
- Once the model runs, go to the Water Quality tab, scroll all the way down, and make a note of the Septic Systems row
  - [x] Ensure it has a non-zero value for at least one column (Nitrogen in the case of the Philadelphia / Schuylkill River HUC-12)
- Click "Add changes to this area" to make a new scenario
- In the new scenario, click "Land Cover" and select a different land cover preset. Click Save.
  - [x] Ensure the Septic Systems now have a different value, proving they are calculated from land cover
- In the new scenario, click "Settings" in the top right and go to the "Waste Water" tab. Set "Normally Functioning Systems" to 0. Click Save.
  - [x] Ensure the Septic Systems have a 0 value