### PR TITLE
Reduce Out of Memory kills of the App VM

### DIFF
--- a/deployment/ansible/roles/model-my-watershed.app/templates/gunicorn.py.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/gunicorn.py.j2
@@ -1,7 +1,5 @@
-import multiprocessing
-
 bind = "127.0.0.1:8000"
-workers = (2 * multiprocessing.cpu_count()) + 1
+workers = (1 * multiprocessing.cpu_count()) + 1
 timeout = 60
 max_requests = 1000
 max_requests_jitter = 100

--- a/deployment/ansible/roles/model-my-watershed.app/templates/gunicorn.py.j2
+++ b/deployment/ansible/roles/model-my-watershed.app/templates/gunicorn.py.j2
@@ -3,6 +3,8 @@ import multiprocessing
 bind = "127.0.0.1:8000"
 workers = (2 * multiprocessing.cpu_count()) + 1
 timeout = 60
+max_requests = 1000
+max_requests_jitter = 100
 
 {% if ['development', 'test'] | some_are_in(group_names) -%}
 accesslog = "-"


### PR DESCRIPTION
## Overview

On July 21 and Aug 4 2026, we noticed a large number of requests that took down the App EC2 VMs and prevented the site from functioning. An investigation showed that the issue was due to pulling in a large number of streams from PostGIS to be serialized into a Celery request.

This PR addresses this in two ways:

1. It reduces the number of Django workers per App VM, which gives each more RAM to work with
    * Looking at historical usage, this will not affect performance, because we don't have that much traffic
2. It auto-cycles the Django workers after 1000 +/- 100 requests, to free up memory and keep things clean

Closes #3730 