### PR TITLE
Use `get` in case keys don't exist

### DIFF
--- a/src/mmw/apps/modeling/views.py
+++ b/src/mmw/apps/modeling/views.py
@@ -79,11 +79,11 @@ def projects(request):
             # Initialize weather simulations for GWLFE projects if not given
             if (
                 serializer.validated_data.get('model_package') == Project.GWLFE
-                and not serializer.validated_data['weather_simulations']
+                and not serializer.validated_data.get('weather_simulations')
             ):
                 serializer.validated_data['weather_simulations'] = \
                     get_available_simulations_for_aoi(
-                        serializer.validated_data['area_of_interest'])
+                        serializer.validated_data.get('area_of_interest'))
 
             serializer.save()
 


### PR DESCRIPTION
## Overview

This protects against rare occurrences where the POST body is missing the new field.

See https://app.rollbar.com/a/WikiWatershed/fix/item/ModelMyWatershed/405

## Testing Instructions

- Check out this branch
- [ ] Ensure project creation works, for both TR-55 and GWLFE projects
- Comment out this line:
    https://github.com/WikiWatershed/model-my-watershed/blob/3ff654a266f7f1347c0f5b2feae932c497353508/src/mmw/js/src/modeling/models.js#L350
- Run `./scripts/bundle.sh --debug`
- [ ] Ensure project creation still works, for both TR-55 and GWLFE projects