### PR TITLE
Upgrade Postgres, PostGIS, Psycopg

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -16,13 +16,13 @@ postgresql_username: mmw
 postgresql_password: mmw
 postgresql_database: mmw
 
-postgresql_version: "13"
-postgresql_package_version: "13.*.pgdg22.04+1"
+postgresql_version: "17"
+postgresql_package_version: "17.*.pgdg22.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "13.*.pgdg22.04+1"
-postgresql_support_psycopg2_version: "2.8.*"
+postgresql_support_libpq_version: "17.*.pgdg22.04+1"
+postgresql_support_psycopg2_version: "2.9.*"
 postgis_version: "3"
-postgis_package_version: "3.5*pgdg22.04+1"
+postgis_package_version: "3.6*pgdg22.04+1"
 
 daemontools_version: "1:0.76-7"
 

--- a/src/mmw/requirements/base.txt
+++ b/src/mmw/requirements/base.txt
@@ -20,7 +20,7 @@ requests[security]==2.28.2
 rollbar==0.16.2
 retry==0.9.2
 python-dateutil==2.8.2
-suds-community==1.0.0
+suds-jurko @ https://github.com/drivendataorg/suds-jurko-wheel/releases/download/v0.6/suds_jurko-0.6-py3-none-any.whl
 django_celery_results==2.2.0
 pandas==1.3.5
 ulmo==0.8.8


### PR DESCRIPTION
## Overview

Upgrades Postgres to 17 (17.6 on staging), PostGIS to 3.6 (3.5 on staging), and Psycopg to 2.9.

Connects #3699 

### Demo

https://staging.modelmywatershed.org/

## Testing Instructions

- Go to https://staging.modelmywatershed.org/
- Model a shape
  - [x] Ensure everything works
- (this will take some time) Reprovision your machines locally and ensure they succeed:
    ```
    vagrant reload --provision
    ```